### PR TITLE
BUGFIX: Remove import site from site creation module and fix delete sites (9.0)

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -28,7 +28,6 @@ use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Package;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Neos\Controller\Module\AbstractModuleController;
@@ -40,10 +39,8 @@ use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
-use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\Neos\Domain\Service\SiteService;
 use Neos\Neos\Domain\Service\UserService;
-use Neos\Utility\Files;
 
 /**
  * The Neos Sites Management module controller
@@ -96,20 +93,9 @@ class SitesController extends AbstractModuleController
      * the site must have a field to define the contentRepositoryId to correctly create sites dynamically.
      *
      * @Flow\InjectConfiguration("sitePresets.default.contentRepository")
+     * @var string|null
      */
     protected $defaultContentRepositoryForNewSites;
-
-    /**
-     * @Flow\Inject
-     * @var SecurityContext
-     */
-    protected $securityContext;
-
-    /**
-     * @Flow\Inject
-     * @var SiteImportService
-     */
-    protected $siteImportService;
 
     #[Flow\Inject]
     protected UserService $domainUserService;
@@ -293,11 +279,7 @@ class SitesController extends AbstractModuleController
     public function createSiteNodeAction($packageKey, $siteName, $nodeType)
     {
         try {
-            // CreateRootWorkspace was denied: Creation of root workspaces is currently only allowed with disabled authorization checks
-            $site = null;
-            $this->securityContext->withoutAuthorizationChecks(function () use (&$site, $packageKey, $siteName, $nodeType) {
-                $site = $this->siteService->createSite($packageKey, $siteName, $nodeType);
-            });
+            $site = $this->siteService->createSite($packageKey, $siteName, $nodeType);
         } catch (NodeTypeNotFound $exception) {
             $this->addFlashMessage(
                 $this->getModuleLabel('sites.siteCreationError.givenNodeTypeNotFound.body', [$nodeType]),

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -263,14 +263,18 @@ class SitesController extends AbstractModuleController
 
         try {
             $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
-            $documentNodeTypes = $contentRepository->getNodeTypeManager()->getSubNodeTypes(NodeTypeNameFactory::forSite(), false);
         } catch (ContentRepositoryNotFoundException $e) {
-            throw new \RuntimeException(sprintf('The default content repository for new sites "%s" could not be instantiated.', $contentRepositoryId->value), 1736946907, $e);
+            throw new \RuntimeException(sprintf('The default content repository for new sites "%s" could not be instantiated.', $contentRepositoryId->value), 1736946907);
         }
+
+        $documentNodeTypes = $contentRepository->getNodeTypeManager()->getSubNodeTypes(NodeTypeNameFactory::forSite(), false);
 
         $sitePackages = $this->packageManager->getFilteredPackages('available', 'neos-site');
 
         $this->view->assignMultiple([
+            'defaultContentRepositoryForNewSites' => $contentRepositoryId->value,
+            // The live workspace has to be empty prior to importing, that's why we disable the functionality
+            'canImportFromPackage' => $this->siteRepository->findFirst() === null,
             'sitePackages' => $sitePackages,
             'documentNodeTypes' => $documentNodeTypes
         ]);

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -329,7 +329,11 @@ class SitesController extends AbstractModuleController
     public function createSiteNodeAction($packageKey, $siteName, $nodeType)
     {
         try {
-            $site = $this->siteService->createSite($packageKey, $siteName, $nodeType);
+            // CreateRootWorkspace was denied: Creation of root workspaces is currently only allowed with disabled authorization checks
+            $site = null;
+            $this->securityContext->withoutAuthorizationChecks(function () use (&$site, $packageKey, $siteName, $nodeType) {
+                $site = $this->siteService->createSite($packageKey, $siteName, $nodeType);
+            });
         } catch (NodeTypeNotFound $exception) {
             $this->addFlashMessage(
                 $this->getModuleLabel('sites.siteCreationError.givenNodeTypeNotFound.body', [$nodeType]),

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -268,13 +268,14 @@ class SitesController extends AbstractModuleController
         }
 
         $documentNodeTypes = $contentRepository->getNodeTypeManager()->getSubNodeTypes(NodeTypeNameFactory::forSite(), false);
+        $liveWorkspace = $contentRepository->findWorkspaceByName(WorkspaceName::forLive());
 
         $sitePackages = $this->packageManager->getFilteredPackages('available', 'neos-site');
 
         $this->view->assignMultiple([
             'defaultContentRepositoryForNewSites' => $contentRepositoryId->value,
             // The live workspace has to be empty prior to importing, that's why we disable the functionality
-            'canImportFromPackage' => $this->siteRepository->findFirst() === null,
+            'canImportFromPackage' => $liveWorkspace === null,
             'sitePackages' => $sitePackages,
             'documentNodeTypes' => $documentNodeTypes
         ]);

--- a/Neos.Neos/Classes/Domain/Service/SiteService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteService.php
@@ -20,6 +20,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Neos\Domain\Exception\SiteNodeNameIsAlreadyInUseByAnotherSite;
@@ -71,13 +72,20 @@ class SiteService
     protected $workspaceService;
 
     /**
+     * @Flow\Inject
+     * @var SecurityContext
+     */
+    protected $securityContext;
+
+    /**
      * Remove given site all nodes for that site and all domains associated.
      */
     public function pruneSite(Site $site): void
     {
         $siteServiceInternals = new SiteServiceInternals(
             $this->contentRepositoryRegistry->get($site->getConfiguration()->contentRepositoryId),
-            $this->workspaceService
+            $this->workspaceService,
+            $this->securityContext
         );
 
         try {
@@ -181,7 +189,8 @@ class SiteService
 
         $siteServiceInternals = new SiteServiceInternals(
             $this->contentRepositoryRegistry->get($site->getConfiguration()->contentRepositoryId),
-            $this->workspaceService
+            $this->workspaceService,
+            $this->securityContext
         );
         $siteServiceInternals->createSiteNodeIfNotExists($site, $nodeTypeName);
 

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
@@ -100,7 +100,7 @@
 		</tbody>
 	</table>
 	<div class="neos-footer">
-		<f:link.action action="newSite" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}">{neos:backend.translate(id: 'sites.add', value: 'Add new site', source: 'Modules')}</f:link.action>
+		<f:link.action action="newSite" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}">{neos:backend.translate(id: 'sites.add', value: 'Add new site', source: 'Modules')} <i>(Deprecated)</i></f:link.action>
 	</div>
 
 	<script>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/Index.html
@@ -100,7 +100,7 @@
 		</tbody>
 	</table>
 	<div class="neos-footer">
-		<f:link.action action="newSite" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}">{neos:backend.translate(id: 'sites.add', value: 'Add new site', source: 'Modules')} <i>(Deprecated)</i></f:link.action>
+		<f:link.action action="newSite" class="neos-button neos-button-primary" title="{neos:backend.translate(id: 'clickToCreate', value: 'Click to create new')}">{neos:backend.translate(id: 'sites.add', value: 'Add new site', source: 'Modules')}</f:link.action>
 	</div>
 
 	<script>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -2,45 +2,14 @@
 <f:layout name="BackendSubModule" />
 
 <f:section name="content">
-	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')} <i>(Deprecated)</i></h2>
-
-	<br>
-	Using the sites management module for creation sites is deprecated please consider using the command line instead.
-	<br>
-	For example <code>./flow site:importall</code> for importing from a package or <code>./flow site:create</code> to create a new site.
-	<br>
-	All site creations will target the content repository: "{defaultContentRepositoryForNewSites}"
+	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')}</h2>
 
   <div class="neos-row-fluid">
-    <f:form action="importSite">
-      <fieldset class="neos-span3">
-        <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site', source: 'Modules')}</legend>
-				<f:if condition="{canImportFromPackage ? false : true}">
-					NOTE: Currently it's only possible to import once into a content repository from a site package.
-					To reimport please prune the sites first via <code>./flow site:pruneall</code>.
-					<br><br>
-				</f:if>
-				<f:if condition="{sitePackages -> f:count()} > 0">
-          <f:then>
-            <div class="neos-control-group">
-              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package', source: 'Modules')}</label>
-              <div class="neos-controls neos-select">
-                <f:form.select disabled="{canImportFromPackage ? false : true}" name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
-              </div>
-            </div>
-            <f:form.submit disabled="{canImportFromPackage ? false : true}" value="{neos:backend.translate(id: 'sites.import', value: 'Import Site', source: 'Modules')}" class="neos-button neos-button-primary" />
-          </f:then>
-          <f:else>
-            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.', source: 'Modules')}
-            </p>
-          </f:else>
-        </f:if>
-      </fieldset>
-    </f:form>
-
     <f:form action="createSiteNode">
-      <fieldset class="neos-span3 neos-offset1">
+      <fieldset class="neos-span3">
         <legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site', source: 'Modules')}</legend>
+				In the content repository: "{defaultContentRepositoryForNewSites}"
+
         <f:if condition="{sitePackages -> f:count()} > 0">
           <f:then>
             <div class="neos-control-group">
@@ -71,18 +40,6 @@
         </f:if>
       </fieldset>
     </f:form>
-
-		<div class="neos neos-row-fluid neos-span3">
-			<legend>Create a new site-package</legend>
-			NOTE: The functionality to create site packages via this module was removed as being too fragile.
-			To get started with neos head over to the setup:
-			<br>
-			<br>
-			<a href="/setup" class="neos-button neos-button-primary">/setup</a>
-			<br>
-			<br>
-			To kickstart a new package use: <code>./flow kickstart:site</code>
-		</div>
 
   </div>
   <div class="neos-footer">

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -3,20 +3,26 @@
 
 <f:section name="content">
 	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')}</h2>
+	All site creations will target the content repository: "{defaultContentRepositoryForNewSites}"
 
   <div class="neos-row-fluid">
     <f:form action="importSite">
       <fieldset class="neos-span3">
         <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site', source: 'Modules')}</legend>
-        <f:if condition="{sitePackages -> f:count()} > 0">
+				<f:if condition="{canImportFromPackage ? false : true}">
+					NOTE: Currently it's only possible to import once into a content repository from a site package.
+					To reimport please prune the sites first via <code>./flow site:pruneall</code>.
+					<br><br>
+				</f:if>
+				<f:if condition="{sitePackages -> f:count()} > 0">
           <f:then>
             <div class="neos-control-group">
               <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package', source: 'Modules')}</label>
               <div class="neos-controls neos-select">
-                <f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
+                <f:form.select disabled="{canImportFromPackage ? false : true}" name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
               </div>
             </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.import', value: 'Import Site', source: 'Modules')}" class="neos-button neos-button-primary" />
+            <f:form.submit disabled="{canImportFromPackage ? false : true}" value="{neos:backend.translate(id: 'sites.import', value: 'Import Site', source: 'Modules')}" class="neos-button neos-button-primary" />
           </f:then>
           <f:else>
             <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.', source: 'Modules')}

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -8,7 +8,7 @@
     <f:form action="createSiteNode">
       <fieldset class="neos-span3">
         <legend>{neos:backend.translate(id: 'sites.createBlank', value: 'Create a blank site', source: 'Modules')}</legend>
-				In the content repository: "{defaultContentRepositoryForNewSites}"
+				{neos:backend.translate(id: 'sites.creationContentRepository', value: 'In the content repository: "{defaultContentRepositoryForNewSites}"', source: 'Modules', arguments: {0: defaultContentRepositoryForNewSites})}
 
         <f:if condition="{sitePackages -> f:count()} > 0">
           <f:then>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -2,7 +2,13 @@
 <f:layout name="BackendSubModule" />
 
 <f:section name="content">
-	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')}</h2>
+	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')} <i>(Deprecated)</i></h2>
+
+	<br>
+	Using the sites management module for creation sites is deprecated please consider using the command line instead.
+	<br>
+	For example <code>./flow site:importall</code> for importing from a package or <code>./flow site:create</code> to create a new site.
+	<br>
 	All site creations will target the content repository: "{defaultContentRepositoryForNewSites}"
 
   <div class="neos-row-fluid">

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -71,6 +71,19 @@
         </f:if>
       </fieldset>
     </f:form>
+
+		<div class="neos neos-row-fluid neos-span3">
+			<legend>Create a new site-package</legend>
+			NOTE: The functionality to create site packages via this module was removed as being too fragile.
+			To get started with neos head over to the setup:
+			<br>
+			<br>
+			<a href="/setup" class="neos-button neos-button-primary">/setup</a>
+			<br>
+			<br>
+			To kickstart a new package use: <code>./flow kickstart:site</code>
+		</div>
+
   </div>
   <div class="neos-footer">
     <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</f:link.action>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -548,12 +548,6 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 			<trans-unit id="sites.theSiteHasBeenImported.body" xml:space="preserve">
 				<source>The site has been imported.</source>
 			</trans-unit>
-			<trans-unit id="sites.importError.title" xml:space="preserve">
-				<source>Import error</source>
-			</trans-unit>
-			<trans-unit id="sites.importError.body" xml:space="preserve">
-				<source>Error: During the import of the "Sites.xml" from the package "{0}" an exception occurred: {1}</source>
-			</trans-unit>
 			<trans-unit id="sites.siteCreationError.siteWithSiteNodeNameAlreadyExists.title" xml:space="preserve">
 				<source>Site creation error</source>
 			</trans-unit>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -359,9 +359,6 @@
 			<trans-unit id="sites.confirmDelete" xml:space="preserve">
 				<source>Yes, delete the site</source>
 			</trans-unit>
-			<trans-unit id="sites.import" xml:space="preserve">
-				<source>Import a site</source>
-			</trans-unit>
 			<trans-unit id="sites.select" xml:space="preserve">
 				<source>Select a site package</source>
 			</trans-unit>
@@ -544,9 +541,6 @@ Click on one of the nodes to only see its fallbacks and variants. Click again to
 			</trans-unit>
 			<trans-unit id="sites.update.body" xml:space="preserve">
 				<source>The site "{0}" has been updated.</source>
-			</trans-unit>
-			<trans-unit id="sites.theSiteHasBeenImported.body" xml:space="preserve">
-				<source>The site has been imported.</source>
 			</trans-unit>
 			<trans-unit id="sites.siteCreationError.siteWithSiteNodeNameAlreadyExists.title" xml:space="preserve">
 				<source>Site creation error</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -368,6 +368,9 @@
 			<trans-unit id="sites.createBlank" xml:space="preserve">
 				<source>Create a blank site</source>
 			</trans-unit>
+      <trans-unit id="sites.creationContentRepository" xml:space="preserve">
+				<source>In the content repository: "{0}"</source>
+			</trans-unit>
 			<trans-unit id="sites.documentType" xml:space="preserve">
 				<source>Select a document nodeType</source>
 			</trans-unit>


### PR DESCRIPTION
Resolves: https://github.com/neos/neos-development-collection/issues/4719

In https://github.com/neos/neos-development-collection/pull/5139 i removed the capabilities to create composer packages via web request which is now obsolete as we have the new CLI / Web setup: https://github.com/neos/neos-development-collection/issues/4243

Now we can also reimplement 'import site' based on new SiteImportService from https://github.com/neos/neos-development-collection/pull/5307 - the thing is this comes with some limitations like in use with CLI:

- as proposed here https://github.com/neos/neos-development-collection/issues/4470#issuecomment-2432140074 the site must have a field to define the contentRepositoryId. In the current state we can only know via the to be created site name plus the site configuration in `Neos.Neos.sites` via its name or the fallback `*` which is the 'destined' content repository.

- a current limitation of the setup is that it can really only be executed once. After the events are set deleting the site (soft, without pruning the cr) a reimport would just duplicate the events again which is not the desired step probably. For that we allow to prune the site via `flow cr:pruneAll`. Those steps are to be used with care and not available via GUI.

The advantage CLI gives us is that for example failures in the done replay and all other steps are not obscured and can easily be be debugged. Also for managing multiple content repositories or changing dimensions configuration changes have to be undertaken which is closer to CLI.

Further we found out that the limitation of running the import only once makes it unusable with no site setup because the backend doesnt really work and we can get rid of the import functionality: https://github.com/neos/neos-development-collection/issues/4719#issuecomment-2598274287


----------

Bugfix: Use `withoutAuthorizationChecks` to remove site via user interface

The CR security was introduced with https://github.com/neos/neos-development-collection/pull/5298

And now fails when fetching the content graph or deleting nodes (see bug https://github.com/neos/neos-development-collection/issues/5429):

> Read access denied for workspace "user-editor": User is a Neos Administrator without explicit role for workspace "user-editor"

The herby proposed fix is not perfect but so is the whole site deletion, instead only the base workspace should need to be deleted and the others need to be rebased.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
