### PR TITLE
TASK: Remove misleading `NodeAggregate::getNodeByCoveredDimensionSpacePoint()`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -161,7 +161,6 @@ final class NodeFactory
         $occupiedDimensionSpacePoints = [];
         $nodesByOccupiedDimensionSpacePoint = [];
         $coveredDimensionSpacePoints = [];
-        $nodesByCoveredDimensionSpacePoints = [];
         $coverageByOccupants = [];
         $occupationByCovering = [];
         $nodeTagsByCoveredDimensionSpacePoint = [];
@@ -192,8 +191,6 @@ final class NodeFactory
             $coverageByOccupants[$occupiedDimensionSpacePoint->hash][$coveredDimensionSpacePoint->hash]
                 = $coveredDimensionSpacePoint;
             $occupationByCovering[$coveredDimensionSpacePoint->hash] = $occupiedDimensionSpacePoint;
-            $nodesByCoveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash]
-                = $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash];
             // ... as we do for the subtree tags
             $nodeTagsByCoveredDimensionSpacePoint[$coveredDimensionSpacePoint->hash] = self::extractNodeTagsFromJson($nodeRow['subtreetags']);
         }
@@ -214,7 +211,6 @@ final class NodeFactory
             $nodesByOccupiedDimensionSpacePoint,
             CoverageByOrigin::fromArray($coverageByOccupants),
             new DimensionSpacePointSet($coveredDimensionSpacePoints),
-            $nodesByCoveredDimensionSpacePoints,
             OriginByCoverage::fromArray($occupationByCovering),
             $nodeTagsByCoveredDimensionSpacePoint,
         );
@@ -240,7 +236,6 @@ final class NodeFactory
         $occupiedDimensionSpacePointsByNodeAggregate = [];
         $nodesByOccupiedDimensionSpacePointsByNodeAggregate = [];
         $coveredDimensionSpacePointsByNodeAggregate = [];
-        $nodesByCoveredDimensionSpacePointsByNodeAggregate = [];
         $classificationByNodeAggregate = [];
         $coverageByOccupantsByNodeAggregate = [];
         $occupationByCoveringByNodeAggregate = [];
@@ -283,10 +278,6 @@ final class NodeFactory
 
             $coveredDimensionSpacePointsByNodeAggregate[$rawNodeAggregateId][$coveredDimensionSpacePoint->hash]
                 = $coveredDimensionSpacePoint;
-            $nodesByCoveredDimensionSpacePointsByNodeAggregate
-                [$rawNodeAggregateId][$coveredDimensionSpacePoint->hash]
-                = $nodesByOccupiedDimensionSpacePointsByNodeAggregate
-                    [$rawNodeAggregateId][$occupiedDimensionSpacePoint->hash];
 
             // ... as we do for the subtree tags
             $nodeTagsByCoveredDimensionSpacePointByNodeAggregate[$rawNodeAggregateId][$coveredDimensionSpacePoint->hash] = self::extractNodeTagsFromJson($nodeRow['subtreetags']);
@@ -311,8 +302,6 @@ final class NodeFactory
                 new DimensionSpacePointSet(
                     $coveredDimensionSpacePointsByNodeAggregate[$rawNodeAggregateId]
                 ),
-                $nodesByCoveredDimensionSpacePointsByNodeAggregate
-                    [$rawNodeAggregateId],
                 OriginByCoverage::fromArray(
                     $occupationByCoveringByNodeAggregate[$rawNodeAggregateId]
                 ),

--- a/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.PostgreSQLAdapter/src/Domain/Repository/NodeFactory.php
@@ -193,7 +193,6 @@ final class NodeFactory
         $coverageByOccupant = [];
         /** @var DimensionSpacePoint[] $coveredDimensionSpacePoints */
         $coveredDimensionSpacePoints = [];
-        $nodesByCoveredDimensionSpacePoint = [];
         $occupationByCovered = [];
         /** @var DimensionSpacePoint[] $disabledDimensionSpacePoints */
         $disabledDimensionSpacePoints = [];
@@ -221,7 +220,6 @@ final class NodeFactory
             $coverageByOccupant[$node->originDimensionSpacePoint->hash][$coveredDimensionSpacePoint->hash]
                 = $coveredDimensionSpacePoint;
             $coveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash] = $coveredDimensionSpacePoint;
-            $nodesByCoveredDimensionSpacePoint[$coveredDimensionSpacePoint->hash] = $node;
             $occupationByCovered[$coveredDimensionSpacePoint->hash] = $node->originDimensionSpacePoint;
             if (isset($nodeRow['disableddimensionspacepointhash']) && $nodeRow['disableddimensionspacepointhash']) {
                 $disabledDimensionSpacePoints[$nodeRow['disableddimensionspacepointhash']]
@@ -240,7 +238,6 @@ final class NodeFactory
             $nodesByOccupiedDimensionSpacePoint,
             CoverageByOrigin::fromArray($coverageByOccupant),
             new DimensionSpacePointSet($coveredDimensionSpacePoints),
-            $nodesByCoveredDimensionSpacePoint,
             OriginByCoverage::fromArray($occupationByCovered),
             // TODO implement (see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory::mapNodeRowsToNodeAggregate())
             array_fill_keys(array_keys($coveredDimensionSpacePoints), NodeTags::createEmpty()),
@@ -275,8 +272,6 @@ final class NodeFactory
         $coverageByOccupant = [];
         /** @var DimensionSpacePoint[][] $coveredDimensionSpacePoints */
         $coveredDimensionSpacePoints = [];
-        /** @var Node[][] $nodesByCoveredDimensionSpacePoint */
-        $nodesByCoveredDimensionSpacePoint = [];
         /** @var OriginDimensionSpacePoint[][] $occupationByCovered */
         $occupationByCovered = [];
         /** @var DimensionSpacePoint[][] $disabledDimensionSpacePoints */
@@ -314,7 +309,6 @@ final class NodeFactory
             $coveredDimensionSpacePoints[$key][$coveredDimensionSpacePoint->hash] = $coveredDimensionSpacePoint;
             $coverageByOccupant[$key][$node->originDimensionSpacePoint->hash][$coveredDimensionSpacePoint->hash]
                 = $coveredDimensionSpacePoint;
-            $nodesByCoveredDimensionSpacePoint[$key][$coveredDimensionSpacePoint->hash] = $node;
             $occupationByCovered[$key][$coveredDimensionSpacePoint->hash] = $node->originDimensionSpacePoint;
             if (!isset($disabledDimensionSpacePoints[$key])) {
                 $disabledDimensionSpacePoints[$key] = [];
@@ -337,7 +331,6 @@ final class NodeFactory
                 $nodesByOccupiedDimensionSpacePoint[$key],
                 CoverageByOrigin::fromArray($coverageByOccupant[$key]),
                 new DimensionSpacePointSet($coveredDimensionSpacePoints[$key]),
-                $nodesByCoveredDimensionSpacePoint[$key],
                 OriginByCoverage::fromArray($occupationByCovered[$key]),
                 // TODO implement (see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory::mapNodeRowsToNodeAggregates())
                 array_fill_keys(array_keys($coveredDimensionSpacePoints), NodeTags::createEmpty()),

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -156,6 +156,18 @@ final readonly class NodeAggregate
         return $coverage;
     }
 
+    /**
+     * Returns the node for the dimension space point which is occupied
+     *
+     * The node aggregate does only know about nodes from dimensions where they originate in.
+     * Fallback nodes are not part of the node aggregate as there is currently no use-case.
+     *
+     * This means this logic can be substituted via
+     *
+     *     $node = $this->getNodeByOccupiedDimensionSpacePoint(
+     *         $this->getOccupationByCovered($coveredDimensionSpacePoint)
+     *     );
+     */
     public function getNodeByCoveredDimensionSpacePoint(DimensionSpacePoint $coveredDimensionSpacePoint): Node
     {
         if (!isset($this->coveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash])) {

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -119,6 +119,18 @@ final readonly class NodeAggregate
         return $this->occupiedDimensionSpacePoints->contains($originDimensionSpacePoint);
     }
 
+    /**
+     * Returns the node for the occupied dimension space point.
+     *
+     * The node aggregate does only know about nodes from dimensions where they originate in.
+     * Fallback nodes are not part of the node aggregate as there is currently no use-case.
+     *
+     * To fetch the occupying node by covered dimension space point use {@see self::getOccupationByCovered}:
+     *
+     *     $node = $this->getNodeByOccupiedDimensionSpacePoint(
+     *         $this->getOccupationByCovered($coveredDimensionSpacePoint)
+     *     );
+     */
     public function getNodeByOccupiedDimensionSpacePoint(
         OriginDimensionSpacePoint $occupiedDimensionSpacePoint
     ): Node {
@@ -151,25 +163,6 @@ final readonly class NodeAggregate
         return $coverage;
     }
 
-    /**
-     * Returns the node for the dimension space point which is occupied
-     *
-     * The node aggregate does only know about nodes from dimensions where they originate in.
-     * Fallback nodes are not part of the node aggregate as there is currently no use-case.
-     *
-     * This method is just an alias for
-     *
-     *     $node = $this->getNodeByOccupiedDimensionSpacePoint(
-     *         $this->getOccupationByCovered($coveredDimensionSpacePoint)
-     *     );
-     */
-    public function getNodeByCoveredDimensionSpacePoint(DimensionSpacePoint $coveredDimensionSpacePoint): Node
-    {
-        return $this->getNodeByOccupiedDimensionSpacePoint(
-            $this->getOccupationByCovered($coveredDimensionSpacePoint)
-        );
-    }
-
     public function getOccupationByCovered(DimensionSpacePoint $coveredDimensionSpacePoint): OriginDimensionSpacePoint
     {
         $occupation = $this->occupationByCovered->getOrigin($coveredDimensionSpacePoint);
@@ -188,14 +181,9 @@ final readonly class NodeAggregate
      *
      * Implementation note:
      *
-     * We need to pass $nodeTagsByCoveredDimensionSpacePoint additionally to the NodeAggregate as this information doesn't exist otherwise.
-     * The nodes in $nodesByCoveredDimensionSpacePoint only point to the occupying nodes without entries for the specialisations.
-     * This means we CANNOT substitute this implementation by iterating over the occupied nodes as explicitly tagged specialisations will not show up as tagged:
-     *
-     *     foreach ($this->coveredDimensionSpacePoints as $coveredDimensionSpacePoint) {
-     *         $node = $this->nodesByCoveredDimensionSpacePoint[$coveredDimensionSpacePoint->hash];
-     *         // ... use $node->tags
-     *     }
+     * We need to pass ${@see $nodeTagsByCoveredDimensionSpacePoint} additionally to the NodeAggregate as this information doesn't exist otherwise.
+     * The node aggregate only knows about its occupying nodes {@see $nodesByOccupiedDimensionSpacePoint} - so no fallbacks.
+     * This means we CANNOT substitute this implementation by iterating over the occupied nodes as explicitly tagged specialisations will not show up as tagged.
      *
      * We could simplify this logic if we also add these specialisation node rows explicitly to the NodeAggregate, but currently there is no use for that.
      *

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -60,7 +60,6 @@ final readonly class NodeAggregate
      * @param non-empty-array<string,Node> $nodesByOccupiedDimensionSpacePoint At least one node will be occupied.
      * @param CoverageByOrigin $coverageByOccupant
      * @param DimensionSpacePointSet $coveredDimensionSpacePoints This node aggregate will cover at least one dimension space.
-     * @param non-empty-array<string,Node> $nodesByCoveredDimensionSpacePoint At least one node will be covered.
      * @param OriginByCoverage $occupationByCovered
      * @param non-empty-array<string,NodeTags> $nodeTagsByCoveredDimensionSpacePoint node tags by every covered dimension space point
      */
@@ -75,7 +74,6 @@ final readonly class NodeAggregate
         private array $nodesByOccupiedDimensionSpacePoint,
         public CoverageByOrigin $coverageByOccupant,
         public DimensionSpacePointSet $coveredDimensionSpacePoints,
-        private array $nodesByCoveredDimensionSpacePoint,
         private OriginByCoverage $occupationByCovered,
         private array $nodeTagsByCoveredDimensionSpacePoint,
     ) {
@@ -83,7 +81,6 @@ final readonly class NodeAggregate
 
     /**
      * @param non-empty-array<string,Node> $nodesByOccupiedDimensionSpacePoint
-     * @param non-empty-array<string,Node> $nodesByCoveredDimensionSpacePoint
      * @param non-empty-array<string,NodeTags> $nodeTagsByCoveredDimensionSpacePoint
      * @internal The signature of this method can change in the future!
      */
@@ -98,7 +95,6 @@ final readonly class NodeAggregate
         array $nodesByOccupiedDimensionSpacePoint,
         CoverageByOrigin $coverageByOccupant,
         DimensionSpacePointSet $coveredDimensionSpacePoints,
-        array $nodesByCoveredDimensionSpacePoint,
         OriginByCoverage $occupationByCovered,
         array $nodeTagsByCoveredDimensionSpacePoint,
     ): self {
@@ -113,7 +109,6 @@ final readonly class NodeAggregate
             $nodesByOccupiedDimensionSpacePoint,
             $coverageByOccupant,
             $coveredDimensionSpacePoints,
-            $nodesByCoveredDimensionSpacePoint,
             $occupationByCovered,
             $nodeTagsByCoveredDimensionSpacePoint,
         );
@@ -162,7 +157,7 @@ final readonly class NodeAggregate
      * The node aggregate does only know about nodes from dimensions where they originate in.
      * Fallback nodes are not part of the node aggregate as there is currently no use-case.
      *
-     * This means this logic can be substituted via
+     * This method is just an alias for
      *
      *     $node = $this->getNodeByOccupiedDimensionSpacePoint(
      *         $this->getOccupationByCovered($coveredDimensionSpacePoint)
@@ -170,14 +165,9 @@ final readonly class NodeAggregate
      */
     public function getNodeByCoveredDimensionSpacePoint(DimensionSpacePoint $coveredDimensionSpacePoint): Node
     {
-        if (!isset($this->coveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash])) {
-            throw NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint::butWasSupposedTo(
-                $this->nodeAggregateId,
-                $coveredDimensionSpacePoint
-            );
-        }
-
-        return $this->nodesByCoveredDimensionSpacePoint[$coveredDimensionSpacePoint->hash];
+        return $this->getNodeByOccupiedDimensionSpacePoint(
+            $this->getOccupationByCovered($coveredDimensionSpacePoint)
+        );
     }
 
     public function getOccupationByCovered(DimensionSpacePoint $coveredDimensionSpacePoint): OriginDimensionSpacePoint


### PR DESCRIPTION
Remove `$nodesByCoveredDimensionSpacePoint` property for NodeAggregate as it doesnt contain new information

Currently, its the same as (at least for the doctrine adapter)
    
```php
$this->getNodeByOccupiedDimensionSpacePoint(
    $this->getOccupationByCovered($coveredDimensionSpacePoint)
);
```

And we agreed to not make the node aggregate contain its fallback nodes for now.

Originally the method `getNodeByCoveredDimensionSpacePoint` was introduced via https://github.com/neos/neos-development-collection/commit/e58fa08f01480b00b4ca8488c858f9d128d6d644

With the ONLY use being here which can definitely be solved else-how: https://github.com/neos/neos-ui/blob/f8c9527320cf133705920c54496bbb22400868b8/Classes/Controller/BackendController.php#L165

So im even considering fully dropping the misleading `getNodeByCoveredDimensionSpacePoint` until the node aggregate really knows all its fallback nodes!

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
