### PR TITLE
BUGFIX: Asset usage prevent orphaned asset usage entries in case of a rebase with conflicts

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -62,6 +62,14 @@ Feature: Rebasing with no conflict
       | rebaseErrorHandlingStrategy | "force"               |
     Then I expect the content stream "user-cs-identifier" to not exist
 
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user-test"
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                     | Expected             |
+      | workspaceName           | "user-test"          |
+      | newContentStreamId      | "user-cs-rebased"    |
+      | previousContentStreamId | "user-cs-identifier" |
+      | hadConflicts            | false                |
+
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-rebased;sir-david-nodenborough;{}
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -68,7 +68,7 @@ Feature: Rebasing with no conflict
       | workspaceName           | "user-test"          |
       | newContentStreamId      | "user-cs-rebased"    |
       | previousContentStreamId | "user-cs-identifier" |
-      | hadConflicts            | false                |
+      | skippedEvents           | []                   |
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-rebased;sir-david-nodenborough;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -185,7 +185,7 @@ Feature: Workspace rebasing - conflicting changes
       | workspaceName           | "user-ws"                    |
       | newContentStreamId      | "user-cs-identifier-rebased" |
       | previousContentStreamId | "user-cs-identifier"         |
-      | hadConflicts            | true                         |
+      | skippedEvents           | [12,14]                      |
 
     Then I expect the content stream "user-cs-identifier" to not exist
     Then I expect the content stream "user-cs-identifier-rebased" to exist

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -179,6 +179,14 @@ Feature: Workspace rebasing - conflicting changes
       | rebasedContentStreamId      | "user-cs-identifier-rebased" |
       | rebaseErrorHandlingStrategy | "force"                      |
 
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user-ws"
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                     | Expected                     |
+      | workspaceName           | "user-ws"                    |
+      | newContentStreamId      | "user-cs-identifier-rebased" |
+      | previousContentStreamId | "user-cs-identifier"         |
+      | hadConflicts            | true                         |
+
     Then I expect the content stream "user-cs-identifier" to not exist
     Then I expect the content stream "user-cs-identifier-rebased" to exist
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -49,6 +49,7 @@ use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWork
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPublished;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Command\RebaseWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\ConflictingEvent;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\PartialWorkspaceRebaseFailed;
@@ -288,7 +289,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $workspace->workspaceName,
                     $newContentStreamId,
                     $workspace->currentContentStreamId,
-                    hadConflicts: false
+                    skippedEvents: []
                 ),
             ),
             ExpectedVersion::ANY()
@@ -405,7 +406,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         $command->workspaceName,
                         $command->rebasedContentStreamId,
                         $workspace->currentContentStreamId,
-                        hadConflicts: $commandSimulator->hasConflicts()
+                        skippedEvents: $commandSimulator->getConflictingEvents()
+                            ->map(fn (ConflictingEvent $conflictingEvent) => $conflictingEvent->getSequenceNumber())
                     ),
                 ),
                 ExpectedVersion::ANY()

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -288,6 +288,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $workspace->workspaceName,
                     $newContentStreamId,
                     $workspace->currentContentStreamId,
+                    hadConflicts: false
                 ),
             ),
             ExpectedVersion::ANY()
@@ -404,6 +405,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         $command->workspaceName,
                         $command->rebasedContentStreamId,
                         $workspace->currentContentStreamId,
+                        hadConflicts: $commandSimulator->hasConflicts()
                     ),
                 ),
                 ExpectedVersion::ANY()

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/ConflictingEvents.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/ConflictingEvents.php
@@ -55,4 +55,14 @@ final readonly class ConflictingEvents implements \IteratorAggregate, \Countable
     {
         return count($this->items);
     }
+
+    /**
+     * @template T
+     * @param \Closure(ConflictingEvent): T $callback
+     * @return list<T>
+     */
+    public function map(\Closure $callback): array
+    {
+        return array_map($callback, $this->items);
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Event/WorkspaceWasRebased.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Event/WorkspaceWasRebased.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event;
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -34,6 +35,10 @@ final readonly class WorkspaceWasRebased implements EventInterface, EmbedsWorksp
          * The old content stream ID (which is not active anymore now)
          */
         public ContentStreamId $previousContentStreamId,
+        /**
+         * Indicates if all events in the workspace were kept or if failing changes were discarded {@see RebaseErrorHandlingStrategy::STRATEGY_FORCE}
+         */
+        public bool $hadConflicts
     ) {
     }
 
@@ -48,6 +53,7 @@ final readonly class WorkspaceWasRebased implements EventInterface, EmbedsWorksp
             WorkspaceName::fromString($values['workspaceName']),
             ContentStreamId::fromString($values['newContentStreamId']),
             ContentStreamId::fromString($values['previousContentStreamId']),
+            $values['hadConflicts'] ?? false
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Event/WorkspaceWasRebased.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Event/WorkspaceWasRebased.php
@@ -36,7 +36,7 @@ final readonly class WorkspaceWasRebased implements EventInterface, EmbedsWorksp
          */
         public ContentStreamId $previousContentStreamId,
         /**
-         * Indicates if all events in the workspace were kept or if failing changes were discarded {@see RebaseErrorHandlingStrategy::STRATEGY_FORCE}
+         * Indicates if failing changes were discarded during a forced rebase {@see RebaseErrorHandlingStrategy::STRATEGY_FORCE} or if all events in the workspace were kept.
          */
         public bool $hadConflicts
     ) {

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -74,7 +74,7 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
             }
         }
 
-        if ($eventInstance instanceof WorkspaceWasRebased && $eventInstance->hadConflicts) {
+        if ($eventInstance instanceof WorkspaceWasRebased && $eventInstance->hasSkippedEvents()) {
             // because we don't know which changes were discarded in a conflict, we discard all changes and will build up the index on succeeding calls (with the kept reapplied events)
             $this->discardWorkspace($eventInstance->getWorkspaceName());
             return;

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -73,6 +73,7 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
             }
         }
 
+        // Note that we don't need to update the index for WorkspaceWasPublished, as updateNode will be invoked already with the published node and then clean up its previous usages in nested workspaces
         match ($eventInstance::class) {
             NodeAggregateWithNodeWasCreated::class => $this->updateNode($eventInstance->getWorkspaceName(), $eventInstance->nodeAggregateId, $eventInstance->originDimensionSpacePoint->toDimensionSpacePoint()),
             NodePeerVariantWasCreated::class => $this->updateNode($eventInstance->getWorkspaceName(), $eventInstance->nodeAggregateId, $eventInstance->peerOrigin->toDimensionSpacePoint()),


### PR DESCRIPTION
Some projections / catchup hooks attempt to optimise to make `WorkspaceWasRebased` a no-op under the idea that all changes in the user workspace are still existent as known previously.

This is mostly true except for the case of a force rebase. Here changes in the user workspace might be discarded. To signal that to the consumer instead of a new even we introduce `WorkspaceWasRebased::hasSkippedEvents()`.

The asset usage was adjusted to flush all entries on force rebase so the state is rebuild from scratch without any orphaned entries that would only be deleted on a discard at some point.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
