### PR TITLE
TASK: Add correlation id and debug metadata to events

### DIFF
--- a/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\EventStore;
 
-use Neos\ContentRepository\Core\EventStore\Events as DomainEvents;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasClosed;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasReopened;
 use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Event\ContentStreamWasCreated;
@@ -26,7 +25,6 @@ use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodePeerVariantWasCr
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeSpecializationVariantWasCreated;
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregateDimensionsWereUpdated;
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregateWithNodeWasCreated;
-use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
@@ -45,7 +43,6 @@ use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\EventData;
 use Neos\EventStore\Model\Event\EventId;
 use Neos\EventStore\Model\Event\EventType;
-use Neos\EventStore\Model\Events;
 
 /**
  * Central authority to convert Content Repository domain events to Event Store EventData and EventType, vice versa.
@@ -154,11 +151,6 @@ final readonly class EventNormalizer
             $causationId,
             $correlationId,
         );
-    }
-
-    public function normalizeEvents(DomainEvents $events): Events
-    {
-        return Events::fromArray($events->map($this->normalize(...)));
     }
 
     public function denormalize(Event $event): EventInterface

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -31,19 +31,15 @@ trait ContentStreamHandling
     private function closeContentStream(
         ContentStreamId $contentStreamId,
         Version $contentStreamVersion,
-        string $causationCommandClassName
     ): EventsToPublish {
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentStreamId)->getEventStreamName();
 
         return new EventsToPublish(
             $streamName,
             Events::with(
-                DecoratedEvent::create(
-                    new ContentStreamWasClosed(
-                        $contentStreamId,
-                    ),
-                    metadata: array_filter(['debug_causationCommand' => substr($causationCommandClassName, strrpos($causationCommandClassName, '\\') + 1)])
-                )
+                new ContentStreamWasClosed(
+                    $contentStreamId,
+                ),
             ),
             ExpectedVersion::fromVersion($contentStreamVersion)
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -55,16 +55,20 @@ trait ContentStreamHandling
      */
     private function reopenContentStreamWithoutConstraintChecks(
         ContentStreamId $contentStreamId,
+        string $debugReason
     ): EventsToPublish {
         return new EventsToPublish(
             ContentStreamEventStreamName::fromContentStreamId($contentStreamId)->getEventStreamName(),
             Events::with(
-                new ContentStreamWasReopened(
-                    $contentStreamId
-                ),
+                DecoratedEvent::create(
+                    new ContentStreamWasReopened(
+                        $contentStreamId
+                    ),
+                    metadata: array_filter(['debug_reason' => $debugReason])
+                )
             ),
             // We operate here without constraints on purpose to ensure this can be commited.
-            //Constraints have been checked beforehand and its expected that the content stream is closed.
+            // Constraints have been checked beforehand and its expected that the content stream is closed.
             ExpectedVersion::ANY()
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -79,16 +79,20 @@ trait ContentStreamHandling
     private function forkContentStream(
         ContentStreamId $newContentStreamId,
         ContentStreamId $sourceContentStreamId,
-        Version $sourceContentStreamVersion
+        Version $sourceContentStreamVersion,
+        string $debugReason
     ): EventsToPublish {
         return new EventsToPublish(
             ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName(),
             Events::with(
-                new ContentStreamWasForked(
-                    $newContentStreamId,
-                    $sourceContentStreamId,
-                    $sourceContentStreamVersion,
-                ),
+                DecoratedEvent::create(
+                    event: new ContentStreamWasForked(
+                        $newContentStreamId,
+                        $sourceContentStreamId,
+                        $sourceContentStreamVersion,
+                    ),
+                    metadata: ['debug_reason' => $debugReason]
+                )
             ),
             // NO_STREAM to ensure the "fork" happens as the first event of the new content stream
             ExpectedVersion::NO_STREAM()

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -206,7 +206,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion
+            $workspaceContentStreamVersion,
+            $command::class
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
@@ -242,7 +243,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 );
             } catch (ConcurrencyException $concurrencyException) {
                 yield $this->reopenContentStreamWithoutConstraintChecks(
-                    $workspace->currentContentStreamId
+                    $workspace->currentContentStreamId,
+                    sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
                 );
                 throw $concurrencyException;
             }
@@ -350,7 +352,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             // if we have no changes in the workspace we can fork from the base directly
             yield $this->closeContentStream(
                 $workspace->currentContentStreamId,
-                $workspaceContentStreamVersion
+                $workspaceContentStreamVersion,
+                $command::class
             );
 
             yield from $this->rebaseWorkspaceWithoutChanges(
@@ -371,7 +374,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion
+            $workspaceContentStreamVersion,
+            $command::class
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
@@ -458,7 +462,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion
+            $workspaceContentStreamVersion,
+            $command::class
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
@@ -579,7 +584,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion
+            $workspaceContentStreamVersion,
+            $command::class
         );
 
         if ($commandsToKeep->isEmpty()) {
@@ -790,8 +796,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $sourceContentStreamId,
             $sourceContentStreamVersion
         )->withAppendedEvents(Events::with(
-            new ContentStreamWasClosed(
-                $newContentStreamId
+            DecoratedEvent::create(
+                new ContentStreamWasClosed(
+                    $newContentStreamId
+                ),
+                metadata: ['debug_reason' => sprintf('Forking %s from %s to publish %d events', $newContentStreamId->value, $sourceContentStreamId->value, $eventsToApplyOnNewContentStream?->count() ?? 0)]
             )
         ));
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -206,8 +206,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion,
-            $command::class
+            $workspaceContentStreamVersion
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
@@ -354,8 +353,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             // if we have no changes in the workspace we can fork from the base directly
             yield $this->closeContentStream(
                 $workspace->currentContentStreamId,
-                $workspaceContentStreamVersion,
-                $command::class
+                $workspaceContentStreamVersion
             );
 
             yield from $this->rebaseWorkspaceWithoutChanges(
@@ -376,8 +374,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion,
-            $command::class
+            $workspaceContentStreamVersion
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
@@ -465,8 +462,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion,
-            $command::class
+            $workspaceContentStreamVersion
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
@@ -590,8 +586,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
-            $workspaceContentStreamVersion,
-            $command::class
+            $workspaceContentStreamVersion
         );
 
         if ($commandsToKeep->isEmpty()) {

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Exception/WorkspaceRebaseFailed.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceRebase/Exception/WorkspaceRebaseFailed.php
@@ -86,6 +86,6 @@ final class WorkspaceRebaseFailed extends \RuntimeException
     private static function renderMessage(ConflictingEvents $conflictingEvents): string
     {
         $firstConflict = $conflictingEvents->first();
-        return sprintf('"%s" and %d further conflicts', $firstConflict?->getException()->getMessage(), count($conflictingEvents) - 1);
+        return sprintf('"%s"%s', $firstConflict?->getException()->getMessage(), count($conflictingEvents) > 1 ? sprintf(' and %d further conflicts', count($conflictingEvents) - 1) : '');
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Service/ContentStreamPruner/ContentStreamForPruning.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentStreamPruner/ContentStreamForPruning.php
@@ -71,13 +71,13 @@ final readonly class ContentStreamForPruning
         ContentStreamId $id,
         ContentStreamStatus $status,
         ?ContentStreamId $sourceContentStreamId,
-        \DateTimeImmutable $create,
+        \DateTimeImmutable $created,
     ): self {
         return new self(
             $id,
             $status,
             $sourceContentStreamId,
-            $create,
+            $created,
             false
         );
     }

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -115,14 +115,14 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
         assert($eventsToPublish instanceof EventsToPublish);
 
         // set correlation id and add debug metadata
-        $correlationId = CorrelationId::fromString(UuidFactory::create());
+        $correlationId = CorrelationId::fromString(sprintf('StructureAdjustment_%s', bin2hex(random_bytes(9))));
         $isFirstEvent = true;
         $normalizedEvents = Events::fromArray($eventsToPublish->events->map(function (EventInterface|DecoratedEvent $event) use (
             &$isFirstEvent, $correlationId, $adjustment
         ) {
             $metadata = $event instanceof DecoratedEvent ? $event->eventMetadata?->value ?? [] : [];
             if ($isFirstEvent) {
-                $metadata['debug_structureAdjustment'] = mb_strimwidth($adjustment->render() , 0, 250, '…');
+                $metadata['debug_reason'] = mb_strimwidth($adjustment->render() , 0, 250, '…');
                 $isFirstEvent = false;
             }
             $decoratedEvent = DecoratedEvent::create(

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -134,11 +134,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
             return $this->eventNormalizer->normalize($decoratedEvent);
         }));
 
-        $this->eventStore->commit(
-            $eventsToPublish->streamName,
-            $normalizedEvents,
-            $eventsToPublish->expectedVersion
-        );
+        $this->eventStore->commit($eventsToPublish->streamName, $normalizedEvents, $eventsToPublish->expectedVersion);
         $this->subscriptionEngine->catchUpActive();
     }
 }


### PR DESCRIPTION
Resolves first iteration of https://github.com/neos/neos-development-collection/issues/3887
Resolves: https://github.com/neos/neos-development-collection/issues/4758

### Debug information for events from publishing & co

The refactored publishing V3 opens another now used advantage we can now centrally add metadata like a simple correlation id. This is especially helpful to determine a publish sequence in the event log.  

| event                    | correlation id                          |
|--------------------------|-----------------------------------------|
| ContentStreamWasForked   | CreateWorkspace_8d7e0569e4ef5a23e4      | 
| WorkspaceWasCreated      | CreateWorkspace_8d7e0569e4ef5a23e4      | 
| NodePropertiesWereSet    | SetNodeProperties_dfff5367b8570a6a53    | 
| NodePropertiesWereSet    | SetNodeProperties_fa36a1a43aab5f8e4f    | 
| NodePropertiesWereSet    | SetNodeProperties_5847b1b016a2a4ec0e    | 
| ContentStreamWasClosed   | PublishIndividualNod_cd08481821b9175938 | 
| NodePropertiesWereSet    | PublishIndividualNod_cd08481821b9175938 | 
| ContentStreamWasForked   | PublishIndividualNod_cd08481821b9175938 | 
| ContentStreamWasClosed   | PublishIndividualNod_cd08481821b9175938 | 
| WorkspaceWasPublished    | PublishIndividualNod_cd08481821b9175938 | 
| NodePropertiesWereSet    | PublishIndividualNod_cd08481821b9175938 | 
| NodePropertiesWereSet    | PublishIndividualNod_cd08481821b9175938 | 
| ContentStreamWasReopened | PublishIndividualNod_cd08481821b9175938 | 
| ContentStreamWasRemoved  | PublishIndividualNod_cd08481821b9175938 | 

Also for special events like `ContentStreamWasForked` `ContentStreamWasReopened` we add additional debug information via `debug_reason`.

### Debug information for events from structure adjustments

As discussed in https://github.com/neos/neos-development-collection/pull/4969#discussion_r1581825304, we group all events emitted by a structure adjustment via a common correlation id and additionally add to the metadata the rendered message of why the structure adjustment was necessary.


| event                           | correlation id                         | metadata                                                                                                                                |
|---------------------------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
| NodeAggregateWithNodeWasCreated | StructureAdjustment_8c9ef43b786f72b75b | `{debug_reason: 'Content Stream: %s; Dimension Space Point: %s, Node Aggregate: %s --- The tethered child node "bar" is missing.'}` |
| NodePropertiesWereSet           | StructureAdjustment_8c9ef43b786f72b75b |                                                                                                                                         |


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
