### PR TITLE
BUGFIX: fix error during site import

### DIFF
--- a/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
+++ b/Neos.Media/Classes/Domain/Model/Adjustment/CropImageAdjustment.php
@@ -161,10 +161,8 @@ class CropImageAdjustment extends AbstractImageAdjustment
 
     /**
      * This setter accepts strings in order to make configuration / mapping of settings easier.
-     *
-     * @param AspectRatio | string | null $aspectRatio
      */
-    public function setAspectRatio($aspectRatio = null): void
+    public function setAspectRatio(AspectRatio|string|null $aspectRatio = null): void
     {
         if ($aspectRatio === null) {
             $this->aspectRatioAsString = null;


### PR DESCRIPTION
This adjusts the annotation to work with Flow 8.3.13  ... before the type with spaces was interpreted as `mixed` and caused the following error during site:import.

```
During the import of the "Sites.xml" from the package "Neos.Demo" an exception occurred: Error: During import an exception occurred: "Could not convert target type "Neos\Media\Domain\Model\ImageVariant": Could not convert target type "Neos\Media\Domain\Model\Adjustment\CropImageAdjustment", at property path "aspectRatio": Could not find a suitable type converter for "mixed" because the class / interface "mixed" does not exist."., see log for further information.
```

Resolves: #5448

**Review instructions**

The new behavior was introduced to flow with pr: https://github.com/neos/flow-development-collection/pull/3424

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
