### PR TITLE
BUGFIX: Reset asset usages on replay

### DIFF
--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -44,6 +44,9 @@ final class AssetUsageCatchUpHook implements CatchUpHookInterface
 
     public function onBeforeCatchUp(SubscriptionStatus $subscriptionStatus): void
     {
+        if ($subscriptionStatus === SubscriptionStatus::BOOTING) {
+            $this->assetUsageIndexingService->pruneIndex($this->contentRepositoryId);
+        }
     }
 
     public function onBeforeEvent(EventInterface $eventInstance, EventEnvelope $eventEnvelope): void

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature
@@ -129,3 +129,11 @@ Feature: Move DimensionSpacePoints
       | asset-2 | sir-david-nodenborough     | asset        | live           | {"language":"de", "market": "DE"} |
       | asset-2 | nody-mc-nodeface           | assets       | live           | {"language":"de", "market": "DE"} |
       | asset-3 | sir-nodeward-nodington-iii | text         | live           | {"language":"fr", "market": "FR"} |
+
+    # Ensure after replay no asset usages are duplicated: https://github.com/neos/neos-development-collection/pull/5511
+    And I replay the contentGraph projection
+    And I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint         |
+      | asset-2 | sir-david-nodenborough     | asset        | live           | {"language":"de", "market": "DE"} |
+      | asset-2 | nody-mc-nodeface           | assets       | live           | {"language":"de", "market": "DE"} |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {"language":"fr", "market": "FR"} |


### PR DESCRIPTION
Attempts to fix

```
Catchup failed: Following errors
    Event 45206 in "contentGraph": Hook "onAfterEvent" failed: "AssetUsageCatchUpHook": An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'default-ccabf5e5-9351-4aa5-8ccc-1d576f3393ff-22a2932d-b7e0-47...' for key 'IDX_14C94F11044B499EB28F27DAEAC5D4BB';
    Event 45207 in "contentGraph": Hook "onAfterEvent" failed: "AssetUsageCatchUpHook": An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'default-ccabf5e5-9351-4aa5-8ccc-1d576f3393ff-22a2932d-b7e0-47...' for key 'IDX_14C94F11044B499EB28F27DAEAC5D4BB'
```

Because the index

```
(`contentrepositoryid`, `assetid`,`originalassetid`,`workspacename`,`nodeaggregateid`,`origindimensionspacepointhash`,`propertyname`)
```

gets violated via `updateAssetUsageDimensionSpacePoint()` when the targets already exists WHICH MUST NOT HAPPEN as per `MoveDimensionSpacePoint`

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
