### PR TITLE
FEATURE: Add `onAfterHandle` to CommandHookInterface

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Configuration/Testing/Settings.yaml
+++ b/Neos.ContentRepository.BehavioralTests/Configuration/Testing/Settings.yaml
@@ -43,6 +43,27 @@ Neos:
             options:
               instanceId: debug
 
+      t_extensibility:
+        eventStore:
+          factoryObjectName: Neos\ContentRepositoryRegistry\Factory\EventStore\DoctrineEventStoreFactory
+        nodeTypeManager:
+          factoryObjectName: Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory
+        contentDimensionSource:
+          factoryObjectName: Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory
+        authProvider:
+          factoryObjectName: Neos\ContentRepository\TestSuite\Fakes\FakeAuthProviderFactory
+        clock:
+          factoryObjectName: Neos\ContentRepositoryRegistry\Factory\Clock\SystemClockFactory
+        subscriptionStore:
+          factoryObjectName: Neos\ContentRepositoryRegistry\Factory\SubscriptionStore\SubscriptionStoreFactory
+        propertyConverters: {}
+        contentGraphProjection:
+          factoryObjectName: Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphProjectionFactory
+          catchUpHooks: {}
+        commandHooks:
+          'Neos.Testing:FakeCommandHook':
+            factoryObjectName: Neos\ContentRepository\TestSuite\Fakes\FakeCommandHookFactory
+
       t_subscription:
         eventStore:
           factoryObjectName: Neos\ContentRepositoryRegistry\Factory\EventStore\DoctrineEventStoreFactory

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Extensibility/AbstractExtensibilityTestCase.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Extensibility/AbstractExtensibilityTestCase.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional\Extensibility;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Neos\ContentRepository\Core\CommandHandler\CommandHookInterface;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
+use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainerFactory;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\TestSuite\Fakes\FakeCommandHookFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Flow\Core\Bootstrap;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal, only for tests of the Neos.* namespace
+ */
+abstract class AbstractExtensibilityTestCase extends TestCase // we don't use Flows functional test case as it would reset the database afterwards
+{
+    protected static ContentRepositoryId $contentRepositoryId;
+
+    protected ContentRepository $contentRepository;
+
+    protected CommandHookInterface&MockObject $fakeCommandHook;
+
+    public static function setUpBeforeClass(): void
+    {
+        static::$contentRepositoryId = ContentRepositoryId::fromString('t_extensibility');
+    }
+
+    public function setUp(): void
+    {
+        if ($this->getObject(Connection::class)->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $this->markTestSkipped('TODO: The content graph is not available in postgres currently: https://github.com/neos/neos-development-collection/issues/3855');
+        }
+
+        $this->fakeCommandHook = $this->getMockBuilder(CommandHookInterface::class)->disableAutoReturnValueGeneration()->getMock();
+
+        FakeCommandHookFactory::setCommandHook(
+            $this->fakeCommandHook
+        );
+
+        FakeNodeTypeManagerFactory::setConfiguration([
+            'Neos.ContentRepository:Root' => [],
+            'Neos.ContentRepository.Testing:Document' => [
+                'properties' => [
+                    'title' => [
+                        'type' => 'string'
+                    ]
+                ]
+            ]
+        ]);
+        FakeContentDimensionSourceFactory::setWithoutDimensions();
+
+        $this->getObject(ContentRepositoryRegistry::class)->resetFactoryInstance(static::$contentRepositoryId);
+
+        /** @var ContentRepositoryMaintainer $contentRepositoryMaintainer */
+        $contentRepositoryMaintainer = $this->getObject(ContentRepositoryRegistry::class)->buildService(static::$contentRepositoryId, new ContentRepositoryMaintainerFactory());
+        $contentRepositoryMaintainer->setUp();
+        // reset events and projections
+        $contentRepositoryMaintainer->prune();
+
+        $this->contentRepository = $this->getObject(ContentRepositoryRegistry::class)->get(static::$contentRepositoryId);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    final protected function getObject(string $className): object
+    {
+        return Bootstrap::$staticObjectManager->get($className);
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Extensibility/CommandHookTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Extensibility/CommandHookTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional\Extensibility;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\CommandHandler\Commands;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\EventStore\DecoratedEvent;
+use Neos\ContentRepository\Core\EventStore\Events;
+use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasClosed;
+use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Event\ContentStreamWasCreated;
+use Neos\ContentRepository\Core\Feature\ContentStreamForking\Event\ContentStreamWasForked;
+use Neos\ContentRepository\Core\Feature\ContentStreamRemoval\Event\ContentStreamWasRemoved;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNodeWasCreated;
+use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregateWithNodeWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\WorkspaceWasCreated;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPublished;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+class CommandHookTest extends AbstractExtensibilityTestCase
+{
+    public function testCommandHookReceivesCommandAndEvents(): void
+    {
+        $command = CreateRootWorkspace::create(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live'));
+        $expectedEvents = Events::fromArray([
+            new ContentStreamWasCreated(ContentStreamId::fromString('cs-live')),
+            new RootWorkspaceWasCreated(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live'))
+        ]);
+
+        $this->fakeCommandHook->expects(self::once())->method('onBeforeHandle')->with($command)->willReturn($command);
+        $this->fakeCommandHook->expects(self::once())->method('onAfterHandle')->with($command, $expectedEvents)->willReturn(Commands::createEmpty());
+
+        $this->contentRepository->handle($command);
+    }
+
+    /**
+     * onBeforeHandle and onAfterHandle are invoked in various cases, for control flow aware commands and also simple ones
+     */
+    public function testCommandHookWithMultipleCommands(): void
+    {
+        $testCases = [
+            [
+                'command' => CreateRootWorkspace::create(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live')),
+                'eventClassNames' => [ContentStreamWasCreated::class, RootWorkspaceWasCreated::class]
+            ],
+            [
+                'command' => CreateWorkspace::create(WorkspaceName::fromString('user'), WorkspaceName::forLive(), ContentStreamId::fromString('cs-user')),
+                'eventClassNames' => [ContentStreamWasForked::class, WorkspaceWasCreated::class]
+            ],
+            [
+                'command' => CreateRootNodeAggregateWithNode::create(WorkspaceName::fromString('user'), NodeAggregateId::fromString('node'), NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)),
+                'eventClassNames' => [RootNodeAggregateWithNodeWasCreated::class]
+            ],
+            [
+                'command' => PublishWorkspace::create(WorkspaceName::fromString('user')),
+                'eventClassNames' => [ContentStreamWasClosed::class, RootNodeAggregateWithNodeWasCreated::class, ContentStreamWasForked::class, WorkspaceWasPublished::class, ContentStreamWasRemoved::class]
+            ],
+        ];
+
+        $this->fakeCommandHook->expects($i = self::exactly(count($testCases)))->method('onBeforeHandle')->willReturnCallback(function (CommandInterface $command) use ($i, $testCases) {
+            $caseIndex = $i->getInvocationCount() - 1;
+
+            $testCase = $testCases[$caseIndex];
+            self::assertEquals($testCase['command'], $command, sprintf('The command at step %s doesnt match as expected', $caseIndex));
+            return $testCase['command'];
+        });
+        $this->fakeCommandHook->expects($i = self::exactly(count($testCases)))->method('onAfterHandle')->willReturnCallback(function (CommandInterface $command, Events $events) use ($i, $testCases) {
+            $caseIndex = $i->getInvocationCount() - 1;
+
+            $testCase = $testCases[$caseIndex];
+            self::assertEquals($testCase['command'], $command, sprintf('The command at step %s doesnt match as expected', $caseIndex));
+            self::assertEquals($testCase['eventClassNames'], $events->map(fn ($event) => DecoratedEvent::create($event)->innerEvent::class), sprintf('The events at step %s doesnt match as expected', $caseIndex));
+            return Commands::createEmpty();
+        });
+
+        foreach ($testCases as $testCase) {
+            $this->contentRepository->handle($testCase['command']);
+        }
+    }
+
+    /**
+     * onBeforeHandle can exchange the command that was passed by returning something else
+     */
+    public function testCommandHookReplacesCommand(): void
+    {
+        $command = CreateRootWorkspace::create(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live'));
+
+        $replacedCommand = CreateRootWorkspace::create(WorkspaceName::fromString('replaced'), ContentStreamId::fromString('cs-replaced'));
+        $expectedEvents = Events::fromArray([
+            new ContentStreamWasCreated(ContentStreamId::fromString('cs-replaced')),
+            new RootWorkspaceWasCreated(WorkspaceName::fromString('replaced'), ContentStreamId::fromString('cs-replaced'))
+        ]);
+
+        $this->fakeCommandHook->expects(self::once())->method('onBeforeHandle')->with($command)->willReturn($replacedCommand);
+        $this->fakeCommandHook->expects(self::once())->method('onAfterHandle')->with($replacedCommand, $expectedEvents)->willReturn(Commands::createEmpty());
+
+        $this->contentRepository->handle($command);
+
+        self::assertNull($this->contentRepository->findWorkspaceByName(WorkspaceName::forLive()));
+        self::assertNotNull($this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('replaced')));
+    }
+
+    /**
+     * Test for simple command handling with a followup, like issue a command on live a node was directly created on live - not published
+     */
+    public function testIssueFollowupCommandsSimpleCase(): void
+    {
+        $this->fakeCommandHook->expects(self::exactly(4))->method('onBeforeHandle')->willReturnArgument(0);
+        $this->fakeCommandHook->expects($i = self::exactly(4))->method('onAfterHandle')->willReturnCallback(function (CommandInterface $command, Events $events) use ($i) {
+            if ($i->getInvocationCount() === 3) {
+                self::assertInstanceOf(CreateNodeAggregateWithNode::class, $command);
+                self::assertEquals([NodeAggregateWithNodeWasCreated::class], $events->map(fn ($event) => DecoratedEvent::create($event)->innerEvent::class));
+
+                $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::withoutRestrictions());
+                $node = $subgraph->findNodeById(NodeAggregateId::fromString('document-node'));
+                self::assertNotNull($node, 'The node must exist onAfterHandle');
+                self::assertNull($node->getProperty('title'));
+
+                return Commands::create(SetNodeProperties::create(
+                    WorkspaceName::forLive(),
+                    NodeAggregateId::fromString('document-node'),
+                    OriginDimensionSpacePoint::createWithoutDimensions(),
+                    PropertyValuesToWrite::fromArray([
+                        'title' => 'set by hook'
+                    ])
+                ));
+            } elseif ($i->getInvocationCount() === 4) {
+                // recursion passes the via the previous onAfterHandle hook back here:
+                self::assertInstanceOf(SetNodeProperties::class, $command);
+
+                return Commands::createEmpty();
+            } else {
+                return Commands::createEmpty();
+            }
+        });
+
+        $this->contentRepository->handle(CreateRootWorkspace::create(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live')));
+        $this->contentRepository->handle(CreateRootNodeAggregateWithNode::create(WorkspaceName::forLive(), NodeAggregateId::fromString('root'), NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)));
+        $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('document-node'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            OriginDimensionSpacePoint::createWithoutDimensions(),
+            parentNodeAggregateId: NodeAggregateId::fromString('root')
+        ));
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::withoutRestrictions());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('document-node'));
+        self::assertNotNull($node);
+        self::assertEquals('set by hook', $node->getProperty('title'));
+    }
+
+    /**
+     * Test for control-flow aware command handling with a followup, like issue a command on live if PublishWorkspace contains a certain creation of a node
+     */
+    public function testIssueFollowupCommandOnPublish(): void
+    {
+        $this->fakeCommandHook->expects(self::exactly(6))->method('onBeforeHandle')->willReturnArgument(0);
+        $this->fakeCommandHook->expects($i = self::exactly(6))->method('onAfterHandle')->willReturnCallback(function (CommandInterface $command, Events $events) use ($i) {
+            if ($i->getInvocationCount() === 5) {
+                self::assertInstanceOf(PublishWorkspace::class, $command);
+                self::assertContains(NodeAggregateWithNodeWasCreated::class, $events->map(fn ($event) => DecoratedEvent::create($event)->innerEvent::class));
+
+                $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::withoutRestrictions());
+                $node = $subgraph->findNodeById(NodeAggregateId::fromString('document-node'));
+                self::assertNotNull($node, 'The node must exist onAfterHandle');
+                self::assertNull($node->getProperty('title'));
+
+                return Commands::create(SetNodeProperties::create(
+                    WorkspaceName::forLive(),
+                    NodeAggregateId::fromString('document-node'),
+                    OriginDimensionSpacePoint::createWithoutDimensions(),
+                    PropertyValuesToWrite::fromArray([
+                        'title' => 'set by hook'
+                    ])
+                ));
+            } elseif ($i->getInvocationCount() === 6) {
+                // recursion passes the via the previous onAfterHandle hook back here:
+                self::assertInstanceOf(SetNodeProperties::class, $command);
+
+                return Commands::createEmpty();
+            } else {
+                return Commands::createEmpty();
+            }
+        });
+
+        $this->contentRepository->handle(CreateRootWorkspace::create(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live')));
+        $this->contentRepository->handle(CreateRootNodeAggregateWithNode::create(WorkspaceName::forLive(), NodeAggregateId::fromString('root'), NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)));
+        $this->contentRepository->handle(CreateWorkspace::create(WorkspaceName::fromString('user'), WorkspaceName::forLive(), ContentStreamId::fromString('cs-user')));
+        $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::fromString('user'),
+            NodeAggregateId::fromString('document-node'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            OriginDimensionSpacePoint::createWithoutDimensions(),
+            parentNodeAggregateId: NodeAggregateId::fromString('root')
+        ));
+        $this->contentRepository->handle(PublishWorkspace::create(WorkspaceName::fromString('user')));
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::withoutRestrictions());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('document-node'));
+        self::assertNotNull($node);
+        self::assertEquals('set by hook', $node->getProperty('title'));
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\CommandHandler;
 
 use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\EventStore\Events;
 
 /**
  * Contract for a hook that is invoked just before any command is processed via {@see ContentRepository::handle()}
@@ -25,7 +26,8 @@ interface CommandHookInterface
 
     /**
      * @param CommandInterface $command The command that was just handled
+     * @param Events $events The events that resulted from the handled command
      * @return Commands This hook must return Commands that will be handled after the incoming $command. The Commands can be empty.
      */
-    public function onAfterHandle(CommandInterface $command): Commands;
+    public function onAfterHandle(CommandInterface $command, Events $events): Commands;
 }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
@@ -22,4 +22,10 @@ interface CommandHookInterface
      * @return CommandInterface This hook must return a command instance. It can be the unaltered incoming $command or a new instance
      */
     public function onBeforeHandle(CommandInterface $command): CommandInterface;
+
+    /**
+     * @param CommandInterface $command The command that was just handled
+     * @return Commands This hook must return Commands that will be handled after the incoming $command. The Commands can be empty.
+     */
+    public function onAfterHandle(CommandInterface $command): Commands;
 }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\CommandHandler;
 
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\EventStore\Events;
+use Neos\ContentRepository\Core\EventStore\PublishedEvents;
 
 /**
  * Contract for a hook that is invoked just before any command is processed via {@see ContentRepository::handle()}
@@ -26,9 +26,8 @@ interface CommandHookInterface
 
     /**
      * @param CommandInterface $command The command that was just handled
-     * TODO Events is not API! And contains the Decorated Event which is not api either ... also the time stamps etc might be cool to have.
-     * @param Events $events The events that resulted from the handled command
+     * @param PublishedEvents $events The events that resulted from the handled command
      * @return Commands This hook must return Commands that will be handled after the incoming $command. The Commands can be empty.
      */
-    public function onAfterHandle(CommandInterface $command, Events $events): Commands;
+    public function onAfterHandle(CommandInterface $command, PublishedEvents $events): Commands;
 }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHookInterface.php
@@ -26,6 +26,7 @@ interface CommandHookInterface
 
     /**
      * @param CommandInterface $command The command that was just handled
+     * TODO Events is not API! And contains the Decorated Event which is not api either ... also the time stamps etc might be cool to have.
      * @param Events $events The events that resulted from the handled command
      * @return Commands This hook must return Commands that will be handled after the incoming $command. The Commands can be empty.
      */

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\CommandHandler;
 
+use Neos\ContentRepository\Core\EventStore\Events;
+
 /**
  * Collection of {@see CommandHookInterface} instances, functioning as a delegating command hook implementation
  *
@@ -54,11 +56,11 @@ final readonly class CommandHooks implements CommandHookInterface, \IteratorAggr
         return $command;
     }
 
-    public function onAfterHandle(CommandInterface $command): Commands
+    public function onAfterHandle(CommandInterface $command, Events $events): Commands
     {
         $commands = Commands::createEmpty();
         foreach ($this->commandHooks as $commandHook) {
-            $commands = $commands->merge($commandHook->onAfterHandle($command));
+            $commands = $commands->merge($commandHook->onAfterHandle($command, $events));
         }
         return $commands;
     }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
@@ -53,4 +53,13 @@ final readonly class CommandHooks implements CommandHookInterface, \IteratorAggr
         }
         return $command;
     }
+
+    public function onAfterHandle(CommandInterface $command): Commands
+    {
+        $commands = Commands::createEmpty();
+        foreach ($this->commandHooks as $commandHook) {
+            $commands = $commands->merge($commandHook->onAfterHandle($command));
+        }
+        return $commands;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\CommandHandler;
 
 use Neos\ContentRepository\Core\EventStore\Events;
+use Neos\ContentRepository\Core\EventStore\PublishedEvents;
 
 /**
  * Collection of {@see CommandHookInterface} instances, functioning as a delegating command hook implementation
@@ -56,7 +57,7 @@ final readonly class CommandHooks implements CommandHookInterface, \IteratorAggr
         return $command;
     }
 
-    public function onAfterHandle(CommandInterface $command, Events $events): Commands
+    public function onAfterHandle(CommandInterface $command, PublishedEvents $events): Commands
     {
         $commands = Commands::createEmpty();
         foreach ($this->commandHooks as $commandHook) {

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -143,10 +143,10 @@ final class ContentRepository
             if ($fullCatchUpResult->hadErrors()) {
                 throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
             }
-            $additionalCommands = $this->commandHook->onAfterHandle($command, $events);
-            foreach ($additionalCommands as $additionalCommand) {
-                $this->handle($additionalCommand);
-            }
+        }
+        $additionalCommands = $this->commandHook->onAfterHandle($command, $events);
+        foreach ($additionalCommands as $additionalCommand) {
+            $this->handle($additionalCommand);
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Core\EventStore\EventNormalizer;
 use Neos\ContentRepository\Core\EventStore\Events as DomainEvents;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\EventStore\InitiatingEventMetadata;
+use Neos\ContentRepository\Core\EventStore\PublishedEvents;
 use Neos\ContentRepository\Core\Feature\Security\AuthProviderInterface;
 use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
 use Neos\ContentRepository\Core\Feature\Security\Exception\AccessDenied;
@@ -37,8 +38,6 @@ use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
 use Neos\ContentRepository\Core\Projection\ProjectionStates;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
-use Neos\ContentRepository\Core\SharedModel\Id\UuidFactory;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreams;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
@@ -106,7 +105,7 @@ final class ContentRepository
             if ($fullCatchUpResult->hadErrors()) {
                 throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
             }
-            $additionalCommands = $this->commandHook->onAfterHandle($command, $toPublish->events);
+            $additionalCommands = $this->commandHook->onAfterHandle($command, $toPublish->events->toInnerEvents());
             foreach ($additionalCommands as $additionalCommand) {
                 $this->handle($additionalCommand);
             }
@@ -114,12 +113,12 @@ final class ContentRepository
         }
 
         // control-flow aware command handling via generator
-        $events = DomainEvents::createEmpty();
+        $publishedEvents = PublishedEvents::createEmpty();
         try {
             foreach ($toPublish as $eventsToPublish) {
                 try {
                     $this->eventStore->commit($eventsToPublish->streamName, $this->enrichAndNormalizeEvents($eventsToPublish->events, $correlationId), $eventsToPublish->expectedVersion);
-                    $events = $events->withAppendedEvents($eventsToPublish->events);
+                    $publishedEvents = $publishedEvents->withAppendedEvents($eventsToPublish->events->toInnerEvents());
                 } catch (ConcurrencyException $concurrencyException) {
                     // we pass the exception into the generator (->throw), so it could be try-caught and reacted upon:
                     //
@@ -144,7 +143,7 @@ final class ContentRepository
                 throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
             }
         }
-        $additionalCommands = $this->commandHook->onAfterHandle($command, $events);
+        $additionalCommands = $this->commandHook->onAfterHandle($command, $publishedEvents);
         foreach ($additionalCommands as $additionalCommand) {
             $this->handle($additionalCommand);
         }

--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -106,6 +106,10 @@ final class ContentRepository
             if ($fullCatchUpResult->hadErrors()) {
                 throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
             }
+            $additionalCommands = $this->commandHook->onAfterHandle($command);
+            foreach ($additionalCommands as $additionalCommand) {
+                $this->handle($additionalCommand);
+            }
             return;
         }
 
@@ -136,6 +140,10 @@ final class ContentRepository
             $fullCatchUpResult = $this->subscriptionEngine->catchUpActive(); // NOTE: we don't batch here, to ensure the catchup is run completely and any errors don't stop it.
             if ($fullCatchUpResult->hadErrors()) {
                 throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
+            }
+            $additionalCommands = $this->commandHook->onAfterHandle($command);
+            foreach ($additionalCommands as $additionalCommand) {
+                $this->handle($additionalCommand);
             }
         }
     }

--- a/Neos.ContentRepository.Core/Classes/EventStore/Events.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/Events.php
@@ -52,14 +52,6 @@ final readonly class Events implements \IteratorAggregate, \Countable
         return new self(...$events);
     }
 
-    /**
-     * @return static
-     */
-    public static function createEmpty(): self
-    {
-        return new self();
-    }
-
     public function getIterator(): \Traversable
     {
         yield from $this->items;
@@ -73,6 +65,11 @@ final readonly class Events implements \IteratorAggregate, \Countable
     public function map(\Closure $callback): array
     {
         return array_map($callback, $this->items);
+    }
+
+    public function toInnerEvents(): PublishedEvents
+    {
+        return PublishedEvents::fromArray($this->map(fn (EventInterface|DecoratedEvent $event) => $event instanceof DecoratedEvent ? $event->innerEvent : $event));
     }
 
     public function count(): int

--- a/Neos.ContentRepository.Core/Classes/EventStore/Events.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/Events.php
@@ -52,6 +52,14 @@ final readonly class Events implements \IteratorAggregate, \Countable
         return new self(...$events);
     }
 
+    /**
+     * @return static
+     */
+    public static function createEmpty(): self
+    {
+        return new self();
+    }
+
     public function getIterator(): \Traversable
     {
         yield from $this->items;

--- a/Neos.ContentRepository.Core/Classes/EventStore/PublishedEvents.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/PublishedEvents.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\EventStore;
+
+/**
+ * A set of Content Repository "domain events"
+ *
+ * @implements \IteratorAggregate<EventInterface>
+ * @api
+ */
+final readonly class PublishedEvents implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var non-empty-array<EventInterface>
+     */
+    public array $items;
+
+    private function __construct(EventInterface ...$events)
+    {
+        /** @var non-empty-array<EventInterface> $events */
+        $this->items = $events;
+    }
+
+    /**
+     * @param non-empty-array<EventInterface> $events
+     * @return static
+     */
+    public static function fromArray(array $events): self
+    {
+        return new self(...$events);
+    }
+
+    public static function createEmpty(): self
+    {
+        return new self();
+    }
+
+    public function withAppendedEvents(PublishedEvents $events): self
+    {
+        return new self(...$this->items, ...$events->items);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->items;
+    }
+
+    /**
+     * @template T
+     * @param \Closure(EventInterface $event): T $callback
+     * @return non-empty-list<T>
+     */
+    public function map(\Closure $callback): array
+    {
+        return array_map($callback, $this->items);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/Neos.ContentRepository.TestSuite/Classes/Fakes/FakeCommandHookFactory.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Fakes/FakeCommandHookFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\TestSuite\Fakes;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandHookInterface;
+use Neos\ContentRepository\Core\Factory\CommandHookFactoryInterface;
+use Neos\ContentRepository\Core\Factory\CommandHooksFactoryDependencies;
+
+final class FakeCommandHookFactory implements CommandHookFactoryInterface
+{
+    private static CommandHookInterface $commandHook;
+
+    public function build(CommandHooksFactoryDependencies $commandHooksFactoryDependencies,): CommandHookInterface
+    {
+        return static::$commandHook ?? throw new \RuntimeException('No command hook defined for Fake.');
+    }
+
+    public static function setCommandHook(CommandHookInterface $commandHook): void
+    {
+        self::$commandHook = $commandHook;
+    }
+}


### PR DESCRIPTION
Followup to #5336

This allows to return additional commands after the just executed one was handled. The onAfterHandle method gets the processed command plus all resulting events.

Example use cases: Add automatic translations to a freshly created node variant. Or create translations in a review workspace when changes are published to the live workspace.

Resolves: #5469 
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
