### PR TITLE
FEATURE: Use proper performant `getDependantWorkspacesRecursively`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -197,7 +197,7 @@ final class ContentRepository
 
     /**
      * Returns all workspaces of this content repository. To limit the set, {@see Workspaces::find()} and {@see Workspaces::filter()} can be used
-     * as well as {@see Workspaces::getBaseWorkspaces()} and {@see Workspaces::getDependantWorkspaces()}.
+     * as well as {@see Workspaces::getBaseWorkspaces()} and {@see Workspaces::getDependantWorkspacesRecursively()}.
      */
     public function findWorkspaces(): Workspaces
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspaces.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspaces.php
@@ -77,23 +77,16 @@ final readonly class Workspaces implements \IteratorAggregate, \Countable
      */
     public function getBaseWorkspaces(WorkspaceName $workspaceName): Workspaces
     {
-        $baseWorkspaces = [];
-
-        $workspace = $this->get($workspaceName);
-        if (!$workspace) {
-            return self::createEmpty();
-        }
-        $baseWorkspaceName = $workspace->baseWorkspaceName;
-        while ($baseWorkspaceName !== null) {
-            $baseWorkspace = $this->get($baseWorkspaceName);
-            if ($baseWorkspace) {
-                $baseWorkspaces[] = $baseWorkspace;
-                $baseWorkspaceName = $baseWorkspace->baseWorkspaceName;
-            } else {
-                $baseWorkspaceName = null;
+        $bases = [];
+        $workspace = $this->workspaces[$workspaceName->value] ?? null;
+        while ($workspace?->baseWorkspaceName !== null) {
+            $workspace = $this->workspaces[$workspace->baseWorkspaceName->value] ?? null;
+            // base workspace might not be in this set!
+            if ($workspace !== null) {
+                $bases[] = $workspace;
             }
         }
-        return self::fromArray($baseWorkspaces);
+        return Workspaces::fromArray($bases);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
@@ -13,56 +13,56 @@ use PHPUnit\Framework\TestCase;
 
 class WorkspacesTest extends TestCase
 {
-    public function provideGetBaseWorkspacesExamples()
+    public static function provideGetBaseWorkspacesExamples()
     {
         yield 'empty workspaces' => [
-            [],
-            'random',
-            []
+            'workspaces' => [],
+            'parameter' => 'random',
+            'baseWorkspaces' => [],
         ];
 
         yield 'not in set' => [
-            [
+            'workspaces' => [
                 self::workspace('a', null),
                 self::workspace('b', 'a'),
             ],
-            'random',
-            []
+            'parameter' => 'random',
+            'baseWorkspaces' => [],
         ];
 
         yield 'one deep (b) -> a' => [
-            [
+            'workspaces' => [
                 self::workspace('a', null),
                 self::workspace('b', 'a'),
             ],
-            'b',
-            ['a']
+            'parameter' => 'b',
+            'baseWorkspaces' => ['a'],
         ];
 
         yield 'recursive (d) -> c -> b -> a' => [
-            [
+            'workspaces' => [
                 self::workspace('a', null),
                 self::workspace('b', 'a'),
                 self::workspace('c', 'b'),
                 self::workspace('d', 'c'),
             ],
-            'd',
-            ['a', 'b', 'c']
+            'parameter' => 'd',
+            'baseWorkspaces' => ['a', 'b', 'c'],
         ];
 
         yield 'recursive, exclude descendants d -> (c) -> b -> a' => [
-            [
+            'workspaces' => [
                 self::workspace('a', null),
                 self::workspace('b', 'a'),
                 self::workspace('c', 'b'),
                 self::workspace('d', 'c'),
             ],
-            'c',
-            ['a', 'b']
+            'parameter' => 'c',
+            'baseWorkspaces' => ['a', 'b'],
         ];
 
         yield 'recursive, exclude descendants and other chains d -> (c) -> b -> a && f -> e -> b -> a && g -> a && y -> z' => [
-            [
+            'workspaces' => [
                 self::workspace('a', null),
                 self::workspace('b', 'a'),
                 self::workspace('c', 'b'),
@@ -76,20 +76,114 @@ class WorkspacesTest extends TestCase
                 self::workspace('z', null),
                 self::workspace('y', 'z'),
             ],
-            'c',
-            ['a', 'b']
+            'parameter' => 'c',
+            'baseWorkspaces' => ['a', 'b']
         ];
+    }
+
+    public static function provideGetDependantWorkspacesExamples()
+    {
+        yield 'empty workspaces' => [
+            'workspaces' => [],
+            'parameter' => 'random',
+            'immediatelyDepending' => [],
+            'recursiveDependingpaces' => [],
+        ];
+
+        yield 'not in set' => [
+            'workspaces' => [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+            ],
+            'parameter' => 'random',
+            'immediatelyDepending' => [],
+            'recursiveDependingpaces' => [],
+        ];
+
+        yield 'one deep b -> (a)' => [
+            'workspaces' => [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+            ],
+            'parameter' => 'a',
+            'immediatelyDepending' => ['b'],
+            'recursiveDependingpaces' => ['b'],
+        ];
+
+        yield 'recursive d -> c -> b -> (a)' => [
+            'workspaces' => [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+                self::workspace('c', 'b'),
+                self::workspace('d', 'c'),
+            ],
+            'parameter' => 'a',
+            'immediatelyDepending' => ['b'],
+            'recursiveDepending' => ['b', 'c', 'd'],
+        ];
+
+        yield 'recursive, exclude bases d -> c -> (b) -> a' => [
+            'workspaces' => [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+                self::workspace('c', 'b'),
+                self::workspace('d', 'c'),
+            ],
+            'parameter' => 'b',
+            'immediatelyDepending' => ['c'],
+            'recursiveDepending' => ['c', 'd'],
+        ];
+
+        yield 'recursive, exclude descendants and other chains d -> c -> (b) -> a && f -> e -> (b) -> a && g -> a && y -> z' => [
+            'workspaces' => [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+                self::workspace('c', 'b'),
+                self::workspace('d', 'c'),
+
+                self::workspace('e', 'b'),
+                self::workspace('f', 'e'),
+
+                self::workspace('g', 'a'),
+
+                self::workspace('z', null),
+                self::workspace('y', 'z'),
+            ],
+            'parameter' => 'b',
+            'immediatelyDepending' => ['c', 'e'],
+            'recursiveDepending' => ['c', 'e', 'd', 'f']
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetDependantWorkspacesExamples
+     */
+    public function testGetDependantWorkspaces(array $workspaces, string $requestedWorkspaceName, array $expectedImmediatelyDepending, array $expectedRecursiveDepending): void
+    {
+        $workspaces =  Workspaces::fromArray($workspaces);
+
+        $actualImmediate = $workspaces->getDependantWorkspaces(WorkspaceName::fromString($requestedWorkspaceName));
+        self::assertSame(
+            $expectedImmediatelyDepending,
+            $actualImmediate->map(fn (Workspace $workspace) => $workspace->workspaceName->value)
+        );
+
+        $actualRecursive = $workspaces->getDependantWorkspacesRecursively(WorkspaceName::fromString($requestedWorkspaceName));
+        self::assertSame(
+            $expectedRecursiveDepending,
+            $actualRecursive->map(fn (Workspace $workspace) => $workspace->workspaceName->value)
+        );
     }
 
     /**
      * @dataProvider provideGetBaseWorkspacesExamples
      */
-    public function testGetBaseWorkspaces(array $workspaces, string $requestedWorkspaceName, array $expectedWorkspaceNames): void
+    public function testGetBaseWorkspaces(array $workspaces, string $requestedWorkspaceName, array $expectedBaseWorkspaceNames): void
     {
         $actual = Workspaces::fromArray($workspaces)->getBaseWorkspaces(WorkspaceName::fromString($requestedWorkspaceName));
         // todo order should be fixed
         self::assertEqualsCanonicalizing(
-            $expectedWorkspaceNames,
+            $expectedBaseWorkspaceNames,
             $actual->map(fn (Workspace $workspace) => $workspace->workspaceName->value)
         );
     }

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
@@ -30,6 +30,14 @@ class WorkspacesTest extends TestCase
             'baseWorkspaces' => [],
         ];
 
+        yield 'base not in set (b) -> ~a~' => [
+            'workspaces' => [
+                self::workspace('b', 'a'),
+            ],
+            'parameter' => 'b',
+            'baseWorkspaces' => [],
+        ];
+
         yield 'one deep (b) -> a' => [
             'workspaces' => [
                 self::workspace('a', null),

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspacesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\SharedModel\Workspace;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
+use PHPUnit\Framework\TestCase;
+
+class WorkspacesTest extends TestCase
+{
+    public function provideGetBaseWorkspacesExamples()
+    {
+        yield 'empty workspaces' => [
+            [],
+            'random',
+            []
+        ];
+
+        yield 'not in set' => [
+            [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+            ],
+            'random',
+            []
+        ];
+
+        yield 'one deep (b) -> a' => [
+            [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+            ],
+            'b',
+            ['a']
+        ];
+
+        yield 'recursive (d) -> c -> b -> a' => [
+            [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+                self::workspace('c', 'b'),
+                self::workspace('d', 'c'),
+            ],
+            'd',
+            ['a', 'b', 'c']
+        ];
+
+        yield 'recursive, exclude descendants d -> (c) -> b -> a' => [
+            [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+                self::workspace('c', 'b'),
+                self::workspace('d', 'c'),
+            ],
+            'c',
+            ['a', 'b']
+        ];
+
+        yield 'recursive, exclude descendants and other chains d -> (c) -> b -> a && f -> e -> b -> a && g -> a && y -> z' => [
+            [
+                self::workspace('a', null),
+                self::workspace('b', 'a'),
+                self::workspace('c', 'b'),
+                self::workspace('d', 'c'),
+
+                self::workspace('e', 'b'),
+                self::workspace('f', 'e'),
+
+                self::workspace('g', 'a'),
+
+                self::workspace('z', null),
+                self::workspace('y', 'z'),
+            ],
+            'c',
+            ['a', 'b']
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetBaseWorkspacesExamples
+     */
+    public function testGetBaseWorkspaces(array $workspaces, string $requestedWorkspaceName, array $expectedWorkspaceNames): void
+    {
+        $actual = Workspaces::fromArray($workspaces)->getBaseWorkspaces(WorkspaceName::fromString($requestedWorkspaceName));
+        // todo order should be fixed
+        self::assertEqualsCanonicalizing(
+            $expectedWorkspaceNames,
+            $actual->map(fn (Workspace $workspace) => $workspace->workspaceName->value)
+        );
+    }
+
+    private static function workspace(string $name, string|null $baseWorkspace): Workspace
+    {
+        return Workspace::create(
+            WorkspaceName::fromString($name),
+            $baseWorkspace ? WorkspaceName::fromString($baseWorkspace) : null,
+            ContentStreamId::create(),
+            WorkspaceStatus::UP_TO_DATE,
+            false
+        );
+    }
+}

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -65,7 +65,12 @@ final readonly class AssetUsageIndexingProcessor
                     if (!$childNode->originDimensionSpacePoint->equals($childNode->dimensionSpacePoint)) {
                         continue;
                     }
-                    $this->assetUsageIndexingService->updateIndex($contentRepository->id, $childNode, $allWorkspaces);
+
+                    $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($childNode->nodeTypeName);
+                    if ($nodeType === null) {
+                        return;
+                    }
+                    $this->assetUsageIndexingService->updateIndex($contentRepository->id, $childNode, $nodeType, $allWorkspaces);
                     array_push($childNodes, ...iterator_to_array($subgraph->findChildNodes($childNode->aggregateId, FindChildNodesFilter::create())));
                 }
             }

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -13,7 +13,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\Neos\AssetUsage\Service\AssetUsageIndexingService;
 
-readonly class AssetUsageIndexingProcessor
+final readonly class AssetUsageIndexingProcessor
 {
     public function __construct(
         private AssetUsageIndexingService $assetUsageIndexingService
@@ -65,7 +65,7 @@ readonly class AssetUsageIndexingProcessor
                     if (!$childNode->originDimensionSpacePoint->equals($childNode->dimensionSpacePoint)) {
                         continue;
                     }
-                    $this->assetUsageIndexingService->updateIndex($contentRepository->id, $childNode);
+                    $this->assetUsageIndexingService->updateIndex($contentRepository->id, $childNode, $allWorkspaces);
                     array_push($childNodes, ...iterator_to_array($subgraph->findChildNodes($childNode->aggregateId, FindChildNodesFilter::create())));
                 }
             }

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -28,19 +28,17 @@ readonly class AssetUsageIndexingProcessor
         $variationGraph = $contentRepository->getVariationGraph();
 
         $allWorkspaces = $contentRepository->findWorkspaces();
-        $liveWorkspace = $contentRepository->findWorkspaceByName(WorkspaceName::forLive());
+        $liveWorkspace = $allWorkspaces->get(WorkspaceName::forLive());
         if ($liveWorkspace === null) {
             throw WorkspaceDoesNotExist::butWasSupposedTo(WorkspaceName::forLive());
         }
 
         $this->assetUsageIndexingService->pruneIndex($contentRepository->id);
 
-        $workspaces = [$liveWorkspace];
+        $workspacesDependingOnLive = $allWorkspaces->getDependantWorkspacesRecursively(WorkspaceName::forLive());
 
         $this->dispatchMessage($callback, sprintf('ContentRepository "%s"', $contentRepository->id->value));
-        while ($workspaces !== []) {
-            $workspace = array_shift($workspaces);
-
+        foreach ($workspacesDependingOnLive as $workspace) {
             $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
             $this->dispatchMessage($callback, sprintf('  Workspace: %s', $contentGraph->getWorkspaceName()->value));
 
@@ -71,8 +69,6 @@ readonly class AssetUsageIndexingProcessor
                     array_push($childNodes, ...iterator_to_array($subgraph->findChildNodes($childNode->aggregateId, FindChildNodesFilter::create())));
                 }
             }
-
-            array_push($workspaces, ...iterator_to_array($allWorkspaces->getDependantWorkspaces($workspace->workspaceName)));
         }
     }
 

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -38,7 +38,7 @@ final readonly class AssetUsageIndexingProcessor
         $workspacesDependingOnLive = $allWorkspaces->getDependantWorkspacesRecursively(WorkspaceName::forLive());
 
         $this->dispatchMessage($callback, sprintf('ContentRepository "%s"', $contentRepository->id->value));
-        foreach ($workspacesDependingOnLive as $workspace) {
+        foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
             $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
             $this->dispatchMessage($callback, sprintf('  Workspace: %s', $contentGraph->getWorkspaceName()->value));
 

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -7,7 +7,6 @@ namespace Neos\Neos\AssetUsage\CatchUpHook;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
-use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Event\DimensionSpacePointWasMoved;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNodeWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
@@ -23,7 +22,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNod
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
-use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
@@ -33,7 +31,7 @@ use Neos\Neos\AssetUsage\Service\AssetUsageIndexingService;
 /**
  * @internal
  */
-class AssetUsageCatchUpHook implements CatchUpHookInterface
+final class AssetUsageCatchUpHook implements CatchUpHookInterface
 {
     public function __construct(
         private readonly ContentRepositoryId $contentRepositoryId,
@@ -91,7 +89,8 @@ class AssetUsageCatchUpHook implements CatchUpHookInterface
 
         $this->assetUsageIndexingService->updateIndex(
             $this->contentRepositoryId,
-            $node
+            $node,
+            $this->contentGraphReadModel->findWorkspaces()
         );
     }
 

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodePeerVariantWasCr
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeSpecializationVariantWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
+use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\CatchUpHook\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
@@ -36,6 +37,7 @@ final class AssetUsageCatchUpHook implements CatchUpHookInterface
     public function __construct(
         private readonly ContentRepositoryId $contentRepositoryId,
         private readonly ContentGraphReadModelInterface $contentGraphReadModel,
+        private readonly NodeTypeManager $nodeTypeManager,
         private readonly AssetUsageIndexingService $assetUsageIndexingService
     ) {
     }
@@ -87,9 +89,15 @@ final class AssetUsageCatchUpHook implements CatchUpHookInterface
             return;
         }
 
+        $nodeType = $this->nodeTypeManager->getNodeType($node->nodeTypeName);
+        if ($nodeType === null) {
+            return;
+        }
+
         $this->assetUsageIndexingService->updateIndex(
             $this->contentRepositoryId,
             $node,
+            $nodeType,
             $this->contentGraphReadModel->findWorkspaces()
         );
     }

--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHookFactory.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHookFactory.php
@@ -34,6 +34,7 @@ class AssetUsageCatchUpHookFactory implements CatchUpHookFactoryInterface
         return new AssetUsageCatchUpHook(
             $dependencies->contentRepositoryId,
             $dependencies->projectionState,
+            $dependencies->nodeTypeManager,
             $this->assetUsageIndexingService
         );
     }

--- a/Neos.Neos/Classes/Fusion/Cache/AssetChangeHandlerForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/AssetChangeHandlerForCacheFlushing.php
@@ -50,7 +50,12 @@ final readonly class AssetChangeHandlerForCacheFlushing
 
                 foreach ($usages as $usage) {
                     $allWorkspaces = $allWorkspaces ??= $contentRepository->findWorkspaces();
-                    foreach ($allWorkspaces->getDependantWorkspacesRecursively($usage->workspaceName) as $workspace) {
+                    $usageWorkspace = $allWorkspaces->get($usage->workspaceName);
+                    if ($usageWorkspace === null) {
+                        continue;
+                    }
+                    $dependantWorkspaces = $allWorkspaces->getDependantWorkspacesRecursively($usage->workspaceName);
+                    foreach ([$usageWorkspace, ...$dependantWorkspaces] as $workspace) {
                         $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
                         $nodeAggregate = $contentGraph->findNodeAggregateById($usage->nodeAggregateId);
                         if ($nodeAggregate === null) {


### PR DESCRIPTION
Previously i noticed that we have used `getDependantWorkspaces` in a while loop with `$contentRepository->findWorkspaces()` which is just needless expensive as `findWorkspaces` is currently uncached (caching was removed via https://github.com/neos/neos-development-collection/pull/5246)

The method `getDependantWorkspaces` was originally introduced via https://github.com/neos/neos-development-collection/pull/5279 but really it does not honour its name, because it only returns the first level of dependants.
Its introduction replaced the previous `WorkspaceFinder::findByBaseWorkspace()` with the same behaviour.

https://github.com/neos/neos-development-collection/blob/595d4ee13cb411a405801049994e9e6df6a09b53/Neos.ContentRepository.Core/Classes/Projection/Workspace/WorkspaceFinder.php#L105-L110

Now this pr introduces a new api `Workspaces::getDependantWorkspacesRecursively()` to handle the actual usecase of finding all dependents of live or any other workspace.

I propose against making `getDependantWorkspaces` a recursive implementation as as this would cause external current implementations to go fully recursive. (though unlikely)
Also i propose to keep a simple `getDependantWorkspaces` method, because it helps for uses in the CLI when warning that a workspace cannot deleted because it direct dependents - it would only bloat the buffer to show all :) Also the new introduced hash map makes `getDependantWorkspaces` a simple index lookup and thus it might make sense to have this exposed as well.
 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
