### PR TITLE
BUGFIX: RootNodeAggregateDimensionsWereUpdated removes subtree tags

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -616,29 +616,56 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             return;
         }
 
-        // delete all hierarchy edges of the root node
-        $deleteHierarchyRelationsStatement = <<<SQL
-            DELETE FROM {$this->tableNames->hierarchyRelation()}
+        $deleteOutdatedRootNodeAggregateDimensionsStatement = <<<SQL
+            DELETE
+                FROM {$this->tableNames->hierarchyRelation()}
             WHERE
                 parentnodeanchor = :parentNodeAnchor
                 AND childnodeanchor = :childNodeAnchor
                 AND contentstreamid = :contentStreamId
+                AND dimensionspacepointhash NOT IN (:coveredDimensionSpacePoints)
         SQL;
         try {
-            $this->dbal->executeStatement($deleteHierarchyRelationsStatement, [
+            $this->dbal->executeStatement($deleteOutdatedRootNodeAggregateDimensionsStatement, [
                 'parentNodeAnchor' => NodeRelationAnchorPoint::forRootEdge()->value,
                 'childNodeAnchor' => $rootNodeAnchorPoint->value,
                 'contentStreamId' => $event->contentStreamId->value,
+                'coveredDimensionSpacePoints' => $event->coveredDimensionSpacePoints->getPointHashes(),
+            ], [
+                'coveredDimensionSpacePoints' => ArrayParameterType::STRING
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to delete hierarchy relation: %s', $e->getMessage()), 1716488943, $e);
         }
-        // recreate hierarchy edges for the root node
+
+        $selectRemainingRootNodeAggregateDimensionsStatement = <<<SQL
+            SELECT dimensionspacepointhash
+                FROM {$this->tableNames->hierarchyRelation()}
+            WHERE parentnodeanchor = :parentNodeAnchor
+                AND childnodeanchor = :childNodeAnchor
+                AND contentstreamid = :contentStreamId
+        SQL;
+        try {
+            $remainingRootNodeAggregateDimensions = $this->dbal->fetchAllAssociative($selectRemainingRootNodeAggregateDimensionsStatement, [
+                'parentNodeAnchor' => NodeRelationAnchorPoint::forRootEdge()->value,
+                'childNodeAnchor' => $rootNodeAnchorPoint->value,
+                'contentStreamId' => $event->contentStreamId->value
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to fetch current root hierarchy relations: %s', $e->getMessage()), 1740689113, $e);
+        }
+
+        $newDimensionSpacePoints = $event->coveredDimensionSpacePoints->points;
+        foreach ($remainingRootNodeAggregateDimensions as $row) {
+            unset($newDimensionSpacePoints[$row['dimensionspacepointhash']]);
+        }
+
+        // add hierarchy edges for newly added dimensions
         $this->connectHierarchy(
             $event->contentStreamId,
             NodeRelationAnchorPoint::forRootEdge(),
             $rootNodeAnchorPoint,
-            $event->coveredDimensionSpacePoints,
+            DimensionSpacePointSet::fromArray($newDimensionSpacePoints),
             null
         );
     }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/RootNodeAggregateDimensionUpdates/UpdateRootNodeAggregateDimensions_WithDimensions.feature
@@ -156,3 +156,26 @@ Feature: Update Root Node aggregate dimensions
     When I am in dimension space point {"language":"en"}
     Then I expect the subgraph projection to consist of exactly 0 nodes
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to no node
+
+  Scenario: Adding a dimension updating the root node keeps subtree tags
+    Given I change the content dimensions in content repository "default" to:
+      | Identifier | Values      | Generalizations |
+      | language   | mul, de, en |                 |
+
+    When I am in dimension space point {"language":"de"}
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "lady-eleonode-rootford" |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+
+    And I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to cover dimension space points [{"language":"mul"},{"language":"de"}]
+    And I expect this node aggregate to disable dimension space points [{"language":"mul"},{"language":"de"}]
+
+    And the command UpdateRootNodeAggregateDimensions is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+
+    And I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to cover dimension space points [{"language":"mul"},{"language":"de"},{"language":"en"}]
+    And I expect this node aggregate to disable dimension space points [{"language":"mul"},{"language":"de"}]


### PR DESCRIPTION
The root node aggregate looses its subtreetags because we drop all existing hierarchy relations and creates new default ones without taking the current tags into account.

This change adds a failing test and updates the implementation to only drop oudated dsps and then diffs the remaining ones to only create plain default hierarchies for really new dimensions.

Keeping the subtree tags as is means that they might not have been issued on that dimension according to the new dimension config but that also keeps the implementation simple.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
