### PR TITLE
FEATURE: Make adjustments for missing tethered nodes recursive

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/MissingTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/MissingTetheredNodes.feature
@@ -1,0 +1,114 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Missing Tethered Nodes integrity violations
+
+  As a user of the CR I want to be able to detect and fix tethered nodes that are missing
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values                      | Generalizations                      |
+      | example    | general, source, spec, peer | spec->source->general, peer->general |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root':
+      childNodes:
+        'originally-tethered-node':
+          type: 'Neos.ContentRepository.Testing:Tethered'
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        'tethered-node':
+          type: 'Neos.ContentRepository.Testing:Tethered'
+    'Neos.ContentRepository.Testing:Tethered':
+      properties:
+        foo:
+          type: "string"
+          defaultValue: "my default applied"
+      childNodes:
+        'tethered-leaf':
+          type: 'Neos.ContentRepository.Testing:TetheredLeaf'
+    'Neos.ContentRepository.Testing:TetheredLeaf': []
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key                                | Value                                                                                                                     |
+      | nodeAggregateId                    | "lady-eleonode-rootford"                                                                                                  |
+      | nodeTypeName                       | "Neos.ContentRepository:Root"                                                                                             |
+      | tetheredDescendantNodeAggregateIds | {"originally-tethered-node": "originode-tetherton", "originally-tethered-node/tethered-leaf": "originode-tetherton-leaf"} |
+    # We have to add another node since root nodes have no dimension space points and thus cannot be varied
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                                | Value                                                                                      |
+      | nodeAggregateId                    | "sir-david-nodenborough"                                                                   |
+      | nodeTypeName                       | "Neos.ContentRepository.Testing:Document"                                                  |
+      | originDimensionSpacePoint          | {"example": "source"}                                                                      |
+      | parentNodeAggregateId              | "lady-eleonode-rootford"                                                                   |
+      | nodeName                           | "document"                                                                                 |
+      | tetheredDescendantNodeAggregateIds | {"tethered-node": "nodewyn-tetherton", "tethered-node/tethered-leaf": "nodimer-tetherton"} |
+    And the command CreateNodeVariant is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "sir-david-nodenborough" |
+      | sourceOrigin    | {"example":"source"}     |
+      | targetOrigin    | {"example":"peer"}       |
+
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Root"
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Tethered"
+    Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:TetheredLeaf"
+
+  Scenario: Adjusting the schema adding a new tethered node leads to a MissingTetheredNode integrity violation
+    Given I change the node types in content repository "default" to:
+    """yaml
+    'Neos.ContentRepository:Root':
+      childNodes:
+        'originally-tethered-node':
+          type: 'Neos.ContentRepository.Testing:Tethered'
+        'tethered-node':
+          type: 'Neos.ContentRepository.Testing:Tethered'
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        'tethered-node':
+          type: 'Neos.ContentRepository.Testing:Tethered'
+        'new-tethered-node':
+          type: 'Neos.ContentRepository.Testing:Tethered'
+    'Neos.ContentRepository.Testing:Tethered':
+      properties:
+        foo:
+          type: "string"
+          defaultValue: "my default applied"
+      childNodes:
+        'tethered-leaf':
+          type: 'Neos.ContentRepository.Testing:TetheredLeaf'
+    'Neos.ContentRepository.Testing:TetheredLeaf': []
+    """
+    And I expect the following structure adjustments for type "Neos.ContentRepository:Root":
+      | Type                  | nodeAggregateId        |
+      | TETHERED_NODE_MISSING | lady-eleonode-rootford |
+    Then I expect the following structure adjustments for type "Neos.ContentRepository.Testing:Document":
+      | Type                  | nodeAggregateId        | dimensionSpacePoint  |
+      | TETHERED_NODE_MISSING | sir-david-nodenborough | {"example":"source"} |
+      | TETHERED_NODE_MISSING | sir-david-nodenborough | {"example":"peer"}   |
+
+    When I adjust the node structure for node type "Neos.ContentRepository:Root"
+    Then I expect exactly 12 events to be published on stream "ContentStream:cs-identifier"
+    And I expect the graph projection to consist of exactly 11 nodes
+
+    And I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
+    And I expect the following structure adjustments for type "Neos.ContentRepository.Testing:Document":
+      | Type                  | nodeAggregateId        | dimensionSpacePoint  |
+      | TETHERED_NODE_MISSING | sir-david-nodenborough | {"example":"source"} |
+      | TETHERED_NODE_MISSING | sir-david-nodenborough | {"example":"peer"}   |
+    And I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Tethered"
+    And I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:TetheredLeaf"
+
+    When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
+    Then I expect exactly 16 events to be published on stream "ContentStream:cs-identifier"
+    And I expect the graph projection to consist of exactly 15 nodes
+
+    And I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
+    And I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
+    And I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Tethered"
+    And I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:TetheredLeaf"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -145,11 +145,15 @@ Feature: Tethered Nodes integrity violations
 
     When I am in workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
     And I get the node at path "document/some-new-child"
-    And I expect this node to have the following properties:
+    Then I expect this node to have the following properties:
       | Key | Value                |
       | foo | "my default applied" |
-    And I get the node at path "tethered-node"
-    And I expect this node to have the following properties:
+
+    When I get the node at path "document/some-new-child/tethered-leaf"
+    Then I expect this node to be of type "Neos.ContentRepository.Testing:TetheredLeaf"
+
+    When I get the node at path "tethered-node"
+    Then I expect this node to have the following properties:
       | Key | Value                |
       | foo | "my default applied" |
 
@@ -173,9 +177,9 @@ Feature: Tethered Nodes integrity violations
     'Neos.ContentRepository.Testing:TetheredLeaf': []
     """
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
-    Then I expect exactly 8 events to be published on stream "ContentStream:cs-identifier"
+    Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
     When I adjust the node structure for node type "Neos.ContentRepository.Testing:Document"
-    Then I expect exactly 8 events to be published on stream "ContentStream:cs-identifier"
+    Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
 
   Scenario: Adjusting the schema removing a tethered node leads to a DisallowedTetheredNode integrity violation (which can be fixed)
     Given I change the node types in content repository "default" to:

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -147,7 +147,7 @@ trait TetheredNodeInternals
             }
 
             $tetheredNodeType = $this->nodeTypeManager->getNodeType($tetheredNodeTypeDefinition->nodeTypeName);
-            foreach ($tetheredNodeType->tetheredNodeTypeDefinitions as $tetheredChildNodeTypeDefinition) {
+            foreach ($tetheredNodeType?->tetheredNodeTypeDefinitions ?: [] as $tetheredChildNodeTypeDefinition) {
                 $events = $events->withAppendedEvents($this->createEventsForMissingTetheredNode(
                     contentGraph: $contentGraph,
                     parentNodeAggregateId: $tetheredNodeAggregateId,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -115,14 +115,6 @@ trait NodeTypeChange
         NodeAggregateIds $alreadyRemovedNodeAggregates,
     ): Events;
 
-    abstract protected function createEventsForMissingTetheredNode(
-        ContentGraphInterface $contentGraph,
-        NodeAggregate $parentNodeAggregate,
-        OriginDimensionSpacePoint $originDimensionSpacePoint,
-        TetheredNodeTypeDefinition $tetheredNodeTypeDefinition,
-        NodeAggregateId $tetheredNodeAggregateId
-    ): Events;
-
     /**
      * @throws NodeTypeNotFound
      * @throws NodeConstraintException

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -84,11 +84,15 @@ class TetheredNodeAdjustments
                             'The tethered child node "' . $tetheredNodeTypeDefinition->name->value . '" is missing.',
                             function () use ($nodeAggregate, $originDimensionSpacePoint, $tetheredNodeTypeDefinition) {
                                 $events = $this->createEventsForMissingTetheredNode(
-                                    $this->contentGraph,
-                                    $nodeAggregate,
-                                    $originDimensionSpacePoint,
-                                    $tetheredNodeTypeDefinition,
-                                    null
+                                    contentGraph: $this->contentGraph,
+                                    parentNodeAggregateId: $nodeAggregate->nodeAggregateId,
+                                    parentNodeTypeName: $nodeAggregate->nodeTypeName,
+                                    parentNodeAggregateCoverageByOccupant: $nodeAggregate->classification->isRoot()
+                                        ? $nodeAggregate->coveredDimensionSpacePoints
+                                        : $nodeAggregate->getCoverageByOccupant($originDimensionSpacePoint),
+                                    originDimensionSpacePoint: $originDimensionSpacePoint,
+                                    tetheredNodeTypeDefinition: $tetheredNodeTypeDefinition,
+                                    tetheredNodeAggregateId: null
                                 );
 
                                 $streamName = ContentStreamEventStreamName::fromContentStreamId(

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/StructureAdjustmentsTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/StructureAdjustmentsTrait.php
@@ -78,9 +78,9 @@ trait StructureAdjustmentsTrait
             if (!isset($row['Type']) || !isset($row['nodeAggregateId'])) {
                 Assert::fail('Type and nodeAggregateId must be specified in assertion!');
             }
-            $adjustment = $this->findAdjustmentsBasedOnTypeAndNodeAggregateId($actualAdjustments, $row['Type'], $row['nodeAggregateId']);
+            $adjustment = $this->findAdjustmentsBasedOnTypeAndNodeAggregateIdAndDimensionSpacePoint($actualAdjustments, $row['Type'], $row['nodeAggregateId'], $row['dimensionSpacePoint'] ?? null);
             foreach ($row as $k => $v) {
-                if (in_array($k, ['Type', 'nodeAggregateId'])) {
+                if (in_array($k, ['Type', 'nodeAggregateId', 'dimensionSpacePoint'])) {
                     continue;
                 }
 
@@ -89,14 +89,25 @@ trait StructureAdjustmentsTrait
         }
     }
 
-    private function findAdjustmentsBasedOnTypeAndNodeAggregateId(array $actualAdjustments, string $type, string $nodeAggregateId): StructureAdjustment
-    {
+    private function findAdjustmentsBasedOnTypeAndNodeAggregateIdAndDimensionSpacePoint(
+        array $actualAdjustments,
+        string $type,
+        string $nodeAggregateId,
+        ?string $dimensionSpacePointAsJSON
+    ): StructureAdjustment {
         foreach ($actualAdjustments as $adjustment) {
             assert($adjustment instanceof StructureAdjustment);
-            if ($adjustment->getType() === $type && $adjustment->getArguments()['nodeAggregateId'] === $nodeAggregateId) {
+            if (
+                $adjustment->getType() === $type
+                && $adjustment->getArguments()['nodeAggregateId'] === $nodeAggregateId
+                && ($dimensionSpacePointAsJSON === null || $adjustment->getArguments()['dimensionSpacePoint'] === $dimensionSpacePointAsJSON)
+            ) {
                 return $adjustment;
             }
         }
-        Assert::fail('Adjustment not found for type "' . $type . '" and node aggregate id "' . $nodeAggregateId . '"');
+        Assert::fail(
+            'Adjustment not found for type "' . $type . '", node aggregate id "' . $nodeAggregateId . '"'
+                ($dimensionSpacePointAsJSON ? ' and dimension space point "' . $dimensionSpacePointAsJSON . '"' : '')
+        );
     }
 }


### PR DESCRIPTION
This makes the "add missing tethered nodes" adjustment work recursively

**Upgrade instructions**

none

**Review instructions**

~This also contains a migration to remove duplicate node peer variation events, whose cause was fixed in #4969.
Not super clean as it is a separate concern; tested successfully in a live project~ -> moved to https://github.com/neos/neos-development-collection/pull/5481

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
