### PR TITLE
POC drop changes during publish inside deleted parts

### DIFF
--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
@@ -77,7 +77,7 @@ final class CommandSimulator
      * We will automatically copy given commands to the workspace this simulation
      * is running in to ensure consistency in the simulations constraint checks.
      */
-    private function handle(RebaseableCommand $rebaseableCommand): void
+    private function handle(RebaseableCommand $rebaseableCommand, bool $collectConflicts = true): void
     {
         // FIXME: Check if workspace already matches and skip this, e.g. $commandInWorkspace = $command->getWorkspaceName()->equals($this->workspaceNameToSimulateIn) ? $command : $command->createCopyForWorkspace($this->workspaceNameToSimulateIn);
         // when https://github.com/neos/neos-development-collection/pull/5298 is merged
@@ -86,6 +86,9 @@ final class CommandSimulator
         try {
             $eventsToPublish = $this->commandBus->handle($commandInWorkspace);
         } catch (\Exception $exception) {
+            if ($collectConflicts === false) {
+                throw $exception;
+            }
             $originalEvent = $this->eventNormalizer->denormalize($rebaseableCommand->originalEvent);
 
             $this->conflictingEvents = $this->conflictingEvents->withAppended(

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -29,6 +29,8 @@ use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStream
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasReopened;
 use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Event\ContentStreamWasCreated;
 use Neos\ContentRepository\Core\Feature\ContentStreamRemoval\Event\ContentStreamWasRemoved;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNodeAndSerializedProperties;
+use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
@@ -478,7 +480,13 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 }
                 $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
                 foreach ($remainingCommands as $remainingCommand) {
-                    $handle($remainingCommand);
+                    try {
+                        $handle($remainingCommand, collectConflicts: in_array(
+                            $remainingCommand->originalCommand::class,
+                            [CreateNodeAggregateWithNodeAndSerializedProperties::class, SetNodeProperties::class]
+                        ));
+                    } catch (\Exception) {
+                    }
                 }
                 return $highestSequenceNumberForMatching;
             }


### PR DESCRIPTION
Attempts to fix https://github.com/neos/neos-development-collection/issues/4997 by silently dropping unapplicable changes where its assumed their parent has been deleted.

Now this is not a trivial task and might be after all a bad choice with unexpected behaviour.

As we don't want to expensively find out which published remove nodes overshadowed changes in the tree we simply make the assumption that any unapplicable change because their target node id cannot be found can be drooped. Almost. 

Now there are exceptions to the rule. For example https://github.com/neos/neos-development-collection/issues/5364 shows that moving a node out of a tree which is later deleted and published first is certainly an expected behaviour. Here this change must not be dropped.

So a more solid solution could do the following when a remaining change fails to apply:
- check if the target node id doesnt exist at the current time, which means indeed the change was overshadowed and is not applicable because of this reason
- check if the change is a change we like to ignore like create node, set properties etc.


One more note: Because of dimensions dropping changes is not trivial at all. For example a remove node is allowed to target only `STRATEGY_ALL_SPECIALIZATIONS` while an overshadowed creation or variant creations could affect other dimensions where the change should still prevail.



**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
