### PR TITLE
TASK: Improve and fix usage of subgraph cache pool

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/CountChildNodesFilter.php
@@ -79,4 +79,9 @@ final readonly class CountChildNodesFilter
             $propertyValue ?? $this->propertyValue,
         );
     }
+
+    public function isEmpty(): bool
+    {
+        return $this->nodeTypes === null && $this->searchTerm === null && $this->propertyValue === null;
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindChildNodesFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/Filter/FindChildNodesFilter.php
@@ -92,4 +92,9 @@ final readonly class FindChildNodesFilter
             $pagination ?? $this->pagination,
         );
     }
+
+    public function isEmpty(): bool
+    {
+        return $this->nodeTypes === null && $this->searchTerm === null && $this->propertyValue === null && $this->ordering === null && $this->pagination === null;
+    }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -117,7 +117,9 @@ final class ContentRepositoryRegistry
     {
         $contentRepository = $this->get($node->contentRepositoryId);
 
-        $uncachedSubgraph = $contentRepository->getContentGraph($node->workspaceName)->getSubgraph(
+        $uncachedSubgraph = $this->subgraphCachePool->getUncachedContentSubgraph(
+            $contentRepository,
+            $node->workspaceName,
             $node->dimensionSpacePoint,
             $node->visibilityConstraints
         );

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -122,7 +122,7 @@ final class ContentRepositoryRegistry
             $node->visibilityConstraints
         );
 
-        return new ContentSubgraphWithRuntimeCaches($uncachedSubgraph, $this->subgraphCachePool);
+        return ContentSubgraphWithRuntimeCaches::decorate($uncachedSubgraph, $this->subgraphCachePool);
     }
 
     /**

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -117,14 +117,12 @@ final class ContentRepositoryRegistry
     {
         $contentRepository = $this->get($node->contentRepositoryId);
 
-        $uncachedSubgraph = $this->subgraphCachePool->getUncachedContentSubgraph(
+        return $this->subgraphCachePool->getContentSubgraph(
             $contentRepository,
             $node->workspaceName,
             $node->dimensionSpacePoint,
             $node->visibilityConstraints
         );
-
-        return ContentSubgraphWithRuntimeCaches::decorate($uncachedSubgraph, $this->subgraphCachePool);
     }
 
     /**

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/ContentSubgraphWithRuntimeCaches.php
@@ -82,7 +82,7 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
 
     public function findChildNodes(NodeAggregateId $parentNodeAggregateId, FindChildNodesFilter $filter): Nodes
     {
-        if (!self::isFilterEmpty($filter)) {
+        if (!$filter->isEmpty()) {
             return $this->wrappedContentSubgraph->findChildNodes($parentNodeAggregateId, $filter);
         }
         $childNodesCache = $this->subgraphCachePool->getAllChildNodesByNodeIdCache($this);
@@ -104,7 +104,7 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
 
     public function countChildNodes(NodeAggregateId $parentNodeAggregateId, CountChildNodesFilter $filter): int
     {
-        if (!self::isFilterEmpty($filter)) {
+        if (!$filter->isEmpty()) {
             return $this->wrappedContentSubgraph->countChildNodes($parentNodeAggregateId, $filter);
         }
         $childNodesCache = $this->subgraphCachePool->getAllChildNodesByNodeIdCache($this);
@@ -250,10 +250,5 @@ final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraph
     public function countNodes(): int
     {
         return $this->wrappedContentSubgraph->countNodes();
-    }
-
-    private static function isFilterEmpty(object $filter): bool
-    {
-        return array_filter(get_object_vars($filter), static fn ($value) => $value !== null) === [];
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/ContentSubgraphWithRuntimeCaches.php
@@ -54,10 +54,18 @@ use Neos\Flow\Annotations as Flow;
  */
 final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraphInterface
 {
-    public function __construct(
+    private function __construct(
         private ContentSubgraphInterface $wrappedContentSubgraph,
         private SubgraphCachePool $subgraphCachePool
     ) {
+    }
+
+    public static function decorate(ContentSubgraphInterface $uncachedSubgraph, SubgraphCachePool $subgraphCachePool): self
+    {
+        if ($uncachedSubgraph instanceof ContentSubgraphWithRuntimeCaches) {
+            return $uncachedSubgraph;
+        }
+        return new self($uncachedSubgraph, $subgraphCachePool);
     }
 
     public function getContentRepositoryId(): ContentRepositoryId

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/ContentSubgraphWithRuntimeCaches.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/ContentSubgraphWithRuntimeCaches.php
@@ -41,6 +41,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Flow\Annotations as Flow;
 
 /**
  * Wrapper for a concrete implementation of the {@see ContentSubgraphInterface} that
@@ -49,6 +50,7 @@ use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
  * It is a rather pragmatic way to speed up (uncached) rendering.
  *
  * @internal implementation detail of {@see ContentRepositoryRegistry::subgraphForNode()}
+ * @Flow\Proxy(false)
  */
 final readonly class ContentSubgraphWithRuntimeCaches implements ContentSubgraphInterface
 {

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/SubgraphCachePool.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/SubgraphCachePool.php
@@ -101,13 +101,15 @@ final class SubgraphCachePool
      * Fetching a content graph requires a sql query. This is why we cache the actual subgraph instances here as well,
      * to avoid having each time fetched the content graph again.
      */
-    public function getUncachedContentSubgraph(ContentRepository $contentRepository, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, VisibilityConstraints $visibilityConstraints): ContentSubgraphInterface
+    public function getContentSubgraph(ContentRepository $contentRepository, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, VisibilityConstraints $visibilityConstraints): ContentSubgraphInterface
     {
         $cacheId = self::cacheIdForArguments($contentRepository->id, $workspaceName, $dimensionSpacePoint, $visibilityConstraints);
-        return $this->subgraphInstancesCache[$cacheId] ??= $contentRepository->getContentGraph($workspaceName)->getSubgraph(
+        $uncachedContentSubgraphInstance = $this->subgraphInstancesCache[$cacheId] ??= $contentRepository->getContentGraph($workspaceName)->getSubgraph(
             $dimensionSpacePoint,
             $visibilityConstraints
         );
+
+        return ContentSubgraphWithRuntimeCaches::decorate($uncachedContentSubgraphInstance, $this);
     }
 
     private static function cacheId(ContentSubgraphInterface $subgraph): string

--- a/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/SubgraphCachePool.php
+++ b/Neos.ContentRepositoryRegistry/Classes/SubgraphCachingInMemory/SubgraphCachePool.php
@@ -40,32 +40,27 @@ final class SubgraphCachePool
     /**
      * @var array<string,NodePathCache>
      */
-    private $nodePathCaches;
+    private array $nodePathCaches = [];
 
     /**
      * @var array<string,NodeByNodeAggregateIdCache>
      */
-    private $nodeByNodeAggregateIdCaches;
+    private array $nodeByNodeAggregateIdCaches = [];
 
     /**
      * @var array<string,AllChildNodesByNodeIdCache>
      */
-    private $allChildNodesByNodeIdCaches;
+    private array $allChildNodesByNodeIdCaches = [];
 
     /**
      * @var array<string,NamedChildNodeByNodeIdCache>
      */
-    private $namedChildNodeByNodeIdCaches;
+    private array $namedChildNodeByNodeIdCaches = [];
 
     /**
      * @var array<string,ParentNodeIdByChildNodeIdCache>
      */
-    private $parentNodeIdByChildNodeIdCaches;
-
-    public function __construct()
-    {
-        $this->reset();
-    }
+    private array $parentNodeIdByChildNodeIdCaches = [];
 
     private static function cacheId(ContentSubgraphInterface $subgraph): string
     {
@@ -75,9 +70,6 @@ final class SubgraphCachePool
             $subgraph->getVisibilityConstraints()->getHash();
     }
 
-    /**
-     * @return NodePathCache
-     */
     public function getNodePathCache(ContentSubgraphInterface $subgraph): NodePathCache
     {
         return $this->nodePathCaches[self::cacheId($subgraph)] ??= new NodePathCache();
@@ -88,25 +80,16 @@ final class SubgraphCachePool
         return $this->nodeByNodeAggregateIdCaches[self::cacheId($subgraph)] ??= new NodeByNodeAggregateIdCache();
     }
 
-    /**
-     * @return AllChildNodesByNodeIdCache
-     */
     public function getAllChildNodesByNodeIdCache(ContentSubgraphInterface $subgraph): AllChildNodesByNodeIdCache
     {
         return $this->allChildNodesByNodeIdCaches[self::cacheId($subgraph)] ??= new AllChildNodesByNodeIdCache();
     }
 
-    /**
-     * @return NamedChildNodeByNodeIdCache
-     */
     public function getNamedChildNodeByNodeIdCache(ContentSubgraphInterface $subgraph): NamedChildNodeByNodeIdCache
     {
         return $this->namedChildNodeByNodeIdCaches[self::cacheId($subgraph)] ??= new NamedChildNodeByNodeIdCache();
     }
 
-    /**
-     * @return ParentNodeIdByChildNodeIdCache
-     */
     public function getParentNodeIdByChildNodeIdCache(ContentSubgraphInterface $subgraph): ParentNodeIdByChildNodeIdCache
     {
         return $this->parentNodeIdByChildNodeIdCaches[self::cacheId($subgraph)] ??= new ParentNodeIdByChildNodeIdCache();

--- a/Neos.Neos/Classes/Controller/Frontend/ContentSubgraphCacheWarmup.php
+++ b/Neos.Neos/Classes/Controller/Frontend/ContentSubgraphCacheWarmup.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Controller\Frontend;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\ContentRepositoryRegistry\SubgraphCachingInMemory\ContentSubgraphWithRuntimeCaches;
+use Neos\ContentRepositoryRegistry\SubgraphCachingInMemory\SubgraphCachePool;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Domain\Service\NodeTypeNameFactory;
+
+/**
+ * Cache warmup for rendering
+ *
+ * When rendering a document its child content nodes are regularly traversed.
+ * This is done conventionally via fusion and flow query traversing the children
+ * via {@see ContentSubgraphInterface::findChildNodes()} recursively.
+ *
+ * To optimise rendering we fetch the subtree, excluding nested document nodes, effectively all child content nodes
+ * of the entry document and use those to fill the cache.
+ *
+ * By ensuring we use {@see ContentRepositoryRegistry::subgraphForNode()} in flow queries, we access the cached subgraph
+ * via {@see ContentSubgraphWithRuntimeCaches}
+ *
+ * Reference loading of nodes is not optimised.
+ *
+ * TODO: Add tests that caches are filled correctly
+ * TODO: Add performance tests as that the findSubtree() CTE is indeed faster, than multiple child node queries.
+ *
+ * @internal implementation detail of the Node controller
+ */
+class ContentSubgraphCacheWarmup
+{
+    #[Flow\Inject]
+    protected SubgraphCachePool $subgraphCachePool;
+
+    public function fillCacheWithContentNodes(
+        NodeAggregateId $entryDocumentNodeAggregateId,
+        ContentSubgraphInterface $subgraph,
+    ): void {
+        $subtree = $subgraph->findSubtree(
+            $entryDocumentNodeAggregateId,
+            FindSubtreeFilter::create(nodeTypes: '!' . NodeTypeNameFactory::NAME_DOCUMENT, maximumLevels: 20)
+        );
+        if ($subtree === null) {
+            return;
+        }
+
+        $currentDocumentNode = $subtree->node;
+
+        foreach ($subtree->children as $childSubtree) {
+            $this->fillCacheInternal(
+                $childSubtree,
+                $currentDocumentNode,
+                $subgraph
+            );
+        }
+    }
+
+    private function fillCacheInternal(
+        Subtree $subtree,
+        Node $parentNode,
+        ContentSubgraphInterface $subgraph,
+    ): void {
+        $node = $subtree->node;
+
+        $parentNodeIdentifierByChildNodeIdentifierCache
+            = $this->subgraphCachePool->getParentNodeIdByChildNodeIdCache($subgraph);
+        $namedChildNodeByNodeIdentifierCache = $this->subgraphCachePool->getNamedChildNodeByNodeIdCache($subgraph);
+        $allChildNodesByNodeIdentifierCache = $this->subgraphCachePool->getAllChildNodesByNodeIdCache($subgraph);
+        if ($node->name !== null) {
+            $namedChildNodeByNodeIdentifierCache->add(
+                $parentNode->aggregateId,
+                $node->name,
+                $node
+            );
+        } else {
+            // @todo use node aggregate identifier instead?
+        }
+
+        $parentNodeIdentifierByChildNodeIdentifierCache->add(
+            $node->aggregateId,
+            $parentNode->aggregateId
+        );
+
+        $allChildNodes = [];
+        foreach ($subtree->children as $childSubtree) {
+            $this->fillCacheInternal($childSubtree, $node, $subgraph);
+            $childNode = $childSubtree->node;
+            $allChildNodes[] = $childNode;
+        }
+        // TODO Explain why this is safe (Content can not contain other documents)
+        $allChildNodesByNodeIdentifierCache->add(
+            $node->aggregateId,
+            null,
+            Nodes::fromArray($allChildNodes)
+        );
+    }
+}

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -206,7 +206,7 @@ class NodeController extends ActionController
         $visibilityConstraints = $visibilityConstraints->merge(NeosVisibilityConstraints::excludeDisabled());
         $uncachedSubgraph = $contentRepository->getContentGraph($nodeAddress->workspaceName)->getSubgraph($nodeAddress->dimensionSpacePoint, $visibilityConstraints);
 
-        $subgraph = new ContentSubgraphWithRuntimeCaches($uncachedSubgraph, $this->subgraphCachePool);
+        $subgraph = ContentSubgraphWithRuntimeCaches::decorate($uncachedSubgraph, $this->subgraphCachePool);
 
         $nodeInstance = $subgraph->findNodeById($nodeAddress->aggregateId);
         if ($nodeInstance === null) {

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFi
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\ContentRepositoryRegistry\SubgraphCachingInMemory\ContentSubgraphWithRuntimeCaches;
 use Neos\ContentRepositoryRegistry\SubgraphCachingInMemory\SubgraphCachePool;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -14,14 +14,9 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Controller\Frontend;
 
-use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
-use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\ContentRepositoryRegistry\SubgraphCachingInMemory\ContentSubgraphWithRuntimeCaches;
 use Neos\ContentRepositoryRegistry\SubgraphCachingInMemory\SubgraphCachePool;
@@ -114,6 +109,9 @@ class NodeController extends ActionController
     #[Flow\Inject]
     protected ContentRepositoryAuthorizationService $contentRepositoryAuthorizationService;
 
+    #[Flow\Inject]
+    protected ContentSubgraphCacheWarmup|null $contentSubgraphCacheWarmup = null;
+
     /**
      * @param string $node
      * @throws NodeNotFoundException
@@ -150,7 +148,7 @@ class NodeController extends ActionController
             throw new NodeNotFoundException("TODO: SITE NOT FOUND; should not happen (for identity " . $nodeAddress->toJson());
         }
 
-        $this->fillCacheWithContentNodes($nodeAddress->aggregateId, $subgraph);
+        $this->contentSubgraphCacheWarmup?->fillCacheWithContentNodes($nodeAddress->aggregateId, $subgraph);
 
         if (
             $this->getNodeType($nodeInstance)->isOfType(NodeTypeNameFactory::NAME_SHORTCUT)
@@ -218,7 +216,7 @@ class NodeController extends ActionController
             throw new NodeNotFoundException(sprintf('The site node of %s could not be resolved.', $nodeAddress->toJson()), 1707300861);
         }
 
-        $this->fillCacheWithContentNodes($nodeAddress->aggregateId, $subgraph);
+        $this->contentSubgraphCacheWarmup?->fillCacheWithContentNodes($nodeAddress->aggregateId, $subgraph);
 
         if ($this->getNodeType($nodeInstance)->isOfType(NodeTypeNameFactory::NAME_SHORTCUT)) {
             $this->handleShortcutNode($nodeAddress);
@@ -302,70 +300,5 @@ class NodeController extends ActionController
         }
 
         $this->redirectToUri($resolvedUri, statusCode: $this->shortcutRedirectHttpStatusCode);
-    }
-
-    private function fillCacheWithContentNodes(
-        NodeAggregateId $nodeAggregateId,
-        ContentSubgraphInterface $subgraph,
-    ): void {
-        $subtree = $subgraph->findSubtree(
-            $nodeAggregateId,
-            FindSubtreeFilter::create(nodeTypes: '!' . NodeTypeNameFactory::NAME_DOCUMENT, maximumLevels: 20)
-        );
-        if ($subtree === null) {
-            return;
-        }
-
-        $currentDocumentNode = $subtree->node;
-
-        foreach ($subtree->children as $childSubtree) {
-            self::fillCacheInternal(
-                $childSubtree,
-                $currentDocumentNode,
-                $this->subgraphCachePool,
-                $subgraph
-            );
-        }
-    }
-
-    private static function fillCacheInternal(
-        Subtree $subtree,
-        Node $parentNode,
-        SubgraphCachePool $subgraphCachePool,
-        ContentSubgraphInterface $subgraph,
-    ): void {
-        $node = $subtree->node;
-
-        $parentNodeIdentifierByChildNodeIdentifierCache
-            = $subgraphCachePool->getParentNodeIdByChildNodeIdCache($subgraph);
-        $namedChildNodeByNodeIdentifierCache = $subgraphCachePool->getNamedChildNodeByNodeIdCache($subgraph);
-        $allChildNodesByNodeIdentifierCache = $subgraphCachePool->getAllChildNodesByNodeIdCache($subgraph);
-        if ($node->name !== null) {
-            $namedChildNodeByNodeIdentifierCache->add(
-                $parentNode->aggregateId,
-                $node->name,
-                $node
-            );
-        } else {
-            // @todo use node aggregate identifier instead?
-        }
-
-        $parentNodeIdentifierByChildNodeIdentifierCache->add(
-            $node->aggregateId,
-            $parentNode->aggregateId
-        );
-
-        $allChildNodes = [];
-        foreach ($subtree->children as $childSubtree) {
-            self::fillCacheInternal($childSubtree, $node, $subgraphCachePool, $subgraph);
-            $childNode = $childSubtree->node;
-            $allChildNodes[] = $childNode;
-        }
-        // TODO Explain why this is safe (Content can not contain other documents)
-        $allChildNodesByNodeIdentifierCache->add(
-            $node->aggregateId,
-            null,
-            Nodes::fromArray($allChildNodes)
-        );
     }
 }

--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -202,9 +202,7 @@ class NodeController extends ActionController
         // In this showAction (= "frontend") we have to explicitly remove those disabled nodes, even if the user was authenticated,
         // to ensure that disabled nodes are NEVER shown recursively.
         $visibilityConstraints = $visibilityConstraints->merge(NeosVisibilityConstraints::excludeDisabled());
-        $uncachedSubgraph = $contentRepository->getContentGraph($nodeAddress->workspaceName)->getSubgraph($nodeAddress->dimensionSpacePoint, $visibilityConstraints);
-
-        $subgraph = ContentSubgraphWithRuntimeCaches::decorate($uncachedSubgraph, $this->subgraphCachePool);
+        $subgraph = $this->subgraphCachePool->getContentSubgraph($contentRepository, $nodeAddress->workspaceName, $nodeAddress->dimensionSpacePoint, $visibilityConstraints);
 
         $nodeInstance = $subgraph->findNodeById($nodeAddress->aggregateId);
         if ($nodeInstance === null) {


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

### Bugfix that flow queries dont have to fetch the content graph over an over again

We choose to deliberately have `getContentGraph` not cache its instances: https://github.com/neos/neos-development-collection/pull/5246

That makes `subgraphForNode()` expensive especially for frontend rendering.

Now the `SubgraphCachePool` also caches all known subgraph instances and like what `getContentGraph()` did previously

Also we ensure that the context() operation uses a `ContentSubgraphWithRuntimeCaches` now

### Split ContentSubgraphCacheWarmup out of NodeController

With flow fixed https://github.com/neos/flow-development-collection/pull/3455 it will be possible to deactivate the warmup:

```yaml
Neos\Neos\Controller\Frontend\NodeController:
  properties:
    contentSubgraphCacheWarmup:
      value: null
```

This was already a requested option in case this optimisation does not make sense.



**Upgrade instructions**



<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
