### PR TITLE
TASK: Remove obsolete possibly expensive `getContentGraph()`

### DIFF
--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -48,15 +48,6 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
 
     public function onBeforeEvent(EventInterface $eventInstance, EventEnvelope $eventEnvelope): void
     {
-        if ($eventInstance instanceof EmbedsWorkspaceName) {
-            try {
-                // Skip if the workspace does not exist: "The source workspace missing does not exist" https://github.com/neos/neos-development-collection/pull/5270
-                $this->contentGraphReadModel->getContentGraph($eventInstance->getWorkspaceName());
-            } catch (WorkspaceDoesNotExist) {
-                return;
-            }
-        }
-
         match ($eventInstance::class) {
             NodeAggregateWasRemoved::class => $this->removeNodes($eventInstance->getWorkspaceName(), $eventInstance->nodeAggregateId, $eventInstance->affectedCoveredDimensionSpacePoints),
             default => null
@@ -65,15 +56,6 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
 
     public function onAfterEvent(EventInterface $eventInstance, EventEnvelope $eventEnvelope): void
     {
-        if ($eventInstance instanceof EmbedsWorkspaceName) {
-            try {
-                // Skip if the workspace does not exist: "The source workspace missing does not exist" https://github.com/neos/neos-development-collection/pull/5270
-                $this->contentGraphReadModel->getContentGraph($eventInstance->getWorkspaceName());
-            } catch (WorkspaceDoesNotExist) {
-                return;
-            }
-        }
-
         // Note that we don't need to update the index for WorkspaceWasPublished, as updateNode will be invoked already with the published node and then clean up its previous usages in nested workspaces
         match ($eventInstance::class) {
             NodeAggregateWithNodeWasCreated::class => $this->updateNode($eventInstance->getWorkspaceName(), $eventInstance->nodeAggregateId, $eventInstance->originDimensionSpacePoint->toDimensionSpacePoint()),

--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -157,11 +157,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
             // cleared, leading to presumably duplicate nodes in the UI.
             || $eventInstance instanceof NodeAggregateWasMoved
         ) {
-            try {
-                $contentGraph = $this->contentGraphReadModel->getContentGraph($eventInstance->workspaceName);
-            } catch (WorkspaceDoesNotExist) {
-                return;
-            }
+            $contentGraph = $this->contentGraphReadModel->getContentGraph($eventInstance->workspaceName);
             $nodeAggregate = $contentGraph->findNodeAggregateById(
                 $eventInstance->getNodeAggregateId()
             );
@@ -197,11 +193,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
             && $eventInstance instanceof EmbedsNodeAggregateId
             && $eventInstance instanceof EmbedsWorkspaceName
         ) {
-            try {
-                $contentGraph = $this->contentGraphReadModel->getContentGraph($eventInstance->getWorkspaceName());
-            } catch (WorkspaceDoesNotExist) {
-                return;
-            }
+            $contentGraph = $this->contentGraphReadModel->getContentGraph($eventInstance->getWorkspaceName());
             $nodeAggregate = $contentGraph->findNodeAggregateById(
                 $eventInstance->getNodeAggregateId()
             );


### PR DESCRIPTION
With Neos 9 Beta 15 we required all dangling content streams to be removed. This means that the exception will not be caused

> The source workspace missing does not exist

as this was only caused because of this migration https://github.com/neos/neos-development-collection/blob/4d65f9c1b576f90b516492227df17cdb9c7cf341/Neos.ContentRepositoryRegistry/Classes/Service/EventMigrationService.php#L491 which added the string "missing" to old events on old content streams.

Reverts: https://github.com/neos/neos-development-collection/pull/5270

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
