### PR TITLE
TASK: Use proper version checks for workspace events

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -142,7 +142,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         $queryBuilder = $this->dbal->createQueryBuilder();
 
         return $queryBuilder
-            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.hasChanges, cs.sourceContentStreamVersion = scs.version as upToDateWithBase')
+            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.hasChanges, cs.sourceContentStreamVersion = scs.version as upToDateWithBase, ws.version')
             ->from($this->tableNames->workspace(), 'ws')
             ->join('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
             ->leftJoin('cs', $this->tableNames->contentStream(), 'scs', 'scs.id = cs.sourceContentStreamId');
@@ -174,6 +174,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
             $baseWorkspaceName === null
                 ? false
                 : (bool)$row['hasChanges'],
+            Version::fromInteger((int)$row['version']),
         );
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -163,15 +163,15 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             NodeSpecializationVariantWasCreated::class => $this->whenNodeSpecializationVariantWasCreated($event, $eventEnvelope),
             RootNodeAggregateDimensionsWereUpdated::class => $this->whenRootNodeAggregateDimensionsWereUpdated($event),
             RootNodeAggregateWithNodeWasCreated::class => $this->whenRootNodeAggregateWithNodeWasCreated($event, $eventEnvelope),
-            RootWorkspaceWasCreated::class => $this->whenRootWorkspaceWasCreated($event),
+            RootWorkspaceWasCreated::class => $this->whenRootWorkspaceWasCreated($event, $eventEnvelope),
             SubtreeWasTagged::class => $this->whenSubtreeWasTagged($event),
             SubtreeWasUntagged::class => $this->whenSubtreeWasUntagged($event),
-            WorkspaceBaseWorkspaceWasChanged::class => $this->whenWorkspaceBaseWorkspaceWasChanged($event),
+            WorkspaceBaseWorkspaceWasChanged::class => $this->whenWorkspaceBaseWorkspaceWasChanged($event, $eventEnvelope),
             WorkspaceRebaseFailed::class => $this->whenWorkspaceRebaseFailed($event),
-            WorkspaceWasCreated::class => $this->whenWorkspaceWasCreated($event),
-            WorkspaceWasDiscarded::class => $this->whenWorkspaceWasDiscarded($event),
-            WorkspaceWasPublished::class => $this->whenWorkspaceWasPublished($event),
-            WorkspaceWasRebased::class => $this->whenWorkspaceWasRebased($event),
+            WorkspaceWasCreated::class => $this->whenWorkspaceWasCreated($event, $eventEnvelope),
+            WorkspaceWasDiscarded::class => $this->whenWorkspaceWasDiscarded($event, $eventEnvelope),
+            WorkspaceWasPublished::class => $this->whenWorkspaceWasPublished($event, $eventEnvelope),
+            WorkspaceWasRebased::class => $this->whenWorkspaceWasRebased($event, $eventEnvelope),
             WorkspaceWasRemoved::class => $this->whenWorkspaceWasRemoved($event),
             default => null,
         };
@@ -669,9 +669,9 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         );
     }
 
-    private function whenRootWorkspaceWasCreated(RootWorkspaceWasCreated $event): void
+    private function whenRootWorkspaceWasCreated(RootWorkspaceWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->createWorkspace($event->workspaceName, null, $event->newContentStreamId);
+        $this->createWorkspace($event->workspaceName, null, $event->newContentStreamId, $eventEnvelope->version);
     }
 
     private function whenSubtreeWasTagged(SubtreeWasTagged $event): void
@@ -684,9 +684,9 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         $this->removeSubtreeTag($event->contentStreamId, $event->nodeAggregateId, $event->affectedDimensionSpacePoints, $event->tag);
     }
 
-    private function whenWorkspaceBaseWorkspaceWasChanged(WorkspaceBaseWorkspaceWasChanged $event): void
+    private function whenWorkspaceBaseWorkspaceWasChanged(WorkspaceBaseWorkspaceWasChanged $event, EventEnvelope $eventEnvelope): void
     {
-        $this->updateBaseWorkspace($event->workspaceName, $event->baseWorkspaceName, $event->newContentStreamId);
+        $this->updateBaseWorkspace($event->workspaceName, $event->baseWorkspaceName, $event->newContentStreamId, $eventEnvelope->version);
     }
 
     private function whenWorkspaceRebaseFailed(WorkspaceRebaseFailed $event): void
@@ -698,24 +698,24 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         $this->reopenContentStream($event->sourceContentStreamId);
     }
 
-    private function whenWorkspaceWasCreated(WorkspaceWasCreated $event): void
+    private function whenWorkspaceWasCreated(WorkspaceWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->createWorkspace($event->workspaceName, $event->baseWorkspaceName, $event->newContentStreamId);
+        $this->createWorkspace($event->workspaceName, $event->baseWorkspaceName, $event->newContentStreamId, $eventEnvelope->version);
     }
 
-    private function whenWorkspaceWasDiscarded(WorkspaceWasDiscarded $event): void
+    private function whenWorkspaceWasDiscarded(WorkspaceWasDiscarded $event, EventEnvelope $eventEnvelope): void
     {
-        $this->updateWorkspaceContentStreamId($event->workspaceName, $event->newContentStreamId);
+        $this->updateWorkspaceContentStreamId($event->workspaceName, $event->newContentStreamId, $eventEnvelope->version);
     }
 
-    private function whenWorkspaceWasPublished(WorkspaceWasPublished $event): void
+    private function whenWorkspaceWasPublished(WorkspaceWasPublished $event, EventEnvelope $eventEnvelope): void
     {
-        $this->updateWorkspaceContentStreamId($event->sourceWorkspaceName, $event->newSourceContentStreamId);
+        $this->updateWorkspaceContentStreamId($event->sourceWorkspaceName, $event->newSourceContentStreamId, $eventEnvelope->version);
     }
 
-    private function whenWorkspaceWasRebased(WorkspaceWasRebased $event): void
+    private function whenWorkspaceWasRebased(WorkspaceWasRebased $event, EventEnvelope $eventEnvelope): void
     {
-        $this->updateWorkspaceContentStreamId($event->workspaceName, $event->newContentStreamId);
+        $this->updateWorkspaceContentStreamId($event->workspaceName, $event->newContentStreamId, $eventEnvelope->version);
     }
 
     private function whenWorkspaceWasRemoved(WorkspaceWasRemoved $event): void

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -110,6 +110,7 @@ class DoctrineDbalContentGraphSchemaBuilder
             DbalSchemaFactory::columnForWorkspaceName('name', $platform)->setNotnull(true),
             DbalSchemaFactory::columnForWorkspaceName('baseWorkspaceName', $platform)->setNotnull(false),
             DbalSchemaFactory::columnForContentStreamId('currentContentStreamId', $platform)->setNotNull(true),
+            (new Column('version', Type::getType(Types::INTEGER)))->setNotnull(true),
         ]);
 
         $workspaceTable->addUniqueIndex(['currentContentStreamId']);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/Workspace.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/Workspace.php
@@ -6,6 +6,7 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\EventStore\Model\Event\Version;
 
 /**
  * The Workspace projection feature trait
@@ -14,12 +15,13 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  */
 trait Workspace
 {
-    private function createWorkspace(WorkspaceName $workspaceName, ?WorkspaceName $baseWorkspaceName, ContentStreamId $contentStreamId): void
+    private function createWorkspace(WorkspaceName $workspaceName, ?WorkspaceName $baseWorkspaceName, ContentStreamId $contentStreamId, Version $version): void
     {
         $this->dbal->insert($this->tableNames->workspace(), [
             'name' => $workspaceName->value,
             'baseWorkspaceName' => $baseWorkspaceName?->value,
-            'currentContentStreamId' => $contentStreamId->value
+            'currentContentStreamId' => $contentStreamId->value,
+            'version' => $version->value,
         ]);
     }
 
@@ -31,13 +33,14 @@ trait Workspace
         );
     }
 
-    private function updateBaseWorkspace(WorkspaceName $workspaceName, WorkspaceName $baseWorkspaceName, ContentStreamId $newContentStreamId): void
+    private function updateBaseWorkspace(WorkspaceName $workspaceName, WorkspaceName $baseWorkspaceName, ContentStreamId $newContentStreamId, Version $version): void
     {
         $this->dbal->update(
             $this->tableNames->workspace(),
             [
                 'baseWorkspaceName' => $baseWorkspaceName->value,
                 'currentContentStreamId' => $newContentStreamId->value,
+                'version' => $version->value,
             ],
             ['name' => $workspaceName->value]
         );
@@ -46,9 +49,11 @@ trait Workspace
     private function updateWorkspaceContentStreamId(
         WorkspaceName $workspaceName,
         ContentStreamId $contentStreamId,
+        Version $version,
     ): void {
         $this->dbal->update($this->tableNames->workspace(), [
             'currentContentStreamId' => $contentStreamId->value,
+            'version' => $version->value,
         ], [
             'name' => $workspaceName->value
         ]);

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
@@ -107,3 +107,18 @@ Feature: Change base workspace works :D what else
     And I expect this node to have the following properties:
       | Key  | Value                |
       | text | "New node in shared" |
+
+    # workspace is writeable (version checks work)
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "user-test"                              |
+      | nodeAggregateId           | "sir-david-nodenborough"                 |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "New node"}                     |
+    # publish events that _actually_ are written on the workspace stream
+    When the command DiscardWorkspace is executed with payload:
+      | Key                | Value                          |
+      | workspaceName      | "user-test"                    |
+      | newContentStreamId | "user-cs-identifier-discarded" |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -139,6 +139,19 @@ Feature: Rebasing with no conflict
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-rebased;sir-nodeward-nodington-iii;{}
 
+    # workspace is writeable (version checks work)
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "user-test"                              |
+      | nodeAggregateId           | "nody-mc-nodeface"                       |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+    # publish events that _actually_ are written on the workspace stream
+    When the command DiscardWorkspace is executed with payload:
+      | Key                | Value                          |
+      | workspaceName      | "user-test"                    |
+      | newContentStreamId | "user-cs-identifier-discarded" |
 
   Scenario: Rebase workspace and base contains changes
     And the command CreateNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/DeleteAndRecreateWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/DeleteAndRecreateWorkspace.feature
@@ -71,3 +71,18 @@ Feature: Test for delete and recreate workspace
 
     Given I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-new;nody-mc-nodeface;{}
+
+    # workspace is writeable (version checks work)
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "user-test"                              |
+      | nodeAggregateId           | "sir-david-nodenborough"                 |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "New node"}                     |
+    # publish events that _actually_ are written on the workspace stream
+    When the command DiscardWorkspace is executed with payload:
+      | Key                | Value                          |
+      | workspaceName      | "user-test"                    |
+      | newContentStreamId | "user-cs-identifier-discarded" |

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -295,7 +295,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     partial: false
                 )
             ),
-            ExpectedVersion::ANY()
+            ExpectedVersion::fromVersion($workspace->version),
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
@@ -324,7 +324,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     skippedEvents: []
                 ),
             ),
-            ExpectedVersion::ANY()
+            ExpectedVersion::fromVersion($workspace->version),
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
@@ -452,7 +452,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                             ->map(fn (ConflictingEvent $conflictingEvent) => $conflictingEvent->getSequenceNumber())
                     ),
                 ),
-                ExpectedVersion::ANY()
+                ExpectedVersion::fromVersion($workspace->version),
             ),
             $this->getCopiedEventsOfEventStream(
                 $command->workspaceName,
@@ -579,7 +579,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         partial: !$remainingCommands->isEmpty()
                     )
                 ]),
-                ExpectedVersion::ANY()
+                ExpectedVersion::fromVersion($workspace->version),
             ),
             $this->getCopiedEventsOfEventStream(
                 $command->workspaceName,
@@ -694,7 +694,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                         partial: true
                     )
                 ),
-                ExpectedVersion::ANY()
+                ExpectedVersion::fromVersion($workspace->version),
             ),
             $this->getCopiedEventsOfEventStream(
                 $command->workspaceName,
@@ -760,7 +760,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     partial: false
                 )
             ),
-            ExpectedVersion::ANY()
+            ExpectedVersion::fromVersion($workspace->version),
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
@@ -812,7 +812,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $command->newContentStreamId,
                 )
             ),
-            ExpectedVersion::ANY()
+            ExpectedVersion::fromVersion($workspace->version),
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
@@ -845,7 +845,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $command->workspaceName,
                 )
             ),
-            ExpectedVersion::ANY()
+            ExpectedVersion::fromVersion($workspace->version),
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\SharedModel\Workspace;
 
+use Neos\EventStore\Model\Event\Version;
+
 /**
  * Workspace Read Model
  *
@@ -32,7 +34,8 @@ final readonly class Workspace
         public ?WorkspaceName $baseWorkspaceName,
         public ContentStreamId $currentContentStreamId,
         public WorkspaceStatus $status,
-        private bool $hasPublishableChanges
+        private bool $hasPublishableChanges,
+        public Version $version,
     ) {
         if ($this->isRootWorkspace() && $this->hasPublishableChanges) {
             throw new \InvalidArgumentException('Root workspaces cannot have changes', 1730371566);
@@ -47,9 +50,10 @@ final readonly class Workspace
         ?WorkspaceName $baseWorkspaceName,
         ContentStreamId $currentContentStreamId,
         WorkspaceStatus $status,
-        bool $hasPublishableChanges
+        bool $hasPublishableChanges,
+        Version $version,
     ): self {
-        return new self($workspaceName, $baseWorkspaceName, $currentContentStreamId, $status, $hasPublishableChanges);
+        return new self($workspaceName, $baseWorkspaceName, $currentContentStreamId, $status, $hasPublishableChanges, $version);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
@@ -9,6 +9,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
+use Neos\EventStore\Model\Event\Version;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
@@ -250,7 +251,8 @@ class WorkspacesTest extends TestCase
             $baseWorkspace ? WorkspaceName::fromString($baseWorkspace) : null,
             ContentStreamId::create(),
             WorkspaceStatus::UP_TO_DATE,
-            false
+            false,
+            Version::first()
         );
     }
 }


### PR DESCRIPTION
Based on https://github.com/neos/neos-development-collection/pull/5860

Follow-up to #5456 enforcing proper version checks for most workspace events

Related: #5058, #5591