### PR TITLE
BUGFIX: Raw content mode for nodes without node type

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/RawContent/NodeProperties.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/RawContent/NodeProperties.fusion
@@ -1,6 +1,6 @@
 prototype(Neos.Neos:RawContent.NodeProperties) < prototype(Neos.Fusion:Component) {
   @private {
-    items = ${Neos.Node.nodeType(node).properties}
+    items = ${Neos.Node.nodeType(node).properties || {}}
     items.@process.sort = ${Neos.Array.sortByPropertyPath(value, 'ui.inspector.position')}
   }
 


### PR DESCRIPTION
with https://github.com/neos/neos-development-collection/pull/5287

`Neos.Node.nodeType` can be `NULL` (and thus `.properties`) which causes a type error if passed to `sortByPropertyPath`

related https://github.com/neos/neos-development-collection/issues/5402#issuecomment-2541836366

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
