### PR TITLE
FEATURE: Add method to generate aggregate ID path for a node

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregateIdPath.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregateIdPath.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+
+final readonly class NodeAggregateIdPath implements \JsonSerializable
+{
+    private function __construct(
+        private NodeAggregateIds $nodeAggregateIds
+    ) {
+    }
+
+    public static function create(NodeAggregateIds $nodeAggregateIds): self
+    {
+        return new self($nodeAggregateIds);
+    }
+
+    public static function fromNodes(Nodes $nodes): self
+    {
+        return new self(NodeAggregateIds::fromNodes($nodes));
+    }
+
+    public function serializeToString(): string
+    {
+        return '/' . join('/', $this->nodeAggregateIds->toStringArray());
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->serializeToString();
+    }
+
+    public function __toString(): string
+    {
+        return $this->serializeToString();
+    }
+}

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -21,7 +21,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregateIdPath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
@@ -30,6 +29,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Neos\Domain\Exception;
 use Neos\Neos\Domain\NodeLabel\NodeLabelGeneratorInterface;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
+use Neos\Neos\Presentation\NodeAggregateIdPath;
 use Neos\Neos\Presentation\VisualNodePath;
 
 /**
@@ -63,7 +63,10 @@ class NodeHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * This path is build on node names. As the node names are not mandatory, this can fail easily.
+     *
      * @deprecated do not rely on this, as it is rather expensive to calculate
+     * @throws \InvalidArgumentException
      */
     public function path(Node $node): string
     {
@@ -76,6 +79,9 @@ class NodeHelper implements ProtectedContextAwareInterface
         return AbsoluteNodePath::fromLeafNodeAndAncestors($node, $ancestors)->serializeToString();
     }
 
+    /**
+     * Returns a reliable path based on node aggregate ids to display the position of the node in the hierarchy.
+     */
     public function aggregateIdPath(Node $node): string
     {
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);

--- a/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/NodeHelper.php
@@ -21,6 +21,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregateIdPath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
@@ -73,6 +74,17 @@ class NodeHelper implements ProtectedContextAwareInterface
         )->reverse();
 
         return AbsoluteNodePath::fromLeafNodeAndAncestors($node, $ancestors)->serializeToString();
+    }
+
+    public function aggregateIdPath(Node $node): string
+    {
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
+        $ancestors = $subgraph->findAncestorNodes(
+            $node->aggregateId,
+            FindAncestorNodesFilter::create()
+        )->reverse();
+
+        return NodeAggregateIdPath::fromNodes($ancestors)->serializeToString();
     }
 
     /**

--- a/Neos.Neos/Classes/Presentation/NodeAggregateIdPath.php
+++ b/Neos.Neos/Classes/Presentation/NodeAggregateIdPath.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Neos\Neos\Presentation;
 

--- a/Neos.Neos/Classes/Presentation/NodeAggregateIdPath.php
+++ b/Neos.Neos/Classes/Presentation/NodeAggregateIdPath.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neos\Neos\Presentation;

--- a/Neos.Neos/Classes/Presentation/NodeAggregateIdPath.php
+++ b/Neos.Neos/Classes/Presentation/NodeAggregateIdPath.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Neos\ContentRepository\Core\Projection\ContentGraph;
+namespace Neos\Neos\Presentation;
 
+use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 
 final readonly class NodeAggregateIdPath implements \JsonSerializable


### PR DESCRIPTION
This helper provides safely paths based on node aggregate ids. E.g:

`/fa0affac-0baa-a530-84d4-58adb5900f93/6c771000-d1d3-47da-9180-5865fd194300/f12e0e79-dce6-46fb-b109-67f6e19d4472`
`/fa0affac-0baa-a530-84d4-58adb5900f93/6c771000-d1d3-47da-9180-5865fd194300`
`/fa0affac-0baa-a530-84d4-58adb5900f93`

This is needed to provide external tools like Elasticsearch more about the hierarchy of nodes.