### PR TITLE
BUGFIX: Render attributes in Neos.Neos:Content as HTML attributes string

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/ArrayHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/ArrayHelper.php
@@ -110,7 +110,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
 
     /**
      * Converts an array into an HTML attributes string like 'class="foo" id="bar"'
-     * @param array $attributes
+     * @param array<string> $attributes
      * @return string
      */
     public function toHtmlAttributesString(array $attributes): string

--- a/Neos.Neos/Classes/Fusion/Helper/ArrayHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/ArrayHelper.php
@@ -17,6 +17,7 @@ namespace Neos\Neos\Fusion\Helper;
 use Doctrine\Common\Collections\Collection;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Service\RenderAttributesTrait;
 use Neos\Utility\ObjectAccess;
 use Neos\Utility\PositionalArraySorter;
 
@@ -29,6 +30,8 @@ use Neos\Utility\PositionalArraySorter;
  */
 class ArrayHelper implements ProtectedContextAwareInterface
 {
+    use RenderAttributesTrait;
+
     /**
      * Filter an array of objects, by only keeping the elements where each object's $filterProperty evaluates to true.
      *
@@ -103,6 +106,16 @@ class ArrayHelper implements ProtectedContextAwareInterface
     public function sortByPropertyPath(array $set, string $positionPropertyPath = 'position'): array
     {
         return (new PositionalArraySorter($set, $positionPropertyPath))->toArray();
+    }
+
+    /**
+     * Converts an array into an HTML attributes string like 'class="foo" id="bar"'
+     * @param array $attributes
+     * @return string
+     */
+    public function toHtmlAttributesString(array $attributes): string
+    {
+        return $this->renderAttributes($attributes);
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/Content.fusion
@@ -11,6 +11,7 @@ prototype(Neos.Neos:Content) < prototype(Neos.Fusion:Template) {
   // @todo simple array join in fusion
   attributes = Neos.Fusion:DataStructure
   attributes.class = ''
+  attributes.@process.toHtmlAttributesString = ${Neos.Array.toHtmlAttributesString(value)}
 
   # The following is used to automatically append a class attribute that reflects the underlying node type of a Fusion object,
   # for example "neos-nodetypes-form", "neos-nodetypes-headline", "neos-nodetypes-html", "neos-nodetypes-image", "neos-nodetypes-menu" and "neos-nodetypes-text"


### PR DESCRIPTION
Resolves: https://github.com/neos/neos-development-collection/issues/4885

Provides better downwards compatibility with old fluid templates, which often rely on `<div {attributes -> f:format:raw() ... >` constructs.