### PR TITLE
WIP: BUGFIX: prevent workspace creation during route resolving

### DIFF
--- a/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -184,7 +184,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         $contentContext = $this->buildContextFromRequestPath($requestPath);
         $requestPathWithoutContext = $this->removeContextFromPath($requestPath);
 
-        $workspace = $contentContext->getWorkspace();
+        $workspace = $contentContext->getWorkspace(false);
         if ($workspace === null) {
             throw new Exception\NoWorkspaceException(sprintf('No workspace found for request path "%s"', $requestPath), 1346949318);
         }


### PR DESCRIPTION
In [slack](https://neos-project.slack.com/archives/C050C8FEK/p1738331051000739) it was noticed that all root paths starting with `@` are interpreted by the frontend node path handler as legacy node path. As far as i know the syntax `localhost/sites/neosdemo@test;language=en_US` was before https://github.com/neos/neos-development-collection/pull/2654 used as preview endpoint for the neos ui. Now if both path and dimensions are empty the uri like `localhost/@test` still gets matched. Or any path starting with `@blabla`.

The problem now is now that there is some weird behaviour in the code, which attempts to create the entered workspace when resolving but then persistAll is not called either way but there is a trace in the log telling that the auto creation of workspaces is deprecated:

```
25-01-31 14:41:12 48         NOTICE    Neos.ContentRepository Notice: Neos\ContentRepository\Domain\Service\Context_Original::getWorkspace() implicitly created the new workspace "test". This behaviour is discouraged and will be removed in future versions. Make sure to create workspaces explicitly by adding a new workspace to the Workspace Repository.
```

------------

With this pr i attempt to circumvent the odd workspace creation. But that in turn now bubbles up a new exception `NoWorkspaceException` that was previously never thrown because workspaces were auto created.

Now changing this behaviour might seem correct but we will leak information to the unauthorised user in the following way:
Existing workspaces like `/@user-admin` will be redirected to the login while non existing workspaces like `/@test` will now cause a 404.

Until we have discussed this the pr must not be merged.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
