### PR TITLE
TASK: Make nullable parameter explicit to become PHP 8.4 compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
         dependencies: ['highest']
         composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         static-analysis: ['no']

--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPlugin.php
@@ -239,7 +239,7 @@ HELPTEXT;
      * @param string $only Only execute the given check or checks (comma separated)
      * @return void
      */
-    public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true, $skip = null, $only = null)
+    public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, ?NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true, $skip = null, $only = null)
     {
         /** @noinspection PhpDeprecationInspection This is only set for backwards compatibility */
         $this->output = $output;
@@ -288,7 +288,7 @@ HELPTEXT;
      * @throws NodeConfigurationException
      * @throws NodeTypeNotFoundException
      */
-    protected function createMissingChildNodes($workspaceName, $dryRun, NodeType $nodeType = null)
+    protected function createMissingChildNodes($workspaceName, $dryRun, ?NodeType $nodeType = null)
     {
         if ($nodeType !== null) {
             $this->dispatch(self::EVENT_NOTICE, sprintf('Checking nodes of type "<i>%s</i>" for missing child nodes ...', $nodeType->getName()));
@@ -437,7 +437,7 @@ HELPTEXT;
      * @throws NodeConfigurationException
      * @throws NodeTypeNotFoundException
      */
-    public function addMissingDefaultValues($workspaceName, $dryRun, NodeType $nodeType = null)
+    public function addMissingDefaultValues($workspaceName, $dryRun, ?NodeType $nodeType = null)
     {
         if ($nodeType !== null) {
             $this->dispatch(self::EVENT_NOTICE, sprintf('Checking nodes of type <i>%s</i> for missing default values ...', $nodeType));
@@ -645,7 +645,7 @@ HELPTEXT;
      * @param NodeType $nodeType Only for this node type, if specified
      * @return void
      */
-    protected function removeOrphanNodes($workspaceName, /** @noinspection PhpUnusedParameterInspection */$dryRun, NodeType $nodeType = null)
+    protected function removeOrphanNodes($workspaceName, /** @noinspection PhpUnusedParameterInspection */$dryRun, ?NodeType $nodeType = null)
     {
         $this->dispatch(self::EVENT_NOTICE, 'Checking for orphan nodes ...');
 
@@ -712,7 +712,7 @@ HELPTEXT;
      * @return void
      * @throws NodeConfigurationException
      */
-    public function removeUndefinedProperties($workspaceName, /** @noinspection PhpUnusedParameterInspection */$dryRun, NodeType $nodeType = null)
+    public function removeUndefinedProperties($workspaceName, /** @noinspection PhpUnusedParameterInspection */$dryRun, ?NodeType $nodeType = null)
     {
         $this->dispatch(self::EVENT_NOTICE, 'Checking for undefined properties ...');
 
@@ -1173,7 +1173,7 @@ HELPTEXT;
      * @throws NodeConfigurationException
      * @throws NodeTypeNotFoundException
      */
-    protected function reorderChildNodes($workspaceName, $dryRun, NodeType $nodeType = null)
+    protected function reorderChildNodes($workspaceName, $dryRun, ?NodeType $nodeType = null)
     {
         if ($nodeType !== null) {
             $this->dispatch(self::EVENT_NOTICE, sprintf('Checking nodes of type "<i>%s</i>" for child nodes that need reordering ...', $nodeType));
@@ -1261,7 +1261,7 @@ HELPTEXT;
      * @param NodeType $nodeType This argument will be ignored
      * @return void
      */
-    protected function repairShadowNodes($workspaceName, /** @noinspection PhpUnusedParameterInspection */$dryRun, NodeType $nodeType = null)
+    protected function repairShadowNodes($workspaceName, /** @noinspection PhpUnusedParameterInspection */$dryRun, ?NodeType $nodeType = null)
     {
         /** @var Workspace $workspace */
         $workspace = $this->workspaceRepository->findByIdentifier($workspaceName);
@@ -1295,7 +1295,7 @@ HELPTEXT;
      * @param NodeType $nodeType
      * @return array in the form [['nodeData' => <nodeDataInstance>, 'shadowPath' => '<shadowPath>'], ...]
      */
-    protected function findMissingShadowNodesInWorkspace(Workspace $workspace, NodeType $nodeType = null)
+    protected function findMissingShadowNodesInWorkspace(Workspace $workspace, ?NodeType $nodeType = null)
     {
         $workspaces = array_merge([$workspace], $workspace->getBaseWorkspaces());
 

--- a/Neos.ContentRepository/Classes/Command/NodeCommandControllerPluginInterface.php
+++ b/Neos.ContentRepository/Classes/Command/NodeCommandControllerPluginInterface.php
@@ -46,5 +46,5 @@ interface NodeCommandControllerPluginInterface
      * @param boolean $cleanup If false, cleanup tasks are skipped
      * @return void
      */
-    public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true);
+    public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, ?NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true);
 }

--- a/Neos.ContentRepository/Classes/Domain/Model/AbstractNodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/AbstractNodeData.php
@@ -416,7 +416,7 @@ abstract class AbstractNodeData
      * @param \DateTimeInterface $lastPublicationDateTime
      * @return void
      */
-    public function setLastPublicationDateTime(\DateTimeInterface $lastPublicationDateTime = null)
+    public function setLastPublicationDateTime(?\DateTimeInterface $lastPublicationDateTime = null)
     {
         $this->lastPublicationDateTime = $lastPublicationDateTime;
     }
@@ -451,7 +451,7 @@ abstract class AbstractNodeData
      * @param \DateTimeInterface $dateTime Date before this node should be hidden
      * @return void
      */
-    public function setHiddenBeforeDateTime(\DateTimeInterface $dateTime = null)
+    public function setHiddenBeforeDateTime(?\DateTimeInterface $dateTime = null)
     {
         if ($this->hiddenBeforeDateTime != $dateTime) {
             $this->hiddenBeforeDateTime = $dateTime;
@@ -475,7 +475,7 @@ abstract class AbstractNodeData
      * @param \DateTimeInterface $dateTime Date after which this node should be hidden or NULL if no such time was set
      * @return void
      */
-    public function setHiddenAfterDateTime(\DateTimeInterface $dateTime = null)
+    public function setHiddenAfterDateTime(?\DateTimeInterface $dateTime = null)
     {
         if ($this->hiddenAfterDateTime != $dateTime) {
             $this->hiddenAfterDateTime = $dateTime;

--- a/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/ContentDimension.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/ContentDimension.php
@@ -67,7 +67,7 @@ class ContentDimension
      * @param ContentDimensionValue|null $fallback
      * @return ContentDimensionValue
      */
-    public function createValue(string $value, ContentDimensionValue $fallback = null): ContentDimensionValue
+    public function createValue(string $value, ?ContentDimensionValue $fallback = null): ContentDimensionValue
     {
         $contentDimensionValue = new ContentDimensionValue($value, $fallback);
         if ($fallback) {

--- a/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/ContentDimensionValue.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/ContentDimensionValue.php
@@ -40,7 +40,7 @@ class ContentDimensionValue
      * @param string $value
      * @param ContentDimensionValue|null $fallback
      */
-    public function __construct(string $value, ContentDimensionValue $fallback = null)
+    public function __construct(string $value, ?ContentDimensionValue $fallback = null)
     {
         $this->value = $value;
         if ($fallback) {

--- a/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/IntraDimensionalFallbackGraph.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/IntraDimension/IntraDimensionalFallbackGraph.php
@@ -27,7 +27,7 @@ class IntraDimensionalFallbackGraph
      * @param string|null $label
      * @return ContentDimension
      */
-    public function createDimension(string $dimensionName, string $label = null): ContentDimension
+    public function createDimension(string $dimensionName, ?string $label = null): ContentDimension
     {
         $dimension = new ContentDimension($dimensionName, $label);
         $this->dimensions[$dimension->getName()] = $dimension;

--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
@@ -345,7 +345,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @param NodeInterface $nodeToMove
      * @return array NodeVariant and old and new path
      */
-    protected function moveVariantOrChild(string $aggregateOriginalPath, string $aggregateDestinationPath, NodeInterface $nodeToMove = null): ?array
+    protected function moveVariantOrChild(string $aggregateOriginalPath, string $aggregateDestinationPath, ?NodeInterface $nodeToMove = null): ?array
     {
         if ($nodeToMove === null) {
             return null;
@@ -605,7 +605,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeTypeNotFoundException
      * @api
      */
-    public function moveBefore(NodeInterface $referenceNode, string $newName = null): void
+    public function moveBefore(NodeInterface $referenceNode, ?string $newName = null): void
     {
         if ($referenceNode === $this) {
             return;
@@ -652,7 +652,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeTypeNotFoundException
      * @api
      */
-    public function moveAfter(NodeInterface $referenceNode, string $newName = null): void
+    public function moveAfter(NodeInterface $referenceNode, ?string $newName = null): void
     {
         if ($referenceNode === $this) {
             return;
@@ -699,7 +699,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeTypeNotFoundException
      * @api
      */
-    public function moveInto(NodeInterface $referenceNode, string $newName = null): void
+    public function moveInto(NodeInterface $referenceNode, ?string $newName = null): void
     {
         if ($referenceNode === $this || $referenceNode === $this->getParent()) {
             return;
@@ -1136,7 +1136,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeTypeNotFoundException
      * @api
      */
-    public function createNode($name, NodeType $nodeType = null, $identifier = null): NodeInterface
+    public function createNode($name, ?NodeType $nodeType = null, $identifier = null): NodeInterface
     {
         $this->emitBeforeNodeCreate($this, $name, $nodeType, $identifier);
         $newNode = $this->createSingleNode($name, $nodeType, $identifier);
@@ -1182,7 +1182,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeExistsException
      * @throws NodeTypeNotFoundException
      */
-    public function createSingleNode($name, NodeType $nodeType = null, $identifier = null): NodeInterface
+    public function createSingleNode($name, ?NodeType $nodeType = null, $identifier = null): NodeInterface
     {
         if ($nodeType !== null && !$this->willChildNodeBeAutoCreated($name) && !$this->isNodeTypeAllowedAsChildNode($nodeType)) {
             throw new NodeConstraintException('Cannot create new node "' . $name . '" of Type "' . $nodeType->getName() . '" in ' . $this->__toString(), 1400782413);
@@ -1416,7 +1416,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeTypeNotFoundException
      * @throws NodeException
      */
-    public function setHiddenBeforeDateTime(\DateTimeInterface $dateTime = null): void
+    public function setHiddenBeforeDateTime(?\DateTimeInterface $dateTime = null): void
     {
         if ($this->getHiddenBeforeDateTime() instanceof \DateTime && $dateTime instanceof \DateTime && $this->getHiddenBeforeDateTime()->format(\DateTime::W3C) === $dateTime->format(\DateTime::W3C)) {
             return;
@@ -1447,7 +1447,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @throws NodeTypeNotFoundException
      * @throws NodeException
      */
-    public function setHiddenAfterDateTime(\DateTimeInterface $dateTime = null): void
+    public function setHiddenAfterDateTime(?\DateTimeInterface $dateTime = null): void
     {
         if ($this->getHiddenAfterDateTime() instanceof \DateTimeInterface && $dateTime instanceof \DateTimeInterface && $this->getHiddenAfterDateTime()->format(\DateTime::W3C) === $dateTime->format(\DateTime::W3C)) {
             return;
@@ -1976,7 +1976,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @param boolean $status
      * @return void
      */
-    public function setNodeDataIsMatchingContext(bool $status = null): void
+    public function setNodeDataIsMatchingContext(?bool $status = null): void
     {
         $this->nodeDataIsMatchingContext = $status;
     }
@@ -2078,7 +2078,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @return TraversableNodes
      * @api
      */
-    public function findChildNodes(NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): TraversableNodes
+    public function findChildNodes(?NodeTypeConstraints $nodeTypeConstraints = null, ?int $limit = null, ?int $offset = null): TraversableNodes
     {
         /** @noinspection PhpDeprecationInspection */
         $filter = $nodeTypeConstraints !== null ? $nodeTypeConstraints->asLegacyNodeTypeFilterString() : null;
@@ -2092,7 +2092,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
      * @param NodeTypeConstraints|null $nodeTypeConstraints
      * @return int
      */
-    public function countChildNodes(NodeTypeConstraints $nodeTypeConstraints = null): int
+    public function countChildNodes(?NodeTypeConstraints $nodeTypeConstraints = null): int
     {
         return count($this->findChildNodes($nodeTypeConstraints));
     }

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -234,7 +234,7 @@ class NodeData extends AbstractNodeData
      * @param string $identifier The node identifier (not the persistence object identifier!). Specifying this only makes sense while creating corresponding nodes
      * @param array $dimensions An array of dimension name to dimension values
      */
-    public function __construct($path, Workspace $workspace, $identifier = null, array $dimensions = null)
+    public function __construct($path, Workspace $workspace, $identifier = null, ?array $dimensions = null)
     {
         parent::__construct();
         $this->creationDateTime = new \DateTime();
@@ -350,7 +350,7 @@ class NodeData extends AbstractNodeData
      * @param Workspace $workspace
      * @return void
      */
-    public function setWorkspace(Workspace $workspace = null)
+    public function setWorkspace(?Workspace $workspace = null)
     {
         if ($this->workspace !== $workspace) {
             $this->workspace = $workspace;
@@ -446,7 +446,7 @@ class NodeData extends AbstractNodeData
      * @param array $dimensions
      * @return NodeData
      */
-    public function createNodeData($name, NodeType $nodeType = null, $identifier = null, Workspace $workspace = null, array $dimensions = null)
+    public function createNodeData($name, ?NodeType $nodeType = null, $identifier = null, ?Workspace $workspace = null, ?array $dimensions = null)
     {
         $newNodeData = $this->createSingleNodeData($name, $nodeType, $identifier, $workspace, $dimensions);
         if ($nodeType !== null) {
@@ -479,7 +479,7 @@ class NodeData extends AbstractNodeData
      * @throws \InvalidArgumentException if the node name is not accepted.
      * @return NodeData
      */
-    public function createSingleNodeData($name, NodeType $nodeType = null, $identifier = null, Workspace $workspace = null, array $dimensions = null)
+    public function createSingleNodeData($name, ?NodeType $nodeType = null, $identifier = null, ?Workspace $workspace = null, ?array $dimensions = null)
     {
         if (!is_string($name) || preg_match(NodeInterface::MATCH_PATTERN_NAME, $name) !== 1) {
             throw new \InvalidArgumentException('Invalid node name "' . $name . '" (a node name must only contain lowercase characters, numbers and the "-" sign).', 1292428697);
@@ -509,7 +509,7 @@ class NodeData extends AbstractNodeData
      * @param array $dimensions
      * @return NodeData the freshly generated node
      */
-    public function createNodeDataFromTemplate(NodeTemplate $nodeTemplate, $nodeName = null, Workspace $workspace = null, array $dimensions = null)
+    public function createNodeDataFromTemplate(NodeTemplate $nodeTemplate, $nodeName = null, ?Workspace $workspace = null, ?array $dimensions = null)
     {
         $newNodeName = $nodeName !== null ? $nodeName : $nodeTemplate->getName();
         $possibleNodeName = $this->nodeService->generateUniqueNodeName($this->getPath(), $newNodeName);
@@ -733,7 +733,7 @@ class NodeData extends AbstractNodeData
      * @param NodeData $nodeData
      * @return void
      */
-    public function setMovedTo(NodeData $nodeData = null)
+    public function setMovedTo(?NodeData $nodeData = null)
     {
         $this->movedTo = $nodeData;
     }
@@ -828,7 +828,7 @@ class NodeData extends AbstractNodeData
      * @param array $dimensions
      * @return boolean
      */
-    public function matchesWorkspaceAndDimensions($workspace, array $dimensions = null)
+    public function matchesWorkspaceAndDimensions($workspace, ?array $dimensions = null)
     {
         if ($this->workspace->getName() !== $workspace->getName()) {
             return false;
@@ -1031,7 +1031,7 @@ class NodeData extends AbstractNodeData
      * @param NodeData $nodeData
      * @return void
      */
-    protected function setAsShadowOf(NodeData $nodeData = null)
+    protected function setAsShadowOf(?NodeData $nodeData = null)
     {
         $this->setMovedTo($nodeData);
         $this->setRemoved(($nodeData !== null));
@@ -1063,7 +1063,7 @@ class NodeData extends AbstractNodeData
      * @param NodeData $nodeData Other NodeData object to addOrUpdate
      * @throws IllegalObjectTypeException
      */
-    protected function addOrUpdate(NodeData $nodeData = null)
+    protected function addOrUpdate(?NodeData $nodeData = null)
     {
         $nodeData = ($nodeData === null ? $this : $nodeData);
 

--- a/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeInterface.php
@@ -229,7 +229,7 @@ interface NodeInterface
      * @return void
      * @api
      */
-    public function setHiddenBeforeDateTime(\DateTimeInterface $dateTime = null);
+    public function setHiddenBeforeDateTime(?\DateTimeInterface $dateTime = null);
 
     /**
      * Returns the date and time before which this node will be automatically hidden.
@@ -245,7 +245,7 @@ interface NodeInterface
      * @return void
      * @api
      */
-    public function setHiddenAfterDateTime(\DateTimeInterface $dateTime = null);
+    public function setHiddenAfterDateTime(?\DateTimeInterface $dateTime = null);
 
     /**
      * Returns the date and time after which this node will be automatically hidden.
@@ -403,7 +403,7 @@ interface NodeInterface
      * @throws NodeExistsException if a node with this path already exists.
      * @api
      */
-    public function createNode($name, NodeType $nodeType = null, $identifier = null);
+    public function createNode($name, ?NodeType $nodeType = null, $identifier = null);
 
     /**
      * Creates, adds and returns a child node of this node, without setting default
@@ -418,7 +418,7 @@ interface NodeInterface
      * @throws \InvalidArgumentException if the node name is not accepted.
      * @throws NodeExistsException if a node with this path already exists.
      */
-    public function createSingleNode($name, NodeType $nodeType = null, $identifier = null);
+    public function createSingleNode($name, ?NodeType $nodeType = null, $identifier = null);
 
     /**
      * Creates and persists a node from the given $nodeTemplate as child node

--- a/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
@@ -140,7 +140,7 @@ class Workspace
      * @param UserInterface $owner The user that created the workspace (if any, "system" workspaces have none)
      * @api
      */
-    public function __construct($name, Workspace $baseWorkspace = null, UserInterface $owner = null)
+    public function __construct($name, ?Workspace $baseWorkspace = null, ?UserInterface $owner = null)
     {
         $this->name = $name;
         $this->title = $name;
@@ -715,7 +715,7 @@ class Workspace
      * @return void
      * @Flow\Signal
      */
-    protected function emitBaseWorkspaceChanged(Workspace $workspace, Workspace $oldBaseWorkspace = null, Workspace $newBaseWorkspace = null): void
+    protected function emitBaseWorkspaceChanged(Workspace $workspace, ?Workspace $oldBaseWorkspace = null, ?Workspace $newBaseWorkspace = null): void
     {
     }
 

--- a/Neos.ContentRepository/Classes/Domain/Projection/Content/TraversableNodeInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Projection/Content/TraversableNodeInterface.php
@@ -86,7 +86,7 @@ interface TraversableNodeInterface extends NodeInterface
      * @return TraversableNodes Traversable nodes that matched the given constraints
      * @api
      */
-    public function findChildNodes(NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): TraversableNodes;
+    public function findChildNodes(?NodeTypeConstraints $nodeTypeConstraints = null, ?int $limit = null, ?int $offset = null): TraversableNodes;
 
     /**
      * Returns the number of direct child nodes of this node from its subgraph.
@@ -94,7 +94,7 @@ interface TraversableNodeInterface extends NodeInterface
      * @param NodeTypeConstraints|null $nodeTypeConstraints If specified, only nodes with that node type are considered
      * @return int
      */
-    public function countChildNodes(NodeTypeConstraints $nodeTypeConstraints = null): int;
+    public function countChildNodes(?NodeTypeConstraints $nodeTypeConstraints = null): int;
 
     /**
      * Retrieves and returns all nodes referenced by this node from its subgraph.

--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -183,7 +183,7 @@ class NodeDataRepository extends Repository
      * @throws \InvalidArgumentException
      * @return NodeData|null The matching node if found, otherwise NULL
      */
-    public function findOneByPath($path, Workspace $workspace, array $dimensions = null, $removedNodes = false)
+    public function findOneByPath($path, Workspace $workspace, ?array $dimensions = null, $removedNodes = false)
     {
         if ($path === '/') {
             return $workspace->getRootNodeData();
@@ -216,7 +216,7 @@ class NodeDataRepository extends Repository
      * @param array|null $dimensions
      * @return NodeData|null
      */
-    public function findShadowNodeByPath($path, Workspace $workspace, array $dimensions = null)
+    public function findShadowNodeByPath($path, Workspace $workspace, ?array $dimensions = null)
     {
         $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
         $nodes = $this->findRawNodesByPath($path, $workspace, $dimensions, true);
@@ -244,7 +244,7 @@ class NodeDataRepository extends Repository
      * @return array
      * @throws \InvalidArgumentException
      */
-    protected function findRawNodesByPath($path, Workspace $workspace, array $dimensions = null, $onlyShadowNodes = false)
+    protected function findRawNodesByPath($path, Workspace $workspace, ?array $dimensions = null, $onlyShadowNodes = false)
     {
         $path = strtolower($path);
         if ($path === '' || ($path !== '/' && ($path[0] !== '/' || substr($path, -1, 1) === '/'))) {
@@ -323,7 +323,7 @@ class NodeDataRepository extends Repository
      * @param bool $removedNodes If shadow nodes should be considered while finding the specified node
      * @return NodeData|null The matching node if found, otherwise NULL
      */
-    public function findOneByIdentifier($identifier, Workspace $workspace, array $dimensions = null, $removedNodes = false)
+    public function findOneByIdentifier($identifier, Workspace $workspace, ?array $dimensions = null, $removedNodes = false)
     {
         $workspaces = [];
         while ($workspace !== null) {
@@ -397,7 +397,7 @@ class NodeDataRepository extends Repository
      * @param callable $callback
      * @return \Generator
      */
-    public function iterate(IterableResult $iterator, callable $callback = null)
+    public function iterate(IterableResult $iterator, ?callable $callback = null)
     {
         $iteration = 0;
         foreach ($iterator as $object) {
@@ -427,7 +427,7 @@ class NodeDataRepository extends Repository
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function setNewIndex(NodeData $node, $position, NodeInterface $referenceNode = null)
+    public function setNewIndex(NodeData $node, $position, ?NodeInterface $referenceNode = null)
     {
         $parentPath = $node->getParentPath();
 
@@ -505,7 +505,7 @@ class NodeDataRepository extends Repository
      * @param boolean $removedNodes If true the result has ONLY removed nodes. If false removed nodes are NOT inside the result. If NULL the result contains BOTH removed and non-removed nodes. (defaults to false)
      * @return array<\Neos\ContentRepository\Domain\Model\NodeData> The nodes found on the given path
      */
-    public function findByParentAndNodeTypeRecursively($parentPath, $nodeTypeFilter, Workspace $workspace, array $dimensions = null, $removedNodes = false)
+    public function findByParentAndNodeTypeRecursively($parentPath, $nodeTypeFilter, Workspace $workspace, ?array $dimensions = null, $removedNodes = false)
     {
         return $this->findByParentAndNodeType($parentPath, $nodeTypeFilter, $workspace, $dimensions, $removedNodes, true);
     }
@@ -528,7 +528,7 @@ class NodeDataRepository extends Repository
      * @return array<\Neos\ContentRepository\Domain\Model\NodeData> The nodes found on the given path
      * @todo Improve implementation by using DQL
      */
-    public function findByParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, array $dimensions = null, $removedNodes = false, $recursive = false)
+    public function findByParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, ?array $dimensions = null, $removedNodes = false, $recursive = false)
     {
         $parentPath = strtolower($parentPath);
         $foundNodes = $this->getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, $workspace, $dimensions, $removedNodes, $recursive);
@@ -587,7 +587,7 @@ class NodeDataRepository extends Repository
      * @param boolean $recursive
      * @return array
      */
-    protected function getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, array $dimensions = null, $removedNodes = false, $recursive = false)
+    protected function getNodeDataForParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, ?array $dimensions = null, $removedNodes = false, $recursive = false)
     {
         $workspaces = $this->collectWorkspaceAndAllBaseWorkspaces($workspace);
 
@@ -715,7 +715,7 @@ class NodeDataRepository extends Repository
      * @param boolean $includeRemovedNodes Should removed nodes be included in the result (defaults to false)
      * @return integer The number of nodes a similar call to findByParentAndNodeType() would return without any pending added nodes
      */
-    public function countByParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, array $dimensions = null, $includeRemovedNodes = false)
+    public function countByParentAndNodeType($parentPath, $nodeTypeFilter, Workspace $workspace, ?array $dimensions = null, $includeRemovedNodes = false)
     {
         return count($this->findByParentAndNodeType($parentPath, $nodeTypeFilter, $workspace, $dimensions, $includeRemovedNodes));
     }
@@ -959,7 +959,7 @@ class NodeDataRepository extends Repository
      * @return array<\Neos\ContentRepository\Domain\Model\NodeData> The nodes found on the given path
      * @todo findOnPath should probably not return child nodes of removed nodes unless removed nodes are included.
      */
-    public function findOnPath($pathStartingPoint, $pathEndPoint, Workspace $workspace, array $dimensions = null, $includeRemovedNodes = false, $nodeTypeFilter = null)
+    public function findOnPath($pathStartingPoint, $pathEndPoint, Workspace $workspace, ?array $dimensions = null, $includeRemovedNodes = false, $nodeTypeFilter = null)
     {
         $pathStartingPoint = strtolower($pathStartingPoint);
         $pathEndPoint = strtolower($pathEndPoint);

--- a/Neos.ContentRepository/Classes/Domain/Service/Cache/FirstLevelNodeCache.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/Cache/FirstLevelNodeCache.php
@@ -63,7 +63,7 @@ class FirstLevelNodeCache
      * @param NodeInterface $node
      * @return void
      */
-    public function setByPath($path, NodeInterface $node = null)
+    public function setByPath($path, ?NodeInterface $node = null)
     {
         $this->nodesByPath[$path] = $node;
         if ($node !== null) {
@@ -96,7 +96,7 @@ class FirstLevelNodeCache
      * @param NodeInterface $node
      * @return void
      */
-    public function setByIdentifier($identifier, NodeInterface $node = null)
+    public function setByIdentifier($identifier, ?NodeInterface $node = null)
     {
         $this->nodesByIdentifier[$identifier] = $node;
         if ($node !== null) {

--- a/Neos.ContentRepository/Classes/Domain/Service/ConfigurationContentDimensionPresetSource.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ConfigurationContentDimensionPresetSource.php
@@ -215,7 +215,7 @@ class ConfigurationContentDimensionPresetSource implements ContentDimensionPrese
      * @param array $currentBestPreset
      * @return array
      */
-    protected function comparePresetsForTargetValue(array $possibleBetterPreset, array $targetValues, array $currentBestPreset = null)
+    protected function comparePresetsForTargetValue(array $possibleBetterPreset, array $targetValues, ?array $currentBestPreset = null)
     {
         if (!isset($possibleBetterPreset['values'][0])) {
             return $currentBestPreset;

--- a/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeExportService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/ImportExport/NodeExportService.php
@@ -144,7 +144,7 @@ class NodeExportService
      * @param string $nodeTypeFilter Filter the node type of the nodes, allows complex expressions (e.g. "Neos.Neos:Page", "!Neos.Neos:Page,Neos.Neos:Text")
      * @return \XMLWriter
      */
-    public function export($startingPointNodePath = '/', $workspaceName = 'live', \XMLWriter $xmlWriter = null, $tidy = true, $endDocument = true, $resourceSavePath = null, $nodeTypeFilter = null)
+    public function export($startingPointNodePath = '/', $workspaceName = 'live', ?\XMLWriter $xmlWriter = null, $tidy = true, $endDocument = true, $resourceSavePath = null, $nodeTypeFilter = null)
     {
         $this->propertyMappingConfiguration = new ImportExportPropertyMappingConfiguration($resourceSavePath);
         $this->exceptionsDuringExport = [];

--- a/Neos.ContentRepository/Classes/Domain/Service/PublishingService.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/PublishingService.php
@@ -112,7 +112,7 @@ class PublishingService implements PublishingServiceInterface
      * @return void
      * @api
      */
-    public function publishNode(NodeInterface $node, Workspace $targetWorkspace = null)
+    public function publishNode(NodeInterface $node, ?Workspace $targetWorkspace = null)
     {
         if ($targetWorkspace === null) {
             $targetWorkspace = $node->getWorkspace()->getBaseWorkspace();
@@ -132,7 +132,7 @@ class PublishingService implements PublishingServiceInterface
      * @return void
      * @api
      */
-    public function publishNodes(array $nodes, Workspace $targetWorkspace = null)
+    public function publishNodes(array $nodes, ?Workspace $targetWorkspace = null)
     {
         $nodes = $this->sortNodesForPublishing($nodes);
         foreach ($nodes as $node) {
@@ -265,7 +265,7 @@ class PublishingService implements PublishingServiceInterface
      * @Flow\Signal
      * @api
      */
-    public function emitNodePublished(NodeInterface $node, Workspace $targetWorkspace = null)
+    public function emitNodePublished(NodeInterface $node, ?Workspace $targetWorkspace = null)
     {
     }
 

--- a/Neos.ContentRepository/Classes/Domain/Service/PublishingServiceInterface.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/PublishingServiceInterface.php
@@ -47,7 +47,7 @@ interface PublishingServiceInterface
      * @return void
      * @api
      */
-    public function publishNode(NodeInterface $node, Workspace $targetWorkspace = null);
+    public function publishNode(NodeInterface $node, ?Workspace $targetWorkspace = null);
 
     /**
      * Publishes the given nodes to the specified target workspace. If no workspace is specified, "live" is assumed.
@@ -57,7 +57,7 @@ interface PublishingServiceInterface
      * @return void
      * @api
      */
-    public function publishNodes(array $nodes, Workspace $targetWorkspace = null);
+    public function publishNodes(array $nodes, ?Workspace $targetWorkspace = null);
 
     /**
      * Discards the given node.

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilegeSubject.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/CreateNodePrivilegeSubject.php
@@ -30,7 +30,7 @@ class CreateNodePrivilegeSubject extends NodePrivilegeSubject
      * @param NodeType $creationNodeType The node type of the new child node, to check if this is type is allowed as new child node under the given parent node
      * @param JoinPointInterface $joinPoint Set, if created by a method interception. Usually the interception of the createNode() method, where the creation of new child nodes takes place
      */
-    public function __construct(NodeInterface $node, NodeType $creationNodeType = null, JoinPointInterface $joinPoint = null)
+    public function __construct(NodeInterface $node, ?NodeType $creationNodeType = null, ?JoinPointInterface $joinPoint = null)
     {
         $this->creationNodeType = $creationNodeType;
         parent::__construct($node, $joinPoint);

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/NodePrivilegeContext.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/NodePrivilegeContext.php
@@ -55,7 +55,7 @@ class NodePrivilegeContext
     /**
      * @param NodeInterface $node
      */
-    public function __construct(NodeInterface $node = null)
+    public function __construct(?NodeInterface $node = null)
     {
         $this->node = $node;
     }

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/NodePrivilegeSubject.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/NodePrivilegeSubject.php
@@ -34,7 +34,7 @@ class NodePrivilegeSubject implements PrivilegeSubjectInterface
      * @param NodeInterface $node The node we will check privileges for
      * @param JoinPointInterface $joinPoint If we intercept node operations, this joinpoint represents the method called on the node and holds a reference to the node we will check privileges for
      */
-    public function __construct(NodeInterface $node, JoinPointInterface $joinPoint = null)
+    public function __construct(NodeInterface $node, ?JoinPointInterface $joinPoint = null)
     {
         $this->node = $node;
         $this->joinPoint = $joinPoint;

--- a/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/PropertyAwareNodePrivilegeSubject.php
+++ b/Neos.ContentRepository/Classes/Security/Authorization/Privilege/Node/PropertyAwareNodePrivilegeSubject.php
@@ -39,7 +39,7 @@ class PropertyAwareNodePrivilegeSubject extends NodePrivilegeSubject
      * @param JoinPointInterface $joinPoint
      * @param string $propertyName
      */
-    public function __construct(NodeInterface $node, JoinPointInterface $joinPoint = null, $propertyName = null)
+    public function __construct(NodeInterface $node, ?JoinPointInterface $joinPoint = null, $propertyName = null)
     {
         $this->propertyName = $propertyName;
         parent::__construct($node, $joinPoint);

--- a/Neos.ContentRepository/Classes/Service/AuthorizationService.php
+++ b/Neos.ContentRepository/Classes/Service/AuthorizationService.php
@@ -70,7 +70,7 @@ class AuthorizationService
      * @param NodeType $typeOfNewNode
      * @return boolean
      */
-    public function isGrantedToCreateNode(NodeInterface $referenceNode, NodeType $typeOfNewNode = null)
+    public function isGrantedToCreateNode(NodeInterface $referenceNode, ?NodeType $typeOfNewNode = null)
     {
         return $this->privilegeManager->isGranted(CreateNodePrivilege::class, new CreateNodePrivilegeSubject($referenceNode, $typeOfNewNode));
     }

--- a/Neos.ContentRepository/Classes/TypeConverter/NodeConverter.php
+++ b/Neos.ContentRepository/Classes/TypeConverter/NodeConverter.php
@@ -138,7 +138,7 @@ class NodeConverter extends AbstractTypeConverter
      * @return mixed An object or \Neos\Error\Messages\Error if the input format is not supported or could not be converted for other reasons
      * @throws NodeException
      */
-    public function convertFrom($source, $targetType, array $subProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $subProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (is_string($source)) {
             $source = ['__contextNodePath' => $source];
@@ -197,7 +197,7 @@ class NodeConverter extends AbstractTypeConverter
      * @return void
      * @throws TypeConverterException
      */
-    protected function setNodeProperties($nodeLike, NodeType $nodeType, array $properties, ContentRepositoryContext $context, PropertyMappingConfigurationInterface $configuration = null)
+    protected function setNodeProperties($nodeLike, NodeType $nodeType, array $properties, ContentRepositoryContext $context, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $nodeTypeProperties = $nodeType->getProperties();
         unset($properties['_lastPublicationDateTime']);
@@ -280,7 +280,7 @@ class NodeConverter extends AbstractTypeConverter
      * @param array $dimensions
      * @return array
      */
-    protected function prepareContextProperties($workspaceName, PropertyMappingConfigurationInterface $configuration = null, array $dimensions = null)
+    protected function prepareContextProperties($workspaceName, ?PropertyMappingConfigurationInterface $configuration = null, ?array $dimensions = null)
     {
         $contextProperties = [
             'workspaceName' => $workspaceName,

--- a/Neos.ContentRepository/Classes/TypeConverter/NodeSerializer.php
+++ b/Neos.ContentRepository/Classes/TypeConverter/NodeSerializer.php
@@ -43,7 +43,7 @@ class NodeSerializer extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return string The node context path
      */
-    public function convertFrom($source, $targetType = null, array $subProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType = null, array $subProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $source->getContextPath();
     }

--- a/Neos.ContentRepository/Classes/TypeConverter/NodeTemplateConverter.php
+++ b/Neos.ContentRepository/Classes/TypeConverter/NodeTemplateConverter.php
@@ -77,7 +77,7 @@ class NodeTemplateConverter extends NodeConverter
      * @return mixed An object or \Neos\Error\Messages\Error if the input format is not supported or could not be converted for other reasons
      * @throws \Exception
      */
-    public function convertFrom($source, $targetType = null, array $subProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType = null, array $subProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $nodeTemplate = new NodeTemplate();
         $nodeType = $this->extractNodeType($targetType, $source);

--- a/Neos.ContentRepository/Migrations/Mysql/Version20150408112832.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20150408112832.php
@@ -24,7 +24,7 @@ class Version20150408112832 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 

--- a/Neos.ContentRepository/Migrations/Postgresql/Version20150309212114.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20150309212114.php
@@ -13,7 +13,7 @@ class Version20150309212114 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function up(Schema $schema): void 
+    public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
@@ -27,7 +27,7 @@ class Version20150309212114 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 

--- a/Neos.ContentRepository/Migrations/Postgresql/Version20150408112833.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20150408112833.php
@@ -24,7 +24,7 @@ class Version20150408112833 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 

--- a/Neos.ContentRepository/Tests/Functional/TypeConverter/NodeConverterTest.php
+++ b/Neos.ContentRepository/Tests/Functional/TypeConverter/NodeConverterTest.php
@@ -240,7 +240,7 @@ class NodeConverterTest extends FunctionalTestCase
      * @param $nodePath
      * @return NodeInterface
      */
-    protected function convert($nodePath, PropertyMappingConfiguration $propertyMappingConfiguration = null)
+    protected function convert($nodePath, ?PropertyMappingConfiguration $propertyMappingConfiguration = null)
     {
         $nodeConverter = new NodeConverter();
         $result = $nodeConverter->convertFrom($nodePath, null, [], $propertyMappingConfiguration);

--- a/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
@@ -81,7 +81,7 @@ class SetDimensionsTest extends UnitTestCase
      * @param array $expectedValues The values that are expected to be set on the node
      * @param array $configuredDimensions Optional set of dimensions "configured in the system"
      */
-    public function setDimensionsWorksAsExpected(array $setValues, array $expectedValues, array $configuredDimensions = null)
+    public function setDimensionsWorksAsExpected(array $setValues, array $expectedValues, ?array $configuredDimensions = null)
     {
         $transformation = new SetDimensions();
 

--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/MergedArrayTreeVisitor.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/MergedArrayTreeVisitor.php
@@ -108,7 +108,7 @@ class MergedArrayTreeVisitor implements AstNodeVisitorInterface
         $this->isInsidePrototypeDeclaration = $wasPreviouslyInPrototypeDeclaration;
     }
 
-    public function visitBlock(Block $block, array $currentPath = null)
+    public function visitBlock(Block $block, ?array $currentPath = null)
     {
         $currentPath ?? throw new \BadMethodCallException('$currentPath is required.');
 
@@ -151,7 +151,7 @@ class MergedArrayTreeVisitor implements AstNodeVisitorInterface
         return [$key];
     }
 
-    public function visitValueAssignment(ValueAssignment $valueAssignment, array $currentPath = null)
+    public function visitValueAssignment(ValueAssignment $valueAssignment, ?array $currentPath = null)
     {
         $currentPath ?? throw new \BadMethodCallException('$currentPath is required.');
 
@@ -214,7 +214,7 @@ class MergedArrayTreeVisitor implements AstNodeVisitorInterface
         return $stringValue->value;
     }
 
-    public function visitValueCopy(ValueCopy $valueCopy, array $currentPath = null)
+    public function visitValueCopy(ValueCopy $valueCopy, ?array $currentPath = null)
     {
         $currentPath ?? throw new \BadMethodCallException('$currentPath is required.');
 
@@ -263,7 +263,7 @@ class MergedArrayTreeVisitor implements AstNodeVisitorInterface
         return $assignedObjectPath->objectPath->visit($this, $path);
     }
 
-    public function visitValueUnset(ValueUnset $valueUnset, array $currentPath = null)
+    public function visitValueUnset(ValueUnset $valueUnset, ?array $currentPath = null)
     {
         $currentPath ?? throw new \BadMethodCallException('$currentPath is required.');
 

--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -677,7 +677,7 @@ class Runtime
      * @return mixed The result of the evaluated Eel expression
      * @throws Exception
      */
-    protected function evaluateEelExpression($expression, AbstractFusionObject $contextObject = null)
+    protected function evaluateEelExpression($expression, ?AbstractFusionObject $contextObject = null)
     {
         if ($expression[0] !== '$' || $expression[1] !== '{') {
             // We still assume this is an EEL expression and wrap the markers for backwards compatibility.
@@ -782,7 +782,7 @@ class Runtime
      * @param AbstractFusionObject $contextObject
      * @return mixed
      */
-    protected function evaluateProcessors($valueToProcess, $configurationWithEventualProcessors, $fusionPath, AbstractFusionObject $contextObject = null)
+    protected function evaluateProcessors($valueToProcess, $configurationWithEventualProcessors, $fusionPath, ?AbstractFusionObject $contextObject = null)
     {
         $processorConfiguration = $configurationWithEventualProcessors['__meta']['process'];
         $positionalArraySorter = new PositionalArraySorter($processorConfiguration, '__meta.position');
@@ -820,7 +820,7 @@ class Runtime
      * @param AbstractFusionObject $contextObject
      * @return boolean
      */
-    protected function evaluateIfCondition($configurationWithEventualIf, $configurationPath, AbstractFusionObject $contextObject = null)
+    protected function evaluateIfCondition($configurationWithEventualIf, $configurationPath, ?AbstractFusionObject $contextObject = null)
     {
         foreach ($configurationWithEventualIf['__meta']['if'] as $conditionKey => $conditionValue) {
             $conditionValue = $this->evaluate($configurationPath . '/__meta/if/' . $conditionKey, $contextObject, self::BEHAVIOR_EXCEPTION);

--- a/Neos.Fusion/Classes/Core/RuntimeFactory.php
+++ b/Neos.Fusion/Classes/Core/RuntimeFactory.php
@@ -35,7 +35,7 @@ class RuntimeFactory
      * @param array<int|string, mixed> $fusionConfiguration
      * @deprecated with Neos 8.3 might be removed with Neos 9.0 use {@link createFromConfiguration} instead.
      */
-    public function create(array $fusionConfiguration, ControllerContext $controllerContext = null): Runtime
+    public function create(array $fusionConfiguration, ?ControllerContext $controllerContext = null): Runtime
     {
         if ($controllerContext === null) {
             $controllerContext = self::createControllerContextFromEnvironment();

--- a/Neos.Fusion/Classes/Eel/BaseUriHelper.php
+++ b/Neos.Fusion/Classes/Eel/BaseUriHelper.php
@@ -28,7 +28,7 @@ class BaseUriHelper implements ProtectedContextAwareInterface
      * @return UriInterface
      * @throws \Exception
      */
-    public function getConfiguredBaseUriOrFallbackToCurrentRequest(ServerRequestInterface $fallbackRequest = null): UriInterface
+    public function getConfiguredBaseUriOrFallbackToCurrentRequest(?ServerRequestInterface $fallbackRequest = null): UriInterface
     {
         try {
             $baseUri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();

--- a/Neos.Fusion/Classes/Exception/RuntimeException.php
+++ b/Neos.Fusion/Classes/Exception/RuntimeException.php
@@ -28,7 +28,7 @@ class RuntimeException extends Exception
      * @param \Exception $previous
      * @param string $fusionPath
      */
-    public function __construct($message = '', $code = 0, \Exception $previous = null, $fusionPath = null)
+    public function __construct($message = '', $code = 0, ?\Exception $previous = null, $fusionPath = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/Neos.Fusion/Classes/FusionObjects/Helpers/FluidView.php
+++ b/Neos.Fusion/Classes/FusionObjects/Helpers/FluidView.php
@@ -35,7 +35,7 @@ class FluidView extends StandaloneView implements FusionAwareViewInterface
      * @param ActionRequest $request The current action request. If none is specified it will be created from the environment.
      * @throws \Neos\FluidAdaptor\Exception
      */
-    public function __construct(AbstractFusionObject $fusionObject, ActionRequest $request = null)
+    public function __construct(AbstractFusionObject $fusionObject, ?ActionRequest $request = null)
     {
         parent::__construct($request);
         $this->fusionObject = $fusionObject;

--- a/Neos.Fusion/Classes/Service/HtmlAugmenter.php
+++ b/Neos.Fusion/Classes/Service/HtmlAugmenter.php
@@ -42,7 +42,7 @@ class HtmlAugmenter
      * @param array $exclusiveAttributes A list of lowercase(!) attribute names that should be exclusive to the root element. If the existing root element contains one of these a new root element is wrapped
      * @param bool $allowEmptyAttributes Allow empty attributes without a value
      */
-    public function addAttributes($html, array $attributes, $fallbackTagName = 'div', array $exclusiveAttributes = null, bool $allowEmptyAttributes = true)
+    public function addAttributes($html, array $attributes, $fallbackTagName = 'div', ?array $exclusiveAttributes = null, bool $allowEmptyAttributes = true)
     {
         if ($attributes === []) {
             return $html;
@@ -129,7 +129,7 @@ class HtmlAugmenter
      * @param array $attributes array of attribute names to check (lowercase)
      * @return boolean true if at least one of the $attributes is contained in the given $element, otherwise false
      */
-    protected function elementHasAttributes(\DOMNode $element, array $attributes = null)
+    protected function elementHasAttributes(\DOMNode $element, ?array $attributes = null)
     {
         if ($attributes === null) {
             return false;

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/TypeConverter/TestModelConverter.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/TypeConverter/TestModelConverter.php
@@ -41,7 +41,7 @@ class TestModelConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return boolean
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         // This would use the identifier of the source in reality
         return unserialize($source);

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/TypeConverter/TestModelSerializer.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/TypeConverter/TestModelSerializer.php
@@ -41,7 +41,7 @@ class TestModelSerializer extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return boolean
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         // This would use the identifier of the source in reality
         return serialize($source);

--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -239,7 +239,7 @@ class AssetController extends ActionController
      * @return void
      * @throws FilesException
      */
-    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
+    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, ?Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, ?AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
     {
         $assetSourceIdentifier = $this->assetConstraints->applyToAssetSourceIdentifiers($assetSourceIdentifier);
 
@@ -861,7 +861,7 @@ class AssetController extends ActionController
      * @param string $sortDirection
      * @param string $filter
      */
-    private function applyViewOptionsToBrowserState(string $view = null, string $sortBy = null, string $sortDirection = null, string $filter = null): void
+    private function applyViewOptionsToBrowserState(?string $view = null, ?string $sortBy = null, ?string $sortDirection = null, ?string $filter = null): void
     {
         if (!empty($view)) {
             $this->browserState->set('view', $view);
@@ -897,7 +897,7 @@ class AssetController extends ActionController
      * @param Tag $tag
      * @param AssetCollection|null $activeAssetCollection
      */
-    private function applyTagToBrowserState(int $tagMode = null, Tag $tag = null, AssetCollection $activeAssetCollection = null): void
+    private function applyTagToBrowserState(?int $tagMode = null, ?Tag $tag = null, ?AssetCollection $activeAssetCollection = null): void
     {
         if ($tagMode === self::TAG_GIVEN && $tag !== null) {
             $this->browserState->set('activeTag', $tag);
@@ -936,7 +936,7 @@ class AssetController extends ActionController
      * @param int $collectionMode
      * @param AssetCollection $assetCollection
      */
-    private function applyAssetCollectionOptionsToBrowserState(int $collectionMode = null, AssetCollection $assetCollection = null): void
+    private function applyAssetCollectionOptionsToBrowserState(?int $collectionMode = null, ?AssetCollection $assetCollection = null): void
     {
         if ($collectionMode === self::COLLECTION_GIVEN && $assetCollection !== null) {
             $this->browserState->set('activeAssetCollection', $assetCollection);

--- a/Neos.Media.Browser/Classes/Controller/ImageController.php
+++ b/Neos.Media.Browser/Classes/Controller/ImageController.php
@@ -52,7 +52,7 @@ class ImageController extends AssetController
      * @return void
      * @throws \Neos\Utility\Exception\FilesException
      */
-    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
+    public function indexAction($view = null, $sortBy = null, $sortDirection = null, $filter = null, $tagMode = self::TAG_GIVEN, ?Tag $tag = null, $searchTerm = null, $collectionMode = self::COLLECTION_GIVEN, ?AssetCollection $assetCollection = null, $assetSourceIdentifier = null): void
     {
         $this->view->assign('filterOptions', []);
         parent::indexAction($view, $sortBy, $sortDirection, 'Image', $tagMode, $tag, $searchTerm, $collectionMode, $assetCollection, $assetSourceIdentifier);
@@ -66,7 +66,7 @@ class ImageController extends AssetController
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
-    public function editAction(string $assetSourceIdentifier = null, string $assetProxyIdentifier = null, AssetInterface $asset = null): void
+    public function editAction(?string $assetSourceIdentifier = null, ?string $assetProxyIdentifier = null, ?AssetInterface $asset = null): void
     {
         if ($assetSourceIdentifier !== null && $assetProxyIdentifier !== null) {
             parent::editAction($assetSourceIdentifier, $assetProxyIdentifier);

--- a/Neos.Media/Classes/Command/MediaCommandController.php
+++ b/Neos.Media/Classes/Command/MediaCommandController.php
@@ -195,7 +195,7 @@ class MediaCommandController extends CommandController
      * @throws IllegalObjectTypeException
      * @throws AssetServiceException
      */
-    public function removeUnusedCommand(string $assetSource = '', bool $quiet = false, bool $assumeYes = false, string $onlyTags = '', int $limit = null, string $onlyCollections = ''): void
+    public function removeUnusedCommand(string $assetSource = '', bool $quiet = false, bool $assumeYes = false, string $onlyTags = '', ?int $limit = null, string $onlyCollections = ''): void
     {
         $iterator = $this->assetRepository->findAllIterator();
         $assetCount = $this->assetRepository->countAll();
@@ -318,7 +318,7 @@ class MediaCommandController extends CommandController
      * @return void
      * @throws ThumbnailServiceException
      */
-    public function createThumbnailsCommand(string $preset = null, bool $async = null, bool $quiet = false)
+    public function createThumbnailsCommand(?string $preset = null, ?bool $async = null, bool $quiet = false)
     {
         $async = $async ?? $this->asyncThumbnails;
         $presets = $preset !== null ? [$preset] : array_keys($this->thumbnailService->getPresets());
@@ -352,7 +352,7 @@ class MediaCommandController extends CommandController
      * @throws IllegalObjectTypeException
      * @throws ThumbnailServiceException
      */
-    public function clearThumbnailsCommand(string $preset = null, bool $quiet = false): void
+    public function clearThumbnailsCommand(?string $preset = null, bool $quiet = false): void
     {
         if ($preset !== null) {
             $thumbnailConfiguration = $this->thumbnailService->getThumbnailConfigurationForPreset($preset);
@@ -385,7 +385,7 @@ class MediaCommandController extends CommandController
      * @param bool $quiet If set, only errors will be displayed.
      * @return void
      */
-    public function renderThumbnailsCommand(int $limit = null, bool $quiet = false)
+    public function renderThumbnailsCommand(?int $limit = null, bool $quiet = false)
     {
         $thumbnailCount = $this->thumbnailRepository->countUngenerated();
         $iterator = $this->thumbnailRepository->findUngeneratedIterator();
@@ -472,7 +472,7 @@ class MediaCommandController extends CommandController
      *
      * @throws StopCommandException
      */
-    public function removeVariantsCommand(string $identifier, string $variantName, bool $quiet = false, bool $assumeYes = false, int $limit = null)
+    public function removeVariantsCommand(string $identifier, string $variantName, bool $quiet = false, bool $assumeYes = false, ?int $limit = null)
     {
         $variantsToRemove = $this->imageVariantRepository->findVariantsByIdentifierAndVariantName($identifier, $variantName, $limit);
         if (empty($variantsToRemove)) {
@@ -536,7 +536,7 @@ class MediaCommandController extends CommandController
      * @throws AssetVariantGeneratorException
      * @throws IllegalObjectTypeException
      */
-    public function renderVariantsCommand(int $limit = null, bool $quiet = false, bool $recreate = false): void
+    public function renderVariantsCommand(?int $limit = null, bool $quiet = false, bool $recreate = false): void
     {
         $resultMessage = null;
         $generatedVariants = 0;

--- a/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -70,7 +70,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setHeight(int $height = null): void
+    public function setHeight(?int $height = null): void
     {
         $this->height = $height;
         $this->aspectRatioAsString = null;
@@ -94,7 +94,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setWidth(int $width = null): void
+    public function setWidth(?int $width = null): void
     {
         $this->width = $width;
         $this->aspectRatioAsString = null;
@@ -118,7 +118,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setX(int $x = null): void
+    public function setX(?int $x = null): void
     {
         $this->x = $x;
         $this->aspectRatioAsString = null;
@@ -142,7 +142,7 @@ class CropImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setY(int $y = null): void
+    public function setY(?int $y = null): void
     {
         $this->y = $y;
         $this->aspectRatioAsString = null;

--- a/Neos.Media/Classes/Domain/Model/Adjustment/QualityImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/QualityImageAdjustment.php
@@ -51,7 +51,7 @@ class QualityImageAdjustment extends AbstractImageAdjustment
      * @param integer $quality
      * @return void
      */
-    public function setQuality(int $quality = null): void
+    public function setQuality(?int $quality = null): void
     {
         $this->quality = $quality;
     }

--- a/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/ResizeImageAdjustment.php
@@ -97,7 +97,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setMaximumHeight(int $maximumHeight = null): void
+    public function setMaximumHeight(?int $maximumHeight = null): void
     {
         $this->maximumHeight = $maximumHeight;
     }
@@ -120,7 +120,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setMaximumWidth(int $maximumWidth = null): void
+    public function setMaximumWidth(?int $maximumWidth = null): void
     {
         $this->maximumWidth = $maximumWidth;
     }
@@ -143,7 +143,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setHeight(int $height = null): void
+    public function setHeight(?int $height = null): void
     {
         $this->height = $height;
     }
@@ -166,7 +166,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setWidth(int $width = null): void
+    public function setWidth(?int $width = null): void
     {
         $this->width = $width;
     }
@@ -189,7 +189,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setMinimumHeight(int $minimumHeight = null): void
+    public function setMinimumHeight(?int $minimumHeight = null): void
     {
         $this->minimumHeight = $minimumHeight;
     }
@@ -212,7 +212,7 @@ class ResizeImageAdjustment extends AbstractImageAdjustment
      * @return void
      * @api
      */
-    public function setMinimumWidth(int $minimumWidth = null): void
+    public function setMinimumWidth(?int $minimumWidth = null): void
     {
         $this->minimumWidth = $minimumWidth;
     }

--- a/Neos.Media/Classes/Domain/Model/AssetSource/AssetProxyRepositoryInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/AssetProxyRepositoryInterface.php
@@ -27,7 +27,7 @@ interface AssetProxyRepositoryInterface
     /**
      * @param AssetTypeFilter $assetType
      */
-    public function filterByType(AssetTypeFilter $assetType = null): void;
+    public function filterByType(?AssetTypeFilter $assetType = null): void;
 
     /**
      * @return AssetProxyQueryResultInterface

--- a/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/Neos/NeosAssetProxyRepository.php
@@ -113,7 +113,7 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
     /**
      * @param AssetTypeFilter $assetType
      */
-    public function filterByType(AssetTypeFilter $assetType = null): void
+    public function filterByType(?AssetTypeFilter $assetType = null): void
     {
         $this->assetTypeFilter = (string)$assetType ?: 'All';
         $this->initializeObject();
@@ -125,7 +125,7 @@ final class NeosAssetProxyRepository implements AssetProxyRepositoryInterface, S
      *
      * @param AssetCollection $assetCollection
      */
-    public function filterByCollection(AssetCollection $assetCollection = null): void
+    public function filterByCollection(?AssetCollection $assetCollection = null): void
     {
         $this->activeAssetCollection = $assetCollection;
     }

--- a/Neos.Media/Classes/Domain/Model/AssetSource/SupportsCollectionsInterface.php
+++ b/Neos.Media/Classes/Domain/Model/AssetSource/SupportsCollectionsInterface.php
@@ -24,5 +24,5 @@ interface SupportsCollectionsInterface
      *
      * @param AssetCollection $assetCollection
      */
-    public function filterByCollection(AssetCollection $assetCollection = null): void;
+    public function filterByCollection(?AssetCollection $assetCollection = null): void;
 }

--- a/Neos.Media/Classes/Domain/Model/Dto/AssetConstraints.php
+++ b/Neos.Media/Classes/Domain/Model/Dto/AssetConstraints.php
@@ -205,7 +205,7 @@ final class AssetConstraints
      * @param string|null $assetType
      * @return AssetTypeFilter
      */
-    public function applyToAssetTypeFilter(string $assetType = null): AssetTypeFilter
+    public function applyToAssetTypeFilter(?string $assetType = null): AssetTypeFilter
     {
         if (!$this->hasMediaTypeConstraint() || in_array($assetType, $this->allowedAssetTypes, true)) {
             return new AssetTypeFilter($assetType ?? 'All');

--- a/Neos.Media/Classes/Domain/Model/ImportedAsset.php
+++ b/Neos.Media/Classes/Domain/Model/ImportedAsset.php
@@ -61,7 +61,7 @@ class ImportedAsset
         string $remoteAssetIdentifier,
         string $localAssetIdentifier,
         \DateTimeImmutable $importedAt,
-        string $localOriginalAssetIdentifier = null
+        ?string $localOriginalAssetIdentifier = null
     ) {
         $this->assetSourceIdentifier = $assetSourceIdentifier;
         $this->remoteAssetIdentifier = $remoteAssetIdentifier;

--- a/Neos.Media/Classes/Domain/Repository/AssetRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/AssetRepository.php
@@ -74,7 +74,7 @@ class AssetRepository extends Repository
      * @return QueryResultInterface
      * @throws InvalidQueryException
      */
-    public function findBySearchTermOrTags($searchTerm, array $tags = [], AssetCollection $assetCollection = null): QueryResultInterface
+    public function findBySearchTermOrTags($searchTerm, array $tags = [], ?AssetCollection $assetCollection = null): QueryResultInterface
     {
         $query = $this->createQuery();
 
@@ -100,7 +100,7 @@ class AssetRepository extends Repository
      * @return QueryResultInterface
      * @throws InvalidQueryException
      */
-    public function findByTag(Tag $tag, AssetCollection $assetCollection = null): QueryResultInterface
+    public function findByTag(Tag $tag, ?AssetCollection $assetCollection = null): QueryResultInterface
     {
         $query = $this->createQuery();
         $query->matching($query->contains('tags', $tag));
@@ -116,7 +116,7 @@ class AssetRepository extends Repository
      * @param AssetCollection $assetCollection
      * @return integer
      */
-    public function countByTag(Tag $tag, AssetCollection $assetCollection = null): int
+    public function countByTag(Tag $tag, ?AssetCollection $assetCollection = null): int
     {
         $rsm = new ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
@@ -144,7 +144,7 @@ class AssetRepository extends Repository
      * @return QueryResultInterface
      * @throws InvalidQueryException
      */
-    public function findAll(AssetCollection $assetCollection = null): QueryResultInterface
+    public function findAll(?AssetCollection $assetCollection = null): QueryResultInterface
     {
         $query = $this->createQuery();
         $this->addAssetVariantToQueryConstraints($query);
@@ -184,7 +184,7 @@ class AssetRepository extends Repository
      * @return QueryResultInterface
      * @throws InvalidQueryException
      */
-    public function findUntagged(AssetCollection $assetCollection = null): QueryResultInterface
+    public function findUntagged(?AssetCollection $assetCollection = null): QueryResultInterface
     {
         $query = $this->createQuery();
         $query->matching($query->isEmpty('tags'));
@@ -199,7 +199,7 @@ class AssetRepository extends Repository
      * @param AssetCollection $assetCollection
      * @return integer
      */
-    public function countUntagged(AssetCollection $assetCollection = null): int
+    public function countUntagged(?AssetCollection $assetCollection = null): int
     {
         $rsm = new ResultSetMapping();
         $rsm->addScalarResult('c', 'c');
@@ -262,7 +262,7 @@ class AssetRepository extends Repository
      * @return void
      * @throws InvalidQueryException
      */
-    protected function addAssetCollectionToQueryConstraints(QueryInterface $query, AssetCollection $assetCollection = null): void
+    protected function addAssetCollectionToQueryConstraints(QueryInterface $query, ?AssetCollection $assetCollection = null): void
     {
         if ($assetCollection === null) {
             return;
@@ -336,7 +336,7 @@ class AssetRepository extends Repository
      * @param callable $callback
      * @return \Generator
      */
-    public function iterate(IterableResult $iterator, callable $callback = null): ?\Generator
+    public function iterate(IterableResult $iterator, ?callable $callback = null): ?\Generator
     {
         $iteration = 0;
         foreach ($iterator as $object) {

--- a/Neos.Media/Classes/Domain/Repository/ImageVariantRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/ImageVariantRepository.php
@@ -31,7 +31,7 @@ class ImageVariantRepository extends AssetRepository
     /**
      * @return ImageVariant[]
      */
-    public function findVariantsByIdentifierAndVariantName(string $identifier, string $variantName, int $limit = null): array
+    public function findVariantsByIdentifierAndVariantName(string $identifier, string $variantName, ?int $limit = null): array
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('iv')
@@ -52,7 +52,7 @@ class ImageVariantRepository extends AssetRepository
     /**
      * @return ImageVariant[]
      */
-    public function findAllWithOutdatedPresets(int $limit = null): array
+    public function findAllWithOutdatedPresets(?int $limit = null): array
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('iv')

--- a/Neos.Media/Classes/Domain/Repository/ThumbnailRepository.php
+++ b/Neos.Media/Classes/Domain/Repository/ThumbnailRepository.php
@@ -54,7 +54,7 @@ class ThumbnailRepository extends Repository
      * @param callable $callback
      * @return \Generator
      */
-    public function iterate(IterableResult $iterator, callable $callback = null): ?\Generator
+    public function iterate(IterableResult $iterator, ?callable $callback = null): ?\Generator
     {
         $iteration = 0;
         foreach ($iterator as $object) {

--- a/Neos.Media/Classes/Domain/Service/AssetService.php
+++ b/Neos.Media/Classes/Domain/Service/AssetService.php
@@ -140,7 +140,7 @@ class AssetService
      * @throws MissingActionNameException
      * @throws HttpException
      */
-    public function getThumbnailUriAndSizeForAsset(AssetInterface $asset, ThumbnailConfiguration $configuration, ActionRequest $request = null): ?array
+    public function getThumbnailUriAndSizeForAsset(AssetInterface $asset, ThumbnailConfiguration $configuration, ?ActionRequest $request = null): ?array
     {
         $thumbnailImage = $this->thumbnailService->getThumbnail($asset, $configuration);
         if (!$thumbnailImage instanceof ImageInterface) {

--- a/Neos.Media/Classes/Domain/Service/ImageService.php
+++ b/Neos.Media/Classes/Domain/Service/ImageService.php
@@ -98,7 +98,7 @@ class ImageService
      * @throws InvalidConfigurationException
      * @throws Exception
      */
-    public function processImage(PersistentResource $originalResource, array $adjustments, string $format = null)
+    public function processImage(PersistentResource $originalResource, array $adjustments, ?string $format = null)
     {
         $additionalOptions = [];
         $adjustmentsApplied = false;

--- a/Neos.Media/Classes/Domain/ValueObject/Configuration/Variant.php
+++ b/Neos.Media/Classes/Domain/ValueObject/Configuration/Variant.php
@@ -40,7 +40,7 @@ final class Variant
      * @param Label $label
      * @param string $description
      */
-    public function __construct(string $identifier, Label $label, string $description = null)
+    public function __construct(string $identifier, Label $label, ?string $description = null)
     {
         $this->setIdentifier($identifier);
         $this->label = $label;

--- a/Neos.Media/Classes/Eel/AssetsHelper.php
+++ b/Neos.Media/Classes/Eel/AssetsHelper.php
@@ -86,7 +86,7 @@ class AssetsHelper implements ProtectedContextAwareInterface
      * @param Tag[]|string[] $tags
      * @return QueryResultInterface<AssetInterface> | null
      */
-    public function search(?string $searchTerm, array $tags = [], AssetCollection|string $collection = null): ?QueryResultInterface
+    public function search(?string $searchTerm, array $tags = [], AssetCollection|string|null $collection = null): ?QueryResultInterface
     {
         if (!$searchTerm) {
             return null;

--- a/Neos.Media/Classes/Imagine/Box.php
+++ b/Neos.Media/Classes/Imagine/Box.php
@@ -87,7 +87,7 @@ class Box implements BoxInterface
     /**
      * {@inheritdoc}
      */
-    public function contains(BoxInterface $box, PointInterface $start = null)
+    public function contains(BoxInterface $box, ?PointInterface $start = null)
     {
         $start = $start ? $start : new Point(0, 0);
 

--- a/Neos.Media/Classes/TypeConverter/ArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/ArrayConverter.php
@@ -110,7 +110,7 @@ class ArrayConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return array The converted asset or NULL
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $identity = $this->persistenceManager->getIdentifierByObject($source);
         switch (true) {

--- a/Neos.Media/Classes/TypeConverter/AspectRatioFromStringConverter.php
+++ b/Neos.Media/Classes/TypeConverter/AspectRatioFromStringConverter.php
@@ -45,7 +45,7 @@ class AspectRatioFromStringConverter extends ObjectConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return AspectRatio|object
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         try {
             return AspectRatio::fromString($source);

--- a/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/AssetCollectionToArrayConverter.php
@@ -95,7 +95,7 @@ class AssetCollectionToArrayConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return array The converted asset collection or NULL
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $identity = $this->persistenceManager->getIdentifierByObject($source);
 

--- a/Neos.Media/Classes/TypeConverter/AssetInterfaceConverter.php
+++ b/Neos.Media/Classes/TypeConverter/AssetInterfaceConverter.php
@@ -166,7 +166,7 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      * @throws InvalidPropertyMappingConfigurationException
      * @throws \InvalidArgumentException
      */
-    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    public function getTargetTypeForSource($source, $originalTargetType, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $targetType = $originalTargetType;
 
@@ -198,7 +198,7 @@ class AssetInterfaceConverter extends PersistentObjectConverter
      * @return Error|AssetInterface The converted Asset, a Validation Error or NULL
      * @throws InvalidTargetException
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $object = null;
         if (is_string($source) && $source !== '') {

--- a/Neos.Media/Classes/TypeConverter/ImageInterfaceArrayPresenter.php
+++ b/Neos.Media/Classes/TypeConverter/ImageInterfaceArrayPresenter.php
@@ -83,7 +83,7 @@ class ImageInterfaceArrayPresenter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return string|Error The converted Image, a Validation Error or NULL
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $data = [
             '__identity' => $this->persistenceManager->getIdentifierByObject($source),

--- a/Neos.Media/Classes/TypeConverter/ImageInterfaceJsonSerializer.php
+++ b/Neos.Media/Classes/TypeConverter/ImageInterfaceJsonSerializer.php
@@ -42,7 +42,7 @@ class ImageInterfaceJsonSerializer extends ImageInterfaceArrayPresenter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return string The converted ImageInterface
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $data = parent::convertFrom($source, 'array', $convertedChildProperties, $configuration);
         return json_encode($data);

--- a/Neos.Media/Classes/TypeConverter/ProcessingInstructionsConverter.php
+++ b/Neos.Media/Classes/TypeConverter/ProcessingInstructionsConverter.php
@@ -56,7 +56,7 @@ class ProcessingInstructionsConverter extends AbstractTypeConverter
      * @throws TypeConverterException thrown in case a developer error occurred
      * @api
      */
-    public function convertFrom($source, $targetType = 'array', array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType = 'array', array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $result = [];
         foreach ($source as $processingInstruction) {

--- a/Neos.Media/Classes/TypeConverter/TagConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagConverter.php
@@ -53,7 +53,7 @@ class TagConverter extends PersistentObjectConverter
      * @throws UnknownObjectException
      * @throws InvalidTargetException
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $object = parent::convertFrom($source, $targetType, $convertedChildProperties, $configuration);
 

--- a/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
+++ b/Neos.Media/Classes/TypeConverter/TagToArrayConverter.php
@@ -91,7 +91,7 @@ class TagToArrayConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return array The converted tag or NULL
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $identity = $this->persistenceManager->getIdentifierByObject($source);
 

--- a/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
@@ -222,7 +222,7 @@ class AssetConstraintsTest extends UnitTestCase
      * @test
      * @dataProvider applyToAssetSourceIdentifiersDataProvider
      */
-    public function applyToAssetSourceIdentifiersTests(array $allowedAssetSourceIdentifiers, string $assetSourceIdentifier = null, string $expectedResult = null): void
+    public function applyToAssetSourceIdentifiersTests(array $allowedAssetSourceIdentifiers, ?string $assetSourceIdentifier = null, ?string $expectedResult = null): void
     {
         $constraints = AssetConstraints::create()->withAssetSourceConstraint($allowedAssetSourceIdentifiers);
         self::assertSame($expectedResult, $constraints->applyToAssetSourceIdentifiers($assetSourceIdentifier));

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -159,7 +159,7 @@ HELPTEXT;
      * @param string $only Only execute the given check or checks (comma separated)
      * @return void
      */
-    public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true, $skip = null, $only = null)
+    public function invokeSubCommand($controllerCommandName, ConsoleOutput $output, ?NodeType $nodeType = null, $workspaceName = 'live', $dryRun = false, $cleanup = true, $skip = null, $only = null)
     {
         /** @noinspection PhpDeprecationInspection This is only set for backwards compatibility */
         $this->output = $output;

--- a/Neos.Neos/Classes/Controller/Backend/ImpersonateController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ImpersonateController.php
@@ -92,7 +92,7 @@ class ImpersonateController extends ActionController
      * @param string $format The format to use for the redirect URI
      * @see redirect()
      */
-    protected function redirectWithParentRequest(string $actionName, string $controllerName = null, string $packageKey = null, array $arguments = [], int $delay = 0, int $statusCode = 303, string $format = null): void
+    protected function redirectWithParentRequest(string $actionName, ?string $controllerName = null, ?string $packageKey = null, array $arguments = [], int $delay = 0, int $statusCode = 303, ?string $format = null): void
     {
         $request = $this->getControllerContext()->getRequest()->getMainRequest();
         $uriBuilder = new UriBuilder();

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -101,7 +101,7 @@ class NodeController extends ActionController
      * @Flow\SkipCsrfProtection
      * @Flow\IgnoreValidation("node")
      */
-    public function showAction(NodeInterface $node = null)
+    public function showAction(?NodeInterface $node = null)
     {
         if ($node === null || !$node->getContext()->isLive()) {
             throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1430218623);
@@ -135,7 +135,7 @@ class NodeController extends ActionController
      * @throws NeosException | NodeNotFoundException | SessionNotStartedException | UnresolvableShortcutException
      * @Flow\IgnoreValidation("node")
      */
-    public function previewAction(NodeInterface $node = null)
+    public function previewAction(?NodeInterface $node = null)
     {
         if ($node === null) {
             throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1430218623);

--- a/Neos.Neos/Classes/Controller/LoginController.php
+++ b/Neos.Neos/Classes/Controller/LoginController.php
@@ -199,7 +199,7 @@ class LoginController extends AbstractAuthenticationController
      * @param AuthenticationRequiredException $exception The exception thrown while the authentication process
      * @return void
      */
-    protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
+    protected function onAuthenticationFailure(?AuthenticationRequiredException $exception = null)
     {
         if ($this->view instanceof JsonView) {
             $this->view->assign('value', ['success' => false]);
@@ -223,7 +223,7 @@ class LoginController extends AbstractAuthenticationController
      * @throws StopActionException
      * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      */
-    protected function onAuthenticationSuccess(ActionRequest $originalRequest = null)
+    protected function onAuthenticationSuccess(?ActionRequest $originalRequest = null)
     {
         if ($this->view instanceof JsonView) {
             $this->view->assign('value', ['success' => $this->authenticationManager->isAuthenticated(), 'csrfToken' => $this->securityContext->getCsrfProtectionToken()]);

--- a/Neos.Neos/Classes/Controller/Module/Administration/DimensionController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/DimensionController.php
@@ -32,7 +32,7 @@ class DimensionController extends AbstractModuleController
      * @param string $subgraphIdentifier
      * @return void
      */
-    public function indexAction(string $type = 'intraDimension', string $subgraphIdentifier = null)
+    public function indexAction(string $type = 'intraDimension', ?string $subgraphIdentifier = null)
     {
         switch ($type) {
             case 'intraDimension':

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -231,7 +231,7 @@ class SitesController extends AbstractModuleController
      * @Flow\IgnoreValidation("$site")
      * @return void
      */
-    public function newSiteAction(Site $site = null)
+    public function newSiteAction(?Site $site = null)
     {
         $sitePackages = $this->packageManager->getFilteredPackages('available', 'neos-site');
         $documentNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.Neos:Document', false);
@@ -517,7 +517,7 @@ class SitesController extends AbstractModuleController
      * @Flow\IgnoreValidation("$domain")
      * @return void
      */
-    public function newDomainAction(Domain $domain = null, Site $site = null)
+    public function newDomainAction(?Domain $domain = null, ?Site $site = null)
     {
         $this->view->assignMultiple([
             'domain' => $domain,

--- a/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/UsersController.php
@@ -150,7 +150,7 @@ class UsersController extends AbstractModuleController
      * @param User $user
      * @return void
      */
-    public function newAction(User $user = null): void
+    public function newAction(?User $user = null): void
     {
         $this->view->assignMultiple([
             'currentUser' => $this->currentUser,
@@ -177,7 +177,7 @@ class UsersController extends AbstractModuleController
      * @Flow\Validate(argumentName="username", type="\Neos\Neos\Validation\Validator\UserDoesNotExistValidator")
      * @Flow\Validate(argumentName="password", type="\Neos\Neos\Validation\Validator\PasswordValidator", options={ "allowEmpty"=0, "minimum"=1, "maximum"=255 })
      */
-    public function createAction(string $username, array $password, User $user, array $roleIdentifiers, string $authenticationProviderName = null): void
+    public function createAction(string $username, array $password, User $user, array $roleIdentifiers, ?string $authenticationProviderName = null): void
     {
         $currentUserRoles = $this->userService->getAllRoles($this->currentUser);
         $isCreationAllowed = $this->userService->currentUserIsAdministrator() || count(array_diff($roleIdentifiers, $currentUserRoles)) === 0;

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -397,7 +397,7 @@ class WorkspacesController extends AbstractModuleController
      * @throws \Neos\Flow\Property\Exception
      * @throws \Neos\Flow\Security\Exception
      */
-    public function publishOrDiscardNodesAction(array $nodes, $action, Workspace $selectedWorkspace = null)
+    public function publishOrDiscardNodesAction(array $nodes, $action, ?Workspace $selectedWorkspace = null)
     {
         $propertyMappingConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
         $propertyMappingConfiguration->setTypeConverterOption(NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN, true);
@@ -733,7 +733,7 @@ class WorkspacesController extends AbstractModuleController
      * @param Workspace $excludedWorkspace If set, this workspace and all its child workspaces will be excluded from the list of returned workspaces
      * @return array
      */
-    protected function prepareBaseWorkspaceOptions(Workspace $excludedWorkspace = null)
+    protected function prepareBaseWorkspaceOptions(?Workspace $excludedWorkspace = null)
     {
         $baseWorkspaceOptions = [];
 

--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -90,7 +90,7 @@ class NodesController extends ActionController
      * @param NodeInterface $contextNode a node to use as context for the search
      * @return void
      */
-    public function indexAction($searchTerm = '', array $nodeIdentifiers = [], $workspaceName = 'live', array $dimensions = [], array $nodeTypes = ['Neos.Neos:Document'], NodeInterface $contextNode = null)
+    public function indexAction($searchTerm = '', array $nodeIdentifiers = [], $workspaceName = 'live', array $dimensions = [], array $nodeTypes = ['Neos.Neos:Document'], ?NodeInterface $contextNode = null)
     {
         $contentContext = $this->createContentContext($workspaceName, $dimensions);
         if ($nodeIdentifiers === []) {

--- a/Neos.Neos/Classes/Domain/Model/Site.php
+++ b/Neos.Neos/Classes/Domain/Model/Site.php
@@ -283,7 +283,7 @@ class Site
      * @return void
      * @api
      */
-    public function setPrimaryDomain(Domain $domain = null)
+    public function setPrimaryDomain(?Domain $domain = null)
     {
         if ($domain === null) {
             $this->primaryDomain = null;
@@ -323,7 +323,7 @@ class Site
      * @param AssetCollection $assetCollection
      * @return void
      */
-    public function setAssetCollection(AssetCollection $assetCollection = null)
+    public function setAssetCollection(?AssetCollection $assetCollection = null)
     {
         $this->assetCollection = $assetCollection;
     }

--- a/Neos.Neos/Classes/Domain/Service/ContentContext.php
+++ b/Neos.Neos/Classes/Domain/Service/ContentContext.php
@@ -74,7 +74,7 @@ class ContentContext extends Context
      * @param Domain $currentDomain The current Domain object
      * @see ContextFactoryInterface
      */
-    public function __construct($workspaceName, \DateTimeInterface $currentDateTime, array $dimensions, array $targetDimensions, $invisibleContentShown, $removedContentShown, $inaccessibleContentShown, Site $currentSite = null, Domain $currentDomain = null)
+    public function __construct($workspaceName, \DateTimeInterface $currentDateTime, array $dimensions, array $targetDimensions, $invisibleContentShown, $removedContentShown, $inaccessibleContentShown, ?Site $currentSite = null, ?Domain $currentDomain = null)
     {
         parent::__construct($workspaceName, $currentDateTime, $dimensions, $targetDimensions, $invisibleContentShown, $removedContentShown, $inaccessibleContentShown);
         $this->currentSite = $currentSite;

--- a/Neos.Neos/Classes/Domain/Service/NodeSearchService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeSearchService.php
@@ -55,7 +55,7 @@ class NodeSearchService implements NodeSearchServiceInterface
      * @param NodeInterface $startingPoint
      * @return array <\Neos\ContentRepository\Domain\Model\NodeInterface>
      */
-    public function findByProperties($term, array $searchNodeTypes, Context $context, NodeInterface $startingPoint = null)
+    public function findByProperties($term, array $searchNodeTypes, Context $context, ?NodeInterface $startingPoint = null)
     {
         if (empty($term)) {
             throw new \InvalidArgumentException('"term" cannot be empty: provide a term to search for.', 1421329285);

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -289,7 +289,7 @@ class UserService
      * @return User The created user instance
      * @api
      */
-    public function createUser($username, $password, $firstName, $lastName, array $roleIdentifiers = null, $authenticationProviderName = null)
+    public function createUser($username, $password, $firstName, $lastName, ?array $roleIdentifiers = null, $authenticationProviderName = null)
     {
         $user = new User();
         $name = new PersonName('', $firstName, '', $lastName, '', $username);
@@ -315,7 +315,7 @@ class UserService
      * @return User The same user object
      * @api
      */
-    public function addUser($username, $password, User $user, array $roleIdentifiers = null, $authenticationProviderName = null)
+    public function addUser($username, $password, User $user, ?array $roleIdentifiers = null, $authenticationProviderName = null)
     {
         if ($roleIdentifiers === null) {
             $roleIdentifiers = ['Neos.Neos:Editor'];

--- a/Neos.Neos/Classes/EventLog/Domain/Model/Event.php
+++ b/Neos.Neos/Classes/EventLog/Domain/Model/Event.php
@@ -98,7 +98,7 @@ class Event
      * @param string $user
      * @param Event $parentEvent
      */
-    public function __construct($eventType, $data, $user = null, Event $parentEvent = null)
+    public function __construct($eventType, $data, $user = null, ?Event $parentEvent = null)
     {
         $this->timestamp = new \DateTime();
         $this->eventType = $eventType;

--- a/Neos.Neos/Classes/Fusion/AbstractMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/AbstractMenuItemsImplementation.php
@@ -121,7 +121,7 @@ abstract class AbstractMenuItemsImplementation extends AbstractFusionObject
      * @param NodeInterface $node
      * @return string
      */
-    protected function calculateItemState(NodeInterface $node = null)
+    protected function calculateItemState(?NodeInterface $node = null)
     {
         if ($node === null) {
             return self::STATE_ABSENT;

--- a/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
+++ b/Neos.Neos/Classes/Fusion/Cache/ContentCacheFlusher.php
@@ -128,7 +128,7 @@ class ContentCacheFlusher
      * @param NodeInterface $node The node which has changed in some way
      * @param Workspace|null $targetWorkspace An optional workspace to flush
      */
-    public function registerNodeChange(NodeInterface $node, Workspace $targetWorkspace = null): void
+    public function registerNodeChange(NodeInterface $node, ?Workspace $targetWorkspace = null): void
     {
         $this->addTagToFlush(ContentCache::TAG_EVERYTHING, 'which were tagged with "Everything".');
 
@@ -242,7 +242,7 @@ class ContentCacheFlusher
      *
      * @throws NodeTypeNotFoundException
      */
-    public function registerChangeOnNodeType(string $nodeTypeName, string $referenceNodeIdentifier = null, string $nodeTypePrefix = ''): void
+    public function registerChangeOnNodeType(string $nodeTypeName, ?string $referenceNodeIdentifier = null, string $nodeTypePrefix = ''): void
     {
         $this->addTagToFlush(ContentCache::TAG_EVERYTHING, 'which were tagged with "Everything".');
 

--- a/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.Neos/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -147,7 +147,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
      * @param array|null $targetDimensions
      * @return string
      */
-    protected function itemLabel(string $pinnedDimensionName = null, NodeInterface $nodeInDimensions = null, array $targetDimensions = null): string
+    protected function itemLabel(?string $pinnedDimensionName = null, ?NodeInterface $nodeInDimensions = null, ?array $targetDimensions = null): string
     {
         if ($nodeInDimensions === null && $pinnedDimensionName === null) {
             $itemLabel = '';

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -82,7 +82,7 @@ class CachingHelper implements ProtectedContextAwareInterface
      * @return string
      *
      */
-    public function nodeTagForIdentifier(string $identifier, NodeInterface $contextNode = null): string
+    public function nodeTagForIdentifier(string $identifier, ?NodeInterface $contextNode = null): string
     {
         $workspaceTag = '';
         if ($contextNode instanceof NodeInterface) {

--- a/Neos.Neos/Classes/Fusion/Helper/LinkHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/LinkHelper.php
@@ -73,7 +73,7 @@ class LinkHelper implements ProtectedContextAwareInterface
      * @param NodeInterface $contextNode
      * @return NodeInterface|AssetInterface|NULL
      */
-    public function convertUriToObject($uri, NodeInterface $contextNode = null)
+    public function convertUriToObject($uri, ?NodeInterface $contextNode = null)
     {
         return $this->linkingService->convertUriToObject($uri, $contextNode);
     }

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -53,7 +53,7 @@ class NodeHelper implements ProtectedContextAwareInterface
      * @param NodeInterface|null $node
      * @return NodeLabelToken
      */
-    public function labelForNode(NodeInterface $node = null): NodeLabelToken
+    public function labelForNode(?NodeInterface $node = null): NodeLabelToken
     {
         return new NodeLabelToken($node);
     }

--- a/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeLabelToken.php
@@ -70,7 +70,7 @@ class NodeLabelToken implements ProtectedContextAwareInterface
         $this->node = $node;
     }
 
-    public function override(string $override = null): NodeLabelToken
+    public function override(?string $override = null): NodeLabelToken
     {
         if (empty($this->label) && $override) {
             $this->label = $override;

--- a/Neos.Neos/Classes/Fusion/PluginImplementation.php
+++ b/Neos.Neos/Classes/Fusion/PluginImplementation.php
@@ -124,7 +124,7 @@ class PluginImplementation extends AbstractArrayFusionObject
      * @throws InvalidActionNameException
      * @throws InvalidControllerNameException
      */
-    protected function resolveDispatchArgumentsForPluginRequest(ActionRequest $pluginRequest, NodeInterface $node = null): ActionRequest
+    protected function resolveDispatchArgumentsForPluginRequest(ActionRequest $pluginRequest, ?NodeInterface $node = null): ActionRequest
     {
         $packageKey = $this->getPackage();
         $subpackageKey = $this->getSubpackage();

--- a/Neos.Neos/Classes/Presentation/Model/Svg/InterDimensionalFallbackGraph.php
+++ b/Neos.Neos/Classes/Presentation/Model/Svg/InterDimensionalFallbackGraph.php
@@ -67,7 +67,7 @@ class InterDimensionalFallbackGraph
     public function __construct(
         InterDimension\InterDimensionalFallbackGraph $fallbackGraph,
         IntraDimension\IntraDimensionalFallbackGraph $intraDimensionalFallbackGraph,
-        string $rootSubgraphIdentifier = null
+        ?string $rootSubgraphIdentifier = null
     ) {
         $this->fallbackGraph = $fallbackGraph;
         $this->intraDimensionalFallbackGraph = $intraDimensionalFallbackGraph;

--- a/Neos.Neos/Classes/Routing/Cache/RouteCacheFlusher.php
+++ b/Neos.Neos/Classes/Routing/Cache/RouteCacheFlusher.php
@@ -63,7 +63,7 @@ class RouteCacheFlusher
      * @param Workspace|null $newBaseWorkspace
      * @return void
      */
-    public function registerBaseWorkspaceChange(Workspace $workspace, Workspace $oldBaseWorkspace = null, Workspace $newBaseWorkspace = null)
+    public function registerBaseWorkspaceChange(Workspace $workspace, ?Workspace $oldBaseWorkspace = null, ?Workspace $newBaseWorkspace = null)
     {
         if (!in_array($workspace->getName(), $this->tagsToFlush)) {
             $this->tagsToFlush[] = $workspace->getName();

--- a/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -428,7 +428,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      * @return ContentContext
      * @throws Exception\NoSiteException
      */
-    protected function buildContextFromWorkspaceName($workspaceName, array $dimensions = null)
+    protected function buildContextFromWorkspaceName($workspaceName, ?array $dimensions = null)
     {
         $contextProperties = [
             'workspaceName' => $workspaceName,

--- a/Neos.Neos/Classes/Service/Controller/DataSourceController.php
+++ b/Neos.Neos/Classes/Service/Controller/DataSourceController.php
@@ -40,7 +40,7 @@ class DataSourceController extends AbstractServiceController
      * @return void
      * @throws NeosException
      */
-    public function indexAction($dataSourceIdentifier, NodeInterface $node = null)
+    public function indexAction($dataSourceIdentifier, ?NodeInterface $node = null)
     {
         $dataSources = static::getDataSources($this->objectManager);
 

--- a/Neos.Neos/Classes/Service/DataSource/DataSourceInterface.php
+++ b/Neos.Neos/Classes/Service/DataSource/DataSourceInterface.php
@@ -38,5 +38,5 @@ interface DataSourceInterface
      * @return mixed JSON serializable data
      * @api
      */
-    public function getData(NodeInterface $node = null, array $arguments = []);
+    public function getData(?NodeInterface $node = null, array $arguments = []);
 }

--- a/Neos.Neos/Classes/Service/ImpersonateService.php
+++ b/Neos.Neos/Classes/Service/ImpersonateService.php
@@ -139,7 +139,7 @@ class ImpersonateService
      * @param Account|null $account
      * @return void
      */
-    protected function refreshTokens(Account $account = null): void
+    protected function refreshTokens(?Account $account = null): void
     {
         if ($account === null) {
             return;

--- a/Neos.Neos/Classes/Service/LinkingService.php
+++ b/Neos.Neos/Classes/Service/LinkingService.php
@@ -199,7 +199,7 @@ class LinkingService
      * @param NodeInterface $contextNode
      * @return NodeInterface|AssetInterface|NULL
      */
-    public function convertUriToObject($uri, NodeInterface $contextNode = null)
+    public function convertUriToObject($uri, ?NodeInterface $contextNode = null)
     {
         if ($uri instanceof UriInterface) {
             $uri = (string)$uri;
@@ -242,7 +242,7 @@ class LinkingService
      * @throws HttpException
      * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
-    public function createNodeUri(ControllerContext $controllerContext, $node = null, NodeInterface $baseNode = null, $format = null, $absolute = false, array $arguments = [], $section = '', $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [], $resolveShortcuts = true): string
+    public function createNodeUri(ControllerContext $controllerContext, $node = null, ?NodeInterface $baseNode = null, $format = null, $absolute = false, array $arguments = [], $section = '', $addQueryString = false, array $argumentsToBeExcludedFromQueryString = [], $resolveShortcuts = true): string
     {
         $this->lastLinkedNode = null;
         if ($resolveShortcuts === false) {

--- a/Neos.Neos/Classes/Service/Mapping/DateStringConverter.php
+++ b/Neos.Neos/Classes/Service/Mapping/DateStringConverter.php
@@ -55,7 +55,7 @@ class DateStringConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return string the target type
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!$source instanceof \DateTime) {
             return null;

--- a/Neos.Neos/Classes/Service/Mapping/NodeReferenceConverter.php
+++ b/Neos.Neos/Classes/Service/Mapping/NodeReferenceConverter.php
@@ -56,7 +56,7 @@ class NodeReferenceConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return string the target type
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (is_array($source)) {
             $result = [];

--- a/Neos.Neos/Classes/Service/Mapping/NodeTypeStringConverter.php
+++ b/Neos.Neos/Classes/Service/Mapping/NodeTypeStringConverter.php
@@ -49,7 +49,7 @@ class NodeTypeStringConverter extends AbstractTypeConverter
      * @return string
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($source instanceof NodeType) {
             return $source->getName();

--- a/Neos.Neos/Classes/Service/PublishingService.php
+++ b/Neos.Neos/Classes/Service/PublishingService.php
@@ -35,7 +35,7 @@ class PublishingService extends \Neos\ContentRepository\Domain\Service\Publishin
      * @return void
      * @api
      */
-    public function publishNode(NodeInterface $node, Workspace $targetWorkspace = null)
+    public function publishNode(NodeInterface $node, ?Workspace $targetWorkspace = null)
     {
         if ($targetWorkspace === null) {
             $targetWorkspace = $node->getWorkspace()->getBaseWorkspace();

--- a/Neos.Neos/Classes/Service/View/NodeView.php
+++ b/Neos.Neos/Classes/Service/View/NodeView.php
@@ -112,7 +112,7 @@ class NodeView extends JsonView
      * @param NodeInterface $untilNode if given, expand all nodes on the rootline towards $untilNode, no matter what is defined with $depth.
      * @return void
      */
-    public function assignChildNodes(NodeInterface $node, $nodeTypeFilter, $outputStyle = self::STYLE_LIST, $depth = 0, NodeInterface $untilNode = null)
+    public function assignChildNodes(NodeInterface $node, $nodeTypeFilter, $outputStyle = self::STYLE_LIST, $depth = 0, ?NodeInterface $untilNode = null)
     {
         $this->outputStyle = $outputStyle;
         $nodes = [];
@@ -133,7 +133,7 @@ class NodeView extends JsonView
      * @param NodeInterface $untilNode if given, expand all nodes on the rootline towards $untilNode, no matter what is defined with $depth.
      * @return void
      */
-    public function assignNodeAndChildNodes(NodeInterface $node, $nodeTypeFilter = '', $depth = 0, NodeInterface $untilNode = null)
+    public function assignNodeAndChildNodes(NodeInterface $node, $nodeTypeFilter = '', $depth = 0, ?NodeInterface $untilNode = null)
     {
         $this->outputStyle = self::STYLE_TREE;
         $data = [];
@@ -175,7 +175,7 @@ class NodeView extends JsonView
      * @param integer $recursionPointer current recursion level
      * @return void
      */
-    protected function collectChildNodeData(array &$nodes, NodeInterface $node, $nodeTypeFilter, $depth = 0, NodeInterface $untilNode = null, $recursionPointer = 1)
+    protected function collectChildNodeData(array &$nodes, NodeInterface $node, $nodeTypeFilter, $depth = 0, ?NodeInterface $untilNode = null, $recursionPointer = 1)
     {
         foreach ($node->getChildNodes($nodeTypeFilter) as $childNode) {
             if (!$this->privilegeManager->isGranted(NodeTreePrivilege::class, new NodePrivilegeSubject($childNode))) {

--- a/Neos.Neos/Classes/TypeConverter/EntityToIdentityConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/EntityToIdentityConverter.php
@@ -72,7 +72,7 @@ class EntityToIdentityConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface $configuration
      * @return array
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return [
             '__identity' => $this->persistenceManager->getIdentifierByObject($source),

--- a/Neos.Neos/Classes/Utility/NodeUriPathSegmentGenerator.php
+++ b/Neos.Neos/Classes/Utility/NodeUriPathSegmentGenerator.php
@@ -62,7 +62,7 @@ class NodeUriPathSegmentGenerator
      * @param string $text Optional text
      * @return string
      */
-    public function generateUriPathSegment(NodeInterface $node = null, $text = null)
+    public function generateUriPathSegment(?NodeInterface $node = null, $text = null)
     {
         if ($node) {
             $text = $text ?: $node->getLabel() ?: $node->getName();

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/AbstractRenderingStateViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/AbstractRenderingStateViewHelper.php
@@ -49,7 +49,7 @@ abstract class AbstractRenderingStateViewHelper extends AbstractViewHelper
      * @return ContentContext
      * @throws ViewHelperException
      */
-    protected function getNodeContext(NodeInterface $node = null)
+    protected function getNodeContext(?NodeInterface $node = null)
     {
         if ($node === null) {
             $node = $this->getContextNode();

--- a/Neos.Neos/Migrations/Postgresql/Version20150309212115.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20150309212115.php
@@ -13,7 +13,7 @@ class Version20150309212115 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function up(Schema $schema): void 
+    public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
@@ -29,7 +29,7 @@ class Version20150309212115 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 

--- a/Neos.Neos/Migrations/Postgresql/Version20170629102140.php
+++ b/Neos.Neos/Migrations/Postgresql/Version20170629102140.php
@@ -33,7 +33,7 @@ class Version20170629102140 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         // No down migration available
     }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -85,7 +85,7 @@ trait FusionTrait
     /**
      * @When the Fusion context request URI is :requestUri
      */
-    public function theFusionContextRequestIs(string $requestUri = null): void
+    public function theFusionContextRequestIs(?string $requestUri = null): void
     {
         $httpRequest = $this->objectManager->get(ServerRequestFactoryInterface::class)->createServerRequest('GET', $requestUri);
         $httpRequest = $this->addRoutingParameters($httpRequest);

--- a/Neos.NodeTypes.Form/Classes/Service/DataSource/FormDefinitionDataSource.php
+++ b/Neos.NodeTypes.Form/Classes/Service/DataSource/FormDefinitionDataSource.php
@@ -34,7 +34,7 @@ class FormDefinitionDataSource extends AbstractDataSource
      * @param array $arguments
      * @return \Neos\Flow\Persistence\QueryResultInterface
      */
-    public function getData(NodeInterface $node = null, array $arguments = [])
+    public function getData(?NodeInterface $node = null, array $arguments = [])
     {
         $formDefinitions['']['label'] = '';
         $forms = $this->yamlPersistenceManager->listForms();


### PR DESCRIPTION
I've used rector to migrate all occurrences.

https://getrector.com/rule-detail/explicit-nullable-param-type-rector

See also for Flow: https://github.com/neos/flow-development-collection/pull/3429

Note: We should run the rector migration again on 9.0 after upmerging this PR