### PR TITLE
TASK: Document that scatter does NOT move fallbacks!

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Dto/RelationDistributionStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/Dto/RelationDistributionStrategy.php
@@ -15,16 +15,14 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\NodeMove\Dto;
 
 /**
- * The relation distribution strategy for node aggregates as defined in the NodeType declaration
+ * The relation distribution strategy for node aggregates
+ *
  * Used for building relations to other node aggregates
  *
- * - `scatter` means that different nodes within the aggregate may be related to different other aggregates
- *      (e.g. parent).
- *      Still, specializations pointing to the same node using the fallback mechanism will be kept gathered.
+ * - `scatter` means that different nodes within the aggregate may be related to different other aggregates (e.g. parent).
  * - `gatherAll` means that all nodes within the aggregate must be related to the same other aggregate (e.g. parent)
  * - `gatherSpecializations` means that when a node is related to another node aggregate (e.g. parent),
- *      all specializations of that node will be related to that same aggregate while generalizations
- *      may be related to others
+ *      all specializations of that node will be related to that same aggregate while generalizations may be related to others
  *
  * @api DTO of {@see MoveNodeAggregate} command
  */


### PR DESCRIPTION
Cherrypicked from bernhards original change in https://github.com/neos/neos-development-collection/pull/4994/files#diff-4a3a69f0f68fa88f95e6a757f42dee32aa9a14a34ed99433e09a6950b5be0ce1

Followup to using scatter now: https://github.com/neos/neos-ui/pull/3876

GOTO a page ("Multiple columns") in EN_US, which only has fallbacks and no content variants.
Move an element in EN_US with the new scatter content behaviour ("Why, Mary Ann..." below "Hand it over here...")
The element is only moved in EN_US and NOT moved in EN_UK.

In Neos 8.3 they were moved, as long it was just a fallback:

<img width="511" alt="image" src="https://github.com/user-attachments/assets/d8fff48a-d2eb-4972-81b2-cadd67cb0d15">

If you previously changed the text in 8.3 (create a variant in EN_UK) the move in US is not affected in UK.

Neos 9.0 makes that behaviour more consistent. In case the variants should also be moved `gatherSpecializations` should be configured:

```
'Neos.Neos:Content':
  options:
    moveNodeStrategy: gatherSpecializations
```

there is no exact behaviour like Neos 8.3 in the core. 

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
