### PR TITLE
TASK: Followup 4969 remove duplicate peer creations

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Command/MigrateEventsCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/MigrateEventsCommandController.php
@@ -184,4 +184,16 @@ class MigrateEventsCommandController extends CommandController
         $eventMigrationService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->eventMigrationServiceFactory);
         $eventMigrationService->migrateCheckpointsToSubscriptions($this->outputLine(...));
     }
+
+    /**
+     * TODO Explain PLZ
+     *
+     * @param string $contentRepository Identifier of the Content Repository to migrate
+     */
+    public function migrateDuplicateNodeVariationsCommand(string $contentRepository = 'default'): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $eventMigrationService = $this->contentRepositoryRegistry->buildService($contentRepositoryId, $this->eventMigrationServiceFactory);
+        $eventMigrationService->migrateDuplicateNodeVariations($this->outputLine(...));
+    }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Command/MigrateEventsCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/MigrateEventsCommandController.php
@@ -186,7 +186,11 @@ class MigrateEventsCommandController extends CommandController
     }
 
     /**
-     * TODO Explain PLZ
+     * Migrates duplicate "NodePeerVariantWasCreated" on the same node which were created by faulty structure adjustments
+     *
+     * Needed for #4969: https://github.com/neos/neos-development-collection/pull/4969
+     *
+     * Included in February 2025 - before final Neos 9.0 release
      *
      * @param string $contentRepository Identifier of the Content Repository to migrate
      */

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -1021,7 +1021,9 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
 
             if (array_key_exists($payloadHash, $legitVariantCreationsPerNodeAggregateIdAndDimensions)) {
                 if (
+                    // structure adjustments started to have a correlation id like StructureAdjustment_123
                     str_starts_with($eventEnvelope->event->correlationId?->value ?? '', 'StructureAdjustment_')
+                    // before that they can most likely be identified by having NO metadata
                     || $eventEnvelope->event->metadata === null
                 ) {
                     $eventsToDrop[] = $eventEnvelope->sequenceNumber->value;
@@ -1054,7 +1056,7 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
         $this->connection->commit();
 
         $outputFn();
-        $outputFn(sprintf('Migration applied to %s events. Please replay the projections `./flow cr:projectionReplayAll`', count($this->eventsModified)));
+        $outputFn(sprintf('Migration applied to %s events. Please replay the projections `./flow subscription:replayall`', count($eventsToDrop)));
     }
 
     /** ------------------------ */

--- a/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php
@@ -982,6 +982,81 @@ final class EventMigrationService implements ContentRepositoryServiceInterface
         }
     }
 
+    public function migrateDuplicateNodeVariations(\Closure $outputFn): void
+    {
+        $eventTableName = DoctrineEventStoreFactory::databaseTableName($this->contentRepositoryId);
+        $backupEventTableName = DoctrineEventStoreFactory::databaseTableName($this->contentRepositoryId)
+            . '_bkp_' . date('Y_m_d_H_i_s');
+        $outputFn(sprintf('Backup: copying events table to %s', $backupEventTableName));
+        $this->copyEventTable($backupEventTableName);
+
+        $legitVariantCreationsPerNodeAggregateIdAndDimensions = [];
+
+        $liveWorkspaceContentStreamId = null;
+        // hardcoded to LIVE
+        foreach ($this->eventStore->load(WorkspaceEventStreamName::fromWorkspaceName(WorkspaceName::forLive())->getEventStreamName(), EventStreamFilter::create(EventTypes::create(EventType::fromString('RootWorkspaceWasCreated')))) as $eventEnvelope) {
+            $rootWorkspaceWasCreated = self::decodeEventPayload($eventEnvelope);
+            $liveWorkspaceContentStreamId = ContentStreamId::fromString($rootWorkspaceWasCreated['newContentStreamId']);
+            break;
+        }
+
+        if (!$liveWorkspaceContentStreamId) {
+            throw new \RuntimeException('Workspace live does not exist. No migration necessary.');
+        }
+
+        $liveContentStreamName = ContentStreamEventStreamName::fromContentStreamId($liveWorkspaceContentStreamId)->getEventStreamName();
+
+        $eventsToDrop = [];
+
+        $eventStream = $this->eventStore->load($liveContentStreamName, EventStreamFilter::create(EventTypes::create(EventType::fromString('NodePeerVariantWasCreated'))));
+        foreach ($eventStream as $eventEnvelope) {
+            $outputRewriteNotice = fn(string $message) => $outputFn(sprintf('%s@%s %s', $eventEnvelope->sequenceNumber->value, $eventEnvelope->event->type->value, $message));
+            if ($eventEnvelope->event->type->value !== 'NodePeerVariantWasCreated') {
+                throw new \RuntimeException(sprintf('Unhandled event: %s', $eventEnvelope->event->type->value));
+            }
+
+            $eventData = self::decodeEventPayload($eventEnvelope);
+
+            $payloadHash = md5(json_encode([$eventData['nodeAggregateId'], $eventData['sourceOrigin'], $eventData['peerOrigin']], JSON_THROW_ON_ERROR));
+
+            if (array_key_exists($payloadHash, $legitVariantCreationsPerNodeAggregateIdAndDimensions)) {
+                if (
+                    str_starts_with($eventEnvelope->event->correlationId?->value ?? '', 'StructureAdjustment_')
+                    || $eventEnvelope->event->metadata === null
+                ) {
+                    $eventsToDrop[] = $eventEnvelope->sequenceNumber->value;
+                    $outputRewriteNotice(sprintf('Duplicate peer variant creation via structure adjustment for %s in dimension %s', $eventData['nodeAggregateId'], json_encode($eventData['peerOrigin'])));
+                    continue;
+                }
+
+                $outputRewriteNotice(sprintf('WARNING: Duplicate peer variant creation %s.', json_encode($eventData)));
+                continue;
+            }
+
+            $legitVariantCreationsPerNodeAggregateIdAndDimensions[$payloadHash] = true;
+        }
+
+        if (!count($eventsToDrop)) {
+            $outputFn('Migration was not necessary.');
+            return;
+        }
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(
+            'DELETE FROM ' . $eventTableName . ' WHERE sequencenumber IN (:sequenceNumbers)',
+            [
+                'sequenceNumbers' => $eventsToDrop
+            ],
+            [
+                'sequenceNumbers' => ArrayParameterType::STRING
+            ]
+        );
+        $this->connection->commit();
+
+        $outputFn();
+        $outputFn(sprintf('Migration applied to %s events. Please replay the projections `./flow cr:projectionReplayAll`', count($this->eventsModified)));
+    }
+
     /** ------------------------ */
 
     /**


### PR DESCRIPTION
Migration to remove duplicate node peer variation events, whose cause was fixed in https://github.com/neos/neos-development-collection/pull/4969.

The duplicate `NodePeerVariantWasCreated` events were targeting for example the site node multiple times, variating the same source to the same target multiple times. The events dont conflict with the graph projection but the uri path projection cannot (rightfully) comprehend those and builds wrong uris.

Tested by Bernhard successfully in a live project with those duplicated events.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
