### PR TITLE
WIP reintroduce `$publishedNodes` and `$discardedNodes` for partial discard and publish v2

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/Common/EmbedsAffectedDimensionSpacePoints.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/EmbedsAffectedDimensionSpacePoints.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\Common;
 
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 
 /**
- * This interface is implemented by **events** which affect a node aggregate.
+ * This interface is implemented by **events** which affect dimension space points.
  *
  * @internal
  */
-interface EmbedsNodeAggregateId
+interface EmbedsAffectedDimensionSpacePoints
 {
-    public function getNodeAggregateId(): NodeAggregateId;
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet;
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/EmbedsContentStreamId.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/EmbedsContentStreamId.php
@@ -17,9 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
- * This interface is implemented by **events** which contain ContentStreamId.
- *
- * This is relevant e.g. for content cache flushing as a result of an event.
+ * This interface is implemented by **events** which affect a content stream.
  *
  * @internal
  */

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/EmbedsWorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/EmbedsWorkspaceName.php
@@ -17,9 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
- * This interface is implemented by **events** which contain WorkspaceName.
- *
- * This is relevant e.g. for content cache flushing as a result of an event.
+ * This interface is implemented by **events** which affect a workspace.
  *
  * @internal
  */

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Event/NodeAggregateWithNodeWasCreated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Event/NodeAggregateWithNodeWasCreated.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeCreation\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -41,6 +42,7 @@ final readonly class NodeAggregateWithNodeWasCreated implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -76,6 +78,11 @@ final readonly class NodeAggregateWithNodeWasCreated implements
     public function getOriginDimensionSpacePoint(): OriginDimensionSpacePoint
     {
         return $this->originDimensionSpacePoint;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->succeedingSiblingsForCoverage->toDimensionSpacePointSet();
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Event/NodeAggregateWasDisabled.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Event/NodeAggregateWasDisabled.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeDisabling\Event;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -36,6 +37,7 @@ final readonly class NodeAggregateWasDisabled implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -60,6 +62,11 @@ final readonly class NodeAggregateWasDisabled implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Event/NodeAggregateWasEnabled.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Event/NodeAggregateWasEnabled.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeDisabling\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\EventNormalizer;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -37,6 +38,7 @@ final readonly class NodeAggregateWasEnabled implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -60,6 +62,11 @@ final readonly class NodeAggregateWasEnabled implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Event/NodePropertiesWereSet.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Event/NodePropertiesWereSet.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeModification\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -43,6 +44,7 @@ final readonly class NodePropertiesWereSet implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -75,6 +77,11 @@ final readonly class NodePropertiesWereSet implements
     public function getOriginDimensionSpacePoint(): OriginDimensionSpacePoint
     {
         return $this->originDimensionSpacePoint;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Event/NodeAggregateWasMoved.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Event/NodeAggregateWasMoved.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\NodeMove\Event;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -56,6 +58,7 @@ final readonly class NodeAggregateWasMoved implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -80,6 +83,11 @@ final readonly class NodeAggregateWasMoved implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->succeedingSiblingsForCoverage->toDimensionSpacePointSet();
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Event/NodeReferencesWereSet.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Event/NodeReferencesWereSet.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeReferencing\Event;
 
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -27,6 +29,7 @@ final readonly class NodeReferencesWereSet implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -57,6 +60,11 @@ final readonly class NodeReferencesWereSet implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedSourceOriginDimensionSpacePoints->toDimensionSpacePointSet();
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Event/NodeAggregateWasRemoved.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Event/NodeAggregateWasRemoved.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeRemoval\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -34,6 +35,7 @@ final readonly class NodeAggregateWasRemoved implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -60,6 +62,11 @@ final readonly class NodeAggregateWasRemoved implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedCoveredDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Event/NodeGeneralizationVariantWasCreated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Event/NodeGeneralizationVariantWasCreated.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeVariation\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -36,6 +37,7 @@ final readonly class NodeGeneralizationVariantWasCreated implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -61,6 +63,11 @@ final readonly class NodeGeneralizationVariantWasCreated implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->variantSucceedingSiblings->toDimensionSpacePointSet();
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Event/NodePeerVariantWasCreated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Event/NodePeerVariantWasCreated.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeVariation\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -34,6 +35,7 @@ final readonly class NodePeerVariantWasCreated implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -59,6 +61,11 @@ final readonly class NodePeerVariantWasCreated implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->peerSucceedingSiblings->toDimensionSpacePointSet();
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Event/NodeSpecializationVariantWasCreated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Event/NodeSpecializationVariantWasCreated.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeVariation\Event;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -36,6 +37,7 @@ final readonly class NodeSpecializationVariantWasCreated implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -61,6 +63,11 @@ final readonly class NodeSpecializationVariantWasCreated implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->specializationSiblings->toDimensionSpacePointSet();
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/RebaseableCommands.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RebaseableCommands.php
@@ -71,6 +71,7 @@ class RebaseableCommands implements \IteratorAggregate
         NodeIdsToPublishOrDiscard $nodeIds,
     ): bool {
         foreach ($nodeIds as $nodeId) {
+            // todo rather use the domain event here and use `EmbedsNodeAggregateId` already!
             if ($command->matchesNodeId($nodeId)) {
                 return true;
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Event/RootNodeAggregateDimensionsWereUpdated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Event/RootNodeAggregateDimensionsWereUpdated.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\RootNodeCreation\Event;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -35,6 +36,7 @@ final readonly class RootNodeAggregateDimensionsWereUpdated implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -59,6 +61,11 @@ final readonly class RootNodeAggregateDimensionsWereUpdated implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->coveredDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Event/RootNodeAggregateWithNodeWasCreated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/Event/RootNodeAggregateWithNodeWasCreated.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\RootNodeCreation\Event;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -36,6 +37,7 @@ final readonly class RootNodeAggregateWithNodeWasCreated implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     public function __construct(
@@ -62,6 +64,11 @@ final readonly class RootNodeAggregateWithNodeWasCreated implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->coveredDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Event/SubtreeWasTagged.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Event/SubtreeWasTagged.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\SubtreeTagging\Event;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -35,6 +36,7 @@ final readonly class SubtreeWasTagged implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     /**
@@ -65,6 +67,11 @@ final readonly class SubtreeWasTagged implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Event/SubtreeWasUntagged.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Event/SubtreeWasUntagged.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\SubtreeTagging\Event;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
@@ -36,6 +37,7 @@ final readonly class SubtreeWasUntagged implements
     PublishableToWorkspaceInterface,
     EmbedsContentStreamId,
     EmbedsNodeAggregateId,
+    EmbedsAffectedDimensionSpacePoints,
     EmbedsWorkspaceName
 {
     /**
@@ -66,6 +68,11 @@ final readonly class SubtreeWasUntagged implements
     public function getWorkspaceName(): WorkspaceName
     {
         return $this->workspaceName;
+    }
+
+    public function getAffectedDimensionSpacePoints(): DimensionSpacePointSet
+    {
+        return $this->affectedDimensionSpacePoints;
     }
 
     public function withWorkspaceNameAndContentStreamId(WorkspaceName $targetWorkspaceName, ContentStreamId $contentStreamId): self

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -477,6 +477,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             return;
         }
 
+        // todo we should - similar to discard - also add the node aggregate IDs with dimension point to the event again. The question is if we use the old events to analyse that or the newly emitted (today) events?
+        // could they come to a different result like MORE or less dimensions are suddenly affected because of a change in configuration? And would it make sense to use the old or new events then? Probably the old
+        // to make it consistent with discard.
+        $nodesToPublish = $this->extractNodeAggregateIdsAndAffectedDimensionSpacePoints($matchingCommands);
+
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
             $workspaceContentStreamVersion
@@ -550,7 +555,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         $baseWorkspace->workspaceName,
                         $command->contentStreamIdForRemainingPart,
                         $workspace->currentContentStreamId,
-                        $command->nodesToPublish
+                        $nodesToPublish
                     )
                 ]),
                 ExpectedVersion::ANY()

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -19,10 +19,13 @@ use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
 use Neos\ContentRepository\Core\CommandHandler\CommandSimulatorFactory;
 use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\DecoratedEvent;
 use Neos\ContentRepository\Core\EventStore\EventNormalizer;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsAffectedDimensionSpacePoints;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
 use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterface;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasClosed;
@@ -46,6 +49,8 @@ use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardIndi
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\DiscardWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishIndividualNodesFromWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Dto\NodeIdsToPublishOrDiscard;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Dto\NodeIdToPublishOrDiscard;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPartiallyPublished;
@@ -59,6 +64,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistY
 use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamIsClosed;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasNoBaseWorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -599,6 +605,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             return;
         }
 
+        $nodesToDiscard = $this->extractNodeAggregateIdsAndAffectedDimensionSpacePoints($commandsToDiscard);
+
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
             $workspaceContentStreamVersion
@@ -644,7 +652,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         $command->workspaceName,
                         $command->newContentStreamId,
                         $workspace->currentContentStreamId,
-                        $command->nodesToDiscard,
+                        $nodesToDiscard,
                     )
                 ),
                 ExpectedVersion::ANY()
@@ -657,6 +665,41 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
+    }
+
+    private function extractNodeAggregateIdsAndAffectedDimensionSpacePoints(RebaseableCommands $commands): NodeIdsToPublishOrDiscard
+    {
+        /** @var array<string,DimensionSpacePointSet> $affectedDimensionSpacePointsByNodeAggregateId */
+        $affectedDimensionSpacePointsByNodeAggregateId = [];
+        foreach ($commands as $command) {
+            $event = $this->eventNormalizer->denormalize($command->originalEvent);
+            assert($event instanceof EmbedsNodeAggregateId);
+            if (!$event instanceof EmbedsAffectedDimensionSpacePoints) {
+                // todo fix change node type and rename case!!! either event must contain all dsp or we need to use the variation graph here?
+                // -> all dimension would be forward compatible if we ever allow node type change for one dsp ...
+                continue;
+            }
+            $affectedDimensionSpacePoints = $affectedDimensionSpacePointsByNodeAggregateId[$event->getNodeAggregateId()->value] ?? null;
+
+            $affectedDimensionSpacePointsByNodeAggregateId[$event->getNodeAggregateId()->value] =
+                $affectedDimensionSpacePoints !== null
+                    ? $affectedDimensionSpacePoints->getUnion($event->getAffectedDimensionSpacePoints())
+                    : $event->getAffectedDimensionSpacePoints();
+
+        }
+
+        $nodeAggregateIdsWithDimension = [];
+        foreach ($affectedDimensionSpacePointsByNodeAggregateId as $nodeId => $affectedDimensionSpacePoints) {
+            foreach ($affectedDimensionSpacePoints as $dimensionSpacePoint) {
+                $nodeAggregateIdsWithDimension[] = new NodeIdToPublishOrDiscard(
+                    NodeAggregateId::fromString($nodeId),
+                    $dimensionSpacePoint
+                );
+            }
+        }
+
+        // todo optimise format like: [{NodeAggregateId -> DimensionSpacePointSet}] and rename collection to NodeAggregateIdsWithDimensionSpacePoints (less clumsy) ... in the event this happened already ... no TO ...!
+        return NodeIdsToPublishOrDiscard::create(...$nodeAggregateIdsWithDimension);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Event/WorkspaceWasPartiallyPublished.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Event/WorkspaceWasPartiallyPublished.php
@@ -41,6 +41,9 @@ final readonly class WorkspaceWasPartiallyPublished implements EventInterface
          * The old content stream, which contains ALL the data (discarded and non-discarded)
          */
         public ContentStreamId $previousSourceContentStreamId,
+        /**
+         * Todo docs!
+         */
         public NodeIdsToPublishOrDiscard $publishedNodes,
     ) {
     }

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -7,7 +7,6 @@ namespace Neos\Neos\AssetUsage\CatchUpHook;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
-use Neos\ContentRepository\Core\Feature\Common\EmbedsContentStreamId;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Event\DimensionSpacePointWasMoved;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNodeWasCreated;


### PR DESCRIPTION
initially extracted from https://github.com/neos/neos-development-collection/pull/5385 wont be needed for 9.0 just ideas how to calculate the node ids to publish in `WorkspaceWasPartiallyDiscared` e.g.

The here shown implementation of `extractNodeAggregateIdsAndAffectedDimensionSpacePoints` to restore the information _which_ nodes were discarded or published, is hard to acquire, as for the discard case we can look through all events that happened - which we are about to discard - while for publish we could decide to look into the information which events were used for the simulation _or_ use the events that come out of the simulation. Ideally they should be the same but there might be edgecases. Maybe we just really need that property at all.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
