### PR TITLE
TASK: (Re-)introduce runtime cache on content repository

### DIFF
--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -62,6 +62,14 @@ use Psr\Clock\ClockInterface;
 final class ContentRepository
 {
     /**
+     * @var array<string,ContentGraphInterface>|false indexed by workspace name, false if disabled
+     */
+    private array|false $contentGraphsRuntimeCache = [];
+
+    /** @var Workspaces|false|null false if disabled */
+    private Workspaces|null|false $workspacesRuntimeCache = null;
+
+    /**
      * @internal use the {@see ContentRepositoryFactory::getOrBuild()} to instantiate
      */
     public function __construct(
@@ -95,6 +103,7 @@ final class ContentRepository
             throw AccessDenied::becauseCommandIsNotGranted($command, $privilege->getReason());
         }
 
+        $this->resetRuntimeCaches(disable: true);
         $toPublish = $this->commandBus->handle($command);
         $correlationId = CorrelationId::fromString(sprintf('%s_%s', substr($command::class, strrpos($command::class, '\\') + 1, 20), bin2hex(random_bytes(9))));
 
@@ -143,12 +152,12 @@ final class ContentRepository
                 throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
             }
         }
+        $this->resetRuntimeCaches();
         $additionalCommands = $this->commandHook->onAfterHandle($command, $publishedEvents);
         foreach ($additionalCommands as $additionalCommand) {
             $this->handle($additionalCommand);
         }
     }
-
 
     /**
      * @template T of ProjectionStateInterface
@@ -169,6 +178,9 @@ final class ContentRepository
         $privilege = $this->authProvider->canReadNodesFromWorkspace($workspaceName);
         if (!$privilege->granted) {
             throw AccessDenied::becauseWorkspaceCantBeRead($workspaceName, $privilege->getReason());
+        }
+        if ($this->contentGraphsRuntimeCache !== false) {
+            return $this->contentGraphsRuntimeCache[$workspaceName->value] ??= $this->contentGraphReadModel->getContentGraph($workspaceName);
         }
         return $this->contentGraphReadModel->getContentGraph($workspaceName);
     }
@@ -192,6 +204,9 @@ final class ContentRepository
      */
     public function findWorkspaceByName(WorkspaceName $workspaceName): ?Workspace
     {
+        if ($this->workspacesRuntimeCache) {
+            return $this->workspacesRuntimeCache->get($workspaceName);
+        }
         return $this->contentGraphReadModel->findWorkspaceByName($workspaceName);
     }
 
@@ -201,6 +216,9 @@ final class ContentRepository
      */
     public function findWorkspaces(): Workspaces
     {
+        if ($this->workspacesRuntimeCache !== false) {
+            return $this->workspacesRuntimeCache ??= $this->contentGraphReadModel->findWorkspaces();
+        }
         return $this->contentGraphReadModel->findWorkspaces();
     }
 
@@ -217,6 +235,15 @@ final class ContentRepository
     public function getContentDimensionSource(): ContentDimensionSourceInterface
     {
         return $this->contentDimensionSource;
+    }
+
+    /**
+     * @param bool $disable to fully reset & deactivate the caches. This is required to deliver correct (uncached) results in case a catchup hook accesses this content repository.
+     */
+    private function resetRuntimeCaches(bool $disable = false): void
+    {
+        $this->workspacesRuntimeCache = $disable ? false : null;
+        $this->contentGraphsRuntimeCache = $disable ? false : [];
     }
 
     private function enrichAndNormalizeEvents(DomainEvents $events, CorrelationId $correlationId): Events

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphReadModelInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphReadModelInterface.php
@@ -33,7 +33,6 @@ interface ContentGraphReadModelInterface extends ProjectionStateInterface
 {
     /**
      * @throws WorkspaceDoesNotExist if the workspace does not exist
-     * todo cache instances to reduce queries (revert https://github.com/neos/neos-development-collection/pull/5246)
      */
     public function getContentGraph(WorkspaceName $workspaceName): ContentGraphInterface;
 


### PR DESCRIPTION
i gave two promises :D for one we said we wont add the runtime caches for the release, but also i told christian ill do it :D so here it is, all to be discussed:

to cache all workspaces `findWorkspaces()` and `getContentGraph()`. Single calls to `findWorkspaceByName()` DONT build up a cache and if `findWorkspaces()` was not used before will not be cached. This is a little odd but simplifies the caching greatly.

History of runtime caches:
- building the content graph got more expensive with the need to fetch the workspaces current content stream id (last optimised via https://github.com/neos/neos-development-collection/pull/5274)
- the default subgraph does not contain runtime caches anymore https://github.com/neos/neos-development-collection/issues/5243
- the content graph runtime cache was removed via https://github.com/neos/neos-development-collection/pull/5246
- the workspaces cache was removed when removing the old WorkspaceFinder https://github.com/neos/neos-development-collection/pull/5096

Also in the history a LOT of rewiring was done over and over. So the final state of the `ContentGraphReadModelInterface` and the `ContentRepository` exposing these API's is relatively knew and allows us to implement caching AND invalidation at the same place.

 The raw `ContentGraphReadModelInterface` still contains no caches and will be uncached inside a catchup hook.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
