### PR TITLE
TASK: Make nullable parameter explicit to become PHP 8.4 compatible

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -399,7 +399,7 @@ class ProjectionContentGraph
     public function findIngoingHierarchyRelationsForNode(
         NodeRelationAnchorPoint $childAnchorPoint,
         ContentStreamId $contentStreamId,
-        DimensionSpacePointSet $restrictToSet = null
+        ?DimensionSpacePointSet $restrictToSet = null
     ): array {
         $ingoingHierarchyRelationsStatement = <<<SQL
             SELECT
@@ -439,7 +439,7 @@ class ProjectionContentGraph
     public function findOutgoingHierarchyRelationsForNode(
         NodeRelationAnchorPoint $parentAnchorPoint,
         ContentStreamId $contentStreamId,
-        DimensionSpacePointSet $restrictToSet = null
+        ?DimensionSpacePointSet $restrictToSet = null
     ): array {
         $outgoingHierarchyRelationsStatement = <<<SQL
             SELECT
@@ -512,7 +512,7 @@ class ProjectionContentGraph
     public function findIngoingHierarchyRelationsForNodeAggregate(
         ContentStreamId $contentStreamId,
         NodeAggregateId $nodeAggregateId,
-        DimensionSpacePointSet $dimensionSpacePointSet = null
+        ?DimensionSpacePointSet $dimensionSpacePointSet = null
     ): array {
         $ingoingHierarchyRelationsStatement = <<<SQL
             SELECT

--- a/Neos.ContentRepository.BehavioralTests/Classes/ProjectionRaceConditionTester/Command/RaceConditionTrackerCommandController.php
+++ b/Neos.ContentRepository.BehavioralTests/Classes/ProjectionRaceConditionTester/Command/RaceConditionTrackerCommandController.php
@@ -52,7 +52,7 @@ final class RaceConditionTrackerCommandController extends CommandController
      * @param string|null $storeTrace The path to store the full trace in NDJSON format (optional).
      * @internal
      */
-    public function analyzeTraceCommand(string $storeTrace = null): void
+    public function analyzeTraceCommand(?string $storeTrace = null): void
     {
         RedisInterleavingLogger::connect($this->configuration['redis']['host'], $this->configuration['redis']['port']);
         $traces = RedisInterleavingLogger::getTraces();

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/InterDimensionalVariationGraph.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/InterDimensionalVariationGraph.php
@@ -326,7 +326,7 @@ final class InterDimensionalVariationGraph
     public function getSpecializationSet(
         DimensionSpacePoint $origin,
         bool $includeOrigin = true,
-        DimensionSpacePointSet $excludedSet = null
+        ?DimensionSpacePointSet $excludedSet = null
     ): DimensionSpacePointSet {
         if (!$this->contentDimensionZookeeper->getAllowedDimensionSubspace()->contains($origin)) {
             throw Exception\DimensionSpacePointNotFound::becauseItIsNotWithinTheAllowedDimensionSubspace($origin);

--- a/Neos.ContentRepository.Core/Classes/EventStore/DecoratedEvent.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/DecoratedEvent.php
@@ -30,10 +30,10 @@ final readonly class DecoratedEvent
      */
     public static function create(
         DecoratedEvent|EventInterface $event,
-        EventId $eventId = null,
-        EventMetadata|array $metadata = null,
-        EventId|CausationId $causationId = null,
-        CorrelationId $correlationId = null,
+        ?EventId $eventId = null,
+        EventMetadata|array|null $metadata = null,
+        EventId|CausationId|null $causationId = null,
+        ?CorrelationId $correlationId = null,
     ): self {
         if ($event instanceof EventInterface) {
             $event = new self($event, null, null, null, null);

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNodeAndSerializedProperties.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/Command/CreateNodeAggregateWithNodeAndSerializedProperties.php
@@ -70,7 +70,7 @@ final readonly class CreateNodeAggregateWithNodeAndSerializedProperties implemen
      * @param SerializedPropertyValues|null $initialPropertyValues The node's initial property values (serialized). Will be merged over the node type's default property values
      * @param SerializedNodeReferences|null $references The node's initial references (serialized).
      */
-    public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, NodeTypeName $nodeTypeName, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, NodeAggregateId $succeedingSiblingNodeAggregateId = null, SerializedPropertyValues $initialPropertyValues = null, SerializedNodeReferences $references = null): self
+    public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, NodeTypeName $nodeTypeName, OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, ?NodeAggregateId $succeedingSiblingNodeAggregateId = null, ?SerializedPropertyValues $initialPropertyValues = null, ?SerializedNodeReferences $references = null): self
     {
         return new self($workspaceName, $nodeAggregateId, $nodeTypeName, $originDimensionSpacePoint, $parentNodeAggregateId, $initialPropertyValues ?? SerializedPropertyValues::createEmpty(), $succeedingSiblingNodeAggregateId, null, NodeAggregateIdsByNodePaths::createEmpty(), $references ?: SerializedNodeReferences::createEmpty());
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ArrayNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ArrayNormalizer.php
@@ -14,12 +14,12 @@ final class ArrayNormalizer implements DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $data;
     }
 
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization($data, $type, ?string $format = null)
     {
         return $type === 'array';
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/CollectionTypeDenormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/CollectionTypeDenormalizer.php
@@ -34,7 +34,7 @@ final class CollectionTypeDenormalizer implements
      * @return array<int|string,mixed>
      * @throws NotNormalizableValueException
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): array
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): array
     {
         if ($this->serializer === null) {
             throw new BadMethodCallException('Please set a serializer before calling denormalize()!', 1596463254);
@@ -72,7 +72,7 @@ final class CollectionTypeDenormalizer implements
      * {@inheritdoc}
      * @param array<string,mixed> $context
      */
-    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         if ($this->serializer === null) {
             throw new BadMethodCallException(sprintf(

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ScalarNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ScalarNormalizer.php
@@ -17,12 +17,12 @@ final class ScalarNormalizer implements NormalizerInterface, DenormalizerInterfa
      * @param array<string,mixed> $context
      * @return int|float|bool|string
      */
-    public function normalize($object, string $format = null, array $context = []): mixed
+    public function normalize($object, ?string $format = null, array $context = []): mixed
     {
         return $object;
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         $type = TypeHandling::getTypeForValue($data);
         return TypeHandling::isSimpleType($type) && !TypeHandling::isCollectionType($type);
@@ -31,12 +31,12 @@ final class ScalarNormalizer implements NormalizerInterface, DenormalizerInterfa
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $data;
     }
 
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization($data, $type, ?string $format = null)
     {
         return TypeHandling::isSimpleType($type) && !TypeHandling::isCollectionType($type);
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/UriNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/UriNormalizer.php
@@ -16,12 +16,12 @@ final class UriNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function normalize($data, string $format = null, array $context = []): string
+    public function normalize($data, ?string $format = null, array $context = []): string
     {
         return (string)$data;
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $data instanceof Uri;
     }
@@ -29,12 +29,12 @@ final class UriNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, ?string $format = null, array $context = [])
     {
         return new Uri($data);
     }
 
-    public function supportsDenormalization($data, string $type, string $format = null)
+    public function supportsDenormalization($data, string $type, ?string $format = null)
     {
         return is_string($data) && $type === Uri::class;
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectArrayDenormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectArrayDenormalizer.php
@@ -14,12 +14,12 @@ final class ValueObjectArrayDenormalizer implements DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $type::fromArray($data);
     }
 
-    public function supportsDenormalization($data, $type, string $format = null): bool
+    public function supportsDenormalization($data, $type, ?string $format = null): bool
     {
         return is_array($data) && class_exists($type) && method_exists($type, 'fromArray');
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectBoolDenormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectBoolDenormalizer.php
@@ -14,12 +14,12 @@ final class ValueObjectBoolDenormalizer implements DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $type::fromBool($data);
     }
 
-    public function supportsDenormalization($data, $type, string $format = null): bool
+    public function supportsDenormalization($data, $type, ?string $format = null): bool
     {
         return is_bool($data) && class_exists($type) && method_exists($type, 'fromBool');
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectFloatDenormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectFloatDenormalizer.php
@@ -14,12 +14,12 @@ final class ValueObjectFloatDenormalizer implements DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $type::fromFloat($data);
     }
 
-    public function supportsDenormalization($data, $type, string $format = null): bool
+    public function supportsDenormalization($data, $type, ?string $format = null): bool
     {
         return is_float($data) && class_exists($type) && method_exists($type, 'fromFloat');
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectIntDenormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectIntDenormalizer.php
@@ -14,12 +14,12 @@ final class ValueObjectIntDenormalizer implements DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $type::fromInt($data);
     }
 
-    public function supportsDenormalization($data, $type, string $format = null): bool
+    public function supportsDenormalization($data, $type, ?string $format = null): bool
     {
         return is_int($data) && class_exists($type) && method_exists($type, 'fromInt');
     }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectStringDenormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/Normalizer/ValueObjectStringDenormalizer.php
@@ -14,12 +14,12 @@ final class ValueObjectStringDenormalizer implements DenormalizerInterface
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $type::fromString($data);
     }
 
-    public function supportsDenormalization($data, $type, string $format = null): bool
+    public function supportsDenormalization($data, $type, ?string $format = null): bool
     {
         return is_string($data) && class_exists($type) && method_exists($type, 'fromString');
     }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountAncestorNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountAncestorNodesFilter.php
@@ -32,7 +32,7 @@ final readonly class CountAncestorNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null
+        NodeTypeCriteria|string|null $nodeTypes = null
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -52,7 +52,7 @@ final readonly class CountAncestorNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null
+        NodeTypeCriteria|string|null $nodeTypes = null
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountBackReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountBackReferencesFilter.php
@@ -49,12 +49,12 @@ final readonly class CountBackReferencesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -89,12 +89,12 @@ final readonly class CountBackReferencesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
@@ -41,9 +41,9 @@ final readonly class CountChildNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -69,9 +69,9 @@ final readonly class CountChildNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountDescendantNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountDescendantNodesFilter.php
@@ -41,9 +41,9 @@ final readonly class CountDescendantNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -69,9 +69,9 @@ final readonly class CountDescendantNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountReferencesFilter.php
@@ -49,12 +49,12 @@ final readonly class CountReferencesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -89,12 +89,12 @@ final readonly class CountReferencesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindAncestorNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindAncestorNodesFilter.php
@@ -32,7 +32,7 @@ final readonly class FindAncestorNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null
+        NodeTypeCriteria|string|null $nodeTypes = null
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -47,7 +47,7 @@ final readonly class FindAncestorNodesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null
+        NodeTypeCriteria|string|null $nodeTypes = null
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindBackReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindBackReferencesFilter.php
@@ -52,14 +52,14 @@ final readonly class FindBackReferencesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -98,14 +98,14 @@ final readonly class FindBackReferencesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindChildNodesFilter.php
@@ -44,11 +44,11 @@ final readonly class FindChildNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -78,11 +78,11 @@ final readonly class FindChildNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindDescendantNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindDescendantNodesFilter.php
@@ -44,11 +44,11 @@ final readonly class FindDescendantNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -78,11 +78,11 @@ final readonly class FindDescendantNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindPrecedingSiblingNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindPrecedingSiblingNodesFilter.php
@@ -44,11 +44,11 @@ final readonly class FindPrecedingSiblingNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -78,11 +78,11 @@ final readonly class FindPrecedingSiblingNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindReferencesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindReferencesFilter.php
@@ -51,14 +51,14 @@ final readonly class FindReferencesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -97,14 +97,14 @@ final readonly class FindReferencesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $nodeSearchTerm = null,
-        PropertyValueCriteriaInterface|string $nodePropertyValue = null,
-        SearchTerm|string $referenceSearchTerm = null,
-        PropertyValueCriteriaInterface|string $referencePropertyValue = null,
-        ReferenceName|string $referenceName = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $nodeSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $nodePropertyValue = null,
+        SearchTerm|string|null $referenceSearchTerm = null,
+        PropertyValueCriteriaInterface|string|null $referencePropertyValue = null,
+        ReferenceName|string|null $referenceName = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindRootNodeAggregatesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindRootNodeAggregatesFilter.php
@@ -33,7 +33,7 @@ final readonly class FindRootNodeAggregatesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeName|string $nodeTypeName = null,
+        NodeTypeName|string|null $nodeTypeName = null,
     ): self {
         if (is_string($nodeTypeName)) {
             $nodeTypeName = NodeTypeName::fromString($nodeTypeName);
@@ -48,7 +48,7 @@ final readonly class FindRootNodeAggregatesFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeName $nodeTypeName = null,
+        ?NodeTypeName $nodeTypeName = null,
     ): self {
         return self::create(
             $nodeTypeName ?? $this->nodeTypeName,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindSubtreeFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindSubtreeFilter.php
@@ -33,8 +33,8 @@ final readonly class FindSubtreeFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        int $maximumLevels = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        ?int $maximumLevels = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -49,8 +49,8 @@ final readonly class FindSubtreeFilter
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        int $maximumLevels = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        ?int $maximumLevels = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindSucceedingSiblingNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindSucceedingSiblingNodesFilter.php
@@ -44,11 +44,11 @@ final readonly class FindSucceedingSiblingNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public static function create(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         if (is_string($nodeTypes)) {
             $nodeTypes = NodeTypeCriteria::fromFilterString($nodeTypes);
@@ -78,11 +78,11 @@ final readonly class FindSucceedingSiblingNodesFilter
      * @param Pagination|array<string, mixed>|null $pagination
      */
     public function with(
-        NodeTypeCriteria|string $nodeTypes = null,
-        SearchTerm|string $searchTerm = null,
-        PropertyValueCriteriaInterface|string $propertyValue = null,
-        Ordering|array $ordering = null,
-        Pagination|array $pagination = null,
+        NodeTypeCriteria|string|null $nodeTypes = null,
+        SearchTerm|string|null $searchTerm = null,
+        PropertyValueCriteriaInterface|string|null $propertyValue = null,
+        Ordering|array|null $ordering = null,
+        Pagination|array|null $pagination = null,
     ): self {
         return self::create(
             $nodeTypes ?? $this->nodeTypes,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Timestamps.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Timestamps.php
@@ -85,10 +85,10 @@ final readonly class Timestamps
      * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
      */
     public function with(
-        DateTimeImmutable $created = null,
-        DateTimeImmutable $originalCreated = null,
-        DateTimeImmutable $lastModified = null,
-        DateTimeImmutable $originalLastModified = null,
+        ?DateTimeImmutable $created = null,
+        ?DateTimeImmutable $originalCreated = null,
+        ?DateTimeImmutable $lastModified = null,
+        ?DateTimeImmutable $originalLastModified = null,
     ): self {
         return new self(
             $created ?? $this->created,

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -76,7 +76,7 @@ final class SubscriptionEngine
         return $errors === [] ? Result::success() : Result::failed(Errors::fromArray($errors));
     }
 
-    public function boot(SubscriptionEngineCriteria|null $criteria = null, \Closure $progressCallback = null, int $batchSize = null): ProcessedResult
+    public function boot(SubscriptionEngineCriteria|null $criteria = null, ?\Closure $progressCallback = null, ?int $batchSize = null): ProcessedResult
     {
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
         return $this->processExclusively(
@@ -84,7 +84,7 @@ final class SubscriptionEngine
         );
     }
 
-    public function catchUpActive(SubscriptionEngineCriteria|null $criteria = null, \Closure $progressCallback = null, int $batchSize = null): ProcessedResult
+    public function catchUpActive(SubscriptionEngineCriteria|null $criteria = null, ?\Closure $progressCallback = null, ?int $batchSize = null): ProcessedResult
     {
         $criteria ??= SubscriptionEngineCriteria::noConstraints();
         return $this->processExclusively(

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngineCriteria.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngineCriteria.php
@@ -21,7 +21,7 @@ final class SubscriptionEngineCriteria
      * @param SubscriptionIds|array<string|SubscriptionId>|null $ids
      */
     public static function create(
-        SubscriptionIds|array $ids = null
+        SubscriptionIds|array|null $ids = null
     ): self {
         if (is_array($ids)) {
             $ids = SubscriptionIds::fromArray($ids);

--- a/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionCriteria.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Store/SubscriptionCriteria.php
@@ -26,8 +26,8 @@ final readonly class SubscriptionCriteria
      * @param SubscriptionStatusFilter|null $status
      */
     public static function create(
-        SubscriptionIds|array $ids = null,
-        SubscriptionStatusFilter $status = null,
+        SubscriptionIds|array|null $ids = null,
+        ?SubscriptionStatusFilter $status = null,
     ): self {
         if (is_array($ids)) {
             $ids = SubscriptionIds::fromArray($ids);

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/Bootstrap/CrImportExportTrait.php
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/Bootstrap/CrImportExportTrait.php
@@ -222,7 +222,7 @@ trait CrImportExportTrait
      * @Then I expect a migration exception
      * @Then I expect a migration exception with the message
      */
-    public function iExpectAMigrationExceptionWithTheMessage(PyStringNode $expectedMessage = null): void
+    public function iExpectAMigrationExceptionWithTheMessage(?PyStringNode $expectedMessage = null): void
     {
         Assert::assertNotNull($this->crImportExportTrait_lastMigrationException, 'Expected the previous migration to lead to an exception, but no exception was thrown');
         if ($expectedMessage !== null) {

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/SiteCommandController.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Command/SiteCommandController.php
@@ -54,7 +54,7 @@ class SiteCommandController extends CommandController
      * @param string|null $config JSON encoded configuration, for example --config '{"dbal": {"dbname": "some-other-db"}, "resourcesPath": "/absolute-path/Data/Persistent/Resources", "rootNodes": {"/sites": "Neos.Neos:Sites", "/other": "My.Package:SomeOtherRoot"}}'
      * @throws \Exception
      */
-    public function exportLegacyDataCommand(string $path, string $contentRepository = 'default', string $config = null, bool $verbose = false): void
+    public function exportLegacyDataCommand(string $path, string $contentRepository = 'default', ?string $config = null, bool $verbose = false): void
     {
         Files::createDirectoryRecursively($path);
         if ($config !== null) {

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -97,7 +97,7 @@ class FeatureContext implements Context
     /**
      * @When I run the event migration
      */
-    public function iRunTheEventMigration(RootNodeTypeMapping $rootNodeTypeMapping = null): void
+    public function iRunTheEventMigration(?RootNodeTypeMapping $rootNodeTypeMapping = null): void
     {
         $nodeTypeManager = $this->currentContentRepository->getNodeTypeManager();
         $propertyMapper = $this->getObject(PropertyMapper::class);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -315,7 +315,7 @@ trait GenericCommandExecutionAndEventPublication
      * @Then the last command should have thrown an exception of type :shortExceptionName with message:
      * @Then the last command should have thrown an exception of type :shortExceptionName
      */
-    public function theLastCommandShouldHaveThrown(string $shortExceptionName, ?int $expectedCode = null, PyStringNode $expectedMessage = null): void
+    public function theLastCommandShouldHaveThrown(string $shortExceptionName, ?int $expectedCode = null, ?PyStringNode $expectedMessage = null): void
     {
         if ($shortExceptionName === 'WorkspaceRebaseFailed' || $shortExceptionName === 'PartialWorkspaceRebaseFailed') {
             throw new \RuntimeException('Please use the assertion "the last command should have thrown the WorkspaceRebaseFailed exception with" instead.');

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -50,7 +50,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findChildNodes query for parent node aggregate id "(?<parentNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
-    public function iExecuteTheFindChildNodesQueryIExpectTheFollowingNodes(string $parentNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', int $expectedTotalCount = null): void
+    public function iExecuteTheFindChildNodesQueryIExpectTheFollowingNodes(string $parentNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', ?int $expectedTotalCount = null): void
     {
         $parentNodeAggregateId = NodeAggregateId::fromString($parentNodeIdSerialized);
         $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
@@ -67,7 +67,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findReferences query for node aggregate id "(?<nodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the references '(?<referencesSerialized>[^']*)'|no references) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
-    public function iExecuteTheFindReferencesQueryIExpectTheFollowingReferences(string $nodeIdSerialized, string $filterSerialized = null, string $referencesSerialized = null, int $expectedTotalCount = null): void
+    public function iExecuteTheFindReferencesQueryIExpectTheFollowingReferences(string $nodeIdSerialized, ?string $filterSerialized = null, ?string $referencesSerialized = null, ?int $expectedTotalCount = null): void
     {
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedReferences = $referencesSerialized !== null ? json_decode($referencesSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
@@ -87,7 +87,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findBackReferences query for node aggregate id "(?<nodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the references '(?<referencesSerialized>[^']*)'|no references) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
-    public function iExecuteTheFindBackReferencesQueryIExpectTheFollowingReferences(string $nodeIdSerialized, string $filterSerialized = null, string $referencesSerialized = null, int $expectedTotalCount = null): void
+    public function iExecuteTheFindBackReferencesQueryIExpectTheFollowingReferences(string $nodeIdSerialized, ?string $filterSerialized = null, ?string $referencesSerialized = null, ?int $expectedTotalCount = null): void
     {
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedReferences = $referencesSerialized !== null ? json_decode($referencesSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
@@ -107,7 +107,7 @@ trait NodeTraversalTrait
      * @When I execute the findNodeById query for node aggregate id :nodeIdSerialized I expect no node to be returned
      * @When I execute the findNodeById query for node aggregate id :nodeIdSerialized I expect the node :expectedNodeIdSerialized to be returned
      */
-    public function iExecuteTheFindNodeByIdQueryIExpectTheFollowingNodes(string $nodeIdSerialized, string $expectedNodeIdSerialized = null): void
+    public function iExecuteTheFindNodeByIdQueryIExpectTheFollowingNodes(string $nodeIdSerialized, ?string $expectedNodeIdSerialized = null): void
     {
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
@@ -120,7 +120,7 @@ trait NodeTraversalTrait
      * @When I execute the findParentNode query for node aggregate id :nodeIdSerialized I expect no node to be returned
      * @When I execute the findParentNode query for node aggregate id :nodeIdSerialized I expect the node :expectedNodeIdSerialized to be returned
      */
-    public function iExecuteTheFindParentNodeQueryIExpectTheFollowingNodes(string $nodeIdSerialized, string $expectedNodeIdSerialized = null): void
+    public function iExecuteTheFindParentNodeQueryIExpectTheFollowingNodes(string $nodeIdSerialized, ?string $expectedNodeIdSerialized = null): void
     {
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
@@ -133,7 +133,7 @@ trait NodeTraversalTrait
      * @When I execute the findNodeByPath query for path :pathSerialized and starting node aggregate id :startingNodeIdSerialized I expect no node to be returned
      * @When I execute the findNodeByPath query for path :pathSerialized and starting node aggregate id :startingNodeIdSerialized I expect the node :expectedNodeIdSerialized to be returned
      */
-    public function iExecuteTheFindNodeByPathQueryIExpectTheFollowingNodes(string $pathSerialized, string $startingNodeIdSerialized, string $expectedNodeIdSerialized = null): void
+    public function iExecuteTheFindNodeByPathQueryIExpectTheFollowingNodes(string $pathSerialized, string $startingNodeIdSerialized, ?string $expectedNodeIdSerialized = null): void
     {
         $path = NodePath::fromString($pathSerialized);
         $startingNodeAggregateId = NodeAggregateId::fromString($startingNodeIdSerialized);
@@ -147,7 +147,7 @@ trait NodeTraversalTrait
      * @When I execute the findNodeByAbsolutePath query for path :pathSerialized I expect no node to be returned
      * @When I execute the findNodeByAbsolutePath query for path :pathSerialized I expect the node :expectedNodeIdSerialized to be returned
      */
-    public function iExecuteTheFindNodeByAbsolutePathQueryIExpectTheFollowingNodes(string $pathSerialized, string $expectedNodeIdSerialized = null): void
+    public function iExecuteTheFindNodeByAbsolutePathQueryIExpectTheFollowingNodes(string $pathSerialized, ?string $expectedNodeIdSerialized = null): void
     {
         $path = AbsoluteNodePath::fromString($pathSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
@@ -160,7 +160,7 @@ trait NodeTraversalTrait
      * @When I execute the findNodeByPath query for parent node aggregate id :parentNodeIdSerialized and node name :edgeNameSerialized as path I expect no node to be returned
      * @When I execute the findNodeByPath query for parent node aggregate id :parentNodeIdSerialized and node name :edgeNameSerialized as path I expect the node :expectedNodeIdSerialized to be returned
      */
-    public function iExecuteTheFindChildNodeByNodeNameQueryIExpectTheFollowingNodes(string $parentNodeIdSerialized, string $edgeNameSerialized, string $expectedNodeIdSerialized = null): void
+    public function iExecuteTheFindChildNodeByNodeNameQueryIExpectTheFollowingNodes(string $parentNodeIdSerialized, string $edgeNameSerialized, ?string $expectedNodeIdSerialized = null): void
     {
         $parentNodeAggregateId = NodeAggregateId::fromString($parentNodeIdSerialized);
         $edgeName = NodeName::fromString($edgeNameSerialized);
@@ -173,7 +173,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findSucceedingSiblingNodes query for sibling node aggregate id "(?<siblingNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned$/
      */
-    public function iExecuteTheFindSucceedingSiblingNodesQueryIExpectTheFollowingNodes(string $siblingNodeIdSerialized, string $filterSerialized = null, string $expectedNodeIdsSerialized = null): void
+    public function iExecuteTheFindSucceedingSiblingNodesQueryIExpectTheFollowingNodes(string $siblingNodeIdSerialized, ?string $filterSerialized = null, ?string $expectedNodeIdsSerialized = null): void
     {
         $siblingNodeAggregateId = NodeAggregateId::fromString($siblingNodeIdSerialized);
         $expectedNodeIds = $expectedNodeIdsSerialized !== null ? array_filter(explode(',', $expectedNodeIdsSerialized)) : [];
@@ -190,7 +190,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findPrecedingSiblingNodes query for sibling node aggregate id "(?<siblingNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned$/
      */
-    public function iExecuteTheFindPrecedingSiblingNodesQueryIExpectTheFollowingNodes(string $siblingNodeIdSerialized, string $filterSerialized = null, string $expectedNodeIdsSerialized = null): void
+    public function iExecuteTheFindPrecedingSiblingNodesQueryIExpectTheFollowingNodes(string $siblingNodeIdSerialized, ?string $filterSerialized = null, ?string $expectedNodeIdsSerialized = null): void
     {
         $siblingNodeAggregateId = NodeAggregateId::fromString($siblingNodeIdSerialized);
         $expectedNodeIds = $expectedNodeIdsSerialized !== null ? array_filter(explode(',', $expectedNodeIdsSerialized)) : [];
@@ -208,7 +208,7 @@ trait NodeTraversalTrait
      * @When I execute the retrieveNodePath query for node aggregate id :nodeIdSerialized I expect the path :expectedPathSerialized to be returned
      * @When I execute the retrieveNodePath query for node aggregate id :nodeIdSerialized I expect an exception :expectedExceptionMessage
      */
-    public function iExecuteTheRetrieveNodePathQueryIExpectTheFollowingNodes(string $nodeIdSerialized, string $expectedPathSerialized = null, string $expectedExceptionMessage = null): void
+    public function iExecuteTheRetrieveNodePathQueryIExpectTheFollowingNodes(string $nodeIdSerialized, ?string $expectedPathSerialized = null, ?string $expectedExceptionMessage = null): void
     {
         try {
             $actualNodePath = $this->getCurrentSubgraph()->retrieveNodePath(NodeAggregateId::fromString($nodeIdSerialized));
@@ -231,7 +231,7 @@ trait NodeTraversalTrait
      * @When I execute the findSubtree query for entry node aggregate id :entryNodeIdSerialized and filter :filterSerialized I expect no results
      * @When /^I execute the findSubtree query for entry node aggregate id "(?<entryNodeIdSerialized>[^"]*)" I expect the following tree (?<withTags>with tags):$/
      */
-    public function iExecuteTheFindSubtreeQueryIExpectTheFollowingTrees(string $entryNodeIdSerialized, string $filterSerialized = null, PyStringNode $expectedTree = null, string $withTags = null): void
+    public function iExecuteTheFindSubtreeQueryIExpectTheFollowingTrees(string $entryNodeIdSerialized, ?string $filterSerialized = null, ?PyStringNode $expectedTree = null, ?string $withTags = null): void
     {
         $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
@@ -263,7 +263,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findDescendantNodes query for entry node aggregate id "(?<entryNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
-    public function iExecuteTheFindDescendantNodesQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', int $expectedTotalCount = null): void
+    public function iExecuteTheFindDescendantNodesQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', ?int $expectedTotalCount = null): void
     {
         $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
         $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
@@ -280,7 +280,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findAncestorNodes query for entry node aggregate id "(?<entryNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
-    public function iExecuteTheFindAncestorNodesQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', int $expectedTotalCount = null): void
+    public function iExecuteTheFindAncestorNodesQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', string $expectedNodeIdsSerialized = '', ?int $expectedTotalCount = null): void
     {
         $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
         $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
@@ -308,7 +308,7 @@ trait NodeTraversalTrait
     /**
      * @When /^I execute the findClosestNode query for entry node aggregate id "(?<entryNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the node "(?<expectedNodeId>[^"]*)"|no node) to be returned?$/
      */
-    public function iExecuteTheFindClosestNodeQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', string $expectedNodeId = null): void
+    public function iExecuteTheFindClosestNodeQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, string $filterSerialized = '', ?string $expectedNodeId = null): void
     {
         $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
@@ -352,7 +352,7 @@ trait NodeTraversalTrait
      * @When I execute the findRootNodeByType query for node type :serializedNodeTypeName I expect no node to be returned
      * @When I execute the findRootNodeByType query for node type :serializedNodeTypeName I expect the node :serializedExpectedNodeId to be returned
      */
-    public function iExecuteTheFindRootNodeByTypeQueryIExpectTheFollowingNodes(string $serializedNodeTypeName, string $serializedExpectedNodeId = null): void
+    public function iExecuteTheFindRootNodeByTypeQueryIExpectTheFollowingNodes(string $serializedNodeTypeName, ?string $serializedExpectedNodeId = null): void
     {
         $expectedNodeAggregateId = $serializedExpectedNodeId !== null
             ? NodeAggregateId::fromString($serializedExpectedNodeId)

--- a/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Unit/NodeSubjectProvider.php
@@ -81,7 +81,7 @@ final class NodeSubjectProvider
 
     public function createMinimalNodeOfType(
         NodeTypeName $nodeTypeName,
-        SerializedPropertyValues $propertyValues = null,
+        ?SerializedPropertyValues $propertyValues = null,
         ?NodeName $nodeName = null
     ): Node {
         return Node::create(

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentGraphIntegrityCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentGraphIntegrityCommandController.php
@@ -30,7 +30,7 @@ final class ContentGraphIntegrityCommandController extends CommandController
     #[Flow\Inject()]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    public function runViolationDetectionCommand(string $contentRepository = 'default', string $outputMode = null): void
+    public function runViolationDetectionCommand(string $contentRepository = 'default', ?string $outputMode = null): void
     {
         $detectionRunner = $this->contentRepositoryRegistry->buildService(
             ContentRepositoryId::fromString($contentRepository),

--- a/Neos.ContentRepositoryRegistry/Classes/Command/StructureAdjustmentsCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/StructureAdjustmentsCommandController.php
@@ -35,7 +35,7 @@ final class StructureAdjustmentsCommandController extends CommandController
      * @param string|null $nodeType The node type to find structure adjustments for. If not provided, all adjustments will be shown. (Default: null)
      * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      */
-    public function detectCommand(string $nodeType = null, string $contentRepository = 'default'): void
+    public function detectCommand(?string $nodeType = null, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $structureAdjustmentService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new StructureAdjustmentServiceFactory());
@@ -58,7 +58,7 @@ final class StructureAdjustmentsCommandController extends CommandController
      * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @return void
      */
-    public function fixCommand(string $nodeType = null, string $contentRepository = 'default'): void
+    public function fixCommand(?string $nodeType = null, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $structureAdjustmentService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new StructureAdjustmentServiceFactory());

--- a/Neos.ContentRepositoryRegistry/Classes/Infrastructure/Property/Normalizer/DoctrinePersistentObjectNormalizer.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Infrastructure/Property/Normalizer/DoctrinePersistentObjectNormalizer.php
@@ -30,7 +30,7 @@ final class DoctrinePersistentObjectNormalizer implements NormalizerInterface, D
      * @param array<string,mixed> $context
      * @return array<string,mixed>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         return [
             '__flow_object_type' => TypeHandling::getTypeForValue($object),
@@ -38,7 +38,7 @@ final class DoctrinePersistentObjectNormalizer implements NormalizerInterface, D
         ];
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return (
             $this->reflectionService->isClassAnnotatedWith(TypeHandling::getTypeForValue($data), Entity::class) ||
@@ -53,12 +53,12 @@ final class DoctrinePersistentObjectNormalizer implements NormalizerInterface, D
     /**
      * @param array<string,mixed> $context
      */
-    public function denormalize($data, $type, string $format = null, array $context = [])
+    public function denormalize($data, $type, ?string $format = null, array $context = [])
     {
         return $this->persistenceManager->getObjectByIdentifier($data['__identifier'], $data['__flow_object_type']);
     }
 
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization($data, $type, ?string $format = null)
     {
         // NOTE: we do not check for $type which is the expected type,
         // but we instead check for $data['__flow_object_type']. This is

--- a/Neos.Fusion/Classes/Core/Cache/FusionContextSerializer.php
+++ b/Neos.Fusion/Classes/Core/Cache/FusionContextSerializer.php
@@ -29,7 +29,7 @@ final class FusionContextSerializer implements NormalizerInterface, Denormalizer
     /**
      * @param array<int|string,mixed> $context
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
     {
         return $this->propertyMapper->convert($data, $type);
     }
@@ -38,17 +38,17 @@ final class FusionContextSerializer implements NormalizerInterface, Denormalizer
      * @param array<int|string,mixed> $context
      * @return array<int|string,mixed>
      */
-    public function normalize(mixed $object, string $format = null, array $context = [])
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
     {
         return $this->propertyMapper->convert($object, 'string');
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null)
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null)
     {
         return true;
     }
 
-    public function supportsNormalization(mixed $data, string $format = null)
+    public function supportsNormalization(mixed $data, ?string $format = null)
     {
         return true;
     }

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -23,7 +23,7 @@ readonly class AssetUsageIndexingProcessor
     /**
      * @param callable(string $message):void|null $callback
      */
-    public function buildIndex(ContentRepository $contentRepository, NodeTypeName $nodeTypeName, callable $callback = null): void
+    public function buildIndex(ContentRepository $contentRepository, NodeTypeName $nodeTypeName, ?callable $callback = null): void
     {
         $variationGraph = $contentRepository->getVariationGraph();
 

--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -172,7 +172,7 @@ class SiteCommandController extends CommandController
      * @param string|null $path relative or absolute path and filename to the export files
      * @return void
      */
-    public function importAllCommand(string $packageKey = null, string $path = null, string $contentRepository = 'default', bool $verbose = false): void
+    public function importAllCommand(?string $packageKey = null, ?string $path = null, string $contentRepository = 'default', bool $verbose = false): void
     {
         // TODO check if this warning is still necessary with Neos 9
         // Since this command uses a lot of memory when large sites are imported, we warn the user to watch for
@@ -212,7 +212,7 @@ class SiteCommandController extends CommandController
      * @param string|null $path relative or absolute path and filename to the export files
      * @return void
      */
-    public function exportAllCommand(string $packageKey = null, string $path = null, string $contentRepository = 'default', bool $verbose = false): void
+    public function exportAllCommand(?string $packageKey = null, ?string $path = null, string $contentRepository = 'default', bool $verbose = false): void
     {
         $path = $this->determineTargetPath($packageKey, $path);
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -140,7 +140,7 @@ class WorkspaceCommandController extends CommandController
      * @param string|null $description Optional description of the workspace
      * @throws WorkspaceAlreadyExists
      */
-    public function createRootCommand(string $name, string $contentRepository = 'default', string $title = null, string $description = null): void
+    public function createRootCommand(string $name, string $contentRepository = 'default', ?string $title = null, ?string $description = null): void
     {
         $workspaceName = WorkspaceName::fromString($name);
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
@@ -165,7 +165,7 @@ class WorkspaceCommandController extends CommandController
      * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
-    public function createPersonalCommand(string $workspace, string $owner, string $baseWorkspace = 'live', string $title = null, string $description = null, string $contentRepository = 'default'): void
+    public function createPersonalCommand(string $workspace, string $owner, string $baseWorkspace = 'live', ?string $title = null, ?string $description = null, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $workspaceOwner = $this->userService->getUser($owner);
@@ -197,7 +197,7 @@ class WorkspaceCommandController extends CommandController
      * @param string $contentRepository Identifier of the content repository. (Default: 'default')
      * @throws StopCommandException
      */
-    public function createSharedCommand(string $workspace, string $baseWorkspace = 'live', string $title = null, string $description = null, string $contentRepository = 'default'): void
+    public function createSharedCommand(string $workspace, string $baseWorkspace = 'live', ?string $title = null, ?string $description = null, string $contentRepository = 'default'): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $workspaceName = WorkspaceName::fromString($workspace);

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -223,7 +223,7 @@ class UserService
      * @param string $authenticationProviderName
      * @return ?string The username or null if the given user does not have a backend account
      */
-    public function getUsername(User $user, string $authenticationProviderName = null): ?string
+    public function getUsername(User $user, ?string $authenticationProviderName = null): ?string
     {
         $authenticationProviderName = $authenticationProviderName ?: $this->defaultAuthenticationProviderName;
         foreach ($user->getAccounts() as $account) {

--- a/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
@@ -122,7 +122,7 @@ final readonly class NodeUriBuilder
      *   - the live node address cannot be found in the projection
      *   Please consult the logs for further information.
      */
-    public function uriFor(NodeAddress $nodeAddress, Options $options = null): UriInterface
+    public function uriFor(NodeAddress $nodeAddress, ?Options $options = null): UriInterface
     {
         $options ??= Options::createEmpty();
 

--- a/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NeosFusionContextSerializer.php
@@ -42,7 +42,7 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
     /**
      * @param array<int|string,mixed> $context
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
     {
         if ($type === Node::class) {
             /** @var $data array<string, mixed> */
@@ -55,7 +55,7 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
      * @param array<int|string,mixed> $context
      * @return array<int|string,mixed>
      */
-    public function normalize(mixed $object, string $format = null, array $context = [])
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
     {
         if ($object instanceof Node) {
             return $this->serializeNode($object);
@@ -99,12 +99,12 @@ final class NeosFusionContextSerializer implements NormalizerInterface, Denormal
         return NodeAddress::fromNode($source)->jsonSerialize();
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null)
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null)
     {
         return true;
     }
 
-    public function supportsNormalization(mixed $data, string $format = null)
+    public function supportsNormalization(mixed $data, ?string $format = null)
     {
         return true;
     }

--- a/Neos.Neos/Classes/TypeConverter/NodeAddressToNodeConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/NodeAddressToNodeConverter.php
@@ -54,7 +54,7 @@ class NodeAddressToNodeConverter extends AbstractTypeConverter
         $source,
         $targetType = null,
         array $subProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null
+        ?PropertyMappingConfigurationInterface $configuration = null
     ) {
         $nodeAddress = NodeAddress::fromJsonString($source);
         $contentRepository = $this->contentRepositoryRegistry->get($nodeAddress->contentRepositoryId);

--- a/Neos.Neos/Classes/TypeConverter/NodeAddressToStringConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/NodeAddressToStringConverter.php
@@ -51,7 +51,7 @@ class NodeAddressToStringConverter extends AbstractTypeConverter
         $source,
         $targetType,
         array $convertedChildProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null
+        ?PropertyMappingConfigurationInterface $configuration = null
     ): string {
         return $source->toJson();
     }

--- a/Neos.Neos/Classes/TypeConverter/NodeToNodeAddressStringConverter.php
+++ b/Neos.Neos/Classes/TypeConverter/NodeToNodeAddressStringConverter.php
@@ -54,7 +54,7 @@ class NodeToNodeAddressStringConverter extends AbstractTypeConverter
         $source,
         $targetType = null,
         array $subProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null
+        ?PropertyMappingConfigurationInterface $configuration = null
     ) {
         return NodeAddress::fromNode($source)->toJson();
     }

--- a/Neos.Neos/Classes/ViewHelpers/Rendering/InPreviewModeViewHelper.php
+++ b/Neos.Neos/Classes/ViewHelpers/Rendering/InPreviewModeViewHelper.php
@@ -78,7 +78,7 @@ class InPreviewModeViewHelper extends AbstractViewHelper
         );
     }
 
-    public function render(Node $node = null, string $mode = null): bool
+    public function render(?Node $node = null, ?string $mode = null): bool
     {
         $renderingMode = $this->getContextVariable('renderingMode');
         if ($renderingMode instanceof RenderingMode) {

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/BrowserTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/BrowserTrait.php
@@ -90,7 +90,7 @@ trait BrowserTrait
      * @param string|null $alias
      * @return \Neos\Neos\FrontendRouting\NodeAddress
      */
-    protected function getCurrentNodeAddress(string $alias = null): NodeAddress
+    protected function getCurrentNodeAddress(?string $alias = null): NodeAddress
     {
         if ($alias === null) {
             $alias = 'DEFAULT';

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/ExceptionsTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/ExceptionsTrait.php
@@ -42,7 +42,7 @@ trait ExceptionsTrait
      * @Then an exception of type :expectedShortExceptionName should be thrown with message:
      * @Then an exception of type :expectedShortExceptionName should be thrown
      */
-    public function anExceptionShouldBeThrown(string $expectedShortExceptionName, ?int $code = null, PyStringNode $expectedExceptionMessage = null): void
+    public function anExceptionShouldBeThrown(string $expectedShortExceptionName, ?int $code = null, ?PyStringNode $expectedExceptionMessage = null): void
     {
         Assert::assertNotNull($this->lastCaughtException, 'Expected an exception but none was thrown');
         $lastCaughtExceptionShortName = (new \ReflectionClass($this->lastCaughtException))->getShortName();

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FlowSecurityTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FlowSecurityTrait.php
@@ -125,7 +125,7 @@ trait FlowSecurityTrait
             ) {
             }
 
-            public function getConfiguration(string $configurationType, string $configurationPath = null)
+            public function getConfiguration(string $configurationType, ?string $configurationPath = null)
             {
                 Assert::assertSame(ConfigurationManager::CONFIGURATION_TYPE_POLICY, $configurationType);
                 Assert::assertSame(null, $configurationPath);

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
@@ -84,7 +84,7 @@ trait RoutingTrait
      * @Given A site exists for node name :nodeName and domain :domain
      * @Given A site exists for node name :nodeName and domain :domain and package :package
      */
-    public function theSiteExists(string $nodeName, string $domain = null, string $package = null): void
+    public function theSiteExists(string $nodeName, ?string $domain = null, ?string $package = null): void
     {
         $siteRepository = $this->getObject(SiteRepository::class);
         $persistenceManager = $this->getObject(PersistenceManagerInterface::class);

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/UserServiceTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/UserServiceTrait.php
@@ -41,7 +41,7 @@ trait UserServiceTrait
      * @Given the Neos user :username exists with first name :firstName and last name :lastName
      * @Given the Neos user :username exists
      */
-    public function theNeosUserExists(string $username, string $id = null, string $firstName = null, string $lastName = null, string $roles = null): void
+    public function theNeosUserExists(string $username, ?string $id = null, ?string $firstName = null, ?string $lastName = null, ?string $roles = null): void
     {
         $this->createUser(
             username: $username,
@@ -72,7 +72,7 @@ trait UserServiceTrait
         }
     }
 
-    private function createUser(string $username, string $firstName = null, string $lastName = null, array $roleIdentifiers = null, string $id = null): void
+    private function createUser(string $username, ?string $firstName = null, ?string $lastName = null, ?array $roleIdentifiers = null, ?string $id = null): void
     {
         $userService = $this->getObject(UserService::class);
         $user = new User();

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
@@ -64,7 +64,7 @@ trait WorkspaceServiceTrait
      * @When the root workspace :workspaceName is created
      * @When the root workspace :workspaceName with title :title and description :description is created
      */
-    public function theRootWorkspaceIsCreated(string $workspaceName, string $title = null, string $description = null): void
+    public function theRootWorkspaceIsCreated(string $workspaceName, ?string $title = null, ?string $description = null): void
     {
         $this->tryCatchingExceptions(fn () => $this->getObject(WorkspaceService::class)->createRootWorkspace(
             $this->currentContentRepository->id,
@@ -272,7 +272,7 @@ trait WorkspaceServiceTrait
      * @When the role :role is assigned to workspace :workspaceName for group :groupName
      * @When the role :role is assigned to workspace :workspaceName for user :username
      */
-    public function theRoleIsAssignedToWorkspaceForGroupOrUser(string $role, string $workspaceName, string $groupName = null, string $username = null): void
+    public function theRoleIsAssignedToWorkspaceForGroupOrUser(string $role, string $workspaceName, ?string $groupName = null, ?string $username = null): void
     {
         if ($groupName !== null) {
             $subject = WorkspaceRoleSubject::createForGroup($groupName);
@@ -293,7 +293,7 @@ trait WorkspaceServiceTrait
      * @When the role for group :groupName is unassigned from workspace :workspaceName
      * @When the role for user :username is unassigned from workspace :workspaceName
      */
-    public function theRoleIsUnassignedFromWorkspace(string $workspaceName, string $groupName = null, string $username = null): void
+    public function theRoleIsUnassignedFromWorkspace(string $workspaceName, ?string $groupName = null, ?string $username = null): void
     {
         if ($groupName !== null) {
             $subject = WorkspaceRoleSubject::createForGroup($groupName);


### PR DESCRIPTION
I've used rector to migrate all occurrences.

https://getrector.com/rule-detail/explicit-nullable-param-type-rector

See also: https://github.com/neos/neos-development-collection/pull/5433