### PR TITLE
BUGFIX: reimplement `appendExceedingArguments` for preview route

### DIFF
--- a/Neos.Neos/Configuration/Routes.Frontend.yaml
+++ b/Neos.Neos/Configuration/Routes.Frontend.yaml
@@ -7,6 +7,7 @@
   uriPattern:    'neos/preview'
   defaults:
     '@action':   'preview'
+  appendExceedingArguments: true
 
 -
   name: 'Default Frontend'

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewDocumentTableRow.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewDocumentTableRow.fusion
@@ -14,12 +14,11 @@ prototype(Neos.Workspace.Ui:Component.ReviewDocumentTableRow) < prototype(Neos.F
     i18n = ${I18n.id('').source('Main').package('Neos.Workspace.Ui')}
 
     openNodeInPreviewAction = Neos.Fusion:ActionUri {
-      request=${request.mainRequest}
-      package='Neos.Neos'
-      controller='Frontend\\\Node'
+      request = ${request.mainRequest}
+      package = 'Neos.Neos'
+      controller = 'Frontend\\\Node'
       action = 'preview'
-      // todo fixme
-      @process.addQuery = ${value + '?node=' + document.document.documentNodeAddress}
+      arguments = ${{node: document.document.documentNodeAddress}}
     }
     discardDocumentAction = Neos.Fusion:ActionUri {
       action = 'discardDocument'


### PR DESCRIPTION
(based on https://github.com/neos/neos-development-collection/pull/5132)

This reintroduces 

```yaml
appendExceedingArguments: true
```

for the preview route so that uris could still build via plain fusion or flows `Neos\Flow\Mvc\Routing\UriBuilder`

```
previewAction = Neos.Fusion:ActionUri {
  request = ${request.mainRequest}
  package = 'Neos.Neos'
  controller = 'Frontend\\\Node'
  action = 'preview'
  arguments = ${{node: someNodeAddress}}
}
```

This was initially reverted via 2c4670c130b14d484bb73308f1867b6f5306a4c9 in https://github.com/neos/neos-development-collection/pull/4892 in effort to get slowly rid of the `appendExceedingArguments` ugliness. But in the Dresden sprint '24 was considered too big of a change for now, especially as there is no alternative to build the uris in fusion without the `queryParameters` option introduced for the `Neos.Fusion:ActionUri` which will only be part of: https://github.com/neos/neos-development-collection/pull/3914