### PR TITLE
TASK: Properly re-remove obsolete legacy `userInformation.personalWorkspaceName` in policy for workspaces

### DIFF
--- a/Neos.Neos/Classes/Service/UserService.php
+++ b/Neos.Neos/Classes/Service/UserService.php
@@ -60,6 +60,18 @@ class UserService
     }
 
     /**
+     * 8.3 behaviour: Returns the name of the currently logged in user's personal workspace
+     * (even if that might not exist at that time).
+     * If no user is logged in this method returns null.
+     *
+     * @deprecated and not implemented with Neos 9.0 - can be removed any time, just for the 8.3 upgrade phase
+     */
+    public function getPersonalWorkspaceName(): ?string
+    {
+        throw new \LogicException('`userInformation.personalWorkspaceName` was removed in Neos 9.0 see https://github.com/neos/neos-development-collection/pull/5418');
+    }
+
+    /**
      * Returns the stored preferences of a user
      *
      * @param string $preference

--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -43,10 +43,6 @@ privilegeTargets:
       label: Access to content service APIs
       matcher: 'method(Neos\Neos\Controller\Backend\SchemaController->(nodeTypeSchema)Action()) || method(Neos\Neos\Controller\Backend\SettingsController->editPreviewAction())'
 
-    'Neos.Neos:Backend.PersonalWorkspaceReadAccess.NodeConverter':
-      label: Access to own personal workspace
-      matcher: 'method(Neos\Neos\TypeConverter\NodeConverter->prepareContextProperties(workspaceName === current.userInformation.personalWorkspaceName))'
-
     'Neos.Neos:Backend.EditContent':
       label: General access to content editing
       matcher: 'method(Neos\Neos\Service\Controller\NodeController->(show|getPrimaryChildNode|getChildNodesForTree|filterChildNodesForTree|getChildNodes|getChildNodesFromParent|create|createAndRender|createNodeForTheTree|move|moveBefore|moveAfter|moveInto|moveAndRender|copy|copyBefore|copyAfter|copyInto|copyAndRender|update|updateAndRender|delete|searchPage|error)Action()) || method(Neos\Neos\Controller\Backend\ContentController->(uploadAsset|assetsWithMetadata|imageWithMetadata|createImageVariant|error)Action()) || method(Neos\Neos\Controller\Service\AssetProxiesController->(index|show|import|error)Action()) || method(Neos\Neos\Controller\Service\AssetsController->(index|show|error)Action()) || method(Neos\Neos\Controller\Service\NodesController->(index|show|create|error)Action())'
@@ -167,10 +163,6 @@ roles:
 
       -
         privilegeTarget: 'Neos.Neos:ContentPreview'
-        permission: GRANT
-
-      -
-        privilegeTarget: 'Neos.Neos:Backend.PersonalWorkspaceReadAccess.NodeConverter'
         permission: GRANT
 
       -


### PR DESCRIPTION
Based on https://github.com/neos/neos-development-collection/pull/5417

`current.userInformation.personalWorkspaceName` (`UserService::getPersonalWorkspaceName()`) was initially removed in c3f51e2e0c37706b2935fde28ffbaaec6be59b3b

because with multiple content repositories we cannot find out the value:

```php
public function getPersonalWorkspaceName(): ?string
{
    $currentUser = $this->userDomainService->getCurrentUser();
    $cr = 'default'; // TODO!!!
    $this->workspaceService->getPersonalWorkspaceForUser($cr, $currentUser);
    return $workspace->workspaceName->value;
}
```

This is luckily no longer needed as the now called `NodeAddressToNodeConverter` (which we decided to keep in Neos 9.0: https://github.com/neos/neos-development-collection/issues/4873)
Will handle this itself through the security in `ContentRepository::getContentSubgraph()` via https://github.com/neos/neos-development-collection/pull/5298

Additionally, this pr makes `UserService::getPersonalWorkspaceName()` throw and exception to ease upgrading as otherwise `NULL` will be evaluated.