### PR TITLE
BUGFIX: Correct node naming scheme in nodetype definition example

### DIFF
--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -3,7 +3,7 @@
 NodeType Definition Reference
 =============================
 
-THe manual to understand NodeType definitions can be found in the Neos Docs (https://docs.neos.io/cms/manual/content-repository/nodetype-definition).
+The manual to understand NodeType definitions can be found in the Neos Docs (https://docs.neos.io/cms/manual/content-repository/nodetype-definition).
 
 The following options are allowed for defining a NodeType:
 
@@ -55,7 +55,7 @@ The following options are allowed for defining a NodeType:
   Here is an example::
 
     childNodes:
-      someChild:
+      'some-child':
         type: 'Neos.Neos:ContentCollection'
         constraints:
           nodeTypes:
@@ -68,11 +68,11 @@ The following options are allowed for defining a NodeType:
 
     'Neos.NodeTypes:Page':
       childNodes:
-        'someChild':
+        'some-child':
           type: 'Neos.Neos:ContentCollection'
           position: 'before main'
 
-  This adds a new ContentCollection called someChild to the default page.
+  This adds a new ContentCollection called ``some-child`` to the default page.
   It will be positioned before the main ContentCollection that the default page has.
   The position setting follows the same sorting logic used in Fusion
   (see the :ref:`neos-fusion-reference`).


### PR DESCRIPTION
The example uses an outdated camelcase variant for node names.

Relates: https://github.com/Sebobo/Shel.Neos.Schema/issues/26