### PR TITLE
TASK: `WorkspaceWasPublished` implement `EmbedsWorkspaceName`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Event/WorkspaceWasPublished.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Event/WorkspaceWasPublished.php
@@ -15,13 +15,14 @@ namespace Neos\ContentRepository\Core\Feature\WorkspacePublication\Event;
  */
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * @api events are the persistence-API of the content repository
  */
-final readonly class WorkspaceWasPublished implements EventInterface
+final readonly class WorkspaceWasPublished implements EventInterface, EmbedsWorkspaceName
 {
     public function __construct(
         /**
@@ -56,6 +57,11 @@ final readonly class WorkspaceWasPublished implements EventInterface
             ContentStreamId::fromString($values['previousSourceContentStreamId']),
             $values['partial'] ?? false,
         );
+    }
+
+    public function getWorkspaceName(): WorkspaceName
+    {
+        return $this->sourceWorkspaceName;
     }
 
     public function jsonSerialize(): array


### PR DESCRIPTION
https://github.com/neos/neos-development-collection/pull/5226 introduced a new `EmbedsWorkspaceName` interface for events but its not implemented by the `WorkspaceWasPublished` but all other publishing events. This pr fixes this inconsistency.

It was noted in https://github.com/neos/neos-development-collection/pull/5406#discussion_r1892342184 that the introduction was deliberately not done because there is a certain ambiguity regarding returning "$sourceWorkspaceName" or "$targetWorkspaceName". Further we currently dont rely on `WorkspaceWasPublished` implementing this interface.

Still i wanted to elaborate why i think its correct and that its a good idea to have it:

> I stumbled upon this while reading the code and this will be not fun to work with. The reason why i think the returning the `sourceWorkspaceName` is correct is because it is the intention of the command. Actually the fact that the `targetWorkspaceName` is part of the command is NEVER evaluated anywhere and might as well be removed (not really ^^) but its just metadata.



There is another related inconsistency regarding the `RootWorkspaceWasCreated` event: https://github.com/neos/neos-development-collection/pull/5226#discussion_r1784916601 so it seems not always easy to mark the events correctly.