### PR TITLE
TASK: Elaborate deprecations in `VisibilityConstraints`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/DisableNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/DisableNodeAggregate.php
@@ -29,7 +29,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  * The duplicated command implementation was removed with Neos 9 Beta 19 and its now discouraged to use these legacy commands
  * which now translate fully to their subtree counterparts.
  *
- * @deprecated please use {@see TagSubtree} instead and specify as {@see SubtreeTag} "disabled"
+ * @deprecated please use {@see TagSubtree} instead and specify as {@see SubtreeTag} "disabled", in neos via {@see \Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled()}. To be removed with Neos 10.
  * @internal
  */
 final readonly class DisableNodeAggregate

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/EnableNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeDisabling/Command/EnableNodeAggregate.php
@@ -29,7 +29,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  * The duplicated command implementation was removed with Neos 9 Beta 19 and its now discouraged to use these legacy commands
  * which now translate fully to their subtree counterparts.
  *
- * @deprecated please use {@see UntagSubtree} instead and specify as {@see SubtreeTag} "disabled"
+ * @deprecated please use {@see UntagSubtree} instead and specify as {@see SubtreeTag} "disabled", in neos via {@see \Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled()}. To be removed with Neos 10.
  * @internal
  */
 final readonly class EnableNodeAggregate

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
@@ -47,18 +47,6 @@ final class SubtreeTag implements \JsonSerializable
         return self::instance($value);
     }
 
-    /**
-     * Legacy, only for Neos.Neos context!, for standalone use please use {@see self::fromString()}
-     *
-     * Please use {@see \Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled()} instead.
-     *
-     * @deprecated with Neos 9 beta 19
-     */
-    public static function disabled(): self
-    {
-        return self::instance('disabled');
-    }
-
     public function equals(self $other): bool
     {
         return $this === $other;
@@ -72,5 +60,19 @@ final class SubtreeTag implements \JsonSerializable
     public function __toString(): string
     {
         return $this->value;
+    }
+
+    /** -------------- deprecations: ------------------- */
+
+    /**
+     * Legacy, only for Neos.Neos context!, for standalone use please use {@see self::fromString()}
+     *
+     * Please use {@see \Neos\Neos\Domain\SubtreeTagging\NeosSubtreeTag::disabled()} instead.
+     *
+     * @deprecated with Neos 9 beta 19. To be removed with Neos 10.
+     */
+    public static function disabled(): self
+    {
+        return self::instance('disabled');
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/VisibilityConstraints.php
@@ -50,8 +50,6 @@ final readonly class VisibilityConstraints implements \JsonSerializable
 
     /**
      * A subgraph without constraints for finding all nodes without filtering
-     *
-     * Nodes for example with tag disabled will be findable
      */
     public static function createEmpty(): self
     {
@@ -77,7 +75,19 @@ final readonly class VisibilityConstraints implements \JsonSerializable
     }
 
     /**
-     * @deprecated with Neos 9 beta 19 please use {@see VisibilityConstraints::excludeSubtreeTags} instead.
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+
+    /** -------------- deprecations: ------------------- */
+
+    /**
+     * Please use {@see VisibilityConstraints::excludeSubtreeTags} instead.
+     *
+     * @deprecated with Neos 9 beta 19. To be removed with Neos 10.
      */
     public static function fromTagConstraints(SubtreeTags $tagConstraints): self
     {
@@ -87,13 +97,13 @@ final readonly class VisibilityConstraints implements \JsonSerializable
     /**
      * Legacy, only for Neos.Neos context!, for standalone use please use {@see self::excludeSubtreeTags()}
      *
-     * Please look into {@see \Neos\Neos\Domain\Service\NeosVisibilityConstraints()} instead.
+     * Please look into {@see \Neos\Neos\Domain\SubtreeTagging\NeosVisibilityConstraints} instead.
      *
-     * @deprecated with Neos 9 beta 19
+     * @deprecated with Neos 9 beta 19. To be removed with Neos 10.
      */
-    public static function default(): VisibilityConstraints
+    public static function default(): self
     {
-        return new self(SubtreeTags::create(SubtreeTag::disabled(), SubtreeTag::fromString('removed')));
+        return self::excludeSubtreeTags(SubtreeTags::create(SubtreeTag::disabled(), SubtreeTag::fromString('removed')));
     }
 
     /**
@@ -110,18 +120,10 @@ final readonly class VisibilityConstraints implements \JsonSerializable
      *
      * Please use {@see \Neos\Neos\Domain\SubtreeTagging\NeosVisibilityConstraints::excludeRemoved()} instead.
      *
-     * @deprecated with Neos 9 beta 19
+     * @deprecated with Neos 9 beta 19. To be removed with Neos 10.
      */
     public static function withoutRestrictions(): self
     {
-        return new self(SubtreeTags::fromStrings('removed'));
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return get_object_vars($this);
+        return self::excludeSubtreeTags(SubtreeTags::fromStrings('removed'));
     }
 }


### PR DESCRIPTION
https://github.com/neos/neos-development-collection/pull/5463 deprecated parts from the `VisibilityConstraints`

I suggest to keep all these now deprecated API's for the final release regardless of introduction date.

- Legacy `DisableNodeAggregate` introduced early
- Legacy `EnableNodeAggregate` introduced early
- Legacy `SubtreeTag::disabled()` introduced via Neos 9 Beta 8
- Legacy `VisibilityConstraints::fromTagConstraints()` introduced via Neos 9 Beta 16
- Legacy `VisibilityConstraints::default()` last changed via Neos 9 Beta 16 - previous `frontend()` introduced early
- Legacy `VisibilityConstraints::withoutRestrictions()` introduced early

The API's will be removed with Neos 10

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
