### PR TITLE
BUGFIX: Recognize removed-state while reducing

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Neos.ContentRepository/Classes/Domain/Repository/NodeDataRepository.php
@@ -1334,6 +1334,7 @@ class NodeDataRepository extends Repository
                 }
             }
             $dimensionPositions[] = $workspacePosition;
+            $dimensionPositions[] = $node->isRemoved() ? PHP_INT_MAX : PHP_INT_MIN;
 
             $identifier = $node->getIdentifier();
             // Yes, it seems to work comparing arrays that way!


### PR DESCRIPTION
Please read Issue #3651, to get the problem. 

By adding the removed-state as 3rd priority while reducing NodeData results, we should always get the not-removed NodeData, if there are 2 (because of Node-move). 

I tested this fix on our projects, and it worked. I can't find something breaking. But since this is deep inside NodeData, I've no idea, if we could get unexpected side-effects on it. Thanks to @Nikdro for the change.

Fixes:  #3651