### PR TITLE
TASK: Provide parallel tests attempting to replicate deadlocks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,11 +318,12 @@ jobs:
           composer test:parallel
       - name: Fail pipeline if Parallel Tests broke
         if: (matrix.parallel-parts == 'escr-behavioral' || matrix.parallel-parts == 'escr-behavioral-mysql') && steps.paralleltests.outcome != 'success'
-        # we want to reach the Upload Postgres/Mysql DB dump step.
-        # Here we want to fail everything, as described in https://stackoverflow.com/a/58003436/4921449
+        shell: bash
         run: |
           cd Packages/Neos
           cat Neos.ContentRepository.BehavioralTests/Tests/Parallel/log.txt
+          echo "\n\nDumping last 100 events\n\n"
+          mysql -u neos -pneos -h 127.0.0.1 -P ${{ matrix.mysqlport }} flow_functional_testing --table < <(echo "SELECT * FROM cr_test_parallel_events ORDER BY sequenceNumber DESC LIMIT 100")
           exit 1
       - name: Run Behavioral Tests (ES CR && Neos.Neos)
         id: escrtests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,12 +310,20 @@ jobs:
       - name: Run Parallel Tests for the ES CR
         # TODO: enable parallel tests also for Postgres
         if: matrix.parallel-parts == 'escr-behavioral' || matrix.parallel-parts == 'escr-behavioral-mysql'
+        id: paralleltests
+        timeout-minutes: 30
+        continue-on-error: true
         run: |
           cd Packages/Neos
-          hasFailure=0
-          composer test:parallel || hasFailure=1
+          composer test:parallel
+      - name: Fail pipeline if Parallel Tests broke
+        if: (matrix.parallel-parts == 'escr-behavioral' || matrix.parallel-parts == 'escr-behavioral-mysql') && steps.paralleltests.outcome != 'success'
+        # we want to reach the Upload Postgres/Mysql DB dump step.
+        # Here we want to fail everything, as described in https://stackoverflow.com/a/58003436/4921449
+        run: |
+          cd Packages/Neos
           cat Neos.ContentRepository.BehavioralTests/Tests/Parallel/log.txt
-          exit $hasFailure
+          exit 1
       - name: Run Behavioral Tests (ES CR && Neos.Neos)
         id: escrtests
         if: matrix.parallel-parts == 'escr-behavioral' || matrix.parallel-parts == 'escr-behavioral-mysql' || matrix.parallel-parts == 'escr-behavioral-postgres'

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/AbstractParallelTestCase.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/AbstractParallelTestCase.php
@@ -80,31 +80,6 @@ abstract class AbstractParallelTestCase extends TestCase // we don't use Flows f
         parent::onNotSuccessfulTest($t);
     }
 
-    public function tearDown(): void
-    {
-        if ($this->hasFailed()) {
-            try {
-                $this->log(sprintf('Error "%s". Logging last 100 events from "test_parallel"', $this->getStatusMessage()));
-                /** @var ContentRepositoryMaintainer $contentRepositoryMaintainer */
-                $contentRepositoryMaintainer = $this->contentRepositoryRegistry->buildService(ContentRepositoryId::fromString('test_parallel'), new ContentRepositoryMaintainerFactory());
-                /** @var EventStoreInterface $eventStore */
-                $eventStore = (new \ReflectionClass($contentRepositoryMaintainer))->getProperty('eventStore')->getValue($contentRepositoryMaintainer);
-
-                /** @var EventEnvelope[] $lastEvents */
-                $lastEvents = iterator_to_array($eventStore->load(VirtualStreamName::all())->limit(100)->backwards(), false);
-                file_put_contents(self::LOGGING_PATH, '| sequence | version | stream | type | data | metadata | causationId | correlationId |' . PHP_EOL, FILE_APPEND);
-                file_put_contents(self::LOGGING_PATH, '| --- | --- | --- | --- | --- | --- | --- | --- |' . PHP_EOL, FILE_APPEND);
-                foreach ($lastEvents as $eventEnvelope) {
-                    $event = $eventEnvelope->event;
-                    file_put_contents(self::LOGGING_PATH, sprintf('| %s | %s | %s | %s | %s | %s | %s | %s |', $eventEnvelope->sequenceNumber->value, $eventEnvelope->version->value, $eventEnvelope->streamName->value, $event->type->value, $event->data->value, json_encode($event->metadata?->value), $event->causationId?->value, $event->correlationId?->value) . PHP_EOL, FILE_APPEND);
-                }
-                $this->log('Fished event logging');
-            } catch (\Throwable $throwable) {
-                $this->log(sprintf('Failed logging events [%s (%d)]: %s', $throwable::class, $throwable->getCode(), $throwable->getMessage()));
-            }
-        }
-    }
-
     final protected function awaitFile(string $filename): void
     {
         $waiting = 0;

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringForking/ForkingDuringForkingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringForking/ForkingDuringForkingTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.BehavioralTests package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\ForkingDuringForking;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
+use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use PHPUnit\Framework\Assert;
+
+class ForkingDuringForkingTest extends AbstractParallelTestCase
+{
+    private const SETUP_LOCK_PATH = __DIR__ . '/setup-lock';
+    private const WRITING_IS_RUNNING_FLAG_PATH = __DIR__ . '/write-is-running-flag';
+
+    private ContentRepository $contentRepository;
+
+    protected ObjectManagerInterface $objectManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->log('------ process started ------');
+
+        $debugProjection = new DebugEventProjection(
+            'cr_test_parallel_debug_projection',
+            $this->objectManager->get(Connection::class)
+        );
+        FakeProjectionFactory::setProjection(
+            'debug',
+            $debugProjection
+        );
+
+        FakeContentDimensionSourceFactory::setWithoutDimensions();
+        FakeNodeTypeManagerFactory::setConfiguration([
+            'Neos.ContentRepository:Root' => [],
+            'Neos.ContentRepository.Testing:Content' => [],
+            'Neos.ContentRepository.Testing:Document' => [
+                'properties' => [
+                    'title' => [
+                        'type' => 'string'
+                    ]
+                ],
+                'childNodes' => [
+                    'tethered-a' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-b' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-c' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-d' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-e' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ]
+                ]
+            ]
+        ]);
+
+        $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
+
+        $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);
+        if ($exclusiveNonBlockingLockResult === false) {
+            $this->log('waiting for setup');
+            if (!flock($setupLockResource, LOCK_SH)) {
+                throw new \RuntimeException('failed to acquire blocking shared lock');
+            }
+            $this->contentRepository = $this->contentRepositoryRegistry
+                ->get(ContentRepositoryId::fromString('test_parallel'));
+            $this->log('wait for setup finished');
+            return;
+        }
+
+        $this->log('setup started');
+        $contentRepository = $this->setUpContentRepository(ContentRepositoryId::fromString('test_parallel'));
+
+        $origin = OriginDimensionSpacePoint::createWithoutDimensions();
+        $contentRepository->handle(CreateRootWorkspace::create(
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('live-cs-id')
+        ));
+        $contentRepository->handle(CreateRootNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)
+        ));
+        $contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('nody-mc-nodeface'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            $origin,
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            initialPropertyValues: PropertyValuesToWrite::fromArray([
+                'title' => 'title-original'
+            ])
+        ));
+
+        for ($i = 0; $i <= 500; $i++) {
+            $contentRepository->handle(CreateNodeAggregateWithNode::create(
+                WorkspaceName::forLive(),
+                NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
+                NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                OriginDimensionSpacePoint::createWithoutDimensions(),
+                NodeAggregateId::fromString('lady-eleonode-rootford'),
+                initialPropertyValues: PropertyValuesToWrite::fromArray([
+                    'title' => 'title'
+                ])
+            ));
+        }
+
+        $this->contentRepository = $contentRepository;
+
+        if (!flock($setupLockResource, LOCK_UN)) {
+            throw new \RuntimeException('failed to release setup lock');
+        }
+
+        $this->log('setup finished');
+    }
+
+    /**
+     * @test
+     */
+    public function whileWorkspacesAreForked(): void
+    {
+        $this->log('1. forking started');
+
+        touch(self::WRITING_IS_RUNNING_FLAG_PATH);
+
+        try {
+            for ($i = 0; $i <= 100; $i++) {
+                $this->contentRepository->handle(CreateWorkspace::create(
+                    WorkspaceName::fromString('user-one-' . $i),
+                    WorkspaceName::forLive(),
+                    ContentStreamId::fromString('user-one-cs-' . $i)
+                ));
+            }
+        } finally {
+            unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
+        }
+
+        $this->log('1. forking finished');
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $workspace = $this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-one-100'));
+        Assert::assertNotNull($workspace);
+    }
+
+    /**
+     * @test
+     */
+    public function thenConcurrentForksAreNotDeadlocked(): void
+    {
+        if (!is_file(self::WRITING_IS_RUNNING_FLAG_PATH)) {
+            $this->log('waiting for 2. writing');
+
+            $this->awaitFile(self::WRITING_IS_RUNNING_FLAG_PATH);
+            // If write is the process that does the (slowish) setup, and then waits for the rebase to start,
+            // We give the CR some time to close the content stream
+            // TODO find another way than to randomly wait!!!
+            // The problem is, if we dont sleep it happens often that the modification works only then the rebase is startet _really_
+            // Doing the modification several times in hope that the second one fails will likely just stop the rebase thread as it cannot close
+            usleep(10000);
+        }
+
+        $this->log('2. forking started');
+
+        for ($i = 0; $i <= 100; $i++) {
+            $this->contentRepository->handle(CreateWorkspace::create(
+                WorkspaceName::fromString('user-two-' . $i),
+                WorkspaceName::forLive(),
+                ContentStreamId::fromString('user-two-cs-' . $i)
+            ));
+        }
+
+        $this->log('2. forking finished');
+
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $workspace = $this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-two-100'));
+        Assert::assertNotNull($workspace);
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.BehavioralTests package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\ForkingDuringWriting;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
+use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use PHPUnit\Framework\Assert;
+
+class ForkingDuringWritingTest extends AbstractParallelTestCase
+{
+    private const SETUP_LOCK_PATH = __DIR__ . '/setup-lock';
+    private const WRITING_IS_RUNNING_FLAG_PATH = __DIR__ . '/write-is-running-flag';
+
+    private ContentRepository $contentRepository;
+
+    protected ObjectManagerInterface $objectManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->log('------ process started ------');
+
+        $debugProjection = new DebugEventProjection(
+            'cr_test_parallel_debug_projection',
+            $this->objectManager->get(Connection::class)
+        );
+        FakeProjectionFactory::setProjection(
+            'debug',
+            $debugProjection
+        );
+
+        FakeContentDimensionSourceFactory::setWithoutDimensions();
+        FakeNodeTypeManagerFactory::setConfiguration([
+            'Neos.ContentRepository:Root' => [],
+            'Neos.ContentRepository.Testing:Content' => [],
+            'Neos.ContentRepository.Testing:Document' => [
+                'properties' => [
+                    'title' => [
+                        'type' => 'string'
+                    ]
+                ],
+                'childNodes' => [
+                    'tethered-a' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-b' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-c' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-d' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-e' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ]
+                ]
+            ]
+        ]);
+
+        $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
+
+        $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);
+        if ($exclusiveNonBlockingLockResult === false) {
+            $this->log('waiting for setup');
+            if (!flock($setupLockResource, LOCK_SH)) {
+                throw new \RuntimeException('failed to acquire blocking shared lock');
+            }
+            $this->contentRepository = $this->contentRepositoryRegistry
+                ->get(ContentRepositoryId::fromString('test_parallel'));
+            $this->log('wait for setup finished');
+            return;
+        }
+
+        $this->log('setup started');
+        $contentRepository = $this->setUpContentRepository(ContentRepositoryId::fromString('test_parallel'));
+
+        $origin = OriginDimensionSpacePoint::createWithoutDimensions();
+        $contentRepository->handle(CreateRootWorkspace::create(
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('live-cs-id')
+        ));
+        $contentRepository->handle(CreateRootNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)
+        ));
+        $contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('nody-mc-nodeface'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            $origin,
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            initialPropertyValues: PropertyValuesToWrite::fromArray([
+                'title' => 'title-original'
+            ])
+        ));
+
+        $this->contentRepository = $contentRepository;
+
+        if (!flock($setupLockResource, LOCK_UN)) {
+            throw new \RuntimeException('failed to release setup lock');
+        }
+
+        $this->log('setup finished');
+    }
+
+    /**
+     * @test
+     */
+    public function whileANodesArWrittenOnLive(): void
+    {
+        $this->log('1. writing started');
+
+        touch(self::WRITING_IS_RUNNING_FLAG_PATH);
+
+        try {
+            for ($i = 0; $i <= 500; $i++) {
+                $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                    WorkspaceName::forLive(),
+                    NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
+                    NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                    OriginDimensionSpacePoint::createWithoutDimensions(),
+                    NodeAggregateId::fromString('lady-eleonode-rootford'),
+                    initialPropertyValues: PropertyValuesToWrite::fromArray([
+                        'title' => 'title'
+                    ])
+                ));
+            }
+        } finally {
+            unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
+        }
+
+        $this->log('1. writing finished');
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('nody-mc-nodeface-500'));
+        Assert::assertNotNull($node);
+    }
+
+    /**
+     * @test
+     */
+    public function thenConcurrentForksAreNotDeadlocked(): void
+    {
+        if (!is_file(self::WRITING_IS_RUNNING_FLAG_PATH)) {
+            $this->log('waiting for 2. writing');
+
+            $this->awaitFile(self::WRITING_IS_RUNNING_FLAG_PATH);
+            // If write is the process that does the (slowish) setup, and then waits for the rebase to start,
+            // We give the CR some time to close the content stream
+            // TODO find another way than to randomly wait!!!
+            // The problem is, if we dont sleep it happens often that the modification works only then the rebase is startet _really_
+            // Doing the modification several times in hope that the second one fails will likely just stop the rebase thread as it cannot close
+            usleep(10000);
+        }
+
+        $this->log('2. forking started');
+
+        for ($i = 0; $i <= 500; $i++) {
+            $this->contentRepository->handle(CreateWorkspace::create(
+                WorkspaceName::fromString('user-test-' . $i),
+                WorkspaceName::forLive(),
+                ContentStreamId::fromString('user-test-cs-' . $i)
+            ));
+        }
+
+        $this->log('2. forking finished');
+
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $workspace = $this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-500'));
+        Assert::assertNotNull($workspace);
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
@@ -147,7 +147,7 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
         touch(self::WRITING_IS_RUNNING_FLAG_PATH);
 
         try {
-            for ($i = 0; $i <= 500; $i++) {
+            for ($i = 0; $i <= 200; $i++) {
                 $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
                     WorkspaceName::forLive(),
                     NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
@@ -167,7 +167,7 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
         Assert::assertTrue(true, 'No exception was thrown ;)');
 
         $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
-        $node = $subgraph->findNodeById(NodeAggregateId::fromString('nody-mc-nodeface-500'));
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('nody-mc-nodeface-200'));
         Assert::assertNotNull($node);
     }
 
@@ -190,7 +190,7 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
 
         $this->log('2. forking started');
 
-        for ($i = 0; $i <= 500; $i++) {
+        for ($i = 0; $i <= 200; $i++) {
             $this->contentRepository->handle(CreateWorkspace::create(
                 WorkspaceName::fromString('user-test-' . $i),
                 WorkspaceName::forLive(),
@@ -202,7 +202,7 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
 
         Assert::assertTrue(true, 'No exception was thrown ;)');
 
-        $workspace = $this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-500'));
+        $workspace = $this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-200'));
         Assert::assertNotNull($workspace);
     }
 }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWritingInWorkspaces/ParallelWritingInWorkspacesTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWritingInWorkspaces/ParallelWritingInWorkspacesTest.php
@@ -150,7 +150,6 @@ class ParallelWritingInWorkspacesTest extends AbstractParallelTestCase
 
     /**
      * @test
-     * @group parallel
      */
     public function whileANodesArWrittenOnLive(): void
     {
@@ -185,9 +184,8 @@ class ParallelWritingInWorkspacesTest extends AbstractParallelTestCase
 
     /**
      * @test
-     * @group parallel
      */
-    public function thenConcurrentPublishLeadsToException(): void
+    public function thenConcurrentlyWritingToAnotherWorkspaceWorks(): void
     {
         if (!is_file(self::WRITING_IS_RUNNING_FLAG_PATH)) {
             $this->log('waiting for 2. writing');

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.BehavioralTests package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\PublishingDuringPublishing;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\WorkspacePublicationDuringWriting\WorkspacePublicationDuringWritingTest;
+use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\EventStore\Exception\ConcurrencyException;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Test that no DeadlockException like: An exception occurred while executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
+ * Is thrown during catchup as this would lead to projection failure which cannot be properly recovered from other than a replay.
+ */
+class PublishingDuringPublishingTest extends AbstractParallelTestCase
+{
+    private const SETUP_LOCK_PATH = __DIR__ . '/setup-lock';
+    private const WRITING_IS_RUNNING_FLAG_PATH = __DIR__ . '/write-is-running-flag';
+
+    private ContentRepository $contentRepository;
+
+    protected ObjectManagerInterface $objectManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->log('------ process started ------');
+
+        $debugProjection = new DebugEventProjection(
+            'cr_test_parallel_debug_projection',
+            $this->objectManager->get(Connection::class)
+        );
+        FakeProjectionFactory::setProjection(
+            'debug',
+            $debugProjection
+        );
+
+        FakeContentDimensionSourceFactory::setWithoutDimensions();
+        FakeNodeTypeManagerFactory::setConfiguration([
+            'Neos.ContentRepository:Root' => [],
+            'Neos.ContentRepository.Testing:Content' => [],
+            'Neos.ContentRepository.Testing:Document' => [
+                'properties' => [
+                    'title' => [
+                        'type' => 'string'
+                    ]
+                ],
+                'childNodes' => [
+                    'tethered-a' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-b' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-c' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-d' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-e' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ]
+                ]
+            ]
+        ]);
+
+        $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
+
+        $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);
+        if ($exclusiveNonBlockingLockResult === false) {
+            $this->log('waiting for setup');
+            if (!flock($setupLockResource, LOCK_SH)) {
+                throw new \RuntimeException('failed to acquire blocking shared lock');
+            }
+            $this->contentRepository = $this->contentRepositoryRegistry
+                ->get(ContentRepositoryId::fromString('test_parallel'));
+            $this->log('wait for setup finished');
+            return;
+        }
+
+        $this->log('setup started');
+        $contentRepository = $this->setUpContentRepository(ContentRepositoryId::fromString('test_parallel'));
+
+        $origin = OriginDimensionSpacePoint::createWithoutDimensions();
+        $contentRepository->handle(CreateRootWorkspace::create(
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('live-cs-id')
+        ));
+        $contentRepository->handle(CreateRootNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)
+        ));
+        $contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('nody-mc-nodeface'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            $origin,
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            initialPropertyValues: PropertyValuesToWrite::fromArray([
+                'title' => 'title-original'
+            ])
+        ));
+        $contentRepository->handle(CreateWorkspace::create(
+            WorkspaceName::fromString('user-test-one'),
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('user-test-cs-one')
+        ));
+        $contentRepository->handle(CreateWorkspace::create(
+            WorkspaceName::fromString('user-test-two'),
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('user-test-cs-two')
+        ));
+
+        $this->contentRepository = $contentRepository;
+
+        if (!flock($setupLockResource, LOCK_UN)) {
+            throw new \RuntimeException('failed to release setup lock');
+        }
+
+        $this->log('setup finished');
+    }
+
+    /**
+     * @test
+     */
+    public function whileANodesArWrittenOnLive(): void
+    {
+        $this->log('1. writing & publishing started');
+
+        touch(self::WRITING_IS_RUNNING_FLAG_PATH);
+
+        try {
+            for ($i = 0; $i <= 500; $i++) {
+                $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                    WorkspaceName::fromString('user-test-one'),
+                    NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
+                    NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                    OriginDimensionSpacePoint::createWithoutDimensions(),
+                    NodeAggregateId::fromString('lady-eleonode-rootford'),
+                    initialPropertyValues: PropertyValuesToWrite::fromArray([
+                        'title' => 'title'
+                    ])
+                ));
+
+                try {
+                    $this->contentRepository->handle(PublishWorkspace::create(
+                        WorkspaceName::fromString('user-test-one')
+                    )->withNewContentStreamId(
+                        ContentStreamId::fromString('user-test-cs-one-' . $i)
+                    ));
+                } catch (ConcurrencyException $concurrencyException) {
+                    /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
+                    $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
+                }
+            }
+        } finally {
+            unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
+        }
+
+        $this->log('1. writing & publishing finished');
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('nody-mc-nodeface-500'));
+        Assert::assertNotNull($node);
+    }
+
+    /**
+     * @test
+     */
+    public function thenConcurrentPublishAreNotDeadlocked(): void
+    {
+        if (!is_file(self::WRITING_IS_RUNNING_FLAG_PATH)) {
+            $this->log('waiting for 2. writing');
+
+            $this->awaitFile(self::WRITING_IS_RUNNING_FLAG_PATH);
+            // If write is the process that does the (slowish) setup, and then waits for the rebase to start,
+            // We give the CR some time to close the content stream
+            // TODO find another way than to randomly wait!!!
+            // The problem is, if we dont sleep it happens often that the modification works only then the rebase is startet _really_
+            // Doing the modification several times in hope that the second one fails will likely just stop the rebase thread as it cannot close
+            usleep(10000);
+        }
+
+        $this->log('2. writing & publishing started');
+
+        for ($i = 0; $i <= 500; $i++) {
+            $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                WorkspaceName::fromString('user-test-two'),
+                NodeAggregateId::fromString('sir-david-nodenborough-' . $i),
+                NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                OriginDimensionSpacePoint::createWithoutDimensions(),
+                NodeAggregateId::fromString('lady-eleonode-rootford'),
+                initialPropertyValues: PropertyValuesToWrite::fromArray([
+                    'title' => 'title'
+                ])
+            ));
+            try {
+                $this->contentRepository->handle(PublishWorkspace::create(
+                    WorkspaceName::fromString('user-test-two')
+                )->withNewContentStreamId(
+                    ContentStreamId::fromString('user-test-cs-two-' . $i)
+                ));
+            } catch (ConcurrencyException $concurrencyException) {
+                /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
+                $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
+            }
+        }
+
+        $this->log('2. writing & publishing finished');
+
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('sir-david-nodenborough-500'));
+        Assert::assertNotNull($node);
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
@@ -28,6 +28,8 @@ use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWork
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -164,17 +166,19 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
         touch(self::WRITING_IS_RUNNING_FLAG_PATH);
 
         try {
-            for ($i = 0; $i <= 500; $i++) {
-                $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
-                    WorkspaceName::fromString('user-test-one'),
-                    NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
-                    NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
-                    OriginDimensionSpacePoint::createWithoutDimensions(),
-                    NodeAggregateId::fromString('lady-eleonode-rootford'),
-                    initialPropertyValues: PropertyValuesToWrite::fromArray([
-                        'title' => 'title'
-                    ])
-                ));
+            for ($i = 0; $i <= 100; $i++) {
+                if (!$this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-one'))->hasPublishableChanges()) {
+                    $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                        WorkspaceName::fromString('user-test-one'),
+                        NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
+                        NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                        OriginDimensionSpacePoint::createWithoutDimensions(),
+                        NodeAggregateId::fromString('lady-eleonode-rootford'),
+                        initialPropertyValues: PropertyValuesToWrite::fromArray([
+                            'title' => 'title'
+                        ])
+                    ));
+                }
 
                 try {
                     $this->contentRepository->handle(PublishWorkspace::create(
@@ -195,8 +199,9 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
         Assert::assertTrue(true, 'No exception was thrown ;)');
 
         $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
-        $node = $subgraph->findNodeById(NodeAggregateId::fromString('nody-mc-nodeface-500'));
-        Assert::assertNotNull($node);
+        $childNodes = $subgraph->findChildNodes(NodeAggregateId::fromString('lady-eleonode-rootford'), FindChildNodesFilter::create());
+        $childNodes = $childNodes->filter(fn (Node $node) => str_starts_with($node->aggregateId->value, 'nody-mc-nodeface-'));
+        Assert::assertGreaterThan(20, $childNodes->count(), 'To few nodes actually published and created');
     }
 
     /**
@@ -218,17 +223,20 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
 
         $this->log('2. writing & publishing started');
 
-        for ($i = 0; $i <= 500; $i++) {
-            $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
-                WorkspaceName::fromString('user-test-two'),
-                NodeAggregateId::fromString('sir-david-nodenborough-' . $i),
-                NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
-                OriginDimensionSpacePoint::createWithoutDimensions(),
-                NodeAggregateId::fromString('lady-eleonode-rootford'),
-                initialPropertyValues: PropertyValuesToWrite::fromArray([
-                    'title' => 'title'
-                ])
-            ));
+        for ($i = 0; $i <= 100; $i++) {
+            if (!$this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-two'))->hasPublishableChanges()) {
+                $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                    WorkspaceName::fromString('user-test-two'),
+                    NodeAggregateId::fromString('sir-david-nodenborough-' . $i),
+                    NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                    OriginDimensionSpacePoint::createWithoutDimensions(),
+                    NodeAggregateId::fromString('lady-eleonode-rootford'),
+                    initialPropertyValues: PropertyValuesToWrite::fromArray([
+                        'title' => 'title'
+                    ])
+                ));
+            }
+
             try {
                 $this->contentRepository->handle(PublishWorkspace::create(
                     WorkspaceName::fromString('user-test-two')
@@ -246,7 +254,8 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
         Assert::assertTrue(true, 'No exception was thrown ;)');
 
         $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
-        $node = $subgraph->findNodeById(NodeAggregateId::fromString('sir-david-nodenborough-500'));
-        Assert::assertNotNull($node);
+        $childNodes = $subgraph->findChildNodes(NodeAggregateId::fromString('lady-eleonode-rootford'), FindChildNodesFilter::create());
+        $childNodes = $childNodes->filter(fn (Node $node) => str_starts_with($node->aggregateId->value, 'sir-david-nodenborough-'));
+        Assert::assertGreaterThan(20, $childNodes->count(), 'To few nodes actually published and created');
     }
 }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/WorkspacePublicationDuringWriting/WorkspacePublicationDuringWritingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/WorkspacePublicationDuringWriting/WorkspacePublicationDuringWritingTest.php
@@ -141,7 +141,6 @@ class WorkspacePublicationDuringWritingTest extends AbstractParallelTestCase
 
     /**
      * @test
-     * @group parallel
      */
     public function whileANodesArWrittenOnLive(): void
     {
@@ -177,7 +176,6 @@ class WorkspacePublicationDuringWritingTest extends AbstractParallelTestCase
 
     /**
      * @test
-     * @group parallel
      */
     public function thenConcurrentPublishLeadsToException(): void
     {

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/WorkspaceWritingDuringRebase/WorkspaceWritingDuringRebaseTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/WorkspaceWritingDuringRebase/WorkspaceWritingDuringRebaseTest.php
@@ -143,7 +143,6 @@ class WorkspaceWritingDuringRebaseTest extends AbstractParallelTestCase
 
     /**
      * @test
-     * @group parallel
      */
     public function whileAWorkspaceIsBeingRebased(): void
     {
@@ -167,7 +166,6 @@ class WorkspaceWritingDuringRebaseTest extends AbstractParallelTestCase
 
     /**
      * @test
-     * @group parallel
      */
     public function thenConcurrentCommandsLeadToAnException(): void
     {


### PR DESCRIPTION
In https://github.com/neos/neos-development-collection/pull/5510 i attempted to cause a locking problem manually and see how the subscription engine reacts.
(see [slack](https://neos-project.slack.com/archives/C04PYL8H3/p1740562595001089?thread_ts=1740558048.229979&cid=C04PYL8H3))
Now these tests are actual parallel tests were we thought we could replicate the problem of a `ContentStreamWasForked` event failing. But instead it showed another problem,

Adds a new test `PublishingDuringPublishingTest` which fails on 9.0

> Doctrine\DBAL\Exception\DeadlockException: An exception occurred while executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
