### PR TITLE
TASK: Remove policy for removed fluid widgets

### DIFF
--- a/Neos.Neos/Configuration/Policy.yaml
+++ b/Neos.Neos/Configuration/Policy.yaml
@@ -17,7 +17,7 @@ privilegeTargets:
 
     'Neos.Neos:WidgetControllers':
       label: General access to Fluid widget controllers
-      matcher: 'method(Neos\FluidAdaptor\ViewHelpers\Widget\Controller\AutocompleteController->(index|autocomplete)Action()) || method(Neos\FluidAdaptor\ViewHelpers\Widget\Controller\PaginateController->indexAction()) || method(Neos\ContentRepository\ViewHelpers\Widget\Controller\PaginateController->indexAction()) || method(Neos\Neos\ViewHelpers\Widget\Controller\LinkRepositoryController->(index|search|lookup)Action())'
+      matcher: 'method(Neos\FluidAdaptor\ViewHelpers\Widget\Controller\AutocompleteController->(index|autocomplete)Action()) || method(Neos\FluidAdaptor\ViewHelpers\Widget\Controller\PaginateController->indexAction())'
 
     'Neos.Neos:PublicFrontendAccess':
       label: General access to frontend rendering


### PR DESCRIPTION
The cr paginate widget was removed see
https://github.com/neos/neos-development-collection/issues/5425

But as identified here there is still a method privilege to be adjusted: https://github.com/neos/neos-development-collection/issues/4478#issuecomment-2575353900

Further long ago a change seemed to contain a hiccup introducing a policy for a `LinkRepositoryController` which was NEVER part of the codebase though:

https://github.com/neos/neos-development-collection/commit/f5053cc94029d2e2f21764d2b69c8666e532e2ec#diff-818aacc12f1dbf0bc391a8711ae5a3d56cceb29494b5997dd2a43d793b6dd44eR8

Thus this line was adjusted further.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
