### PR TITLE
BUGFIX: Fixed table view of asset editor

### DIFF
--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -49,6 +49,9 @@ window.addEventListener('DOMContentLoaded', () => {
 		const assets = document.querySelectorAll('[data-asset-identifier]');
 		assets.forEach((asset) => {
 			asset.addEventListener('click', (e) => {
+				if(e.target.closest('.neos-action')) {
+					return;
+				}
 				const assetLink = e.currentTarget;
 
 				const localAssetIdentifier = assetLink.dataset.localAssetIdentifier;

--- a/Neos.Media.Browser/Resources/Public/JavaScript/select.js
+++ b/Neos.Media.Browser/Resources/Public/JavaScript/select.js
@@ -49,17 +49,14 @@ window.addEventListener('DOMContentLoaded', () => {
 		const assets = document.querySelectorAll('[data-asset-identifier]');
 		assets.forEach((asset) => {
 			asset.addEventListener('click', (e) => {
-				const assetLink = e.target.closest('a[data-asset-identifier], button[data-asset-identifier]');
-				if (!assetLink) {
-					return;
-				}
+				const assetLink = e.currentTarget;
 
-				const localAssetIdentifier = asset.dataset.localAssetIdentifier;
+				const localAssetIdentifier = assetLink.dataset.localAssetIdentifier;
 				if (localAssetIdentifier !== '' && !NeosCMS.Helper.isNil(localAssetIdentifier)) {
 					NeosMediaBrowserCallbacks.assetChosen(localAssetIdentifier);
 				} else {
-					if (asset.dataset.importInProcess !== 'true') {
-						asset.dataset.importInProcess = 'true';
+					if (assetLink.dataset.importInProcess !== 'true') {
+                        assetLink.dataset.importInProcess = 'true';
 						const message = NeosCMS.I18n.translate(
 							'assetImport.importInfo',
 							'Asset is being imported. Please wait.',
@@ -67,7 +64,7 @@ window.addEventListener('DOMContentLoaded', () => {
 						);
 						NeosCMS.Notification.ok(message);
 
-						importAsset(asset);
+						importAsset(assetLink);
 					} else {
 						const message = NeosCMS.I18n.translate(
 							'assetImport.importInProcess',


### PR DESCRIPTION
Related to https://github.com/neos/neos-development-collection/issues/5430

This table view:

<img width="1594" alt="image" src="https://github.com/user-attachments/assets/3ff81f3e-477a-42fe-ad77-3074fa0d14ae" />

doesn't currently work because the event listener checks whether there is an <a> or a <button> but doesn't check for <tr>. I fixed it by removing the check completely and using e.currentTarget instead of e.target.

The check was not necessary because the eventlistener was already only added to the elements that meet the criteria.
The use of event.currentTarget ensures that you always use the element that the eventlistener was actually added to, whereas event.target is the element that was clicked, which is not necessary in this case.

Nothing has to be adjusted to use this.