### PR TITLE
POC Handle publish individual nodes scope in core via simulation

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -177,6 +177,7 @@ final class ContentRepositoryFactory
                 $commandSimulatorFactory,
                 $this->eventStore,
                 $this->eventNormalizer,
+                $this->nodeTypeManager
             )
         );
         $authProvider = $this->authProviderFactory->build($this->contentRepositoryId, $contentGraphReadModel);

--- a/Neos.ContentRepository.Core/Classes/Feature/RebaseableCommand.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RebaseableCommand.php
@@ -9,6 +9,24 @@ use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\InitiatingEventMetadata;
 use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
 use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterface;
+use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\AddDimensionShineThrough;
+use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\MoveDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNodeAndSerializedProperties;
+use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\DisableNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeDisabling\Command\EnableNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeDuplication\Command\CopyNodesRecursively;
+use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetSerializedNodeProperties;
+use Neos\ContentRepository\Core\Feature\NodeMove\Command\MoveNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeReferencing\Command\SetSerializedNodeReferences;
+use Neos\ContentRepository\Core\Feature\NodeRemoval\Command\RemoveNodeAggregate;
+use Neos\ContentRepository\Core\Feature\NodeRenaming\Command\ChangeNodeAggregateName;
+use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;
+use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\UpdateRootNodeAggregateDimensions;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\TagSubtree;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\UntagSubtree;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\EventId;
 use Neos\EventStore\Model\Event\EventMetadata;
@@ -27,6 +45,33 @@ final readonly class RebaseableCommand
         public SequenceNumber $originalSequenceNumber
     ) {
     }
+
+    public function getClosestAffectedNodeAggregateId(): NodeAggregateId|null
+    {
+        return match ($this->originalCommand::class) {
+            CreateRootNodeAggregateWithNode::class => null,
+            CreateNodeAggregateWithNodeAndSerializedProperties::class => $this->originalCommand->parentNodeAggregateId,
+            DisableNodeAggregate::class,
+            EnableNodeAggregate::class,
+            SetSerializedNodeProperties::class,
+            MoveNodeAggregate::class, // todo moving behaves wrong and cant be published
+            RemoveNodeAggregate::class,
+            ChangeNodeAggregateName::class,
+            ChangeNodeAggregateType::class,
+            CreateNodeVariant::class,
+            TagSubtree::class,
+            UntagSubtree::class,
+            UpdateRootNodeAggregateDimensions::class,
+            => $this->originalCommand->nodeAggregateId,
+            CopyNodesRecursively::class => null,
+            SetSerializedNodeReferences::class => $this->originalCommand->sourceNodeAggregateId,
+            // for non node-aggregate-changes we return null, so they are kept as remainder:
+            AddDimensionShineThrough::class,
+            MoveDimensionSpacePoint::class => null,
+            default => throw new \RuntimeException(sprintf('Command %s does not have matching strategy. Partial workspace rebase not possible.', $this->originalCommand::class), 1645393655)
+        };
+    }
+
 
     public static function extractFromEventEnvelope(EventEnvelope $eventEnvelope): self
     {

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -54,11 +54,17 @@ use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingS
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\PartialWorkspaceRebaseFailed;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\WorkspaceRebaseFailed;
+use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
+use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\ExpandedNodeTypeCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamAlreadyExists;
 use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamDoesNotExistYet;
 use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamIsClosed;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasNoBaseWorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -81,6 +87,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         private CommandSimulatorFactory $commandSimulatorFactory,
         private EventStoreInterface $eventStore,
         private EventNormalizer $eventNormalizer,
+        private NodeTypeManager $nodeTypeManager
     ) {
     }
 
@@ -458,23 +465,33 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             )
         );
 
-        [$matchingCommands, $remainingCommands] = $rebaseableCommands->separateMatchingAndRemainingCommands($command->nodesToPublish);
-
-        if ($matchingCommands->isEmpty()) {
-            throw WorkspaceCommandSkipped::becauseFilterDidNotMatch($command->workspaceName, $command->nodesToPublish);
-        }
-
         yield $this->closeContentStream(
             $workspace->currentContentStreamId,
             $workspaceContentStreamVersion
         );
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
+        $contentGraph = $commandHandlingDependencies->getContentGraph($baseWorkspace->workspaceName);
+        $expandedNodeTypeCriteria = ExpandedNodeTypeCriteria::create(NodeTypeCriteria::createWithAllowedNodeTypeNames(NodeTypeNames::with($command->nodeTypeScope)), $this->nodeTypeManager);
 
         $highestSequenceNumberForMatching = $commandSimulator->run(
-            static function ($handle) use ($commandSimulator, $matchingCommands, $remainingCommands): SequenceNumber {
-                foreach ($matchingCommands as $matchingCommand) {
-                    $handle($matchingCommand);
+            function ($handle) use ($commandSimulator, $rebaseableCommands, $contentGraph, $command, $expandedNodeTypeCriteria): SequenceNumber {
+
+
+                $remainingCommands = [];
+                foreach ($rebaseableCommands as $rebaseableCommand) {
+                    $affectedNodeId = $rebaseableCommand->getClosestAffectedNodeAggregateId();
+
+                    // $subgraph = $contentGraph->getSubgraph(DimensionSpacePoint::fromArray(['language' => 'en_US']), VisibilityConstraints::withoutRestrictions()); // todo
+                    // $closestNode = $affectedNodeId ? $subgraph->findClosestNode($affectedNodeId, FindClosestNodeFilter::create(NodeTypeCriteria::createWithAllowedNodeTypeNames(NodeTypeNames::with($command->nodeTypeScope)))) : null;
+
+                    $closestNodeAggregateId = $affectedNodeId ? $this->findClosestAncestorNodeAggregate($contentGraph, $affectedNodeId, $expandedNodeTypeCriteria) : null;
+
+                    if ($closestNodeAggregateId !== null && $closestNodeAggregateId->equals($command->startingNodeAggregateId)) {
+                        $handle($rebaseableCommand);
+                        continue;
+                    }
+                    $remainingCommands[] = $rebaseableCommand;
                 }
                 $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
                 foreach ($remainingCommands as $remainingCommand) {
@@ -535,7 +552,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         $baseWorkspace->workspaceName,
                         $command->contentStreamIdForRemainingPart,
                         $workspace->currentContentStreamId,
-                        partial: !$remainingCommands->isEmpty()
+                        partial: true // todo
                     )
                 ]),
                 ExpectedVersion::ANY()
@@ -549,6 +566,23 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
+    }
+
+
+    public function findClosestAncestorNodeAggregate(ContentGraphInterface $contentGraph, NodeAggregateId $entryNodeAggregateId, ExpandedNodeTypeCriteria $nodeTypeCriteria): NodeAggregateId|null
+    {
+        $stack = [$entryNodeAggregateId];
+
+        while ($stack !== []) {
+            $currentNodeAggregateId = array_shift($stack);
+            foreach ($contentGraph->findParentNodeAggregates($currentNodeAggregateId) as $nodeAggregate) {
+                if ($nodeTypeCriteria->matches($nodeAggregate->nodeTypeName)) {
+                    return $nodeAggregate->nodeAggregateId;
+                }
+                $stack[] = $nodeAggregate->nodeAggregateId;
+            }
+        }
+        return null;
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Command/PublishIndividualNodesFromWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspacePublication/Command/PublishIndividualNodesFromWorkspace.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\WorkspacePublication\Command;
 
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -28,39 +29,39 @@ final readonly class PublishIndividualNodesFromWorkspace implements CommandInter
 {
     /**
      * @param WorkspaceName $workspaceName Name of the affected workspace
-     * @param NodeAggregateIds $nodesToPublish Ids of the nodes to publish or discard
+     * @param NodeAggregateId $startingNodeAggregateId Node aggregate id of the node and its descendants to publish
      * @param ContentStreamId $contentStreamIdForRemainingPart The id of the new content stream that will contain all remaining events {@see self::withContentStreamIdForRemainingPart()}
      */
     private function __construct(
         public WorkspaceName $workspaceName,
-        public NodeAggregateIds $nodesToPublish,
+        public NodeAggregateId $startingNodeAggregateId,
+        public NodeTypeName $nodeTypeScope,
         public ContentStreamId $contentStreamIdForRemainingPart
     ) {
-        if ($this->nodesToPublish->isEmpty()) {
-            throw new \InvalidArgumentException(sprintf('The command "PublishIndividualNodesFromWorkspace" for workspace %s must contain nodes to publish', $this->workspaceName->value), 1737448717);
-        }
     }
 
     /**
      * @param WorkspaceName $workspaceName Name of the affected workspace
-     * @param NodeAggregateIds $nodesToPublish Ids of the nodes to publish or discard
+     * @param NodeAggregateId $startingNodeAggregateId Node aggregate id of the node and its descendants to publish
      */
-    public static function create(WorkspaceName $workspaceName, NodeAggregateIds $nodesToPublish): self
+    public static function create(WorkspaceName $workspaceName, NodeAggregateId $startingNodeAggregateId, NodeTypeName $nodeTypeScope): self
     {
         return new self(
             $workspaceName,
-            $nodesToPublish,
+            $startingNodeAggregateId,
+            $nodeTypeScope,
             ContentStreamId::create()
         );
     }
 
     public static function fromArray(array $array): self
     {
-        return new self(
-            WorkspaceName::fromString($array['workspaceName']),
-            NodeAggregateIds::fromArray($array['nodesToPublish']),
-            isset($array['contentStreamIdForRemainingPart']) ? ContentStreamId::fromString($array['contentStreamIdForRemainingPart']) : ContentStreamId::create(),
-        );
+        throw new \BadMethodCallException();
+        // return new self(
+        //     WorkspaceName::fromString($array['workspaceName']),
+        //     NodeAggregateId::fromString($array['startingNodeAggregateId']),
+        //     isset($array['contentStreamIdForRemainingPart']) ? ContentStreamId::fromString($array['contentStreamIdForRemainingPart']) : ContentStreamId::create(),
+        // );
     }
 
     /**
@@ -71,6 +72,6 @@ final readonly class PublishIndividualNodesFromWorkspace implements CommandInter
      */
     public function withContentStreamIdForRemainingPart(ContentStreamId $contentStreamIdForRemainingPart): self
     {
-        return new self($this->workspaceName, $this->nodesToPublish, $contentStreamIdForRemainingPart);
+        return new self($this->workspaceName, $this->startingNodeAggregateId, $this->nodeTypeScope, $contentStreamIdForRemainingPart);
     }
 }

--- a/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
@@ -113,25 +113,23 @@ final class WorkspacePublishingService
         if ($crWorkspace->isRootWorkspace()) {
             throw new \InvalidArgumentException(sprintf('Failed to publish workspace "%s" because it has no base workspace', $workspaceName->value), 1717517240);
         }
-        $ancestorNodeTypeName = NodeTypeNameFactory::forSite();
         $this->requireNodeToBeOfType(
             $contentRepository,
             $workspaceName,
             $siteId,
-            $ancestorNodeTypeName
+            NodeTypeNameFactory::forSite()
         );
 
-        $nodeIdsToPublish = $this->resolveNodeIdsToPublishOrDiscard(
-            $contentRepository,
-            $workspaceName,
-            $siteId,
-            $ancestorNodeTypeName
+        $contentRepository->handle(
+            PublishIndividualNodesFromWorkspace::create(
+                $workspaceName,
+                $siteId,
+                NodeTypeNameFactory::forSite()
+            )
         );
-
-        $this->publishNodes($contentRepository, $workspaceName, $nodeIdsToPublish);
 
         return new PublishingResult(
-            count($nodeIdsToPublish),
+            42, // todo
             $crWorkspace->baseWorkspaceName,
         );
     }
@@ -146,25 +144,23 @@ final class WorkspacePublishingService
         if ($crWorkspace->isRootWorkspace()) {
             throw new \InvalidArgumentException(sprintf('Failed to publish workspace "%s" because it has no base workspace', $workspaceName->value), 1717517467);
         }
-        $ancestorNodeTypeName = NodeTypeNameFactory::forDocument();
         $this->requireNodeToBeOfType(
             $contentRepository,
             $workspaceName,
             $documentId,
-            $ancestorNodeTypeName
+            NodeTypeNameFactory::forDocument()
         );
 
-        $nodeIdsToPublish = $this->resolveNodeIdsToPublishOrDiscard(
-            $contentRepository,
-            $workspaceName,
-            $documentId,
-            $ancestorNodeTypeName
+        $contentRepository->handle(
+            PublishIndividualNodesFromWorkspace::create(
+                $workspaceName,
+                $documentId,
+                NodeTypeNameFactory::forDocument()
+            )
         );
-
-        $this->publishNodes($contentRepository, $workspaceName, $nodeIdsToPublish);
 
         return new PublishingResult(
-            count($nodeIdsToPublish),
+            42, // todo
             $crWorkspace->baseWorkspaceName,
         );
     }
@@ -269,22 +265,6 @@ final class WorkspacePublishingService
             DiscardIndividualNodesFromWorkspace::create(
                 $workspaceName,
                 $nodeIdsToDiscard
-            )
-        );
-    }
-
-    /**
-     * @throws WorkspaceRebaseFailed|PartialWorkspaceRebaseFailed|WorkspaceCommandSkipped
-     */
-    private function publishNodes(
-        ContentRepository $contentRepository,
-        WorkspaceName $workspaceName,
-        NodeAggregateIds $nodeIdsToPublish
-    ): void {
-        $contentRepository->handle(
-            PublishIndividualNodesFromWorkspace::create(
-                $workspaceName,
-                $nodeIdsToPublish
             )
         );
     }


### PR DESCRIPTION
Attempts to implement "gather nodes to publish during simulation" from https://github.com/neos/neos-development-collection/issues/5459#issuecomment-2637368045

```php
PublishIndividualNodesFromWorkspace::create(
    $workspaceName,
    $siteId,
    NodeTypeNameFactory::forSite()
)
```

That indeed fixes the problem with [publishing with the removals](https://github.com/neos/neos-development-collection/issues/4997) ... but so far the logic is broken for other things like moves as there the last position counts ... so not easy after all. Also i found out that we cannot use `findClosestNode` as we operate on the content graph ... so need a new method (see `findClosestAncestorNodeAggregate`)


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
