### PR TITLE
TASK: Code style adjust 5 internal usages of `Object::none()` to `::createEmpty()`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHooks.php
@@ -31,7 +31,7 @@ final readonly class CommandHooks implements CommandHookInterface, \IteratorAggr
         return new self(...$commandHooks);
     }
 
-    public static function none(): self
+    public static function createEmpty(): self
     {
         return new self();
     }

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositorySubscriberFactories.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositorySubscriberFactories.php
@@ -29,7 +29,7 @@ final class ContentRepositorySubscriberFactories implements \IteratorAggregate
         return new self(...$subscriberFactories);
     }
 
-    public static function none(): self
+    public static function createEmpty(): self
     {
         return new self();
     }

--- a/Neos.ContentRepository.Core/Classes/Projection/Projections.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/Projections.php
@@ -28,7 +28,7 @@ final class Projections implements \IteratorAggregate, \Countable
         $this->projections = $projections;
     }
 
-    public static function empty(): self
+    public static function createEmpty(): self
     {
         return new self();
     }

--- a/Neos.ContentRepository.Core/Classes/Subscription/Subscriber/Subscribers.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Subscriber/Subscribers.php
@@ -44,7 +44,7 @@ final class Subscribers implements \IteratorAggregate, \Countable, \JsonSerializ
         return new self($subscribersById);
     }
 
-    public static function none(): self
+    public static function createEmpty(): self
     {
         return self::fromArray([]);
     }

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionIds.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionIds.php
@@ -39,7 +39,7 @@ final class SubscriptionIds implements \IteratorAggregate, \Countable, \JsonSeri
         return new self($subscriptionIdsById);
     }
 
-    public static function none(): self
+    public static function createEmpty(): self
     {
         return self::fromArray([]);
     }

--- a/Neos.ContentRepository.Core/Classes/Subscription/Subscriptions.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Subscriptions.php
@@ -38,7 +38,7 @@ final class Subscriptions implements \IteratorAggregate, \Countable, \JsonSerial
         return new self($subscriptionsById);
     }
 
-    public static function none(): self
+    public static function createEmpty(): self
     {
         return self::fromArray([]);
     }

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/SubscriptionStore/DoctrineSubscriptionStore.php
@@ -94,7 +94,7 @@ final class DoctrineSubscriptionStore implements SubscriptionStoreInterface
         assert($result instanceof Result);
         $rows = $result->fetchAllAssociative();
         if ($rows === []) {
-            return Subscriptions::none();
+            return Subscriptions::createEmpty();
         }
         return Subscriptions::fromArray(array_map(self::fromDatabase(...), $rows));
     }

--- a/Neos.Fusion/Classes/Core/FusionGlobals.php
+++ b/Neos.Fusion/Classes/Core/FusionGlobals.php
@@ -41,7 +41,7 @@ final readonly class FusionGlobals
     ) {
     }
 
-    public static function empty(): self
+    public static function createEmpty(): self
     {
         return new self([]);
     }

--- a/Neos.Fusion/Classes/Core/FusionSourceCodeCollection.php
+++ b/Neos.Fusion/Classes/Core/FusionSourceCodeCollection.php
@@ -34,6 +34,11 @@ final class FusionSourceCodeCollection implements \IteratorAggregate, \Countable
         $this->fusionCodeCollection = self::deduplicateItemsAndKeepLast($fusionSourceCode);
     }
 
+    public static function createEmpty(): self
+    {
+        return new self();
+    }
+
     public static function fromFilePath(string $filePath): self
     {
         return new self(FusionSourceCode::fromFilePath($filePath));
@@ -47,7 +52,7 @@ final class FusionSourceCodeCollection implements \IteratorAggregate, \Countable
     public static function tryFromFilePath(string $filePath): self
     {
         if (!is_readable($filePath)) {
-            return self::empty();
+            return self::createEmpty();
         }
         return self::fromFilePath($filePath);
     }
@@ -61,9 +66,12 @@ final class FusionSourceCodeCollection implements \IteratorAggregate, \Countable
         return self::tryFromFilePath($fusionPathAndFilename);
     }
 
+    /**
+     * @deprecated with Neos 9, remove me :)
+     */
     public static function empty(): self
     {
-        return new self();
+        return self::createEmpty();
     }
 
     public function union(FusionSourceCodeCollection $other): self

--- a/Neos.Fusion/Tests/Benchmark/RuntimeBench.php
+++ b/Neos.Fusion/Tests/Benchmark/RuntimeBench.php
@@ -95,7 +95,7 @@ class RuntimeBench
                 ]
             ]
         ];
-        $this->runtime = (new RuntimeFactory())->createFromConfiguration(FusionConfiguration::fromArray($fusionConfiguration), FusionGlobals::empty());
+        $this->runtime = (new RuntimeFactory())->createFromConfiguration(FusionConfiguration::fromArray($fusionConfiguration), FusionGlobals::createEmpty());
 
         // Build an EEL evaluator suitable for benchmarking
         $evaluator = $this->buildEelEvaluator();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
@@ -55,7 +55,7 @@ class ExpressionsTest extends AbstractFusionObjectTest
     {
         $fusionAst = (new Parser())->parseFromSource(FusionSourceCodeCollection::fromString('root = ${"foo"}'));
 
-        $runtime = (new RuntimeFactory())->createFromConfiguration($fusionAst, FusionGlobals::empty());
+        $runtime = (new RuntimeFactory())->createFromConfiguration($fusionAst, FusionGlobals::createEmpty());
 
         $renderedFusion = $runtime->render('root');
 

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
@@ -30,7 +30,7 @@ class ReservedKeysTest extends AbstractFusionObjectTest
         $this->expectException(Exception::class);
         $this->objectManager->get(RuntimeFactory::class)->createFromSourceCode(
             FusionSourceCodeCollection::fromFilePath(__DIR__ . '/Fixtures/ReservedKeysFusion/ReservedKeys.fusion'),
-            FusionGlobals::empty()
+            FusionGlobals::createEmpty()
         );
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/FusionSourceCodeDtosTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/FusionSourceCodeDtosTest.php
@@ -45,7 +45,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         self::assertEquals("a", $code->getSourceCode());
         self::assertEquals("memory://a", $code->getFilePath());
 
-        $code = FusionSourceCodeCollection::empty();
+        $code = FusionSourceCodeCollection::createEmpty();
         self::assertCount(0, $code);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
@@ -59,7 +59,7 @@ class RuntimeTest extends UnitTestCase
         $this->expectException(Exception::class);
         $objectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->setMethods(['isRegistered', 'get'])->getMock();
         $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'), 'root');
-        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::empty());
+        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::createEmpty());
         $this->inject($runtime, 'objectManager', $objectManager);
         $exceptionHandlerSetting = 'settings';
         $runtime->injectSettings(['rendering' => ['exceptionHandler' => $exceptionHandlerSetting]]);
@@ -81,7 +81,7 @@ class RuntimeTest extends UnitTestCase
             self::callback(fn (ProtectedContext $actualContext) => $actualContext->get('foo') === '19')
         );
 
-        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::empty());
+        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::createEmpty());
         $this->inject($runtime, 'eelEvaluator', $eelEvaluator);
 
         $runtime->pushContextArray(['foo' => '19']);
@@ -108,7 +108,7 @@ class RuntimeTest extends UnitTestCase
                     ]
                 ]
             ]
-        ]), FusionGlobals::empty());
+        ]), FusionGlobals::createEmpty());
 
         $runtime->evaluate('foo/bar');
     }
@@ -131,7 +131,7 @@ class RuntimeTest extends UnitTestCase
      */
     public function runtimeCurrentContextStackWorksSimplePushPop()
     {
-        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::empty());
+        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::createEmpty());
 
         self::assertSame([], $runtime->getCurrentContext(), 'context should be empty at start.');
 
@@ -149,7 +149,7 @@ class RuntimeTest extends UnitTestCase
      */
     public function runtimeCurrentContextStack3PushesAndPops()
     {
-        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::empty());
+        $runtime = new Runtime(FusionConfiguration::fromArray([]), FusionGlobals::createEmpty());
 
         self::assertSame([], $runtime->getCurrentContext(), 'empty at start');
 
@@ -298,7 +298,7 @@ class RuntimeTest extends UnitTestCase
     public function renderEntryPathStream(mixed $rawValue, string $expectedStreamContents)
     {
         $runtime = $this->getMockBuilder(Runtime::class)
-            ->setConstructorArgs([FusionConfiguration::fromArray([]), FusionGlobals::empty()])
+            ->setConstructorArgs([FusionConfiguration::fromArray([]), FusionGlobals::createEmpty()])
             ->onlyMethods(['render'])
             ->getMock();
 
@@ -319,7 +319,7 @@ class RuntimeTest extends UnitTestCase
     public function renderEntryPathResponse(mixed $rawValue, string $expectedHttpResponseString)
     {
         $runtime = $this->getMockBuilder(Runtime::class)
-            ->setConstructorArgs([FusionConfiguration::fromArray([]), FusionGlobals::empty()])
+            ->setConstructorArgs([FusionConfiguration::fromArray([]), FusionGlobals::createEmpty()])
             ->onlyMethods(['render'])
             ->getMock();
 
@@ -372,7 +372,7 @@ class RuntimeTest extends UnitTestCase
         $this->expectExceptionMessage(sprintf('Fusion entry path "path" is expected to render a compatible http response body: string|\Stringable|null. Got %s instead.', get_debug_type($illegalValue)));
 
         $runtime = $this->getMockBuilder(Runtime::class)
-            ->setConstructorArgs([FusionConfiguration::fromArray([]), FusionGlobals::empty()])
+            ->setConstructorArgs([FusionConfiguration::fromArray([]), FusionGlobals::createEmpty()])
             ->onlyMethods(['render'])
             ->getMock();
 

--- a/Neos.Neos/Classes/Domain/Import/LiveWorkspaceCreationProcessor.php
+++ b/Neos.Neos/Classes/Domain/Import/LiveWorkspaceCreationProcessor.php
@@ -47,7 +47,7 @@ final readonly class LiveWorkspaceCreationProcessor implements ProcessorInterfac
             $this->contentRepository->id,
             WorkspaceName::forLive(),
             WorkspaceTitle::fromString('Public live workspace'),
-            WorkspaceDescription::empty(),
+            WorkspaceDescription::createEmpty(),
             WorkspaceRoleAssignments::createForLiveWorkspace()
         );
     }

--- a/Neos.Neos/Classes/Domain/Model/WorkspaceDescription.php
+++ b/Neos.Neos/Classes/Domain/Model/WorkspaceDescription.php
@@ -27,7 +27,7 @@ final readonly class WorkspaceDescription implements \JsonSerializable
         return new self($value);
     }
 
-    public static function empty(): self
+    public static function createEmpty(): self
     {
         return new self('');
     }

--- a/Neos.Neos/Classes/Domain/Service/FusionSourceCodeFactory.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionSourceCodeFactory.php
@@ -50,7 +50,7 @@ class FusionSourceCodeFactory
 
     public function createFromAutoIncludes(): FusionSourceCodeCollection
     {
-        $sourcecode = FusionSourceCodeCollection::empty();
+        $sourcecode = FusionSourceCodeCollection::createEmpty();
         foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
             if (isset($this->autoIncludeConfiguration[$packageKey]) && $this->autoIncludeConfiguration[$packageKey] === true) {
                 $sourcecode = $this->fusionAutoIncludeHandler->loadFusionFromPackage($packageKey, $sourcecode);

--- a/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteServiceInternals.php
@@ -108,7 +108,7 @@ readonly class SiteServiceInternals
                     $this->contentRepository->id,
                     WorkspaceName::forLive(),
                     WorkspaceTitle::fromString('Public live workspace'),
-                    WorkspaceDescription::empty(),
+                    WorkspaceDescription::createEmpty(),
                     WorkspaceRoleAssignments::createForLiveWorkspace()
                 )
             );

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
@@ -209,7 +209,7 @@ final readonly class WorkspaceService
             $contentRepositoryId,
             $workspaceName,
             WorkspaceTitle::fromString($user->getLabel()),
-            WorkspaceDescription::empty(),
+            WorkspaceDescription::createEmpty(),
             WorkspaceName::forLive(),
             $user->getId(),
         );

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
@@ -95,7 +95,7 @@ trait WorkspaceServiceTrait
             $this->currentContentRepository->id,
             WorkspaceName::forLive(),
             WorkspaceTitle::fromString('Public live workspace'),
-            WorkspaceDescription::empty(),
+            WorkspaceDescription::createEmpty(),
             WorkspaceRoleAssignments::createForLiveWorkspace()
         );
     }


### PR DESCRIPTION
We had the discussion again how to name an empty object and for normal collections we used `createEmpty()` in the past (25 present definitions) and should continue to do so. The use of `none()` snuck in lately via the subscription engine.

https://github.com/neos/neos-development-collection/pull/5463#discussion_r1981186635


<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
