### PR TITLE
BUGFIX: Fix return type error with `getUriForThumbnail()`

### DIFF
--- a/Neos.Media/Classes/Domain/Service/ThumbnailService.php
+++ b/Neos.Media/Classes/Domain/Service/ThumbnailService.php
@@ -255,7 +255,15 @@ class ThumbnailService
     {
         $resource = $thumbnail->getResource();
         if ($resource) {
-            return $this->resourceManager->getPublicPersistentResourceUri($resource);
+            $uri = $this->resourceManager->getPublicPersistentResourceUri($resource);
+            if ($uri === false) {
+                throw new ThumbnailServiceException(sprintf(
+                    'Could not generate URI for resource "%s".',
+                    $this->persistenceManager->getIdentifierByObject($resource)
+                ), 1737558490);
+            }
+
+            return $uri;
         }
 
         $staticResource = $thumbnail->getStaticResource();


### PR DESCRIPTION
In `getUriForThumbnail()` the result of `getPublicPersistentResourceUri()` is returned unchecked, but may be `false`. This conflicts with the declared return type `string`.

In that case an exception is now thrown (similar to when a static resource thumbnail URI cannot be generated).

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
