### PR TITLE
TASK: Remove policy for removed `Neos\Neos\Service\Controller\NodeController`

### DIFF
--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -45,7 +45,7 @@ privilegeTargets:
 
     'Neos.Neos:Backend.EditContent':
       label: General access to content editing
-      matcher: 'method(Neos\Neos\Service\Controller\NodeController->(show|getPrimaryChildNode|getChildNodesForTree|filterChildNodesForTree|getChildNodes|getChildNodesFromParent|create|createAndRender|createNodeForTheTree|move|moveBefore|moveAfter|moveInto|moveAndRender|copy|copyBefore|copyAfter|copyInto|copyAndRender|update|updateAndRender|delete|searchPage|error)Action()) || method(Neos\Neos\Controller\Backend\ContentController->(uploadAsset|assetsWithMetadata|imageWithMetadata|createImageVariant|error)Action()) || method(Neos\Neos\Controller\Service\AssetProxiesController->(index|show|import|error)Action()) || method(Neos\Neos\Controller\Service\AssetsController->(index|show|error)Action()) || method(Neos\Neos\Controller\Service\NodesController->(index|show|create|error)Action())'
+      matcher: 'method(Neos\Neos\Controller\Backend\ContentController->(uploadAsset|assetsWithMetadata|imageWithMetadata|createImageVariant|error)Action()) || method(Neos\Neos\Controller\Service\AssetProxiesController->(index|show|import|error)Action()) || method(Neos\Neos\Controller\Service\AssetsController->(index|show|error)Action()) || method(Neos\Neos\Controller\Service\NodesController->(index|show|create|error)Action())'
 
     #
     # User management and user settings


### PR DESCRIPTION
(Based on https://github.com/neos/neos-development-collection/pull/5418)

This legacy service controller was removed see
https://github.com/neos/neos-development-collection/issues/5423

But as identified here there is still a method privilege to be adjusted:
https://github.com/neos/neos-development-collection/issues/4478#issuecomment-2575353900