### PR TITLE
BUGFIX: Find child node aggregate with multiple parents

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/Domain/Repository/NodeFactoryTest.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/Domain/Repository/NodeFactoryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Tests\Domain\Repository;
+
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\DimensionSpacePointsRepository;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Serializer;
+
+class NodeFactoryTest extends TestCase
+{
+    /** @test */
+    public function nodeAggregatesAreBuiltOnlyWithTheActualOccupiedNodeRows(): void
+    {
+        $rows = <<<JSON
+        [{
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{}",
+            "covereddimensionspacepoint": "{\"language\":\"de\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{\"disabled\": null}",
+            "covereddimensionspacepoint": "{\"language\":\"en\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{}",
+            "covereddimensionspacepoint": "{\"language\":\"ltz\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{\"disabled\": null}",
+            "covereddimensionspacepoint": "{\"language\":\"mul\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{}",
+            "covereddimensionspacepoint": "{\"language\":\"gsw\"}"
+        }]
+        JSON;
+
+        $dspRepository = $this->getMockBuilder(DimensionSpacePointsRepository::class)->onlyMethods(['getOriginDimensionSpacePointByHash'])->disableOriginalConstructor()->disableAutoReturnValueGeneration()->getMock();
+
+        $dspRepository->method('getOriginDimensionSpacePointByHash')->with('81e25df248aa99d536dba0be7ddf2ac5')->willReturn(OriginDimensionSpacePoint::fromArray(['language' => 'mul']));
+
+        $nodeFactory = new NodeFactory(
+            ContentRepositoryId::fromString('testing'),
+            new PropertyConverter(new Serializer()),
+            $dspRepository,
+        );
+
+        $nodeAggregate = $nodeFactory->mapNodeRowsToNodeAggregate(
+            json_decode($rows, true),
+            WorkspaceName::forLive(),
+            VisibilityConstraints::createEmpty()
+        );
+
+        self::assertSame('nody-mc-nodeface', $nodeAggregate->nodeAggregateId->value);
+
+        // As subtree tags reside on edges we must pick the correct node row to get this occupied node.
+        // If we don't use the row where origindimensionspacepoint equals covereddimensionspacepoint we use subtree tags from a random other edge which is not expected.
+        $mulVariant = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint(OriginDimensionSpacePoint::fromArray(['language' => 'mul']));
+        self::assertSame([], $mulVariant->tags->withoutInherited()->toStringArray());
+        self::assertSame(['disabled'], $mulVariant->tags->onlyInherited()->toStringArray());
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/DimensionSpacePointsRepository.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/DimensionSpacePointsRepository.php
@@ -25,7 +25,7 @@ use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
  *
  * @internal you should never need this in userland code
  */
-final class DimensionSpacePointsRepository
+class DimensionSpacePointsRepository
 {
     /**
      * @var array<string, string>

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -167,8 +167,11 @@ final class NodeFactory
 
         foreach ($nodeRows as $nodeRow) {
             // A node can occupy exactly one DSP and cover multiple ones...
+            $coveredDimensionSpacePoint = DimensionSpacePoint::fromJsonString(
+                $nodeRow['covereddimensionspacepoint']
+            );
             $occupiedDimensionSpacePoint = $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']);
-            if (!isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])) {
+            if ($coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash || $nodeRow['classification'] === 'root') {
                 // ... so we handle occupation exactly once ...
                 $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
                     $nodeRow,
@@ -183,9 +186,6 @@ final class NodeFactory
                 $rawNodeAggregateClassification = $rawNodeAggregateClassification ?: $nodeRow['classification'];
             }
             // ... and coverage always ...
-            $coveredDimensionSpacePoint = DimensionSpacePoint::fromJsonString(
-                $nodeRow['covereddimensionspacepoint']
-            );
             $coveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash] = $coveredDimensionSpacePoint;
 
             $coverageByOccupants[$occupiedDimensionSpacePoint->hash][$coveredDimensionSpacePoint->hash]

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -171,10 +171,8 @@ final class NodeFactory
                 $nodeRow['covereddimensionspacepoint']
             );
             $occupiedDimensionSpacePoint = $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']);
-            if (
-                $coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash
-                // Todo hack, support for partial NodeAggregates by picking an arbitrary node row for occupation. See https://github.com/neos/neos-development-collection/pull/5489
-                || !isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])
+            if ($coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash
+                || (!isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash]) && $nodeRow['classification'] === 'root')
             ) {
                 // ... so we handle occupation exactly once ...
                 $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -198,7 +198,9 @@ final class NodeFactory
         ksort($coveredDimensionSpacePoints);
 
         // a nodeAggregate only exists if it at least contains one node
-        assert($nodesByOccupiedDimensionSpacePoint !== []);
+        if ($nodesByOccupiedDimensionSpacePoint === []) {
+            throw new \RuntimeException(sprintf('Fatal, no occupation found in fetched node rows for aggregate "%s"', $nodeRows[0]['nodeaggregateid'] ?? ''), 1778049288);
+        }
 
         return NodeAggregate::create(
             $this->contentRepositoryId,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -171,7 +171,11 @@ final class NodeFactory
                 $nodeRow['covereddimensionspacepoint']
             );
             $occupiedDimensionSpacePoint = $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']);
-            if ($coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash || $nodeRow['classification'] === 'root') {
+            if (
+                $coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash
+                // Todo hack, support for partial NodeAggregates by picking an arbitrary node row for occupation. See https://github.com/neos/neos-development-collection/pull/5489
+                || !isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])
+            ) {
                 // ... so we handle occupation exactly once ...
                 $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
                     $nodeRow,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -54,12 +54,14 @@ final readonly class NodeQueryBuilder
     public function buildChildNodeAggregateQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamId $contentStreamId): QueryBuilder
     {
         return $this->createQueryBuilder()
-            ->select('cn.*, ch.contentstreamid, ch.subtreetags, cdsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->select('cn.*, ch.contentstreamid, ch.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'pn')
+            ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'ph', 'ph.childnodeanchor = pn.relationanchorpoint')
             ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = pn.relationanchorpoint')
-            ->innerJoin('ch', $this->tableNames->dimensionSpacePoints(), 'cdsp', 'cdsp.hash = ch.dimensionspacepointhash')
+            ->innerJoin('ph', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = ph.dimensionspacepointhash')
             ->innerJoin('ch', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
             ->where('pn.nodeaggregateid = :parentNodeAggregateId')
+            ->andWhere('ph.contentstreamid = :contentStreamId')
             ->andWhere('ch.contentstreamid = :contentStreamId')
             ->orderBy('ch.position')
             ->setParameters([

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -91,6 +91,12 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | Key                          | Value           |
       | nodeAggregateId              | "a2a3-disabled" |
       | nodeVariantSelectionStrategy | "allVariants"   |
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "b"                |
+      | dimensionSpacePoint          | {"language": "ch"} |
+      | newParentNodeAggregateId     | "a"                |
+      | relationDistributionStrategy | "scatter"          |
 
   Scenario:
       # Child nodes without filter
@@ -158,3 +164,21 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
     When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "timestampField", "field": "CREATED", "direction": "ASCENDING"}]}' I expect the nodes "a2a1,a2a2,a2a4,a2a5,a2a6-empty" to be returned
     When I execute the findChildNodes query for parent node aggregate id "a2a" and filter '{"ordering": [{"type": "timestampField", "field": "LAST_MODIFIED", "direction": "DESCENDING"}]}' I expect the nodes "a2a5,a2a1,a2a2,a2a4,a2a6-empty" to be returned
 
+  Scenario:
+  Contentgraph queries
+    # subtree tags are fetched correctly
+    When I execute the findChildNodeAggregates query for node aggregate id "a2a" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions          |
+      | a2a1            | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+      | a2a2            | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+      | a2a3-disabled   | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
+      | a2a4            | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+      | a2a5            | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+      | a2a6-empty      | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+
+    # multiple child node aggregates (via move) are fetched
+    When I execute the findChildNodeAggregates query for node aggregate id "a" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      | a1              | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+      | a2              | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+      | b               | Neos.ContentRepository.Testing:Page | [{"language":"ch"}]                   | [{"language":"de"}]          | []                           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -181,4 +181,12 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
       | a1              | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
       | a2              | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
-      | b               | Neos.ContentRepository.Testing:Page | [{"language":"ch"}]                   | [{"language":"de"}]          | []                           |
+      | b               | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+
+    # children of the moved node
+    When I execute the findChildNodeAggregates query for node aggregate id "b" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      | b1              | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+
+    When I execute the findChildNodeAggregates query for node aggregate id "non-existing" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -71,6 +71,18 @@ trait NodeTraversalTrait
     }
 
     /**
+     * @When I execute the findChildNodeAggregates query for node aggregate id :entryNodeIdSerialized I expect the following node aggregates to be returned:
+     */
+    public function iExecuteTheFindChildNodeAggregatesQueryIExpectTheFollowingNodes(string $entryNodeIdSerialized, TableNode $expectedNodes): void
+    {
+        $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
+        $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
+        $actualNodeAggregates = $contentGraph->findChildNodeAggregates($entryNodeAggregateId);
+
+        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), $actualNodeAggregates, 'findChildNodeAggregates returned an unexpected result');
+    }
+
+    /**
      * @When /^I execute the findReferences query for node aggregate id "(?<nodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the references '(?<referencesSerialized>[^']*)'|no references) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
     public function iExecuteTheFindReferencesQueryIExpectTheFollowingReferences(string $nodeIdSerialized, ?string $filterSerialized = null, ?string $referencesSerialized = null, ?int $expectedTotalCount = null): void


### PR DESCRIPTION
Based on https://github.com/neos/neos-development-collection/pull/5817

While working https://github.com/neos/neos-development-collection/pull/5480 i also wanted to test the child node aggregates query.
Now it seems it was also optimised by https://github.com/neos/neos-development-collection/pull/5268 to remove a join which was really not used!.

But i found that the query has problems with multiple parents in multiple dimensions.

Now moving b only in the specialisation to a from home and querying all childnodes of a, will only result the node row b from the specialisation to be queried.
But to build the whole node aggregate we need also the noderow where b is in the source dimension.

Now it seems that the intention of find child node aggregates and the node aggregate itself contradict. As when being interested in children from a, well the node row b is only that for the specialisation.
A node aggregate should in my opinion be node a question from the perspective of how it was retrieved but should always contain the same node rows - as find by id would return.

Either we introduce a new object here to only really shown the affected node rows or attempt to fix the original query which i did - but im not sure if that is correct yet. Thought the test says yes.

@kitsunet and @dlubitz also discussed it might be worth to just return the node identifiers and have a separate query to turn them into aggregates or let the node factory do that.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
