### PR TITLE
BUGFIX: Find nodes marked as removed in other dimension

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -1086,7 +1086,7 @@ class NodeData extends AbstractNodeData
 
         // If the node is marked to be removed but didn't exist in a base workspace yet, we can delete it for real, without creating a shadow node.
         // This optimization cannot be made for shadow nodes which are moved.
-        if ($nodeData->isRemoved() && $nodeData->getMovedTo() === null && $this->nodeDataRepository->findOneByIdentifier($nodeData->getIdentifier(), $this->workspace->getBaseWorkspace()) === null) {
+        if ($nodeData->isRemoved() && $nodeData->getMovedTo() === null && $this->nodeDataRepository->findOneByIdentifier($nodeData->getIdentifier(), $this->workspace->getBaseWorkspace(), removedNodes: true) === null) {
             if ($this->persistenceManager->isNewObject($nodeData) === false) {
                 $this->nodeDataRepository->remove($nodeData);
             }


### PR DESCRIPTION
If you delete a node in a workspace that has already been deleted in the workspace in another dimension, the node is not marked as removed in the database.

With this PR, nodes marked as removed are also found in non-live workspaces.

related: #5031 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
