### PR TITLE
FEATURE: Workspace UI - Add second confirmation window for rebasing

### DIFF
--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -64,6 +64,8 @@ use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\PendingChangesProjection\ChangeFinder;
 use Neos\Neos\PendingChangesProjection\Changes;
 use Neos\Neos\Security\Authorization\ContentRepositoryAuthorizationService;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\ConflictingEvent;
+use Neos\Neos\Ui\Infrastructure\ContentRepository\ConflictsFactory;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 use Neos\Workspace\Ui\ViewModel\ChangeItem;
 use Neos\Workspace\Ui\ViewModel\ContentChangeItem;
@@ -728,10 +730,48 @@ class WorkspaceController extends AbstractModuleController
                 $this->addFlashMessage($this->getModuleLabel('workspaces.ForceRebaseWorkspaceFailed'));
                 $this->forward('index');
             }
+            $conflictInformation = array_map(fn (ConflictingEvent $conflictingEvent) => [
+                'error' => $conflictingEvent->getException()->getMessage(),
+                'affectedNode' => $conflictingEvent->getAffectedNodeAggregateId(),
+                'event' => $conflictingEvent->getSequenceNumber()->value . '@' . (new \ReflectionClass($conflictingEvent->getEvent()))->getShortName(),
+                'eventPayload' => htmlentities(json_encode($conflictingEvent->getEvent()), ENT_NOQUOTES),
+            ], iterator_to_array($e->conflictingEvents));
+
         }
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $workspace = $contentRepository->findWorkspaceByName($workspaceName);
+        $workspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->workspaceName);
+        $baseWorkspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->baseWorkspaceName);
         $this->response->addHttpHeader('HX-Retarget', '#popover-container');
         $this->response->addHttpHeader('HX-ReSwap', 'innerHTML');
-        $this->view->assign('workspaceName', $workspaceName->value);
+
+        $this->view->assignMultiple([
+            'workspaceName' => $workspaceName->value,
+            'workspaceTitle' => $workspaceMetadata->title->value,
+            'baseWorkspaceTitle' => $baseWorkspaceMetadata->title->value,
+            'conflictCount' => $e->conflictingEvents->count(),
+            'conflictInformation' => $conflictInformation,
+        ]);
+
+
+    }
+
+    /**
+     * Confirm force rebase a workspace
+     */
+    public function rebaseConfirmAction(WorkspaceName $workspaceName, int $conflictCount): void
+    {
+        $contentRepositoryId = SiteDetectionResult::fromRequest($this->request->getHttpRequest())->contentRepositoryId;
+
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $workspace = $contentRepository->findWorkspaceByName($workspaceName);
+        $workspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->workspaceName);
+
+        $this->view->assignMultiple([
+            'workspaceName' => $workspaceName->value,
+            'workspaceTitle' => $workspaceMetadata->title->value,
+            'conflictCount' => $conflictCount
+        ]);
     }
 
     /**

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -733,12 +733,20 @@ class WorkspaceController extends AbstractModuleController
                 'error' => $conflictingEvent->getException()->getMessage(),
                 'affectedNode' => $conflictingEvent->getAffectedNodeAggregateId(),
                 'event' => $conflictingEvent->getSequenceNumber()->value . '@' . (new \ReflectionClass($conflictingEvent->getEvent()))->getShortName(),
-                'eventPayload' => htmlentities(json_encode($conflictingEvent->getEvent()), ENT_NOQUOTES),
+                'eventPayload' => htmlentities(json_encode($conflictingEvent->getEvent()), ENT_NOQUOTES ?? ''),
             ], iterator_to_array($e->conflictingEvents));
 
         }
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $workspace = $contentRepository->findWorkspaceByName($workspaceName);
+        if ($workspace === null) {
+            $this->addFlashMessage(
+                $this->getModuleLabel('workspaces.workspaceDoesNotExist'),
+                '',
+                Message::SEVERITY_ERROR
+            );
+            $this->throwStatus(404, 'Workspace does not exist');
+        }
         $workspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->workspaceName);
         $baseWorkspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->baseWorkspaceName);
         $this->response->addHttpHeader('HX-Retarget', '#popover-container');

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -65,7 +65,6 @@ use Neos\Neos\PendingChangesProjection\ChangeFinder;
 use Neos\Neos\PendingChangesProjection\Changes;
 use Neos\Neos\Security\Authorization\ContentRepositoryAuthorizationService;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\ConflictingEvent;
-use Neos\Neos\Ui\Infrastructure\ContentRepository\ConflictsFactory;
 use Neos\Neos\Utility\NodeTypeWithFallbackProvider;
 use Neos\Workspace\Ui\ViewModel\ChangeItem;
 use Neos\Workspace\Ui\ViewModel\ContentChangeItem;
@@ -749,7 +748,6 @@ class WorkspaceController extends AbstractModuleController
             'workspaceName' => $workspaceName->value,
             'workspaceTitle' => $workspaceMetadata->title->value,
             'baseWorkspaceTitle' => $baseWorkspaceMetadata->title->value,
-            'conflictCount' => $e->conflictingEvents->count(),
             'conflictInformation' => $conflictInformation,
         ]);
 

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -732,8 +732,8 @@ class WorkspaceController extends AbstractModuleController
             $conflictInformation = array_map(fn (ConflictingEvent $conflictingEvent) => [
                 'error' => $conflictingEvent->getException()->getMessage(),
                 'affectedNode' => $conflictingEvent->getAffectedNodeAggregateId(),
-                'event' => $conflictingEvent->getSequenceNumber()->value . '@' . (new \ReflectionClass($conflictingEvent->getEvent()))->getShortName(),
-                'eventPayload' => htmlentities((json_encode($conflictingEvent->getEvent()) !== false ? json_encode($conflictingEvent->getEvent()) : ''), ENT_NOQUOTES),
+                'event' => (new \ReflectionClass($conflictingEvent->getEvent()))->getShortName() . ' ' . $conflictingEvent->getSequenceNumber()->value,
+                'eventPayload' => htmlentities(json_encode($conflictingEvent->getEvent(), JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT), ENT_NOQUOTES),
             ], iterator_to_array($e->conflictingEvents));
 
         }

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -733,7 +733,7 @@ class WorkspaceController extends AbstractModuleController
                 'error' => $conflictingEvent->getException()->getMessage(),
                 'affectedNode' => $conflictingEvent->getAffectedNodeAggregateId(),
                 'event' => $conflictingEvent->getSequenceNumber()->value . '@' . (new \ReflectionClass($conflictingEvent->getEvent()))->getShortName(),
-                'eventPayload' => htmlentities((json_encode($conflictingEvent->getEvent()) ?? ''), ENT_NOQUOTES),
+                'eventPayload' => htmlentities((json_encode($conflictingEvent->getEvent()) !== false ? json_encode($conflictingEvent->getEvent()) : ''), ENT_NOQUOTES),
             ], iterator_to_array($e->conflictingEvents));
 
         }
@@ -748,6 +748,14 @@ class WorkspaceController extends AbstractModuleController
             $this->throwStatus(404, 'Workspace does not exist');
         }
         $workspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->workspaceName);
+        if ($workspace->baseWorkspaceName === null) {
+            $this->addFlashMessage(
+                $this->getModuleLabel('workspaces.workspaceDoesNotExist'),
+                '',
+                Message::SEVERITY_ERROR
+            );
+            $this->throwStatus(404, 'Workspace does not exist');
+        }
         $baseWorkspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->baseWorkspaceName);
         $this->response->addHttpHeader('HX-Retarget', '#popover-container');
         $this->response->addHttpHeader('HX-ReSwap', 'innerHTML');

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -733,7 +733,7 @@ class WorkspaceController extends AbstractModuleController
                 'error' => $conflictingEvent->getException()->getMessage(),
                 'affectedNode' => $conflictingEvent->getAffectedNodeAggregateId(),
                 'event' => $conflictingEvent->getSequenceNumber()->value . '@' . (new \ReflectionClass($conflictingEvent->getEvent()))->getShortName(),
-                'eventPayload' => htmlentities(json_encode($conflictingEvent->getEvent()), ENT_NOQUOTES ?? ''),
+                'eventPayload' => htmlentities((json_encode($conflictingEvent->getEvent()) ?? ''), ENT_NOQUOTES),
             ], iterator_to_array($e->conflictingEvents));
 
         }
@@ -771,6 +771,14 @@ class WorkspaceController extends AbstractModuleController
 
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $workspace = $contentRepository->findWorkspaceByName($workspaceName);
+        if ($workspace === null) {
+            $this->addFlashMessage(
+                $this->getModuleLabel('workspaces.workspaceDoesNotExist'),
+                '',
+                Message::SEVERITY_ERROR
+            );
+            $this->throwStatus(404, 'Workspace does not exist');
+        }
         $workspaceMetadata = $this->workspaceService->getWorkspaceMetadata($contentRepositoryId, $workspace->workspaceName);
 
         $this->view->assignMultiple([

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
@@ -14,7 +14,6 @@ Neos.Workspace.Ui.WorkspaceController.rebase = Neos.Fusion:Component {
       workspaceName={props.workspaceName}
       workspaceTitle={props.workspaceTitle}
       baseWorkspaceTitle={props.baseWorkspaceTitle}
-      conflictCount={conflictCount}
       conflictInformation={conflictInformation}
     />
   `

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
@@ -1,10 +1,21 @@
 Neos.Workspace.Ui.WorkspaceController.rebase = Neos.Fusion:Component {
   /// string
   workspaceName = ${workspaceName}
+  /// string
+  workspaceTitle = ${workspaceTitle}
+  /// string
+  baseWorkspaceTitle = ${baseWorkspaceTitle}
+  /// array
+  conflictInformation = ${conflictInformation}
+
 
   renderer = afx`
     <Neos.Workspace.Ui:Component.Modal.Rebase
       workspaceName={props.workspaceName}
+      workspaceTitle={props.workspaceTitle}
+      baseWorkspaceTitle={props.baseWorkspaceTitle}
+      conflictCount={conflictCount}
+      conflictInformation={conflictInformation}
     />
   `
 }

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
@@ -5,7 +5,7 @@ Neos.Workspace.Ui.WorkspaceController.rebase = Neos.Fusion:Component {
   workspaceTitle = ${workspaceTitle}
   /// string
   baseWorkspaceTitle = ${baseWorkspaceTitle}
-  /// array
+  /// array{error: string, affectedNode: string, event: string, eventPayload: string}
   conflictInformation = ${conflictInformation}
 
 

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/Rebase.fusion
@@ -14,7 +14,7 @@ Neos.Workspace.Ui.WorkspaceController.rebase = Neos.Fusion:Component {
       workspaceName={props.workspaceName}
       workspaceTitle={props.workspaceTitle}
       baseWorkspaceTitle={props.baseWorkspaceTitle}
-      conflictInformation={conflictInformation}
+      conflictInformation={props.conflictInformation}
     />
   `
 }

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/RebaseConfirm.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/RebaseConfirm.fusion
@@ -9,8 +9,8 @@ Neos.Workspace.Ui.WorkspaceController.rebaseConfirm = Neos.Fusion:Component {
   renderer = afx`
     <Neos.Workspace.Ui:Component.Modal.RebaseConfirm
       workspaceName={props.workspaceName}
-      workspaceTitle={workspaceTitle}
-      conflictCount={conflictCount}
+      workspaceTitle={props.workspaceTitle}
+      conflictCount={props.conflictCount}
     />
   `
 }

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/RebaseConfirm.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Actions/RebaseConfirm.fusion
@@ -1,0 +1,16 @@
+Neos.Workspace.Ui.WorkspaceController.rebaseConfirm = Neos.Fusion:Component {
+  /// string
+  workspaceName = ${workspaceName}
+  /// string
+  workspaceTitle = ${workspaceTitle}
+  /// int
+  conflictCount = ${conflictCount}
+
+  renderer = afx`
+    <Neos.Workspace.Ui:Component.Modal.RebaseConfirm
+      workspaceName={props.workspaceName}
+      workspaceTitle={workspaceTitle}
+      conflictCount={conflictCount}
+    />
+  `
+}

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
@@ -1,23 +1,29 @@
 prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Component) {
   /// string
-  workspaceName = null
+  workspaceName = ''
+  /// string
+  workspaceTitle = ''
+  /// string
+  baseWorkspaceTitle = ''
+  /// array
+  conflictInformation = null
 
   @private {
     i18n = ${I18n.id('').source('Main').package('Neos.Workspace.Ui')}
     popoverId = 'workspace-rebase-modal'
-
-    forceRebaseWorkspaceUri = Neos.Fusion:ActionUri {
-      action = 'rebase'
+    popoverConfirmId = 'workspace-rebase-confirm-modal'
+    confirmRebaseUri = Neos.Fusion:ActionUri {
+      action = 'rebaseConfirm'
       format = 'htmx'
       arguments {
         workspaceName = ${workspaceName}
-        force = true
+        conflictCount = ${Array.length(conflictInformation)}
       }
     }
   }
 
   renderer = afx`
-    <div popover id={private.popoverId}>
+    <div popover class="error" id={private.popoverId}>
       <header>
         <button
           type="button"
@@ -28,11 +34,42 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
           <Neos.Workspace.Ui:Component.Icon icon="times"/>
         </button>
         <div class="neos-header">
-          {private.i18n.id('workspaces.dialog.forceSyncWorkspace')}
+          <i class="fas fa-bolt"></i> {private.i18n.id('workspaces.dialog.forceSyncWorkspace').arguments([props.workspaceTitle, props.baseWorkspaceTitle])}
         </div>
       </header>
       <section>
-        <p>{private.i18n.id('workspaces.dialog.thisCanLeadToLostChanges')}</p>
+        <p>{private.i18n.id('workspaces.dialog.thisCanLeadToLostChanges').arguments([props.baseWorkspaceTitle, props.workspaceTitle])}</p>
+        <details>
+          <summary>
+            {private.i18n.id('workspaces.dialog.ShowInformationAboutConflict').arguments([Array.length(props.conflictInformation)])}
+          </summary>
+          <Neos.Fusion:Loop items={props.conflictInformation} itemName="conflict">
+            <table class="neos-table">
+              <tbody>
+            <tr>
+              <td>Error:</td>
+              <td><b>{conflict.error}</b></td>
+            </tr>
+              <tr>
+                <td>Node:</td>
+                <td>
+                  {conflict.affectedNode}
+                </td>
+              </tr>
+              <tr>
+                <td>Event:</td>
+                <td>{conflict.event}</td>
+              </tr>
+
+            <tr>
+              <td>Event details:</td>
+              <td>{Json.stringify(conflict.eventPayload, ['JSON_PRETTY_PRINT'])}</td>
+            </tr>
+              </tbody>
+            </table>
+          </Neos.Fusion:Loop>
+        </details>
+        <p>{private.i18n.id('workspaces.dialog.thisCanLeadToLostChangesConfirmation').arguments([props.conflictCount])}</p>
       </section>
       <footer>
         <button
@@ -46,12 +83,13 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
         <Neos.Workspace.Ui:Component.Button
           isDanger
           label={private.i18n.id('workspaces.modal.yesRebaseWorkspace')}
-          attributes.hx-get={private.forceRebaseWorkspaceUri}
-          attributes.hx-target="#workspace-module-content"
+          attributes.hx-get={private.confirmRebaseUri}
+          attributes.hx-target={'#' + private.popoverConfirmId}
           attributes.hx-swap="outerHTML"
-          attributes.hx-on--after-request={'document.getElementById("' + private.popoverId + '").hidePopover()'}
+          attributes.hx-on--after-request={'document.getElementById("' + private.popoverConfirmId + '").showPopover()'}
         />
       </footer>
+      <div popover id={private.popoverConfirmId}></div>
     </div>
   `
 }

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
@@ -17,7 +17,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
       format = 'htmx'
       arguments {
         workspaceName = ${workspaceName}
-        conflictCount = ${Array.length(conflictInformation)}
+        conflictCount = ${Array.length(props.conflictInformation)}
       }
     }
   }

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
@@ -43,13 +43,14 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
           <summary>
             {private.i18n.id('workspaces.dialog.ShowInformationAboutConflict').arguments([Array.length(props.conflictInformation)])}
           </summary>
+          <br/>
           <Neos.Fusion:Loop items={props.conflictInformation} itemName="conflict">
             <table class="neos-table">
               <tbody>
-            <tr>
-              <td>{private.i18n.id('workspaces.dialog.rebase.error')}:</td>
-              <td><b>{conflict.error}</b></td>
-            </tr>
+              <tr>
+                <td>{private.i18n.id('workspaces.dialog.rebase.error')}:</td>
+                <td><b>{conflict.error}</b></td>
+              </tr>
               <tr>
                 <td>{private.i18n.id('workspaces.dialog.rebase.node')}:</td>
                 <td>
@@ -58,13 +59,15 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
               </tr>
               <tr>
                 <td>{private.i18n.id('workspaces.dialog.rebase.event')}:</td>
-                <td>{conflict.event}</td>
+                <td>
+                  <details>
+                    <summary>{private.i18n.id('workspaces.dialog.rebase.eventDetails')}: {conflict.event}</summary>
+                    <pre style="line-height: 1.5">
+                        {conflict.eventPayload}
+                    </pre>
+                  </details>
+                </td>
               </tr>
-
-            <tr>
-              <td>{private.i18n.id('workspaces.dialog.rebase.eventDetails')}:</td>
-              <td>{Json.stringify(conflict.eventPayload, ['JSON_PRETTY_PRINT'])}</td>
-            </tr>
               </tbody>
             </table>
           </Neos.Fusion:Loop>

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
@@ -69,7 +69,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
             </table>
           </Neos.Fusion:Loop>
         </details>
-        <p>{private.i18n.id('workspaces.dialog.thisCanLeadToLostChangesConfirmation').arguments([props.conflictCount])}</p>
+        <p>{private.i18n.id('workspaces.dialog.thisCanLeadToLostChangesConfirmation').arguments([Array.length(props.conflictInformation)])}</p>
       </section>
       <footer>
         <button

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Rebase.fusion
@@ -47,22 +47,22 @@ prototype(Neos.Workspace.Ui:Component.Modal.Rebase) < prototype(Neos.Fusion:Comp
             <table class="neos-table">
               <tbody>
             <tr>
-              <td>Error:</td>
+              <td>{private.i18n.id('workspaces.dialog.rebase.error')}:</td>
               <td><b>{conflict.error}</b></td>
             </tr>
               <tr>
-                <td>Node:</td>
+                <td>{private.i18n.id('workspaces.dialog.rebase.node')}:</td>
                 <td>
                   {conflict.affectedNode}
                 </td>
               </tr>
               <tr>
-                <td>Event:</td>
+                <td>{private.i18n.id('workspaces.dialog.rebase.event')}:</td>
                 <td>{conflict.event}</td>
               </tr>
 
             <tr>
-              <td>Event details:</td>
+              <td>{private.i18n.id('workspaces.dialog.rebase.eventDetails')}:</td>
               <td>{Json.stringify(conflict.eventPayload, ['JSON_PRETTY_PRINT'])}</td>
             </tr>
               </tbody>

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/RebaseConfirm.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/RebaseConfirm.fusion
@@ -1,0 +1,63 @@
+prototype(Neos.Workspace.Ui:Component.Modal.RebaseConfirm) < prototype(Neos.Fusion:Component) {
+  /// string
+  workspaceName = ''
+  /// string
+  workspaceTitle = ''
+  /// int
+  conflictCount = 0
+
+  @private {
+    i18n = ${I18n.id('').source('Main').package('Neos.Workspace.Ui')}
+    popoverId = 'workspace-rebase-confirm-modal'
+    popoverRebaseId = 'workspace-rebase-modal'
+
+    forceRebaseWorkspaceUri = Neos.Fusion:ActionUri {
+      action = 'rebase'
+      format = 'htmx'
+      arguments {
+        workspaceName = ${workspaceName}
+        force = true
+      }
+    }
+  }
+
+  renderer = afx`
+    <div popover class="error" id={private.popoverId}>
+      <header>
+        <button
+          type="button"
+          class="neos-close neos-button"
+          popovertarget={private.popoverId}
+          popovertargetaction="close"
+        >
+          <Neos.Workspace.Ui:Component.Icon icon="times"/>
+        </button>
+        <div class="neos-header">
+          <i class="fas fa-bolt"></i> {private.i18n.id('workspaces.dialog.ConfirmationDropConflictingChanges').arguments([props.workspaceTitle])}
+        </div>
+      </header>
+      <section>
+        <p>{private.i18n.id('workspaces.dialog.ConfirmationDropConflictingChangesCount').arguments([props.conflictCount])}</p>
+        <p>{private.i18n.id('workspaces.dialog.ConfirmationDropConflictingChangesText')}</p>
+      </section>
+      <footer>
+        <button
+          type="button"
+          class="neos-button"
+          popovertarget={private.popoverRebaseId}
+          popovertargetaction="close"
+        >
+          {private.i18n.id('cancel')}
+        </button>
+        <Neos.Workspace.Ui:Component.Button
+          isDanger
+          label={private.i18n.id('workspaces.modal.yesRebaseWorkspace')}
+          attributes.hx-get={private.forceRebaseWorkspaceUri}
+          attributes.hx-target="#workspace-module-content"
+          attributes.hx-swap="outerHTML"
+          attributes.hx-on--after-request={'document.getElementById("' + private.popoverRebaseId + '").hidePopover()'}
+        />
+      </footer>
+    </div>
+  `
+}

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/RebaseConfirm.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/RebaseConfirm.fusion
@@ -15,7 +15,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.RebaseConfirm) < prototype(Neos.Fusi
       action = 'rebase'
       format = 'htmx'
       arguments {
-        workspaceName = ${workspaceName}
+        workspaceName = ${props.workspaceName}
         force = true
       }
     }

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/RebaseConfirm.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/RebaseConfirm.fusion
@@ -33,7 +33,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.RebaseConfirm) < prototype(Neos.Fusi
           <Neos.Workspace.Ui:Component.Icon icon="times"/>
         </button>
         <div class="neos-header">
-          <i class="fas fa-bolt"></i> {private.i18n.id('workspaces.dialog.ConfirmationDropConflictingChanges').arguments([props.workspaceTitle])}
+          <i class="fas fa-exclamation-triangle"></i> {private.i18n.id('workspaces.dialog.ConfirmationDropConflictingChanges').arguments([props.workspaceTitle])}
         </div>
       </header>
       <section>

--- a/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
@@ -175,10 +175,25 @@
 				<source>This will delete the workspace including all unpublished content. This operation cannot be undone.</source>
 			</trans-unit>
       <trans-unit id="workspaces.dialog.forceSyncWorkspace" xml:space="preserve">
-				<source>Syncing has failed</source>
+				<source>Conflicts between workspace "{0}" and "{1}"</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.ShowInformationAboutConflict" xml:space="preserve">
+				<source>Show information about {0} conflict(s)</source>
 			</trans-unit>
       <trans-unit id="workspaces.dialog.thisCanLeadToLostChanges" xml:space="preserve">
-				<source>A conflict occured while syncing the workspace. Do you want to drop the conflicting changes?</source>
+				<source>Workspace "{0}" contains modifications that are in conflict with the changes in workspace "{1}".</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.thisCanLeadToLostChangesConfirmation" xml:space="preserve">
+				<source>Do you want to drop {0} conflicting changes?</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.ConfirmationDropConflictingChanges" xml:space="preserve">
+				<source>Do you really want to drop all conflicting changes from workspace "{0}"?</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.ConfirmationDropConflictingChangesCount" xml:space="preserve">
+				<source>This will remove {0} change(s) from the workspace.</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.ConfirmationDropConflictingChangesText" xml:space="preserve">
+				<source>This can not be undone! Do you wish to proceed?</source>
 			</trans-unit>
       <trans-unit id="workspaces.modal.yesRebaseWorkspace" xml:space="preserve">
 				<source>Yes, drop changes</source>

--- a/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
@@ -184,7 +184,7 @@
 				<source>Workspace "{0}" contains modifications that are in conflict with the changes in workspace "{1}".</source>
 			</trans-unit>
       <trans-unit id="workspaces.dialog.thisCanLeadToLostChangesConfirmation" xml:space="preserve">
-				<source>Do you want to drop {0} conflicting changes?</source>
+				<source>Do you want to drop {0} conflicting change(s)?</source>
 			</trans-unit>
       <trans-unit id="workspaces.dialog.ConfirmationDropConflictingChanges" xml:space="preserve">
 				<source>Do you really want to drop all conflicting changes from workspace "{0}"?</source>

--- a/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
@@ -195,6 +195,18 @@
       <trans-unit id="workspaces.dialog.ConfirmationDropConflictingChangesText" xml:space="preserve">
 				<source>This can not be undone! Do you wish to proceed?</source>
 			</trans-unit>
+      <trans-unit id="workspaces.dialog.rebase.error" xml:space="preserve">
+				<source>Error</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.rebase.node" xml:space="preserve">
+				<source>Node</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.rebase.event" xml:space="preserve">
+				<source>Event</source>
+			</trans-unit>
+      <trans-unit id="workspaces.dialog.rebase.eventDetails" xml:space="preserve">
+				<source>Event details</source>
+			</trans-unit>
       <trans-unit id="workspaces.modal.yesRebaseWorkspace" xml:space="preserve">
 				<source>Yes, drop changes</source>
 			</trans-unit>

--- a/Neos.Workspace.Ui/Resources/Public/Styles/Module.css
+++ b/Neos.Workspace.Ui/Resources/Public/Styles/Module.css
@@ -193,6 +193,25 @@ button .icon:not(:last-child) {
   justify-content: flex-end;
 }
 
+[popover].error {
+  border: 1px solid var(--warning);
+}
+
+[popover].error .neos-header i {
+  color: var(--orange);
+}
+[popover].error p {
+  margin: var(--defaultMargin) 0;
+}
+[popover]#workspace-rebase-modal{
+  width: 50vw;
+}
+[popover] details[open] {
+  max-height: 50vh;
+  overflow: auto;
+  max-width: max-content;
+}
+
 /**
  * Form styles
  */


### PR DESCRIPTION
As discussed in #5450 the "force rebase" journey is a little bit too harmless for dropping changes. 

We discussed restricting the force rebase to editors but that was also not ideal since perhaps editors should not have to have admin permissions.

Changes in this PR: 

1. The popup looks more dangerous 
2. The conflicting changes are shown (just basic parsing, no details)
3. A confirmation popup is shown 


![Bildschirmfoto 2025-01-29 um 10 45 59](https://github.com/user-attachments/assets/ec4fe2dc-aa4a-4456-a1ba-0ace11643618)

![Bildschirmfoto 2025-01-29 um 10 46 14](https://github.com/user-attachments/assets/a083b578-1263-431f-a512-0284dae25e40)

![Bildschirmfoto 2025-01-29 um 11 20 08](https://github.com/user-attachments/assets/adc387ed-98ad-4e9f-80a5-f53567132d6f)


 

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
