### PR TITLE
BUGFIX: Remove users personal workspace on user deletion

### DIFF
--- a/Neos.Neos/Classes/Domain/Repository/WorkspaceMetadataAndRoleRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/WorkspaceMetadataAndRoleRepository.php
@@ -362,6 +362,30 @@ final readonly class WorkspaceMetadataAndRoleRepository
     }
 
     /**
+     * @return \Traversable<ContentRepositoryId,WorkspaceName>
+     */
+    public function findAllPersonalWorkspaceNamesByUser(UserId $userId): \Traversable
+    {
+        $tableMetadata = self::TABLE_NAME_WORKSPACE_METADATA;
+        $query = <<<SQL
+            SELECT
+                content_repository_id, workspace_name
+            FROM
+                {$tableMetadata}
+            WHERE
+                classification = :personalWorkspaceClassification
+                AND owner_user_id = :userId
+        SQL;
+        $rows = $this->dbal->fetchAllAssociative($query, [
+            'personalWorkspaceClassification' => WorkspaceClassification::PERSONAL->value,
+            'userId' => $userId->value,
+        ]);
+        foreach ($rows as $row) {
+            yield ContentRepositoryId::fromString($row['content_repository_id']) => WorkspaceName::fromString($row['workspace_name']);
+        }
+    }
+
+    /**
      * @param \Closure(): void $fn
      * @return void
      */


### PR DESCRIPTION
With https://github.com/neos/neos-development-collection/pull/5146 indeed most problems outlined in https://github.com/neos/neos-development-collection/issues/4566 were solved. Now one non-feature point is kindof left open:

> a user Foo has a personal workspace named user-Foo. If the user is deleted and a new user named Foo is created it will use the previously still existent workspace user-Foo.

In the current state this will no longer happen as `WorkspaceService::getPersonalWorkspaceForUser` operates on the neos UUID user identifier and not the name of the account. Recreating a new user with the same name would mean it will get the workspace `Foo2`. So the only part that is not "fixed" yet is that deleting a user does not cleanup its workspaces.

This change adds a query to determine all content repositories a user was active in and then proceeds to delete the workspaces.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
