### PR TITLE
FEATURE: Introduce `ContentGraphInterface::findNodeAggregatesTaggedBy`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -312,7 +312,7 @@ final class ContentGraph implements ContentGraphInterface
         return new DimensionSpacePointSet($dimensionSpacePoints);
     }
 
-    public function findNodeAggregatesTaggedWith(SubtreeTag $subtreeTag): NodeAggregates
+    public function findNodeAggregatesTaggedBy(SubtreeTag $subtreeTag): NodeAggregates
     {
         $queryBuilder =  $this->createQueryBuilder()
             ->select('n.*, h.contentstreamid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -23,6 +23,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
@@ -309,6 +310,19 @@ final class ContentGraph implements ContentGraphInterface
         }
 
         return new DimensionSpacePointSet($dimensionSpacePoints);
+    }
+
+    public function findNodeAggregatesTaggedWith(SubtreeTag $subtreeTag): NodeAggregates
+    {
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
+            ->orderBy('n.relationanchorpoint', 'DESC')
+            ->andWhere('JSON_EXTRACT(h.subtreetags, :tagPath)')
+            ->setParameters([
+                'tagPath' => '$.' . $subtreeTag->value,
+                'contentStreamId' => $this->contentStreamId->value
+            ]);
+
+        return $this->mapQueryBuilderToNodeAggregates($queryBuilder);
     }
 
     public function findUsedNodeTypeNames(): NodeTypeNames

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
@@ -274,7 +274,7 @@ final class ContentHypergraph implements ContentGraphInterface
         return new DimensionSpacePointSet($occupiedDimensionSpacePoints);
     }
 
-    public function findNodeAggregatesTaggedWith(SubtreeTag $subtreeTag): NodeAggregates
+    public function findNodeAggregatesTaggedBy(SubtreeTag $subtreeTag): NodeAggregates
     {
         throw new \BadMethodCallException('Not implemented.', 1740574672);
     }

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/ContentHypergraph.php
@@ -21,6 +21,7 @@ use Neos\ContentGraph\PostgreSQLAdapter\Domain\Repository\Query\HypergraphQuery;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
@@ -271,6 +272,11 @@ final class ContentHypergraph implements ContentGraphInterface
         }
 
         return new DimensionSpacePointSet($occupiedDimensionSpacePoints);
+    }
+
+    public function findNodeAggregatesTaggedWith(SubtreeTag $subtreeTag): NodeAggregates
+    {
+        throw new \BadMethodCallException('Not implemented.', 1740574672);
     }
 
     public function findUsedNodeTypeNames(): NodeTypeNames

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
@@ -105,11 +105,11 @@ Feature: Find nodes using the findNodeById query
       | tag                          | "tag1"        |
 
   Scenario:
-    ContentGraph queries
+  ContentGraph queries
 
     When I execute the findNodeAggregatesTaggedWith query for tag "disabled" I expect the following node aggregates to be returned:
       | nodeAggregateId | nodeTypeName                               | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions          |
-      | b1              | Neos.ContentRepository.Testing:Page        | [{"language":"ch"}]                   | [{"language":"de"}]          | [{"language":"ch"}]                   |
+      | b1              | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"ch"}]                   |
       | a2a1            | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
       | a2a             | Neos.ContentRepository.Testing:SpecialPage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
@@ -107,14 +107,14 @@ Feature: Find nodes using the findNodeById query
   Scenario:
   ContentGraph queries
 
-    When I execute the findNodeAggregatesTaggedWith query for tag "disabled" I expect the following node aggregates to be returned:
+    When I execute the findNodeAggregatesTaggedBy query for tag "disabled" I expect the following node aggregates to be returned:
       | nodeAggregateId | nodeTypeName                               | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions          |
       | b1              | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"ch"}]                   |
       | a2a1            | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
       | a2a             | Neos.ContentRepository.Testing:SpecialPage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
 
 
-    When I execute the findNodeAggregatesTaggedWith query for tag "tag1" I expect the following node aggregates to be returned:
+    When I execute the findNodeAggregatesTaggedBy query for tag "tag1" I expect the following node aggregates to be returned:
       | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
       # b is not 'disabled' but tagged tag1
       | b               | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
@@ -1,0 +1,120 @@
+@contentrepository @adapters=DoctrineDBAL,Postgres
+Feature: Find nodes using the findNodeById query
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values          | Generalizations      |
+      | language   | mul, de, en, ch | ch->de->mul, en->mul |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:AbstractPage':
+      abstract: true
+      properties:
+        text:
+          type: string
+      references:
+        refs:
+          properties:
+            foo:
+              type: string
+        ref:
+          constraints:
+            maxItems: 1
+          properties:
+            foo:
+              type: string
+    'Neos.ContentRepository.Testing:SomeMixin':
+      abstract: true
+    'Neos.ContentRepository.Testing:Homepage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      childNodes:
+        terms:
+          type: 'Neos.ContentRepository.Testing:Terms'
+        contact:
+          type: 'Neos.ContentRepository.Testing:Contact'
+
+    'Neos.ContentRepository.Testing:Terms':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+      properties:
+        text:
+          defaultValue: 'Terms default'
+    'Neos.ContentRepository.Testing:Contact':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+        'Neos.ContentRepository.Testing:SomeMixin': true
+      properties:
+        text:
+          defaultValue: 'Contact default'
+    'Neos.ContentRepository.Testing:Page':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    'Neos.ContentRepository.Testing:SpecialPage':
+      superTypes:
+        'Neos.ContentRepository.Testing:AbstractPage': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                  | Value                |
+      | workspaceName        | "live"               |
+      | newContentStreamId   | "cs-identifier"      |
+    And I am in workspace "live" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeName | nodeTypeName                               | parentNodeAggregateId  | initialPropertyValues | tetheredDescendantNodeAggregateIds       |
+      | home            | home     | Neos.ContentRepository.Testing:Homepage    | lady-eleonode-rootford | {}                    | {"terms": "terms", "contact": "contact"} |
+      | a               | a        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "a"}         | {}                                       |
+      | a1              | a1       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a1"}        | {}                                       |
+      | a2              | a2       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a2"}        | {}                                       |
+      | a2a             | a2a      | Neos.ContentRepository.Testing:SpecialPage | a2                     | {"text": "a2a"}       | {}                                       |
+      | a2a1            | a2a1     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a1"}      | {}                                       |
+      | a2a2            | a2a2     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2"}      | {}                                       |
+      | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}         | {}                                       |
+      | b1              | b1       | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}        | {}                                       |
+
+    # disable a2a
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a2a"         |
+      | nodeVariantSelectionStrategy | "allVariants" |
+
+    # disable child of a2a
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a2a1"        |
+      | nodeVariantSelectionStrategy | "allVariants" |
+
+    # disable b only in spezialisation
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "b1"                 |
+      | coveredDimensionSpacePoint   | {"language":"ch"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+
+    # tag another node differently
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "b"           |
+      | nodeVariantSelectionStrategy | "allVariants" |
+      | tag                          | "tag1"        |
+
+  Scenario:
+    ContentGraph queries
+
+    When I execute the findNodeAggregatesTaggedWith query for tag "disabled" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                               | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions          |
+      | b1              | Neos.ContentRepository.Testing:Page        | [{"language":"ch"}]                   | [{"language":"de"}]          | [{"language":"ch"}]                   |
+      | a2a1            | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
+      | a2a             | Neos.ContentRepository.Testing:SpecialPage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
+
+
+    When I execute the findNodeAggregatesTaggedWith query for tag "tag1" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      # b is not 'disabled' but tagged tag1
+      | b               | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
@@ -150,6 +151,11 @@ interface ContentGraphInterface extends ProjectionStateInterface
         OriginDimensionSpacePoint $parentNodeOriginDimensionSpacePoint,
         DimensionSpacePointSet $dimensionSpacePointsToCheck
     ): DimensionSpacePointSet;
+
+    /**
+     * @internal experimental api, the order of the returned node aggregates is undefined and does not follow the hierarchy
+     */
+    public function findNodeAggregatesTaggedWith(SubtreeTag $subtreeTag): NodeAggregates;
 
     /** @internal The content stream id where the workspace name points to for this instance */
     public function getContentStreamId(): ContentStreamId;

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphInterface.php
@@ -155,7 +155,7 @@ interface ContentGraphInterface extends ProjectionStateInterface
     /**
      * @internal experimental api, the order of the returned node aggregates is undefined and does not follow the hierarchy
      */
-    public function findNodeAggregatesTaggedWith(SubtreeTag $subtreeTag): NodeAggregates;
+    public function findNodeAggregatesTaggedBy(SubtreeTag $subtreeTag): NodeAggregates;
 
     /** @internal The content stream id where the workspace name points to for this instance */
     public function getContentStreamId(): ContentStreamId;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -352,14 +352,14 @@ trait NodeTraversalTrait
     }
 
     /**
-     * @When I execute the findNodeAggregatesTaggedWith query for tag :subtreeTag I expect the following node aggregates to be returned:
+     * @When I execute the findNodeAggregatesTaggedBy query for tag :subtreeTag I expect the following node aggregates to be returned:
      */
-    public function iExecuteTheFindNodeAggregatesTaggedWithQueryIExpectTheFollowingNodes(string $subtreeTag, TableNode $expectedNodes): void
+    public function iExecuteTheFindNodeAggregatesTaggedByQueryIExpectTheFollowingNodes(string $subtreeTag, TableNode $expectedNodes): void
     {
         $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
-        $actualNodeAggregates = $contentGraph->findNodeAggregatesTaggedWith(SubtreeTag::fromString($subtreeTag));
+        $actualNodeAggregates = $contentGraph->findNodeAggregatesTaggedBy(SubtreeTag::fromString($subtreeTag));
 
-        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), $actualNodeAggregates, 'findNodeAggregatesTaggedWith returned an unexpected result');
+        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), $actualNodeAggregates, 'findNodeAggregatesTaggedBy returned an unexpected result');
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -16,6 +16,8 @@ namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
@@ -33,6 +35,8 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFil
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregates;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Reference;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
@@ -347,6 +351,16 @@ trait NodeTraversalTrait
         Assert::assertEquals($expectedTimestamps, $actualTimestamps);
     }
 
+    /**
+     * @When I execute the findNodeAggregatesTaggedWith query for tag :subtreeTag I expect the following node aggregates to be returned:
+     */
+    public function iExecuteTheFindNodeAggregatesTaggedWithQueryIExpectTheFollowingNodes(string $subtreeTag, TableNode $expectedNodes): void
+    {
+        $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
+        $actualNodeAggregates = $contentGraph->findNodeAggregatesTaggedWith(SubtreeTag::fromString($subtreeTag));
+
+        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), $actualNodeAggregates, 'findNodeAggregatesTaggedWith returned an unexpected result');
+    }
 
     /**
      * @When I execute the findRootNodeByType query for node type :serializedNodeTypeName I expect no node to be returned
@@ -360,5 +374,28 @@ trait NodeTraversalTrait
 
         $actualNode = $this->getCurrentSubgraph()->findRootNodeByType(NodeTypeName::fromString($serializedNodeTypeName));
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
+    }
+
+    private static function assertNodeAggregatesEqualTable(array $expectedNodeAggregates, NodeAggregates $actualNodeAggregates, string $message): void
+    {
+        $actualNodeAggregatesTable = array_map(static fn (NodeAggregate $nodeAggregate) => [
+            'nodeAggregateId' => $nodeAggregate->nodeAggregateId->value,
+            'nodeTypeName' => $nodeAggregate->nodeTypeName->value,
+            'coveredDimensionSpacePoints' => $nodeAggregate->coveredDimensionSpacePoints->toJson(),
+            'occupiedDimensionSpacePoints' => $nodeAggregate->occupiedDimensionSpacePoints->toJson(),
+            'explicitlyDisabledDimensions' => $nodeAggregate->getDimensionSpacePointsTaggedWith(SubtreeTag::disabled())->toJson(),
+        ], iterator_to_array($actualNodeAggregates));
+
+        $expectedNodeAggregatesWithNormalisedJson = array_map(
+            fn (array $row) => [
+                ...$row,
+                'coveredDimensionSpacePoints' => DimensionSpacePointSet::fromJsonString($row['coveredDimensionSpacePoints'])->toJson(),
+                'occupiedDimensionSpacePoints' => DimensionSpacePointSet::fromJsonString($row['occupiedDimensionSpacePoints'])->toJson(),
+                'explicitlyDisabledDimensions' => DimensionSpacePointSet::fromJsonString($row['explicitlyDisabledDimensions'])->toJson(),
+            ],
+            $expectedNodeAggregates
+        );
+
+        Assert::assertSame($expectedNodeAggregatesWithNormalisedJson, $actualNodeAggregatesTable, $message);
     }
 }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

Preparation to make https://github.com/neos/neos-development-collection/pull/5479 a competitive and viable solution by using the new queries.

Currently we use this logic which iterates expensively over ALL `findChildNodeAggregates`

```php
private function findNodeAggregatesInWorkspaceByExplicitRemovedTag(ContentGraphInterface $contentGraph): NodeAggregateIdsWithDimensionSpacePoints
 {
     // todo super expensive, filter via sql! getNodeAggregatesTaggedBy
     $softRemovedNodes = [];

     /** @var array<NodeAggregate> $stack */
     $stack = iterator_to_array($contentGraph->findRootNodeAggregates(FindRootNodeAggregatesFilter::create()));
     while ($stack !== []) {
         $nodeAggregate = array_shift($stack);
         $softRemovedDimensions = $nodeAggregate->getDimensionSpacePointsTaggedWith(SubtreeTag::removed());
         if (!$softRemovedDimensions->isEmpty()) {
             $softRemovedNodes[] = NodeAggregateIdWithDimensionSpacePoints::create(
                 $nodeAggregate->nodeAggregateId,
                 $softRemovedDimensions
             );
         }
         $stack = [...$stack, ...iterator_to_array($contentGraph->findChildNodeAggregates($nodeAggregate->nodeAggregateId))];
     }

     return NodeAggregateIdsWithDimensionSpacePoints::fromArray($softRemovedNodes);
 }
```

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
