### PR TITLE
TASK: Render command references 

### DIFF
--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -620,7 +620,7 @@ Neos:
     commandReferences:
       'Neos:NeosCommands':
         title: 'Neos Command Reference'
-        packageKeys:
+        packageKeys: # These are actually no package keys, but rather command controller identifiers extracted out of namespaces.
           'Neos.Flow': true
           'Neos.Party': true
           'Neos.FluidAdaptor': true
@@ -628,8 +628,11 @@ Neos:
           'Neos.Welcome': true
           'Neos.Media': true
           'Neos.ContentRepository': true
+          'Neos.ContentRepository.Migration': true
           'Neos.SiteKickstarter': true
           'Neos.Neos': true
+          'Neos.Neos.Setup': true
+          'Neos.Setup': true
         savePathAndFilename: '%FLOW_PATH_PACKAGES%Neos/Neos.Neos/Documentation/References/CommandReference.rst'
     references:
       'TYPO3Fluid:ViewHelpers':


### PR DESCRIPTION
also for Neos.ContentRepository.Migration, Neos.Neos.Setup and Neos.Setup

They were simply missing in the list of command identifier which are allowed to render the command reference.

See: https://github.com/neos/neos-development-collection/pull/4177#issuecomment-2598509517
