### PR TITLE
FEATURE: Introduce signal when cache entry tags have been flushed.

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -227,6 +227,7 @@ class ContentCacheFlusher
             $affectedEntries = $this->contentCache->flushByTags(array_keys($tagsToFlush));
             $this->systemLogger->debug(sprintf('Content cache: Removed %s entries', $affectedEntries));
         }
+        $this->emitTagsFlushed($tagsToFlush);
     }
 
     /**
@@ -269,5 +270,16 @@ class ContentCacheFlusher
     public function shutdownObject(): void
     {
         $this->flushCollectedTags();
+    }
+
+    /**
+     * Signal that is triggered whenever cache tags get flushed
+     *
+     * @Flow\Signal
+     * @param array<string, string> $tagsToFlush
+     * @return void
+     */
+    protected function emitTagsFlushed(array $tagsToFlush): void
+    {
     }
 }


### PR DESCRIPTION
Adds a new signal which is triggered when content cache tags got flushed as extension point for external packages.

See e.g.: https://github.com/Flowpack/Flowpack.FullPageCache/issues/26