### PR TITLE
TASK: Remove obvious occurrences of legacy content repository class references

### DIFF
--- a/Neos.Neos/Classes/Domain/Model/Site.php
+++ b/Neos.Neos/Classes/Domain/Model/Site.php
@@ -19,6 +19,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
 use Neos\Media\Domain\Model\AssetCollection;
+use Neos\Neos\Domain\Service\SiteNodeUtility;
 use Neos\Utility\Arrays;
 
 /**
@@ -158,8 +159,7 @@ class Site
     /**
      * Returns the node name of this site
      *
-     * If you need to fetch the root node for this site, use the content
-     * context, do not use the NodeDataRepository!
+     * If you need to fetch the root node for this site, use {@see SiteNodeUtility::findSiteNodeBySite()}
      *
      * @return SiteNodeName The node name
      * @api

--- a/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Link/NodeViewHelper.php
@@ -223,7 +223,7 @@ class NodeViewHelper extends AbstractTagBasedViewHelper
         $this->registerArgument(
             'baseNodeName',
             'string',
-            'The name of the base node inside the Fusion context to use for the ContentContext'
+            'The name of the base node inside the Fusion context to use for the subgraph'
             . ' or resolving relative paths',
             false,
             'documentNode'

--- a/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Uri/NodeViewHelper.php
@@ -171,7 +171,7 @@ class NodeViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'baseNodeName',
             'string',
-            'The name of the base node inside the Fusion context to use for the ContentContext'
+            'The name of the base node inside the Fusion context to use for the subgraph'
             . ' or resolving relative paths',
             false,
             'documentNode'

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -496,9 +496,6 @@ Neos:
                 fusionPathPatterns: ['resource://Neos.Neos/Private/Fusion/Error/Root.fusion']
                 enableContentCache: false
                 templatePathAndFilename: ~
-      debugger:
-        ignoredClasses:
-          Neos\\Neos\\Domain\\Service\\ContentContextFactory: true
 
     package:
       packagesPathByType:

--- a/Neos.Neos/Documentation/References/InspectorViewsReference/index.rst
+++ b/Neos.Neos/Documentation/References/InspectorViewsReference/index.rst
@@ -19,16 +19,12 @@ A data source is a PHP class implementing ``Neos\Neos\Service\DataSource\DataSou
 
   <?php
 
-  /*
-   * This script belongs to the package "Vendor.Site".
-   */
-
   declare(strict_types=1);
 
   namespace Vendor\Site\Application\Neos\DataSource;
 
   use Neos\Neos\Service\DataSource\AbstractDataSource;
-  use Neos\ContentRepository\Domain\Model\NodeInterface;
+  use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
   final class ColumnViewDataSource extends AbstractDataSource
   {
@@ -38,11 +34,15 @@ A data source is a PHP class implementing ``Neos\Neos\Service\DataSource\DataSou
       static protected $identifier = 'vendor-site-column-view';
 
       /**
-      * Get data
-      *
-      * {@inheritdoc}
-      */
-      public function getData(NodeInterface $node = NULL, array $arguments = [])
+       * Get data
+       *
+       * The return value must be JSON serializable data structure.
+       *
+       * @param Node $node The node that is currently edited (optional)
+       * @param array<mixed> $arguments Additional arguments (key / value)
+       * @return mixed JSON serializable data
+       */
+      public function getData(Node $node = null, array $arguments = [])
       {
           return [
               'data' => [
@@ -134,30 +134,30 @@ A data source is a PHP class implementing ``Neos\Neos\Service\DataSource\DataSou
 
   <?php
 
-  /*
-   * This script belongs to the package "Vendor.Site".
-   */
-
   declare(strict_types=1);
 
   namespace Vendor\Site\Application\Neos\DataSource;
 
   use Neos\Neos\Service\DataSource\AbstractDataSource;
-  use Neos\ContentRepository\Domain\Model\NodeInterface;
+  use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
   final class TableViewDataSource extends AbstractDataSource
   {
       /**
-      * @var string
-      */
+       * @var string
+       */
       static protected $identifier = 'vendor-site-table-view';
 
       /**
-      * Get data
-      *
-      * {@inheritdoc}
-      */
-      public function getData(NodeInterface $node = NULL, array $arguments = [])
+       * Get data
+       *
+       * The return value must be JSON serializable data structure.
+       *
+       * @param Node $node The node that is currently edited (optional)
+       * @param array<mixed> $arguments Additional arguments (key / value)
+       * @return mixed JSON serializable data
+       */
+      public function getData(Node $node = null, array $arguments = [])
       {
           return [
               'data' => [
@@ -262,20 +262,24 @@ A data source is a PHP class implementing ``Neos\Neos\Service\DataSource\DataSou
   namespace Vendor\Site\Application\Neos\DataSource;
 
   use Neos\Neos\Service\DataSource\AbstractDataSource;
-  use Neos\ContentRepository\Domain\Model\NodeInterface;
+  use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
   final class TimeSeriesViewDataSource extends AbstractDataSource
   {
       /**
-      * @var string
-      */
+       * @var string
+       */
       static protected $identifier = 'vendor-site-time-series-view';
 
       /**
-      * Get data
-      *
-      * {@inheritdoc}
-      */
+       * Get data
+       *
+       * The return value must be JSON serializable data structure.
+       *
+       * @param Node $node The node that is currently edited (optional)
+       * @param array<mixed> $arguments Additional arguments (key / value)
+       * @return mixed JSON serializable data
+       */
       public function getData(NodeInterface $node = NULL, array $arguments = [])
       {
           return [


### PR DESCRIPTION
in the documentation

I used a simple find with the following cases. Maybe such thing can also help as final step in rector to make sure we got EVERYTHING?

- `AbstractNodeData`
- `ContentContext`
- `ContentContextFactory`
- `ContentDimensionRepository`
- `ContentObjectProxy`
- `ContextFactory`
- `NodeAggregateIdentifier`
- `NodeData`
- `NodeDataRepository`
- `NodeDimension`
- `NodeFactory`
- `NodeInterface`
- `NodePropertyConversionService`
- `NodePropertyConverterService`
- `NodeTemplate`
- `NodeTypeConstraintFactory`
- `PropertyCollectionInterface`
- `PublishingService`
- `PublishingServiceInterface`
- `TraversableNodeInterface`
- `TraversableNodes`
- `WorkspaceRepository`

And further checked via this regex

```
Neos\\ContentRepository\\(Command|Configuration|Domain|Eel|Exception|Migration|NodeTypePostprocessor|Persistence|Security|Service|TypeConverter|Validation|ViewHelpers|Utility|Exception)
```

All other possible fully qualified class names like `Neos\ContentRepository\Domain\Model\Node`, `Neos\ContentRepository\Domain\Model\NodeType` or `Neos\ContentRepository\Domain\Model\Workspace` and more.
