### PR TITLE
BUGFIX: `findParentNodeAggregates` returns subtree tags of child node

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -177,8 +177,10 @@ final class ContentGraph implements ContentGraphInterface
     public function findParentNodeAggregates(
         NodeAggregateId $childNodeAggregateId
     ): NodeAggregates {
-        $queryBuilder = $this->nodeQueryBuilder->buildParentNodeAggregateQuery()
-            ->innerJoin('h', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = h.childnodeanchor')
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
+            ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
+            ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
+            ->andWhere('ch.contentstreamid = :contentStreamId')
             ->andWhere('cn.nodeaggregateid = :nodeAggregateId')
             ->setParameters([
                 'nodeAggregateId' => $childNodeAggregateId->value,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -179,7 +179,6 @@ final class ContentGraph implements ContentGraphInterface
     ): NodeAggregates {
         $queryBuilder = $this->nodeQueryBuilder->buildParentNodeAggregateQuery()
             ->innerJoin('h', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = h.childnodeanchor')
-            ->andWhere('h.contentstreamid = :contentStreamId')
             ->andWhere('cn.nodeaggregateid = :nodeAggregateId')
             ->setParameters([
                 'nodeAggregateId' => $childNodeAggregateId->value,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -68,18 +68,6 @@ final readonly class NodeQueryBuilder
             ]);
     }
 
-    public function buildParentNodeAggregateQuery(): QueryBuilder
-    {
-        return $this->createQueryBuilder()
-            ->select('n.*, h.contentstreamid, hp.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
-            ->from($this->tableNames->node(), 'n')
-            ->innerJoin('n', $this->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = n.relationanchorpoint')
-            ->innerJoin('h', $this->tableNames->hierarchyRelation(), 'hp', 'hp.childnodeanchor = h.parentnodeanchor')
-            ->innerJoin('hp', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = hp.dimensionspacepointhash')
-            ->where('h.contentstreamid = :contentStreamId')
-            ->andWhere('hp.contentstreamid = :contentStreamId');
-    }
-
     public function buildFindRootNodeAggregatesQuery(ContentStreamId $contentStreamId, FindRootNodeAggregatesFilter $filter): QueryBuilder
     {
         $queryBuilder = $this->buildBasicNodeAggregateQuery()

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -74,7 +74,7 @@ final readonly class NodeQueryBuilder
             ->select('n.*, h.contentstreamid, hp.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'n')
             ->innerJoin('n', $this->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = n.relationanchorpoint')
-            ->innerJoin('h', $this->tableNames->hierarchyRelation(), 'hp', 'hp.childnodeanchor = h.parentnodeanchor AND hp.dimensionspacepointhash = h.dimensionspacepointhash')
+            ->innerJoin('h', $this->tableNames->hierarchyRelation(), 'hp', 'hp.childnodeanchor = h.parentnodeanchor')
             ->innerJoin('hp', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = hp.dimensionspacepointhash')
             ->where('h.contentstreamid = :contentStreamId')
             ->andWhere('hp.contentstreamid = :contentStreamId');

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -71,11 +71,13 @@ final readonly class NodeQueryBuilder
     public function buildParentNodeAggregateQuery(): QueryBuilder
     {
         return $this->createQueryBuilder()
-            ->select('n.*, h.contentstreamid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->select('n.*, h.contentstreamid, hp.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'n')
             ->innerJoin('n', $this->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = n.relationanchorpoint')
-            ->innerJoin('h', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = h.dimensionspacepointhash')
-            ->where('h.contentstreamid = :contentStreamId');
+            ->innerJoin('h', $this->tableNames->hierarchyRelation(), 'hp', 'hp.childnodeanchor = h.parentnodeanchor AND hp.dimensionspacepointhash = h.dimensionspacepointhash')
+            ->innerJoin('hp', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = hp.dimensionspacepointhash')
+            ->where('h.contentstreamid = :contentStreamId')
+            ->andWhere('hp.contentstreamid = :contentStreamId');
     }
 
     public function buildFindRootNodeAggregatesQuery(ContentStreamId $contentStreamId, FindRootNodeAggregatesFilter $filter): QueryBuilder

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -111,6 +111,9 @@ Feature: Find nodes using the findParentNodes query
 
     # multiple parent node aggregates (via move) are fetched
     When I execute the findParentNodeAggregates query for node aggregate id "b" I expect the following node aggregates to be returned:
-      | nodeAggregateId | nodeTypeName                            | coveredDimensionSpacePoints | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
-      | home            | Neos.ContentRepository.Testing:Homepage | [{"language":"de"}]         | [{"language":"de"}]          | []                           |
-      | a               | Neos.ContentRepository.Testing:Page     | [{"language":"ch"}]         | [{"language":"de"}]          | []                           |
+      | nodeAggregateId | nodeTypeName                            | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      | home            | Neos.ContentRepository.Testing:Homepage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+      | a               | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+
+    When I execute the findParentNodeAggregates query for node aggregate id "non-existing" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -81,8 +81,15 @@ Feature: Find nodes using the findParentNodes query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a"         |
       | nodeVariantSelectionStrategy | "allVariants" |
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "b"                |
+      | dimensionSpacePoint          | {"language": "ch"} |
+      | newParentNodeAggregateId     | "a"                |
+      | relationDistributionStrategy | "scatter"          |
 
   Scenario:
+    Subgraph queries
     # findParentNode queries without result
     When I execute the findParentNode query for node aggregate id "non-existing" I expect no node to be returned
     When I execute the findParentNode query for node aggregate id "lady-eleonode-rootford" I expect no node to be returned
@@ -94,3 +101,16 @@ Feature: Find nodes using the findParentNodes query
     # findParentNode queries with result
     When I execute the findParentNode query for node aggregate id "home" I expect the node "lady-eleonode-rootford" to be returned
     When I execute the findParentNode query for node aggregate id "a2" I expect the node "a" to be returned
+
+  Scenario:
+    Contentgraph queries
+    # subtree tags are fetched correctly
+    When I execute the findParentNodeAggregates query for node aggregate id "a2a1" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                               | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions            |
+      | a2a             | Neos.ContentRepository.Testing:SpecialPage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"}, {"language": "ch"}] |
+
+    # multiple parent node aggregates (via move) are fetched
+    When I execute the findParentNodeAggregates query for node aggregate id "b" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                            | coveredDimensionSpacePoints | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      | home            | Neos.ContentRepository.Testing:Homepage | [{"language":"de"}]         | [{"language":"de"}]          | []                           |
+      | a               | Neos.ContentRepository.Testing:Page     | [{"language":"ch"}]         | [{"language":"de"}]          | []                           |

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/DimensionSpacePointsBySubtreeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/DimensionSpacePointsBySubtreeTags.php
@@ -12,6 +12,21 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 /**
  * DTO that holds the dimension space points any subtree tag is explicitly set for in a {@see NodeAggregate}
  *
+ * We need to pass this explicit to the NodeAggregate as this information doesn't exist otherwise.
+ *
+ * Because $coveredDimensionSpacePoints only points to the occupying nodes there are no entries for specialisations,
+ * and we CANNOT replace {@see NodeAggregate::getDimensionSpacePointsTaggedWith()} by iterating over these as explicitly
+ * disabled specialisations will not show up as tagged:
+ *
+ *     foreach ($this->coveredDimensionSpacePoints as $dimensionSpacePoint) {
+ *         $node = $this->getNodeByCoveredDimensionSpacePoint($dimensionSpacePoint);
+ *         if ($node->tags->withoutInherited()->contain($subtreeTag)) {
+ *             $taggedDimensions[] = $dimensionSpacePoint;
+ *         }
+ *     }
+ *
+ * We could replace this object if we also add these specialisation node rows explicitly to the NodeAggregate.
+ *
  * @internal used by {@see NodeAggregate} but this is a low level concept that should not be relied upon outside the core and in tests
  */
 final readonly class DimensionSpacePointsBySubtreeTags implements JsonSerializable


### PR DESCRIPTION
for the structure

node-a
  - node-b {disabled: true}
    - node-c {disabled: null}

fetching the parent of `node-c` would give node-b {disabled: null}

and fetching the parent of node-b gives node-a {disabled: true}

this is wrong, and we need to join the parent hierarchy relation

Regression from https://github.com/neos/neos-development-collection/pull/5268 which optimised the queries by removing joins. Now the queries are restored (and possibly a little slower again) but the change in https://github.com/neos/neos-development-collection/pull/5261 got rid of these queries in the performant critical paths either way. So this should not be a problem!

**Checklist**

- [x] Tests
- [x] Find out what #5268 exactly broke
