### PR TITLE
BUGFIX: Ensure that its not attempted to publish 0 events

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
@@ -67,7 +67,7 @@ Feature: Set node properties: Constraint checks
       | Key                       | Value                    |
       | nodeAggregateId           | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"language":"de"}        |
-      | propertyValues            | {}                       |
+      | propertyValues            | {"text":"New text"}      |
     Then the last command should have thrown an exception of type "NodeAggregateIsRoot"
 
   Scenario: Try to set properties in an origin dimension space point that does not exist

--- a/Neos.ContentRepository.Core/Classes/EventStore/Events.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/Events.php
@@ -10,16 +10,17 @@ namespace Neos\ContentRepository\Core\EventStore;
  * @implements \IteratorAggregate<EventInterface|DecoratedEvent>
  * @internal only used during event publishing (from within command handlers) - and their implementation is not API
  */
-final class Events implements \IteratorAggregate, \Countable
+final readonly class Events implements \IteratorAggregate, \Countable
 {
     /**
-     * @var array<EventInterface|DecoratedEvent>
+     * @var non-empty-array<EventInterface|DecoratedEvent>
      */
-    private readonly array $events;
+    public array $items;
 
     private function __construct(EventInterface|DecoratedEvent ...$events)
     {
-        $this->events = $events;
+        /** @var non-empty-array<EventInterface|DecoratedEvent> $events */
+        $this->items = $events;
     }
 
     public static function with(EventInterface|DecoratedEvent $event): self
@@ -29,11 +30,11 @@ final class Events implements \IteratorAggregate, \Countable
 
     public function withAppendedEvents(Events $events): self
     {
-        return new self(...$this->events, ...$events->events);
+        return new self(...$this->items, ...$events->items);
     }
 
     /**
-     * @param array<EventInterface|DecoratedEvent> $events
+     * @param non-empty-array<EventInterface|DecoratedEvent> $events
      * @return static
      */
     public static function fromArray(array $events): self
@@ -43,21 +44,21 @@ final class Events implements \IteratorAggregate, \Countable
 
     public function getIterator(): \Traversable
     {
-        yield from $this->events;
+        yield from $this->items;
     }
 
     /**
      * @template T
      * @param \Closure(EventInterface|DecoratedEvent $event): T $callback
-     * @return list<T>
+     * @return non-empty-list<T>
      */
     public function map(\Closure $callback): array
     {
-        return array_map($callback, $this->events);
+        return array_map($callback, $this->items);
     }
 
     public function count(): int
     {
-        return count($this->events);
+        return count($this->items);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/EventStore/Events.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/Events.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\EventStore;
 
+use Neos\EventStore\EventStoreInterface;
+
 /**
- * A set of Content Repository "domain events"
+ * A set of Content Repository "domain events", part of {@see EventsToPublish}
+ *
+ * For better type checking we ensure that this collection is never empty.
+ * That is because {@see EventStoreInterface::commit()} will throw an exception if there are 0 events passed:
+ *
+ * > Writable events must contain at least one event
+ *
+ * We do not skip the case for 0 events to ensure each command always maps to a mutation.
+ * Forgiving noop behaviour is not intended for this low level code.
  *
  * @implements \IteratorAggregate<EventInterface|DecoratedEvent>
  * @internal only used during event publishing (from within command handlers) - and their implementation is not API

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
@@ -16,7 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
-use Neos\ContentRepository\Core\EventStore\Events;
+use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
@@ -34,13 +34,15 @@ trait NodeTypeChangeInternals
     /**
      * NOTE: when changing this method, {@see NodeTypeChange::requireConstraintsImposedByHappyPathStrategyAreMet}
      * needs to be modified as well (as they are structurally the same)
+     *
+     * @return array<EventInterface>
      */
     private function deleteDisallowedNodesWhenChangingNodeType(
         ContentGraphInterface $contentGraph,
         NodeAggregate $nodeAggregate,
         NodeType $newNodeType,
         NodeAggregateIds &$alreadyRemovedNodeAggregateIds,
-    ): Events {
+    ): array {
         $events = [];
         // if we have children, we need to check whether they are still allowed
         // after we changed the node type of the $nodeAggregate to $newNodeType.
@@ -117,15 +119,18 @@ trait NodeTypeChangeInternals
             }
         }
 
-        return Events::fromArray($events);
+        return $events;
     }
 
+    /**
+     * @return array<EventInterface>
+     */
     private function deleteObsoleteTetheredNodesWhenChangingNodeType(
         ContentGraphInterface $contentGraph,
         NodeAggregate $nodeAggregate,
         NodeType $newNodeType,
         NodeAggregateIds &$alreadyRemovedNodeAggregateIds,
-    ): Events {
+    ): array {
         $events = [];
         // find disallowed tethered nodes
         $tetheredNodeAggregates = $contentGraph->findTetheredChildNodeAggregates($nodeAggregate->nodeAggregateId);
@@ -156,7 +161,7 @@ trait NodeTypeChangeInternals
             }
         }
 
-        return Events::fromArray($events);
+        return $events;
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -89,7 +89,7 @@ trait NodeVariationInternals
 
     /**
      * @param array<int,EventInterface> $events
-     * @return array<int,EventInterface>
+     * @return non-empty-array<int,EventInterface>
      */
     protected function collectNodeSpecializationVariantsThatWillHaveBeenCreated(
         ContentGraphInterface $contentGraph,
@@ -152,7 +152,7 @@ trait NodeVariationInternals
 
     /**
      * @param array<int,EventInterface> $events
-     * @return array<int,EventInterface>
+     * @return non-empty-array<int,EventInterface>
      */
     protected function collectNodeGeneralizationVariantsThatWillHaveBeenCreated(
         ContentGraphInterface $contentGraph,
@@ -215,7 +215,7 @@ trait NodeVariationInternals
 
     /**
      * @param array<int,EventInterface> $events
-     * @return array<int,EventInterface>
+     * @return non-empty-array<int,EventInterface>
      */
     protected function collectNodePeerVariantsThatWillHaveBeenCreated(
         ContentGraphInterface $contentGraph,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Command/SetNodeProperties.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Command/SetNodeProperties.php
@@ -48,6 +48,9 @@ final readonly class SetNodeProperties implements CommandInterface
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
         public PropertyValuesToWrite $propertyValues,
     ) {
+        if ($this->propertyValues->isEmpty()) {
+            throw new \InvalidArgumentException(sprintf('The command "SetNodeProperties" for node %s must contain property values', $this->nodeAggregateId->value), 1733394351);
+        }
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/PropertyValuesToWrite.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/PropertyValuesToWrite.php
@@ -95,4 +95,9 @@ final readonly class PropertyValuesToWrite
             )
         );
     }
+
+    public function isEmpty(): bool
+    {
+        return $this->values === [];
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/NodeModification.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/NodeModification.php
@@ -129,6 +129,11 @@ trait NodeModification
 
         $events = $this->mergeSplitEvents($events);
 
+        if ($events === []) {
+            // cannot happen here as the command could not be instantiated without any intention see constructor validation
+            throw new \RuntimeException('Cannot handle "SetSerializedNodeProperties" with no properties to modify', 1736798016);
+        }
+
         return new EventsToPublish(
             ContentStreamEventStreamName::fromContentStreamId($contentGraph->getContentStreamId())
                 ->getEventStreamName(),

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Command/SetNodeReferences.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/Command/SetNodeReferences.php
@@ -36,6 +36,9 @@ final readonly class SetNodeReferences implements CommandInterface
         public OriginDimensionSpacePoint $sourceOriginDimensionSpacePoint,
         public NodeReferencesToWrite $references,
     ) {
+        if ($this->references->isEmpty()) {
+            throw new \InvalidArgumentException(sprintf('The command "SetNodeReferences" for node %s must contain references to modify', $this->sourceNodeAggregateId->value), 1736797678);
+        }
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/NodeReferencing.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/NodeReferencing.php
@@ -148,6 +148,11 @@ trait NodeReferencing
             );
         }
 
+        if ($events === []) {
+            // cannot happen here as the command could not be instantiated without any intention see constructor validation
+            throw new \RuntimeException('Cannot handle "SetSerializedNodeReferences" with no references to modify', 1736797975);
+        }
+
         $events = Events::fromArray($events);
 
         return new EventsToPublish(

--- a/Neos.ContentRepository.Core/Classes/Feature/RebaseableCommand.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RebaseableCommand.php
@@ -66,7 +66,7 @@ final readonly class RebaseableCommand
         $processedEvents = [];
         $causationId = null;
         $i = 0;
-        foreach ($events as $event) {
+        foreach ($events->items as $event) {
             if ($event instanceof DecoratedEvent) {
                 $undecoratedEvent = $event->innerEvent;
                 if (!$undecoratedEvent instanceof PublishableToWorkspaceInterface) {

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -232,24 +232,26 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $commandSimulator->eventStream(),
         );
 
-        try {
-            yield new EventsToPublish(
-                ContentStreamEventStreamName::fromContentStreamId($baseWorkspace->currentContentStreamId)
-                    ->getEventStreamName(),
-                $eventsOfWorkspaceToPublish,
-                ExpectedVersion::fromVersion($baseWorkspaceContentStreamVersion)
-            );
-        } catch (ConcurrencyException $concurrencyException) {
-            yield $this->reopenContentStreamWithoutConstraintChecks(
-                $workspace->currentContentStreamId
-            );
-            throw $concurrencyException;
+        if ($eventsOfWorkspaceToPublish !== null) {
+            try {
+                yield new EventsToPublish(
+                    ContentStreamEventStreamName::fromContentStreamId($baseWorkspace->currentContentStreamId)
+                        ->getEventStreamName(),
+                    $eventsOfWorkspaceToPublish,
+                    ExpectedVersion::fromVersion($baseWorkspaceContentStreamVersion)
+                );
+            } catch (ConcurrencyException $concurrencyException) {
+                yield $this->reopenContentStreamWithoutConstraintChecks(
+                    $workspace->currentContentStreamId
+                );
+                throw $concurrencyException;
+            }
         }
 
         yield $this->forkContentStream(
             $command->newContentStreamId,
             $baseWorkspace->currentContentStreamId,
-            Version::fromInteger($baseWorkspaceContentStreamVersion->value + $eventsOfWorkspaceToPublish->count())
+            Version::fromInteger($baseWorkspaceContentStreamVersion->value + ($eventsOfWorkspaceToPublish?->count() ?? 0))
         );
 
         yield new EventsToPublish(
@@ -303,7 +305,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         WorkspaceName $targetWorkspaceName,
         ContentStreamId $targetContentStreamId,
         EventStreamInterface $eventStream
-    ): Events {
+    ): Events|null {
         $events = [];
         foreach ($eventStream as $eventEnvelope) {
             $event = $this->eventNormalizer->denormalize($eventEnvelope->event);
@@ -316,7 +318,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             }
         }
 
-        return Events::fromArray($events);
+        // this could technically empty, but we handle it as a no-op
+        return $events !== [] ? Events::fromArray($events) : null;
     }
 
     /**
@@ -485,31 +488,32 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             };
         }
 
-        // this could empty and a no-op for the rare case when a command returns empty events e.g. the node was already tagged with this subtree tag
         $selectedEventsOfWorkspaceToPublish = $this->getCopiedEventsOfEventStream(
             $baseWorkspace->workspaceName,
             $baseWorkspace->currentContentStreamId,
             $commandSimulator->eventStream()->withMaximumSequenceNumber($highestSequenceNumberForMatching),
         );
 
-        try {
-            yield new EventsToPublish(
-                ContentStreamEventStreamName::fromContentStreamId($baseWorkspace->currentContentStreamId)
-                    ->getEventStreamName(),
-                $selectedEventsOfWorkspaceToPublish,
-                ExpectedVersion::fromVersion($baseWorkspaceContentStreamVersion)
-            );
-        } catch (ConcurrencyException $concurrencyException) {
-            yield $this->reopenContentStreamWithoutConstraintChecks(
-                $workspace->currentContentStreamId
-            );
-            throw $concurrencyException;
+        if ($selectedEventsOfWorkspaceToPublish !== null) {
+            try {
+                yield new EventsToPublish(
+                    ContentStreamEventStreamName::fromContentStreamId($baseWorkspace->currentContentStreamId)
+                        ->getEventStreamName(),
+                    $selectedEventsOfWorkspaceToPublish,
+                    ExpectedVersion::fromVersion($baseWorkspaceContentStreamVersion)
+                );
+            } catch (ConcurrencyException $concurrencyException) {
+                yield $this->reopenContentStreamWithoutConstraintChecks(
+                    $workspace->currentContentStreamId
+                );
+                throw $concurrencyException;
+            }
         }
 
         yield from $this->forkNewContentStreamAndApplyEvents(
             $command->contentStreamIdForRemainingPart,
             $baseWorkspace->currentContentStreamId,
-            Version::fromInteger($baseWorkspaceContentStreamVersion->value + $selectedEventsOfWorkspaceToPublish->count()),
+            Version::fromInteger($baseWorkspaceContentStreamVersion->value + ($selectedEventsOfWorkspaceToPublish?->count() ?? 0)),
             new EventsToPublish(
                 WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName(),
                 Events::fromArray([
@@ -780,7 +784,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         ContentStreamId $sourceContentStreamId,
         Version $sourceContentStreamVersion,
         EventsToPublish $pointWorkspaceToNewContentStream,
-        Events $eventsToApplyOnNewContentStream,
+        Events|null $eventsToApplyOnNewContentStream,
     ): \Generator {
         yield $this->forkContentStream(
             $newContentStreamId,
@@ -797,13 +801,12 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         yield new EventsToPublish(
             ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)
                 ->getEventStreamName(),
-            $eventsToApplyOnNewContentStream->withAppendedEvents(
-                Events::with(
-                    new ContentStreamWasReopened(
-                        $newContentStreamId
-                    )
+            Events::fromArray([
+                ...($eventsToApplyOnNewContentStream ?? []),
+                new ContentStreamWasReopened(
+                    $newContentStreamId
                 )
-            ),
+            ]),
             ExpectedVersion::fromVersion(Version::first()->next())
         );
     }

--- a/Neos.ContentRepository.Core/Classes/NodeType/TetheredNodeTypeDefinitions.php
+++ b/Neos.ContentRepository.Core/Classes/NodeType/TetheredNodeTypeDefinitions.php
@@ -63,16 +63,18 @@ final class TetheredNodeTypeDefinitions implements \IteratorAggregate
         return $this->tetheredNodeTypeDefinitions[$nodeName] ?? null;
     }
 
+    /**
+     * @template T
+     * @param \Closure(TetheredNodeTypeDefinition): T $callback
+     * @return list<T>
+     */
+    public function map(\Closure $callback): array
+    {
+        return array_map($callback, array_values($this->tetheredNodeTypeDefinitions));
+    }
+
     public function getIterator(): \Traversable
     {
         yield from $this->tetheredNodeTypeDefinitions;
-    }
-
-    /**
-     * @return array<TetheredNodeTypeDefinition>
-     */
-    public function toArray(): array
-    {
-        return $this->tetheredNodeTypeDefinitions;
     }
 }

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -141,7 +141,9 @@ class TetheredNodeAdjustments
                         }
                     }
 
-                    if (array_keys($actualTetheredChildNodes) !== array_keys($nodeType->tetheredNodeTypeDefinitions->toArray())) {
+                    $expectedTetheredNodeOrder = array_keys($nodeType->tetheredNodeTypeDefinitions->toArray());
+                    if (count($expectedTetheredNodeOrder) > 1 && array_keys($actualTetheredChildNodes) !== $expectedTetheredNodeOrder) {
+                        /** @var array<int<2,max>,string> $expectedTetheredNodeOrder */
                         // we need to re-order: We go from the last to the first
                         yield StructureAdjustment::createForNodeIdentity(
                             $nodeAggregate->workspaceName,
@@ -149,7 +151,7 @@ class TetheredNodeAdjustments
                             $nodeAggregate->nodeAggregateId,
                             StructureAdjustment::TETHERED_NODE_WRONGLY_ORDERED,
                             'Tethered nodes wrongly ordered, expected: '
-                                . implode(', ', array_keys($nodeType->tetheredNodeTypeDefinitions->toArray()))
+                                . implode(', ', $expectedTetheredNodeOrder)
                                 . ' - actual: '
                                 . implode(', ', array_keys($actualTetheredChildNodes)),
                             fn () => $this->reorderNodes(
@@ -157,7 +159,7 @@ class TetheredNodeAdjustments
                                 $this->contentGraph->getContentStreamId(),
                                 $nodeAggregate->getCoverageByOccupant($originDimensionSpacePoint),
                                 $actualTetheredChildNodes,
-                                array_keys($nodeType->tetheredNodeTypeDefinitions->toArray())
+                                $expectedTetheredNodeOrder
                             )
                         );
                     }
@@ -216,7 +218,7 @@ class TetheredNodeAdjustments
      * array key: name of tethered child node. Value: the Node itself.
      * @param array<string,Node> $actualTetheredChildNodes
      * an array depicting the expected tethered order, like ["node1", "node2"]
-     * @param array<int,string> $expectedNodeOrdering
+     * @param array<int<2,max>,string> $expectedNodeOrdering
      */
     private function reorderNodes(
         WorkspaceName $workspaceName,
@@ -254,6 +256,7 @@ class TetheredNodeAdjustments
             $succeedingSiblingNodeName = $nodeNameToMove;
         }
 
+        /** @var non-empty-array<NodeAggregateWasMoved> $events */
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentStreamId);
         return new EventsToPublish(
             $streamName->getEventStreamName(),

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\NodeType\TetheredNodeTypeDefinition;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
@@ -141,7 +142,7 @@ class TetheredNodeAdjustments
                         }
                     }
 
-                    $expectedTetheredNodeOrder = array_keys($nodeType->tetheredNodeTypeDefinitions->toArray());
+                    $expectedTetheredNodeOrder = $nodeType->tetheredNodeTypeDefinitions->map(fn (TetheredNodeTypeDefinition $definition) => $definition->name->value);
                     if (count($expectedTetheredNodeOrder) > 1 && array_keys($actualTetheredChildNodes) !== $expectedTetheredNodeOrder) {
                         /** @var array<int<2,max>,string> $expectedTetheredNodeOrder */
                         // we need to re-order: We go from the last to the first


### PR DESCRIPTION
followup to https://github.com/neos/neos-development-collection/pull/5357

see https://github.com/neos/neos-development-collection/pull/5357#issuecomment-2481546116

currently `SetNodeProperties` with 0 properties attempts to publish 0 events which throws an error since #5357

> Writable events must contain at least one event

Instead we throw an exception in `SetNodeProperties`. We DONT expect `PropertyValuesToWrite` to be empty as suggested: https://github.com/neos/neos-development-collection/pull/5357#issuecomment-2481580889

As there is code using `PropertyValuesToWrite` as builder and 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
