### PR TITLE
BUGFIX: Handle nodes with missing UriPathSegments in uriPathProjection

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -209,7 +209,7 @@ final class DocumentUriPathProjection implements ProjectionInterface, WithMarkSt
         }
 
         $propertyValues = $event->initialPropertyValues->getPlainValues();
-        $uriPathSegment = $propertyValues['uriPathSegment'] ?? '';
+        $uriPathSegment = $propertyValues['uriPathSegment'] ?? $event->nodeAggregateId->value;
 
         $shortcutTarget = null;
         if ($documentTypeClassification === DocumentTypeClassification::CLASSIFICATION_SHORTCUT) {

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
@@ -1,0 +1,104 @@
+@flowEntities @contentrepository
+Feature: Basic routing functionality if path segments are missing after node creation (like with tethered nodes)
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document': {}
+    'Neos.Neos:Content': {}
+    'Neos.Neos:Test.Routing.Page':
+      superTypes:
+        'Neos.Neos:Document': true
+      properties:
+        uriPathSegment:
+          type: string
+    'Neos.Neos:Test.Routing.Content':
+      superTypes:
+        'Neos.Neos:Content': true
+      properties:
+        uriPathSegment:
+          type: string
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+
+    When the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | nodeTypeName    | "Neos.Neos:Sites"        |
+
+    # lady-eleonode-rootford
+    #   shernode-homes
+    #      sir-david-nodenborough
+    #        duke-of-contentshire (content node)
+    #        earl-o-documentbourgh
+    #      nody-mc-nodeface
+    #
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId        | parentNodeAggregateId  | nodeTypeName                   | initialPropertyValues  | nodeName |
+      | shernode-homes         | lady-eleonode-rootford | Neos.Neos:Test.Routing.Page    | {}                     | node1    |
+      | sir-david-nodenborough | shernode-homes         | Neos.Neos:Test.Routing.Page    | {}                     | node2    |
+      | duke-of-contentshire   | sir-david-nodenborough | Neos.Neos:Test.Routing.Content | {}                     | node3    |
+      | earl-o-documentbourgh  | sir-david-nodenborough | Neos.Neos:Test.Routing.Page    | {}                     | node4    |
+      | nody-mc-nodeface       | shernode-homes         | Neos.Neos:Test.Routing.Page    | {}                     | node5    |
+    And A site exists for node name "node1"
+    And the sites configuration is:
+    """yaml
+    Neos:
+      Neos:
+        sites:
+          'node1':
+            preset: 'default'
+            uriPathSuffix: ''
+            contentDimensions:
+              resolver:
+                factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\NoopResolverFactory
+    """
+  Scenario: Match homepage URL
+    When I am on URL "/"
+    Then the matched node should be "shernode-homes" in content stream "cs-identifier" and dimension "{}"
+
+  Scenario: Resolve nodes correctly from homepage
+    When I am on URL "/"
+    Then the node "shernode-homes" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/"
+    And the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-o-documentbourgh"
+
+  Scenario: Match node lower in the tree
+    When I am on URL "/sir-david-nodenborough/earl-o-documentbourgh"
+    Then the matched node should be "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}"
+
+  Scenario: Resolve from node lower in the tree
+    When I am on URL "/sir-david-nodenborough/earl-o-documentbourgh"
+    Then the node "shernode-homes" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/"
+    And the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-o-documentbourgh"
+
+  Scenario: Change uri path segment on first level
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "sir-david-nodenborough"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": "david-nodenborough-updated"} |
+    And I am on URL "/"
+    Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated/earl-o-documentbourgh"
+
+  Scenario: Change uri path segment on second level
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "earl-o-documentbourgh"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": "earl-documentbourgh-updated"} |
+    And I am on URL "/"
+    Then the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-documentbourgh-updated"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
@@ -102,3 +102,47 @@ Feature: Routing functionality if path segments are missing like during tethered
       | propertyValues            | {"uriPathSegment": "earl-documentbourgh-updated"} |
     And I am on URL "/"
     Then the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-documentbourgh-updated"
+
+  Scenario: Add empty uri path segment on first level
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "sir-david-nodenborough"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": ""} |
+    And I am on URL "/"
+    Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-o-documentbourgh"
+
+  Scenario: Uri path segment is unset after having been set before
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "sir-david-nodenborough"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": "david-nodenborough-updated"} |
+    And I am on URL "/"
+    Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated/earl-o-documentbourgh"
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "sir-david-nodenborough"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": null}                         |
+    Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-o-documentbourgh"
+
+  Scenario: Uri path segment is set to empty string having been set before
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "sir-david-nodenborough"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": "david-nodenborough-updated"} |
+    And I am on URL "/"
+    Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated/earl-o-documentbourgh"
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                                            |
+      | nodeAggregateId           | "sir-david-nodenborough"                         |
+      | originDimensionSpacePoint | {}                                               |
+      | propertyValues            | {"uriPathSegment": ""}                           |
+    Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough"
+    And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-o-documentbourgh"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
@@ -1,5 +1,5 @@
 @flowEntities @contentrepository
-Feature: Basic routing functionality if path segments are missing after node creation (like with tethered nodes)
+Feature: Routing functionality if path segments are missing like during tethered node creation
 
   Background:
     Given using no content dimensions
@@ -84,7 +84,7 @@ Feature: Basic routing functionality if path segments are missing after node cre
     And the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough"
     And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/sir-david-nodenborough/earl-o-documentbourgh"
 
-  Scenario: Change uri path segment on first level
+  Scenario: Add uri path segment on first level
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
       | nodeAggregateId           | "sir-david-nodenborough"                         |
@@ -94,7 +94,7 @@ Feature: Basic routing functionality if path segments are missing after node cre
     Then the node "sir-david-nodenborough" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated"
     And the node "earl-o-documentbourgh" in content stream "cs-identifier" and dimension "{}" should resolve to URL "/david-nodenborough-updated/earl-o-documentbourgh"
 
-  Scenario: Change uri path segment on second level
+  Scenario: Add uri path segment on second level
     When the command SetNodeProperties is executed with payload:
       | Key                       | Value                                            |
       | nodeAggregateId           | "earl-o-documentbourgh"                         |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
@@ -36,6 +36,7 @@ Feature: Test cases for node creation edge cases
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
+      | nodeName                  | "site"                   |
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Let's prepare some siblings to check orderings. Also, everything gets better with siblings.

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
@@ -36,6 +36,7 @@ Feature: Test cases for node variation edge cases
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
+      | nodeName                  | "site"                   |
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                |
       | nodeAggregateId | "shernode-homes"     |
@@ -135,6 +136,7 @@ Feature: Test cases for node variation edge cases
       | nodeTypeName              | "Neos.Neos:Site"          |
       | parentNodeAggregateId     | "lady-eleonode-rootford"  |
       | originDimensionSpacePoint | {"example":"rootGeneral"} |
+      | nodeName                  | "site"                    |
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | originDimensionSpacePoint | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Let's create some siblings, both in source and target, to check ordering
@@ -225,6 +227,7 @@ Feature: Test cases for node variation edge cases
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
+      | nodeName                  | "site"                   |
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId      | nodeName          | parentNodeAggregateId | succeedingSiblingNodeAggregateId | nodeTypeName       | initialPropertyValues          |
     # Let's create our test subject...

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
@@ -36,6 +36,7 @@ Feature: Test cases for partial publish to live and uri path generation
       | nodeTypeName              | "Neos.Neos:Site"         |
       | parentNodeAggregateId     | "lady-eleonode-rootford" |
       | originDimensionSpacePoint | {"example":"source"}     |
+      | nodeName                  | "site"                   |
     And the command CreateWorkspace is executed with payload:
       | Key                       | Value                    |
       | workspaceName             | "myworkspace"            |
@@ -49,7 +50,7 @@ Feature: Test cases for partial publish to live and uri path generation
       | nodeTypeName              | "Neos.Neos:Document"      |
       | parentNodeAggregateId     | "shernode-homes"          |
       | originDimensionSpacePoint | {"example":"source"}      |
-      | properties                | {"uriPathSegment": "just"}|
+      | initialPropertyValues     | {"uriPathSegment": "just"}|
       | workspaceName             | "myworkspace"             |
     And the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                       | Value                      |
@@ -65,4 +66,4 @@ Feature: Test cases for partial publish to live and uri path generation
       | "65901ded4f068dac14ad0dce4f459b29" | ""         | "lady-eleonode-rootford"                                     | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"    |
       | "fbe53ddc3305685fbb4dbf529f283a0e" | ""         | "lady-eleonode-rootford"                                     | "lady-eleonode-rootford" | null                     | null                     | null                      | "Neos.Neos:Sites"    |
       | "65901ded4f068dac14ad0dce4f459b29" | ""         | "lady-eleonode-rootford/shernode-homes"                      | "shernode-homes"         | "lady-eleonode-rootford" | null                     | null                      | "Neos.Neos:Site"     |
-      | "65901ded4f068dac14ad0dce4f459b29" | ""         | "lady-eleonode-rootford/shernode-homes/justsomepage"         | "justsomepage"           | "shernode-homes"         | null                     | null                      | "Neos.Neos:Document"     |
+      | "65901ded4f068dac14ad0dce4f459b29" | "just"     | "lady-eleonode-rootford/shernode-homes/justsomepage"         | "justsomepage"           | "shernode-homes"         | null                     | null                      | "Neos.Neos:Document"     |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
@@ -39,6 +39,7 @@ Feature: Basic routing functionality (match & resolve nodes with unknown types)
       | nodeTypeName                | "Neos.Neos:Test.Routing.Page" |
       | parentNodeAggregateId       | "lady-eleonode-rootford"      |
       | nodeAggregateClassification | "regular"                     |
+      | nodeName                    | "site"                        |
     And the event NodeAggregateWithNodeWasCreated was published with payload:
       | Key                         | Value                                                                 |
       | workspaceName               | "live"                                                                |


### PR DESCRIPTION
Use nodeAggregateId as fallback for missing uriPathSegments in uriPathProjection. 

This is necessary as the fallback to "" can create empty pathes for documents without uriPathSegment which is later on confused with root urls of the site. Falling back to the nodeAggregate id which is by definition unique and url-safe ensures that all documents get a valid url by the projection that can be adjusted later.  
 
Empty uriPathSegments are usually avoided by validation and autocreation from the title but those mechanisms do not work for tethered nodes. This is even more problematic as this cannot be fixed later since the full uriPath is only created oCreate and laster on only the last segment of the path is adjusted without ever reevaluating the parentPath.

In addition this pr adds a nodeName to the site node in multiple test cases as this is actually required and only worked in the past because the empty uriPathSegment behaved like a site node.

Resolves:  #5413

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
