### PR TITLE
TASK: Base exception on `\RuntimeException` instead of `\DomainException` for ESCR core

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionIdIsInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionIdIsInvalid.php
@@ -18,7 +18,7 @@ namespace Neos\ContentRepository\Core\Dimension\Exception;
  * The exception to be thrown if an invalid content dimension id was attempted to be initialized
  * @api
  */
-class ContentDimensionIdIsInvalid extends \DomainException
+class ContentDimensionIdIsInvalid extends \RuntimeException
 {
     public static function becauseItMustNotBeEmpty(): self
     {

--- a/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionValueIsInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionValueIsInvalid.php
@@ -18,7 +18,7 @@ namespace Neos\ContentRepository\Core\Dimension\Exception;
  * The exception to be thrown if an invalid content dimension value was attempted to be initialized
  * @api
  */
-class ContentDimensionValueIsInvalid extends \DomainException
+class ContentDimensionValueIsInvalid extends \RuntimeException
 {
     public static function becauseItMustNotBeEmpty(): self
     {

--- a/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionValueSpecializationDepthIsInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionValueSpecializationDepthIsInvalid.php
@@ -18,7 +18,7 @@ namespace Neos\ContentRepository\Core\Dimension\Exception;
  * The exception to be thrown if an invalid content dimension value specialization depth was tried to be initialized
  * @api
  */
-class ContentDimensionValueSpecializationDepthIsInvalid extends \DomainException
+class ContentDimensionValueSpecializationDepthIsInvalid extends \RuntimeException
 {
     public static function becauseItMustBeNonNegative(int $attemptedValue): self
     {

--- a/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionValuesAreInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/Dimension/Exception/ContentDimensionValuesAreInvalid.php
@@ -18,7 +18,7 @@ namespace Neos\ContentRepository\Core\Dimension\Exception;
  * The exception to be thrown if content dimension values are tried to be initialized empty
  * @api
  */
-class ContentDimensionValuesAreInvalid extends \DomainException
+class ContentDimensionValuesAreInvalid extends \RuntimeException
 {
     public static function becauseTheyMustNotBeEmpty(): self
     {

--- a/Neos.ContentRepository.Core/Classes/Dimension/Exception/GeneralizationIsInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/Dimension/Exception/GeneralizationIsInvalid.php
@@ -21,7 +21,7 @@ use Neos\ContentRepository\Core\Dimension\ContentDimensionValue;
  * The exception to be thrown if an invalid generalization of a content dimension value was tried to be initialized
  * @api
  */
-class GeneralizationIsInvalid extends \DomainException
+class GeneralizationIsInvalid extends \RuntimeException
 {
     public static function becauseComparedValueIsNoSpecialization(
         ContentDimensionValue $value,

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/Exception/ContentSubgraphVariationWeightsAreIncomparable.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/Exception/ContentSubgraphVariationWeightsAreIncomparable.php
@@ -21,7 +21,7 @@ use Neos\ContentRepository\Core\DimensionSpace\ContentSubgraphVariationWeight;
  * e.g. if they compose of different dimension combinations
  * @api
  */
-class ContentSubgraphVariationWeightsAreIncomparable extends \DomainException
+class ContentSubgraphVariationWeightsAreIncomparable extends \RuntimeException
 {
     public static function butWereAttemptedTo(
         ContentSubgraphVariationWeight $first,

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/Exception/DimensionSpacePointIsNoSpecialization.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/Exception/DimensionSpacePointIsNoSpecialization.php
@@ -21,7 +21,7 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
  * as a specialization of another one but isn't
  * @api
  */
-class DimensionSpacePointIsNoSpecialization extends \DomainException
+class DimensionSpacePointIsNoSpecialization extends \RuntimeException
 {
     public static function butWasSupposedToBe(DimensionSpacePoint $target, DimensionSpacePoint $source): self
     {

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/Exception/DimensionSpacePointNotFound.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/Exception/DimensionSpacePointNotFound.php
@@ -20,7 +20,7 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
  * A dimension space point was not found
  * @api
  */
-class DimensionSpacePointNotFound extends \DomainException
+class DimensionSpacePointNotFound extends \RuntimeException
 {
     public static function becauseItIsNotWithinTheAllowedDimensionSubspace(
         DimensionSpacePoint $dimensionSpacePoint

--- a/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/Exception/DimensionSpacePointAlreadyExists.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/Exception/DimensionSpacePointAlreadyExists.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Exception
  *
  * @api
  */
-final class DimensionSpacePointAlreadyExists extends \DomainException
+final class DimensionSpacePointAlreadyExists extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Exception/NodeAggregateIsAlreadyDisabled.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Exception/NodeAggregateIsAlreadyDisabled.php
@@ -17,6 +17,6 @@ namespace Neos\ContentRepository\Core\Feature\NodeDisabling\Exception;
 /**
  * @api
  */
-final class NodeAggregateIsAlreadyDisabled extends \DomainException
+final class NodeAggregateIsAlreadyDisabled extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Exception/NodeAggregateIsAlreadyEnabled.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Exception/NodeAggregateIsAlreadyEnabled.php
@@ -17,6 +17,6 @@ namespace Neos\ContentRepository\Core\Feature\NodeDisabling\Exception;
 /**
  * @api
  */
-final class NodeAggregateIsAlreadyEnabled extends \DomainException
+final class NodeAggregateIsAlreadyEnabled extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Exception/DimensionSpacePointIsAlreadyOccupied.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/Exception/DimensionSpacePointIsAlreadyOccupied.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\Feature\NodeVariation\Exception;
  *
  * @api
  */
-final class DimensionSpacePointIsAlreadyOccupied extends \DomainException
+final class DimensionSpacePointIsAlreadyOccupied extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Exception/SubtreeIsAlreadyTagged.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Exception/SubtreeIsAlreadyTagged.php
@@ -17,6 +17,6 @@ namespace Neos\ContentRepository\Core\Feature\SubtreeTagging\Exception;
 /**
  * @api
  */
-final class SubtreeIsAlreadyTagged extends \DomainException
+final class SubtreeIsAlreadyTagged extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Exception/SubtreeIsNotTagged.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Exception/SubtreeIsNotTagged.php
@@ -17,6 +17,6 @@ namespace Neos\ContentRepository\Core\Feature\SubtreeTagging\Exception;
 /**
  * @api
  */
-final class SubtreeIsNotTagged extends \DomainException
+final class SubtreeIsNotTagged extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCreation/Exception/BaseWorkspaceDoesNotExist.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCreation/Exception/BaseWorkspaceDoesNotExist.php
@@ -19,7 +19,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 /**
  * @api
  */
-final class BaseWorkspaceDoesNotExist extends \DomainException
+final class BaseWorkspaceDoesNotExist extends \RuntimeException
 {
     public static function butWasSupposedTo(WorkspaceName $name): self
     {

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCreation/Exception/WorkspaceAlreadyExists.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCreation/Exception/WorkspaceAlreadyExists.php
@@ -17,6 +17,6 @@ namespace Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception;
 /**
  * @api
  */
-final class WorkspaceAlreadyExists extends \DomainException
+final class WorkspaceAlreadyExists extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceModification/Exception/CircularRelationBetweenWorkspacesException.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceModification/Exception/CircularRelationBetweenWorkspacesException.php
@@ -7,6 +7,6 @@ namespace Neos\ContentRepository\Core\Feature\WorkspaceModification\Exception;
 /**
  * @api
  */
-class CircularRelationBetweenWorkspacesException extends \DomainException
+class CircularRelationBetweenWorkspacesException extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/PropertyType.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/PropertyType.php
@@ -47,7 +47,7 @@ final readonly class PropertyType
         if ($this->isArrayOf()) {
             $arrayOfType = self::tryFromString($this->getArrayOf());
             if (!$arrayOfType || $arrayOfType->isArray()) {
-                throw new \DomainException(sprintf(
+                throw new \InvalidArgumentException(sprintf(
                     'Array declaration "%s" has invalid subType. Expected either class string or int',
                     $this->value
                 ));

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/AbsoluteNodePathIsInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/AbsoluteNodePathIsInvalid.php
@@ -19,7 +19,7 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because this might have to be handled in the application layer
  */
-final class AbsoluteNodePathIsInvalid extends \DomainException
+final class AbsoluteNodePathIsInvalid extends \RuntimeException
 {
     public static function becauseItDoesNotMatchTheRequiredPattern(string $attemptedValue): self
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamAlreadyExists.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamAlreadyExists.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class ContentStreamAlreadyExists extends \DomainException
+final class ContentStreamAlreadyExists extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamDoesNotExistYet.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamDoesNotExistYet.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class ContentStreamDoesNotExistYet extends \DomainException
+final class ContentStreamDoesNotExistYet extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamIsClosed.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamIsClosed.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class ContentStreamIsClosed extends \DomainException
+final class ContentStreamIsClosed extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamIsNotClosed.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ContentStreamIsNotClosed.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class ContentStreamIsNotClosed extends \DomainException
+final class ContentStreamIsNotClosed extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/DimensionSpacePointIsNotYetOccupied.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/DimensionSpacePointIsNotYetOccupied.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class DimensionSpacePointIsNotYetOccupied extends \DomainException
+final class DimensionSpacePointIsNotYetOccupied extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/InvalidNodeTypePostprocessorException.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/InvalidNodeTypePostprocessorException.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api
  */
-class InvalidNodeTypePostprocessorException extends \DomainException
+class InvalidNodeTypePostprocessorException extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyDoesNotExist.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyDoesNotExist.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateCurrentlyDoesNotExist extends \DomainException
+final class NodeAggregateCurrentlyDoesNotExist extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyExists.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateCurrentlyExists.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateCurrentlyExists extends \DomainException
+final class NodeAggregateCurrentlyExists extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint extends \DomainException
+final class NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint extends \RuntimeException
 {
     public static function butWasSupposedTo(
         NodeAggregateId $nodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateDoesCurrentlyNotCoverDimensionSpacePointSet.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateDoesCurrentlyNotCoverDimensionSpacePointSet.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateDoesCurrentlyNotCoverDimensionSpacePointSet extends \DomainException
+final class NodeAggregateDoesCurrentlyNotCoverDimensionSpacePointSet extends \RuntimeException
 {
     public static function butWasSupposedTo(
         NodeAggregateId $nodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateDoesCurrentlyNotOccupyDimensionSpacePoint.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateDoesCurrentlyNotOccupyDimensionSpacePoint.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateDoesCurrentlyNotOccupyDimensionSpacePoint extends \DomainException
+final class NodeAggregateDoesCurrentlyNotOccupyDimensionSpacePoint extends \RuntimeException
 {
     public static function butWasSupposedTo(
         NodeAggregateId $nodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsAmbiguous.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsAmbiguous.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsAmbiguous extends \DomainException
+final class NodeAggregateIsAmbiguous extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsDescendant.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsDescendant.php
@@ -21,6 +21,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsDescendant extends \DomainException
+final class NodeAggregateIsDescendant extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNoChild.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNoChild.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsNoChild extends \DomainException
+final class NodeAggregateIsNoChild extends \RuntimeException
 {
     public static function butWasExpectedToBeInDimensionSpacePoint(
         NodeAggregateId $nodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNoSibling.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNoSibling.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsNoSibling extends \DomainException
+final class NodeAggregateIsNoSibling extends \RuntimeException
 {
     public static function butWasExpectedToBeInDimensionSpacePoint(NodeAggregateId $nodeAggregateId, NodeAggregateId $referenceNodeAggregateId, DimensionSpacePoint $dimensionSpacePoint): self
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNotRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsNotRoot.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsNotRoot extends \DomainException
+final class NodeAggregateIsNotRoot extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsRoot.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsRoot extends \DomainException
+final class NodeAggregateIsRoot extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsTethered.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsTethered.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsTethered extends \DomainException
+final class NodeAggregateIsTethered extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsUntethered.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregateIsUntethered.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregateIsUntethered extends \DomainException
+final class NodeAggregateIsUntethered extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregatesTypeIsAmbiguous.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeAggregatesTypeIsAmbiguous.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeAggregatesTypeIsAmbiguous extends \DomainException
+final class NodeAggregatesTypeIsAmbiguous extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeConfigurationException.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeConfigurationException.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api
  */
-class NodeConfigurationException extends \DomainException
+class NodeConfigurationException extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeConstraintException.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeConstraintException.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api
  */
-class NodeConstraintException extends \DomainException
+class NodeConstraintException extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeNameIsAlreadyCovered.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeNameIsAlreadyCovered.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeNameIsAlreadyCovered extends \DomainException
+final class NodeNameIsAlreadyCovered extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsAbstract.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsAbstract.php
@@ -21,7 +21,7 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeName;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeTypeIsAbstract extends \DomainException
+final class NodeTypeIsAbstract extends \RuntimeException
 {
     public static function butWasNotSupposedToBe(NodeTypeName $nodeTypeName): self
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsFinalException.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsFinalException.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api
  */
-class NodeTypeIsFinalException extends \DomainException
+class NodeTypeIsFinalException extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsNotOfTypeRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsNotOfTypeRoot.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeTypeIsNotOfTypeRoot extends \DomainException
+final class NodeTypeIsNotOfTypeRoot extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsOfTypeRoot.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/NodeTypeIsOfTypeRoot.php
@@ -20,6 +20,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class NodeTypeIsOfTypeRoot extends \DomainException
+final class NodeTypeIsOfTypeRoot extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/PropertyCannotBeSet.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/PropertyCannotBeSet.php
@@ -22,7 +22,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class PropertyCannotBeSet extends \DomainException
+final class PropertyCannotBeSet extends \RuntimeException
 {
     public static function becauseTheValueDoesNotMatchTheConfiguredType(
         PropertyName $propertyName,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/PropertyTypeIsInvalid.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/PropertyTypeIsInvalid.php
@@ -22,7 +22,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class PropertyTypeIsInvalid extends \DomainException
+final class PropertyTypeIsInvalid extends \RuntimeException
 {
     public static function becauseItIsUndefined(
         PropertyName $propertyName,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ReferenceCannotBeSet.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/ReferenceCannotBeSet.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class ReferenceCannotBeSet extends \DomainException
+final class ReferenceCannotBeSet extends \RuntimeException
 {
     public static function becauseTheNodeTypeDoesNotDeclareIt(
         ReferenceName $propertyName,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/RootNodeAggregateTypeIsAlreadyOccupied.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/RootNodeAggregateTypeIsAlreadyOccupied.php
@@ -9,7 +9,7 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 /**
  * @api Userland code might have to react to this
  */
-final class RootNodeAggregateTypeIsAlreadyOccupied extends \DomainException
+final class RootNodeAggregateTypeIsAlreadyOccupied extends \RuntimeException
 {
     public static function butWasExpectedNotTo(NodeTypeName $nodeTypeName): self
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/TetheredNodeAggregateCannotBeRemoved.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/TetheredNodeAggregateCannotBeRemoved.php
@@ -19,6 +19,6 @@ namespace Neos\ContentRepository\Core\SharedModel\Exception;
  *
  * @api because exception is thrown during invariant checks on command execution
  */
-final class TetheredNodeAggregateCannotBeRemoved extends \DomainException
+final class TetheredNodeAggregateCannotBeRemoved extends \RuntimeException
 {
 }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceDoesNotExist.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceDoesNotExist.php
@@ -19,7 +19,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 /**
  * @api because exception is thrown during invariant checks on command execution
  */
-final class WorkspaceDoesNotExist extends \DomainException
+final class WorkspaceDoesNotExist extends \RuntimeException
 {
     public static function butWasSupposedTo(WorkspaceName $name): self
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceHasNoBaseWorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceHasNoBaseWorkspaceName.php
@@ -19,7 +19,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 /**
  * @api because exception is thrown during invariant checks on command execution
  */
-final class WorkspaceHasNoBaseWorkspaceName extends \DomainException
+final class WorkspaceHasNoBaseWorkspaceName extends \RuntimeException
 {
     public static function butWasSupposedTo(WorkspaceName $name): self
     {


### PR DESCRIPTION
Initially i adapted the style to use `DomainExceptions` too which is part of this RFC: https://discuss.neos.io/t/rfc-updated-default-code-style/5836#exceptions-5 but then @bwaidelich pointed out that this is not correct (todo why?) and that we should not base exceptions on that.

There are already 50 cases where use `throw \RuntimeException` and `WorkspaceIsNotEmptyException`, `PartialWorkspaceRebaseFailed`, `WorkspaceRebaseFailed`

As i was tempted to change it for the `WorkspaceDoesNotExistException` which will be thrown very likely via https://github.com/neos/neos-development-collection/pull/5334#discussion_r1876184800 i might as well do it once and for all for all cases before we have to do it later (its fairly simple string replace)

We just have to agree on a common pattern here.

Disclaimer: Im not really that invested in whatever we agree on - as long as everybody is happy and its consistent. Maybe we agree that is currently okay as well?

Todo:
- [ ] when to use `class AccessDenied extends \Exception` instead of `\RuntimeException`?
- [ ] check other new escr like packages

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
