### PR TITLE
FEATURE: Allow to register custom node migrations

### DIFF
--- a/Neos.ContentRepository.NodeMigration/src/Filter/DimensionSpacePointsFilterFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/DimensionSpacePointsFilterFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\VariantType;
@@ -35,14 +36,10 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
  */
 class DimensionSpacePointsFilterFactory implements FilterFactoryInterface
 {
-    public function __construct(private readonly InterDimensionalVariationGraph $interDimensionalVariationGraph)
-    {
-    }
-
     /**
      * @param array<string,mixed> $settings
      */
-    public function build(array $settings): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
+    public function build(array $settings, ContentRepository $contentRepository): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
     {
         $points = OriginDimensionSpacePointSet::fromArray($settings['points']);
 
@@ -54,7 +51,7 @@ class DimensionSpacePointsFilterFactory implements FilterFactoryInterface
         return new class (
             $points,
             $includeSpecializations,
-            $this->interDimensionalVariationGraph
+            $contentRepository->getVariationGraph()
         ) implements NodeBasedFilterInterface {
             public function __construct(
                 private readonly OriginDimensionSpacePointSet $points,

--- a/Neos.ContentRepository.NodeMigration/src/Filter/FilterFactoryInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/FilterFactoryInterface.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
+
 interface FilterFactoryInterface
 {
     /**
      * @param array<string,mixed> $settings
      */
-    public function build(array $settings): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface;
+    public function build(array $settings, ContentRepository $contentRepository): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Filter/FilterFactoryInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/FilterFactoryInterface.php
@@ -6,6 +6,9 @@ namespace Neos\ContentRepository\NodeMigration\Filter;
 
 use Neos\ContentRepository\Core\ContentRepository;
 
+/**
+ * Factory to build a filter
+ */
 interface FilterFactoryInterface
 {
     /**

--- a/Neos.ContentRepository.NodeMigration/src/Filter/FiltersFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/FiltersFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\NodeMigration\MigrationException;
 use Neos\ContentRepository\NodeMigration\NodeMigrationService;
 
@@ -16,6 +17,11 @@ class FiltersFactory
      * @var array<string,FilterFactoryInterface>
      */
     private array $filterFactories = [];
+
+    public function __construct(
+        private readonly ContentRepository $contentRepository
+    ) {
+    }
 
     /**
      * @param array<int,array<string,mixed>> $filterConfigurations
@@ -45,7 +51,7 @@ class FiltersFactory
     ): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
     {
         $filterFactory = $this->resolveFilterFactory($filterConfiguration['type']);
-        return $filterFactory->build($filterConfiguration['settings'] ?? []);
+        return $filterFactory->build($filterConfiguration['settings'] ?? [], $this->contentRepository);
     }
 
     /**

--- a/Neos.ContentRepository.NodeMigration/src/Filter/NodeNameFilterFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/NodeNameFilterFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 
@@ -25,7 +26,7 @@ class NodeNameFilterFactory implements FilterFactoryInterface
     /**
      * @param array<string,string> $settings
      */
-    public function build(array $settings): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
+    public function build(array $settings, ContentRepository $contentRepository): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
     {
         $nodeName = NodeName::fromString($settings['nodeName']);
 

--- a/Neos.ContentRepository.NodeMigration/src/Filter/NodeTypeFilterFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/NodeTypeFilterFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
@@ -23,14 +24,10 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
  */
 class NodeTypeFilterFactory implements FilterFactoryInterface
 {
-    public function __construct(private readonly NodeTypeManager $nodeTypeManager)
-    {
-    }
-
     /**
      * @param array<string,mixed> $settings
      */
-    public function build(array $settings): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
+    public function build(array $settings, ContentRepository $contentRepository): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
     {
         $nodeType = NodeTypeName::fromString($settings['nodeType']);
         $withSubTypes = false;
@@ -47,7 +44,7 @@ class NodeTypeFilterFactory implements FilterFactoryInterface
             $nodeType,
             $withSubTypes,
             $exclude,
-            $this->nodeTypeManager
+            $contentRepository->getNodeTypeManager()
         ) implements NodeAggregateBasedFilterInterface {
             public function __construct(
                 /**

--- a/Neos.ContentRepository.NodeMigration/src/Filter/PropertyNotEmptyFilterFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/PropertyNotEmptyFilterFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 /**
@@ -24,7 +25,7 @@ class PropertyNotEmptyFilterFactory implements FilterFactoryInterface
     /**
      * @param array<string,string> $settings
      */
-    public function build(array $settings): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
+    public function build(array $settings, ContentRepository $contentRepository): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
     {
         $propertyName = $settings['propertyName'];
 

--- a/Neos.ContentRepository.NodeMigration/src/Filter/PropertyValueFilterFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Filter/PropertyValueFilterFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Filter;
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 /**
@@ -24,7 +25,7 @@ class PropertyValueFilterFactory implements FilterFactoryInterface
     /**
      * @param array<string,mixed> $settings
      */
-    public function build(array $settings): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
+    public function build(array $settings, ContentRepository $contentRepository): NodeAggregateBasedFilterInterface|NodeBasedFilterInterface
     {
         return new class ($settings['propertyName'], $settings['serializedValue']) implements NodeBasedFilterInterface {
             public function __construct(

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
@@ -32,10 +32,10 @@ class NodeMigrationServiceFactory implements ContentRepositoryServiceFactoryInte
 {
     public function build(ContentRepositoryServiceFactoryDependencies $serviceFactoryDependencies): NodeMigrationService
     {
-        $filtersFactory = new FiltersFactory();
-        $filtersFactory->registerFilter('DimensionSpacePoints', new DimensionSpacePointsFilterFactory($serviceFactoryDependencies->interDimensionalVariationGraph));
+        $filtersFactory = new FiltersFactory($serviceFactoryDependencies->contentRepository);
+        $filtersFactory->registerFilter('DimensionSpacePoints', new DimensionSpacePointsFilterFactory());
         $filtersFactory->registerFilter('NodeName', new NodeNameFilterFactory());
-        $filtersFactory->registerFilter('NodeType', new NodeTypeFilterFactory($serviceFactoryDependencies->nodeTypeManager));
+        $filtersFactory->registerFilter('NodeType', new NodeTypeFilterFactory());
         $filtersFactory->registerFilter('PropertyNotEmpty', new PropertyNotEmptyFilterFactory());
         $filtersFactory->registerFilter('PropertyValue', new PropertyValueFilterFactory());
 

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
@@ -13,9 +13,9 @@ use Neos\ContentRepository\NodeMigration\Filter\NodeTypeFilterFactory;
 use Neos\ContentRepository\NodeMigration\Filter\PropertyNotEmptyFilterFactory;
 use Neos\ContentRepository\NodeMigration\Filter\PropertyValueFilterFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\AddDimensionShineThroughTransformationFactory;
-use Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyTransformationFactory;
+use Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyConverterAwareTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\ChangeNodeTypeTransformationFactory;
-use Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyValueTransformationFactory;
+use Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyValueConverterAwareTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\MoveDimensionSpacePointTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\RemoveNodeTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\RemovePropertyTransformationFactory;
@@ -41,9 +41,9 @@ class NodeMigrationServiceFactory implements ContentRepositoryServiceFactoryInte
 
         $transformationsFactory = new TransformationsFactory($serviceFactoryDependencies->contentRepository, $serviceFactoryDependencies->propertyConverter);
         $transformationsFactory->registerTransformation('AddDimensionShineThrough', new AddDimensionShineThroughTransformationFactory());
-        $transformationsFactory->registerTransformation('AddNewProperty', new AddNewPropertyTransformationFactory());
+        $transformationsFactory->registerTransformation('AddNewProperty', new AddNewPropertyConverterAwareTransformationFactory());
         $transformationsFactory->registerTransformation('ChangeNodeType', new ChangeNodeTypeTransformationFactory());
-        $transformationsFactory->registerTransformation('ChangePropertyValue', new ChangePropertyValueTransformationFactory());
+        $transformationsFactory->registerTransformation('ChangePropertyValue', new ChangePropertyValueConverterAwareTransformationFactory());
         $transformationsFactory->registerTransformation('MoveDimensionSpacePoint', new MoveDimensionSpacePointTransformationFactory());
         $transformationsFactory->registerTransformation('RemoveNode', new RemoveNodeTransformationFactory());
         $transformationsFactory->registerTransformation('RemoveProperty', new RemovePropertyTransformationFactory());

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
@@ -7,6 +7,7 @@ namespace Neos\ContentRepository\NodeMigration;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryDependencies;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
 use Neos\ContentRepository\NodeMigration\Filter\DimensionSpacePointsFilterFactory;
+use Neos\ContentRepository\NodeMigration\Filter\FilterFactoryInterface;
 use Neos\ContentRepository\NodeMigration\Filter\FiltersFactory;
 use Neos\ContentRepository\NodeMigration\Filter\NodeNameFilterFactory;
 use Neos\ContentRepository\NodeMigration\Filter\NodeTypeFilterFactory;
@@ -17,40 +18,68 @@ use Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyConverterA
 use Neos\ContentRepository\NodeMigration\Transformation\ChangeNodeTypeTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyValueConverterAwareTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\MoveDimensionSpacePointTransformationFactory;
+use Neos\ContentRepository\NodeMigration\Transformation\PropertyConverterAwareTransformationFactoryInterface;
 use Neos\ContentRepository\NodeMigration\Transformation\RemoveNodeTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\RemovePropertyTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\RenameNodeAggregateTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\RenamePropertyTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\StripTagsOnPropertyTransformationFactory;
+use Neos\ContentRepository\NodeMigration\Transformation\TransformationFactoryInterface;
 use Neos\ContentRepository\NodeMigration\Transformation\TransformationsFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\UpdateRootNodeAggregateDimensionsTransformationFactory;
 
 /**
  * @implements ContentRepositoryServiceFactoryInterface<NodeMigrationService>
  */
-class NodeMigrationServiceFactory implements ContentRepositoryServiceFactoryInterface
+final readonly class NodeMigrationServiceFactory implements ContentRepositoryServiceFactoryInterface
 {
+    /**
+     * @param array<string,class-string<FilterFactoryInterface>> $filterFactories
+     * @param array<string,class-string<TransformationFactoryInterface|PropertyConverterAwareTransformationFactoryInterface>> $transformationFactories
+     */
+    public function __construct(
+        private array $filterFactories,
+        private array $transformationFactories
+    ) {
+    }
+
+    public static function createDefault(): self
+    {
+        return new self(
+            filterFactories: [
+                'DimensionSpacePoints' => DimensionSpacePointsFilterFactory::class,
+                'NodeName' => NodeNameFilterFactory::class,
+                'NodeType' => NodeTypeFilterFactory::class,
+                'PropertyNotEmpty' => PropertyNotEmptyFilterFactory::class,
+                'PropertyValue' => PropertyValueFilterFactory::class,
+            ],
+            transformationFactories: [
+                'AddDimensionShineThrough' => AddDimensionShineThroughTransformationFactory::class,
+                'AddNewProperty' => AddNewPropertyConverterAwareTransformationFactory::class,
+                'ChangeNodeType' => ChangeNodeTypeTransformationFactory::class,
+                'ChangePropertyValue' => ChangePropertyValueConverterAwareTransformationFactory::class,
+                'MoveDimensionSpacePoint' => MoveDimensionSpacePointTransformationFactory::class,
+                'RemoveNode' => RemoveNodeTransformationFactory::class,
+                'RemoveProperty' => RemovePropertyTransformationFactory::class,
+                'RenameNodeAggregate' => RenameNodeAggregateTransformationFactory::class,
+                'RenameProperty' => RenamePropertyTransformationFactory::class,
+                'StripTagsOnProperty' => StripTagsOnPropertyTransformationFactory::class,
+                'UpdateRootNodeAggregateDimensions' => UpdateRootNodeAggregateDimensionsTransformationFactory::class,
+            ]
+        );
+    }
+
     public function build(ContentRepositoryServiceFactoryDependencies $serviceFactoryDependencies): NodeMigrationService
     {
         $filtersFactory = new FiltersFactory($serviceFactoryDependencies->contentRepository);
-        $filtersFactory->registerFilter('DimensionSpacePoints', new DimensionSpacePointsFilterFactory());
-        $filtersFactory->registerFilter('NodeName', new NodeNameFilterFactory());
-        $filtersFactory->registerFilter('NodeType', new NodeTypeFilterFactory());
-        $filtersFactory->registerFilter('PropertyNotEmpty', new PropertyNotEmptyFilterFactory());
-        $filtersFactory->registerFilter('PropertyValue', new PropertyValueFilterFactory());
+        foreach ($this->filterFactories as $filterIdentifier => $filterFactoryClassName) {
+            $filtersFactory->registerFilter($filterIdentifier, new $filterFactoryClassName());
+        }
 
         $transformationsFactory = new TransformationsFactory($serviceFactoryDependencies->contentRepository, $serviceFactoryDependencies->propertyConverter);
-        $transformationsFactory->registerTransformation('AddDimensionShineThrough', new AddDimensionShineThroughTransformationFactory());
-        $transformationsFactory->registerTransformation('AddNewProperty', new AddNewPropertyConverterAwareTransformationFactory());
-        $transformationsFactory->registerTransformation('ChangeNodeType', new ChangeNodeTypeTransformationFactory());
-        $transformationsFactory->registerTransformation('ChangePropertyValue', new ChangePropertyValueConverterAwareTransformationFactory());
-        $transformationsFactory->registerTransformation('MoveDimensionSpacePoint', new MoveDimensionSpacePointTransformationFactory());
-        $transformationsFactory->registerTransformation('RemoveNode', new RemoveNodeTransformationFactory());
-        $transformationsFactory->registerTransformation('RemoveProperty', new RemovePropertyTransformationFactory());
-        $transformationsFactory->registerTransformation('RenameNodeAggregate', new RenameNodeAggregateTransformationFactory());
-        $transformationsFactory->registerTransformation('RenameProperty', new RenamePropertyTransformationFactory());
-        $transformationsFactory->registerTransformation('StripTagsOnProperty', new StripTagsOnPropertyTransformationFactory());
-        $transformationsFactory->registerTransformation('UpdateRootNodeAggregateDimensions', new UpdateRootNodeAggregateDimensionsTransformationFactory());
+        foreach ($this->transformationFactories as $transformationIdentifier => $transformationFactoryClassName) {
+            $transformationsFactory->registerTransformation($transformationIdentifier, new $transformationFactoryClassName());
+        }
 
         return new NodeMigrationService(
             $serviceFactoryDependencies->contentRepository,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
@@ -17,7 +17,6 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\AddDimensionShineThrough;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -35,7 +34,6 @@ class AddDimensionShineThroughTransformationFactory implements TransformationFac
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         return new class (
             DimensionSpacePoint::fromArray($settings['from']),

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddNewPropertyConverterAwareTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddNewPropertyConverterAwareTransformationFactory.php
@@ -19,14 +19,12 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
-class AddNewPropertyTransformationFactory implements TransformationFactoryInterface
+class AddNewPropertyConverterAwareTransformationFactory implements PropertyConverterAwareTransformationFactoryInterface
 {
     /**
      * @param array<string,mixed> $settings

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
@@ -17,7 +17,6 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
@@ -37,7 +36,6 @@ class ChangeNodeTypeTransformationFactory implements TransformationFactoryInterf
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         // by default, we won't delete anything.
         $nodeAggregateTypeChangeChildConstraintConflictResolutionStrategy

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyValueConverterAwareTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyValueConverterAwareTransformationFactory.php
@@ -17,13 +17,10 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
-use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetSerializedNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -37,7 +34,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  *
  * If search and replace are given, that replacement will be done on the value (after applying the newValue if set).
  */
-class ChangePropertyValueTransformationFactory implements TransformationFactoryInterface
+class ChangePropertyValueConverterAwareTransformationFactory implements PropertyConverterAwareTransformationFactoryInterface
 {
     /**
      * @param array<string,string> $settings

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
@@ -17,7 +17,6 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Command\MoveDimensionSpacePoint;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -31,7 +30,6 @@ class MoveDimensionSpacePointTransformationFactory implements TransformationFact
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         $from = DimensionSpacePoint::fromArray($settings['from']);
         $to = DimensionSpacePoint::fromArray($settings['to']);

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/PropertyConverterAwareTransformationFactoryInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/PropertyConverterAwareTransformationFactoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeMigration\Transformation;
+
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
+
+/**
+ * @internal builds transformators similar to {@see TransformationFactoryInterface} with the additional perk of
+ * making the internal {@see PropertyConverter} available.
+ * Custom transformations depending on the property converter are not public api.
+ */
+interface PropertyConverterAwareTransformationFactoryInterface
+{
+    /**
+     * @param array<string,mixed> $settings
+     */
+    public function build(
+        array $settings,
+        ContentRepository $contentRepository,
+        PropertyConverter $propertyConverter,
+    ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface;
+}

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RemoveNodeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RemoveNodeTransformationFactory.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeRemoval\Command\RemoveNodeAggregate;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeVariantSelectionStrategy;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
@@ -35,7 +34,6 @@ class RemoveNodeTransformationFactory implements TransformationFactoryInterface
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         $strategy = null;
         if (isset($settings['strategy'])) {

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RemovePropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RemovePropertyTransformationFactory.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -34,7 +33,6 @@ class RemovePropertyTransformationFactory implements TransformationFactoryInterf
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         $propertyName = $settings['property'];
         return new class (

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RenameNodeAggregateTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RenameNodeAggregateTransformationFactory.php
@@ -16,7 +16,6 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Feature\NodeRenaming\Command\ChangeNodeAggregateName;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
@@ -30,7 +29,6 @@ class RenameNodeAggregateTransformationFactory implements TransformationFactoryI
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         $newNodeName = $settings['newNodeName'];
 

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RenamePropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RenamePropertyTransformationFactory.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -34,7 +33,6 @@ class RenamePropertyTransformationFactory implements TransformationFactoryInterf
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface
     {
         return new class (

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/StripTagsOnPropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/StripTagsOnPropertyTransformationFactory.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -34,7 +33,6 @@ class StripTagsOnPropertyTransformationFactory implements TransformationFactoryI
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         return new class (
             $settings['property'],

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationFactoryInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationFactoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\NodeMigration\Transformation;
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 
 interface TransformationFactoryInterface
 {
@@ -14,7 +13,6 @@ interface TransformationFactoryInterface
      */
     public function build(
         array $settings,
-        ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
+        ContentRepository $contentRepository
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationFactoryInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationFactoryInterface.php
@@ -6,6 +6,9 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 
 use Neos\ContentRepository\Core\ContentRepository;
 
+/**
+ * Factory to build a transformation
+ */
 interface TransformationFactoryInterface
 {
     /**

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationsFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationsFactory.php
@@ -15,7 +15,7 @@ use Neos\ContentRepository\NodeMigration\NodeMigrationService;
 class TransformationsFactory
 {
     /**
-     * @var array<string,TransformationFactoryInterface>
+     * @var array<string,TransformationFactoryInterface|PropertyConverterAwareTransformationFactoryInterface>
      */
     private array $transformationFactories = [];
 
@@ -25,7 +25,7 @@ class TransformationsFactory
     ) {
     }
 
-    public function registerTransformation(string $transformationIdentifier, TransformationFactoryInterface $transformationFactory): self
+    public function registerTransformation(string $transformationIdentifier, TransformationFactoryInterface|PropertyConverterAwareTransformationFactoryInterface $transformationFactory): self
     {
         $this->transformationFactories[$transformationIdentifier] = $transformationFactory;
         return $this;
@@ -60,7 +60,10 @@ class TransformationsFactory
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface
     {
         $transformationFactory = $this->resolveTransformationFactory($transformationConfiguration['type']);
-        return $transformationFactory->build($transformationConfiguration['settings'] ?? [], $this->contentRepository, $this->propertyConverter);
+        if ($transformationFactory instanceof PropertyConverterAwareTransformationFactoryInterface) {
+            return $transformationFactory->build($transformationConfiguration['settings'] ?? [], $this->contentRepository, $this->propertyConverter);
+        }
+        return $transformationFactory->build($transformationConfiguration['settings'] ?? [], $this->contentRepository);
     }
 
     /**
@@ -72,7 +75,7 @@ class TransformationsFactory
      * @param string $transformationName
      * @throws MigrationException
      */
-    protected function resolveTransformationFactory(string $transformationName): TransformationFactoryInterface
+    protected function resolveTransformationFactory(string $transformationName): TransformationFactoryInterface|PropertyConverterAwareTransformationFactoryInterface
     {
         if (isset($this->transformationFactories[$transformationName])) {
             return $this->transformationFactories[$transformationName];

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
@@ -6,7 +6,6 @@ namespace Neos\ContentRepository\NodeMigration\Transformation;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\UpdateRootNodeAggregateDimensions;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\NodeMigration\MigrationException;
@@ -19,7 +18,6 @@ class UpdateRootNodeAggregateDimensionsTransformationFactory implements Transfor
     public function build(
         array $settings,
         ContentRepository $contentRepository,
-        PropertyConverter $propertyConverter,
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         if (!isset($settings['nodeType'])) {
             throw new MigrationException(

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/MigrationsTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/MigrationsTrait.php
@@ -45,7 +45,7 @@ trait MigrationsTrait
         );
 
         /** @var NodeMigrationService $nodeMigrationService */
-        $nodeMigrationService = $this->getContentRepositoryService(new NodeMigrationServiceFactory());
+        $nodeMigrationService = $this->getContentRepositoryService(NodeMigrationServiceFactory::createDefault());
         $nodeMigrationService->executeMigration($command);
     }
 

--- a/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
+++ b/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
@@ -104,3 +104,23 @@ Neos:
         # commandHooks:
         #   'My.Package:SomeCommandHook': # just a name
         #     factoryObjectName: My\Package\CommandHook\SomeCommandHookFactory
+
+    nodeMigration:
+      filterFactories:
+        DimensionSpacePoints: Neos\ContentRepository\NodeMigration\Filter\DimensionSpacePointsFilterFactory
+        NodeName: Neos\ContentRepository\NodeMigration\Filter\NodeNameFilterFactory
+        NodeType: Neos\ContentRepository\NodeMigration\Filter\NodeTypeFilterFactory
+        PropertyNotEmpty: Neos\ContentRepository\NodeMigration\Filter\PropertyNotEmptyFilterFactory
+        PropertyValue: Neos\ContentRepository\NodeMigration\Filter\PropertyValueFilterFactory
+      transformationFactories:
+        AddDimensionShineThrough: Neos\ContentRepository\NodeMigration\Transformation\AddDimensionShineThroughTransformationFactory
+        AddNewProperty: Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyConverterAwareTransformationFactory
+        ChangeNodeType: Neos\ContentRepository\NodeMigration\Transformation\ChangeNodeTypeTransformationFactory
+        ChangePropertyValue: Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyValueConverterAwareTransformationFactory
+        MoveDimensionSpacePoint: Neos\ContentRepository\NodeMigration\Transformation\MoveDimensionSpacePointTransformationFactory
+        RemoveNode: Neos\ContentRepository\NodeMigration\Transformation\RemoveNodeTransformationFactory
+        RemoveProperty: Neos\ContentRepository\NodeMigration\Transformation\RemovePropertyTransformationFactory
+        RenameNodeAggregate: Neos\ContentRepository\NodeMigration\Transformation\RenameNodeAggregateTransformationFactory
+        RenameProperty: Neos\ContentRepository\NodeMigration\Transformation\RenamePropertyTransformationFactory
+        StripTagsOnProperty: Neos\ContentRepository\NodeMigration\Transformation\StripTagsOnPropertyTransformationFactory
+        UpdateRootNodeAggregateDimensions: Neos\ContentRepository\NodeMigration\Transformation\UpdateRootNodeAggregateDimensionsTransformationFactory


### PR DESCRIPTION
As requested in [slack](https://neos-project.slack.com/archives/C050C8FEK/p1739294689567579?thread_ts=1739263113.699029&cid=C050C8FEK) and wrongly promoted by our [documentation](https://docs.neos.io/guide/content-repository/node-migrations-v9#available-transformations):

> All of these transformations implement the Neos\ContentRepository\NodeMigration\Transformation\TransformationFactoryInterface. If you need custom transformations, you can develop them using this interface. When specifying a custom transformation, use its fully qualified class name.

we need a way to extend node migrations.

The code is really flexible already and should easily allow that for transformations, as all the TransformationFactories dont require any constructor arguments which is crucial.

For the filters to be extensible we need to provide in FilterFactoryFactory::build() the at least $nodeTypeManager or the $variationGraph as at the current state the constructors seem to expect these dependencies and cannot resolve them otherwise!

The NodeMigrationServiceFactory::_construct is adjusted to require configuration in the form of `[AddDimensionShineThrough => AddDimensionShineThroughTransformationFactory::class
...]`

All filters and transformations are now registered in yaml under `nodeMigration`:

```yaml
Neos:
  ContentRepositoryRegistry:
    nodeMigration:
      filterFactories:
        DimensionSpacePoints: Neos\ContentRepository\NodeMigration\Filter\DimensionSpacePointsFilterFactory
        NodeName: Neos\ContentRepository\NodeMigration\Filter\NodeNameFilterFactory
        # ...
      transformationFactories:
        AddDimensionShineThrough: Neos\ContentRepository\NodeMigration\Transformation\AddDimensionShineThroughTransformationFactory
        AddNewProperty: Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyConverterAwareTransformationFactory
        ChangeNodeType: Neos\ContentRepository\NodeMigration\Transformation\ChangeNodeTypeTransformationFactory
        # ...
```

This allows to implement custom ones using the factory interfaces `FilterFactoryInterface` and `TransformationFactoryInterface`.

Note that now there is a new internal kind of factory, the `PropertyConverterAwareTransformationFactoryInterface` to avoid leaking the internal `PropertyConverter` into userland:

> builds transformators similar to `TransformationFactoryInterface` with the additional perk of making the internal `PropertyConverter` available.
> Custom transformations depending on the property converter are not public api.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
