### PR TITLE
TASK: Remove obsolete affected source dsp from node aggregate was removed

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -46,7 +46,6 @@ Feature: Remove NodeAggregate
       | Key                                  | Expected        |
       | contentStreamId                      | "cs-identifier" |
       | nodeAggregateId                      | "nodingers-cat" |
-      | affectedOccupiedDimensionSpacePoints | [[]]            |
       | affectedCoveredDimensionSpacePoints  | [[]]            |
     Then I expect the graph projection to consist of exactly 2 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -49,7 +49,6 @@ Feature: Remove NodeAggregate
       | Key                                  | Expected                               |
       | contentStreamId                      | "cs-identifier"                        |
       | nodeAggregateId                      | "nodingers-cat"                        |
-      | affectedOccupiedDimensionSpacePoints | [{"language":"en"}]                    |
       | affectedCoveredDimensionSpacePoints  | [{"language":"de"},{"language":"gsw"}] |
     Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
@@ -195,7 +194,6 @@ Feature: Remove NodeAggregate
       | Key                                  | Expected                                                                   |
       | contentStreamId                      | "cs-identifier"                                                            |
       | nodeAggregateId                      | "nodingers-cat"                                                            |
-      | affectedOccupiedDimensionSpacePoints | [{"language":"de"},{"language":"en"}]                                      |
       | affectedCoveredDimensionSpacePoints  | [{"language":"de"},{"language":"en"},{"language":"gsw"},{"language":"fr"}] |
     Then I expect the graph projection to consist of exactly 2 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/02-ChangeNodeAggregateType_DeleteStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/02-ChangeNodeAggregateType_DeleteStrategy.feature
@@ -305,7 +305,6 @@ Feature: Change node aggregate type - behavior of DELETE strategy
       | workspaceName                        | "live"                                 |
       | contentStreamId                      | "cs-identifier"                        |
       | nodeAggregateId                      | "nodingers-cat"                        |
-      | affectedOccupiedDimensionSpacePoints | [{"language":"de"},{"language":"gsw"}] |
       | affectedCoveredDimensionSpacePoints  | [{"language":"de"},{"language":"gsw"}] |
     And event at index 14 is of type "NodeAggregateTypeWasChanged" with payload:
       | Key             | Expected                                             |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -47,7 +47,6 @@ Feature: Disable a node aggregate
       | workspaceName                        | "live"             |
       | contentStreamId                      | "cs-identifier"    |
       | nodeAggregateId                      | "nody-mc-nodeface" |
-      | affectedOccupiedDimensionSpacePoints | [{}]               |
       | affectedCoveredDimensionSpacePoints  | [{}]               |
 
     When the command CreateNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
@@ -217,12 +217,6 @@ trait NodeTypeChangeInternals
             $contentGraph->getWorkspaceName(),
             $contentGraph->getContentStreamId(),
             $nodeAggregate->nodeAggregateId,
-            // TODO: we also use the covered dimension space points as OCCUPIED dimension space points
-            // - however the OCCUPIED dimension space points are not really used by now
-            // (except for the change projector, which needs love anyways...)
-            OriginDimensionSpacePointSet::fromDimensionSpacePointSet(
-                $coveredDimensionSpacePointsToBeRemoved
-            ),
             $coveredDimensionSpacePointsToBeRemoved,
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Event/NodeAggregateWasRemoved.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Event/NodeAggregateWasRemoved.php
@@ -44,7 +44,6 @@ final readonly class NodeAggregateWasRemoved implements
         public WorkspaceName $workspaceName,
         public ContentStreamId $contentStreamId,
         public NodeAggregateId $nodeAggregateId,
-        public OriginDimensionSpacePointSet $affectedOccupiedDimensionSpacePoints,
         public DimensionSpacePointSet $affectedCoveredDimensionSpacePoints,
         ?NodeAggregateId $removalAttachmentPoint = null
     ) {
@@ -72,7 +71,6 @@ final readonly class NodeAggregateWasRemoved implements
             $targetWorkspaceName,
             $contentStreamId,
             $this->nodeAggregateId,
-            $this->affectedOccupiedDimensionSpacePoints,
             $this->affectedCoveredDimensionSpacePoints,
             $this->removalAttachmentPoint
         );
@@ -84,7 +82,6 @@ final readonly class NodeAggregateWasRemoved implements
             WorkspaceName::fromString($values['workspaceName']),
             ContentStreamId::fromString($values['contentStreamId']),
             NodeAggregateId::fromString($values['nodeAggregateId']),
-            OriginDimensionSpacePointSet::fromArray($values['affectedOccupiedDimensionSpacePoints']),
             DimensionSpacePointSet::fromArray($values['affectedCoveredDimensionSpacePoints']),
             isset($values['removalAttachmentPoint'])
                 ? NodeAggregateId::fromString($values['removalAttachmentPoint'])

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/NodeRemoval.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/NodeRemoval.php
@@ -69,11 +69,6 @@ trait NodeRemoval
                 $contentGraph->getWorkspaceName(),
                 $contentGraph->getContentStreamId(),
                 $command->nodeAggregateId,
-                $command->nodeVariantSelectionStrategy->resolveAffectedOriginDimensionSpacePoints(
-                    $nodeAggregate->getOccupationByCovered($command->coveredDimensionSpacePoint),
-                    $nodeAggregate,
-                    $this->getInterDimensionalVariationGraph()
-                ),
                 $command->nodeVariantSelectionStrategy->resolveAffectedDimensionSpacePoints(
                     $command->coveredDimensionSpacePoint,
                     $nodeAggregate,

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeVariantSelectionStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeVariantSelectionStrategy.php
@@ -64,19 +64,6 @@ enum NodeVariantSelectionStrategy: string implements \JsonSerializable
         };
     }
 
-    public function resolveAffectedOriginDimensionSpacePoints(
-        OriginDimensionSpacePoint $referenceDimensionSpacePoint,
-        NodeAggregate $nodeAggregate,
-        InterDimensionalVariationGraph $variationGraph
-    ): OriginDimensionSpacePointSet {
-        return match ($this) {
-            self::STRATEGY_ALL_VARIANTS => $nodeAggregate->occupiedDimensionSpacePoints,
-            self::STRATEGY_ALL_SPECIALIZATIONS => OriginDimensionSpacePointSet::fromDimensionSpacePointSet(
-                $variationGraph->getSpecializationSet($referenceDimensionSpacePoint->toDimensionSpacePoint())
-            )->getIntersection($nodeAggregate->occupiedDimensionSpacePoints)
-        };
-    }
-
     public function equals(self $other): bool
     {
         return $this === $other;

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DisallowedChildNodeAdjustment.php
@@ -125,15 +125,11 @@ class DisallowedChildNodeAdjustment
         NodeAggregate $nodeAggregate,
         DimensionSpacePoint $dimensionSpacePoint
     ): EventsToPublish {
-        $referenceOrigin = OriginDimensionSpacePoint::fromDimensionSpacePoint($dimensionSpacePoint);
         $events = Events::with(
             new NodeAggregateWasRemoved(
                 $this->contentGraph->getWorkspaceName(),
                 $this->contentGraph->getContentStreamId(),
                 $nodeAggregate->nodeAggregateId,
-                $nodeAggregate->occupiesDimensionSpacePoint($referenceOrigin)
-                    ? new OriginDimensionSpacePointSet([$referenceOrigin])
-                    : new OriginDimensionSpacePointSet([]),
                 new DimensionSpacePointSet([$dimensionSpacePoint]),
             )
         );

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/RemoveNodeAggregateTrait.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/RemoveNodeAggregateTrait.php
@@ -21,7 +21,6 @@ trait RemoveNodeAggregateTrait
                 $contentGraph->getWorkspaceName(),
                 $contentGraph->getContentStreamId(),
                 $tetheredNodeAggregate->nodeAggregateId,
-                $tetheredNodeAggregate->occupiedDimensionSpacePoints,
                 $tetheredNodeAggregate->coveredDimensionSpacePoints,
             )
         );

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/06-NodeRemoval/02-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/06-NodeRemoval/02-RemoveNodeAggregate_WithDimensions.feature
@@ -115,6 +115,7 @@ Feature: Hard remove node aggregate with node
     Then I expect to have the following changes in workspace "user-workspace":
       | nodeAggregateId  | created | changed | moved | deleted | originDimensionSpacePoint |
       | nody-mc-nodeface | 0       | 0       | 0     | 1       | {"language": "de"}        |
+      | nody-mc-nodeface | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
     And I expect to have no changes in workspace "live"
 
     Then I expect the publishing of document "nody-mc-nodeface" from workspace "user-workspace" to fail
@@ -131,6 +132,8 @@ Feature: Hard remove node aggregate with node
     Then I expect to have the following changes in workspace "user-workspace":
       | nodeAggregateId  | created | changed | moved | deleted | originDimensionSpacePoint |
       | nody-mc-nodeface | 0       | 0       | 0     | 1       | {"language": "de"}        |
+      | nody-mc-nodeface | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
+
     And I expect to have no changes in workspace "live"
 
     Then I expect the publishing of site "site" from workspace "user-workspace" to fail
@@ -165,6 +168,7 @@ Feature: Hard remove node aggregate with node
       | nodeAggregateId | created | changed | moved | deleted | originDimensionSpacePoint |
       # changed 1 disappears which is not okay
       | davids-child    | 0       | 0       | 0     | 1       | {"language": "de"}        |
+      | davids-child    | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
       | davids-child    | 0       | 1       | 0     | 0       | {"language": "fr"}        |
     And I expect to have no changes in workspace "live"
 
@@ -197,6 +201,7 @@ Feature: Hard remove node aggregate with node
     Then I expect to have the following changes in workspace "user-workspace":
       | nodeAggregateId        | created | changed | moved | deleted | originDimensionSpacePoint |
       | davids-child           | 0       | 0       | 0     | 1       | {"language": "de"}        |
+      | davids-child           | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
       | sir-david-nodenborough | 0       | 1       | 0     | 0       | {"language": "de"}        |
     And I expect to have no changes in workspace "live"
 
@@ -236,7 +241,9 @@ Feature: Hard remove node aggregate with node
       | nodeAggregateId   | created | changed | moved | deleted | originDimensionSpacePoint |
       | davids-child      | 0       | 1       | 0     | 0       | {"language": "de"}        |
       | site-two-document | 0       | 0       | 0     | 1       | {"language": "de"}        |
+      | site-two-document | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
       | nody-mc-nodeface  | 0       | 0       | 0     | 1       | {"language": "de"}        |
+      | nody-mc-nodeface  | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
     And I expect to have no changes in workspace "live"
 
     When I publish the 1 changes in site "site" from workspace "user-workspace" to "live"

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/00-WithoutImpendingConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/00-WithoutImpendingConflicts.feature
@@ -85,7 +85,6 @@ Feature: Tests for soft removal garbage collection without impending conflicts
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nonly-lively"                                  |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
   Scenario: Garbage collection will transform a soft removal of a node which is published to live from the only other workspace
@@ -109,7 +108,6 @@ Feature: Tests for soft removal garbage collection without impending conflicts
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -146,14 +144,12 @@ Feature: Tests for soft removal garbage collection without impending conflicts
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-kittens-plaything"                   |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
     And event at index 9 is of type "NodeAggregateWasRemoved" with payload:
       | Key                                  | Expected                                        |
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-kitten"                              |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -201,7 +197,6 @@ Feature: Tests for soft removal garbage collection without impending conflicts
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-kitten"                              |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     # the event for the nested removal is never explicitly emitted; the corresponding command fails and gets caught for now
@@ -239,7 +234,6 @@ Feature: Tests for soft removal garbage collection without impending conflicts
       | workspaceName                        | "live"                  |
       | contentStreamId                      | "cs-identifier"         |
       | nodeAggregateId                      | "nodingers-cat"         |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}] |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/02-NodeCreationConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/02-NodeCreationConflicts.feature
@@ -143,7 +143,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -191,7 +190,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/03-NodeVariationConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/03-NodeVariationConflicts.feature
@@ -211,7 +211,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-kitten"                              |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -262,7 +261,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-kitten"                              |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/04-NodeModificationConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/04-NodeModificationConflicts.feature
@@ -180,7 +180,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -232,7 +231,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                   |
       | contentStreamId                      | "cs-identifier"          |
       | nodeAggregateId                      | "nodingers-cat"          |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]  |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -289,5 +287,4 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/05-NodeReferencingConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/05-NodeReferencingConflicts.feature
@@ -243,7 +243,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -319,7 +318,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                   |
       | contentStreamId                      | "cs-identifier"          |
       | nodeAggregateId                      | "nodingers-cat"          |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]  |
       | affectedCoveredDimensionSpacePoints  | [{"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/06-SubtreeTaggingConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/06-SubtreeTaggingConflicts.feature
@@ -235,7 +235,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -287,7 +286,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -333,7 +331,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -392,7 +389,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/07-NodeRemovalConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/07-NodeRemovalConflicts.feature
@@ -150,7 +150,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -200,7 +199,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/08-NodeMoveConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/08-NodeMoveConflicts.feature
@@ -152,7 +152,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                   |
       | contentStreamId                      | "cs-identifier"          |
       | nodeAggregateId                      | "nodingers-cat"          |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]  |
       | affectedCoveredDimensionSpacePoints  | [{"example": "special"}] |
 
     When the command PublishWorkspace is executed with payload:
@@ -168,7 +167,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                  |
       | contentStreamId                      | "cs-identifier"         |
       | nodeAggregateId                      | "nodingers-cat"         |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}] |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}] |
 
   Scenario: Garbage collection will ignore a soft removal if the node affects an unpublished inbound move in another workspace
@@ -266,7 +264,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -336,7 +333,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/09-ChangeNodeAggregateNameConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/09-ChangeNodeAggregateNameConflicts.feature
@@ -142,7 +142,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/11-ChangeNodeAggregateTypeConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/11-ChangeNodeAggregateTypeConflicts.feature
@@ -139,7 +139,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/DebugWip.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/DebugWip.feature
@@ -114,7 +114,6 @@ Feature: Tests for soft removal garbage collection with impending conflicts caus
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/MultiWorkspaceConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/MultiWorkspaceConflicts.feature
@@ -188,5 +188,4 @@ Feature: Tests for soft removal garbage collection with conflicts across workspa
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/WorkspaceConflictsCleanup.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/WorkspaceConflictsCleanup.feature
@@ -89,7 +89,6 @@ Feature: Tests that impending conflicts are cleaned up in workspaces
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
   Scenario: Discard flushes impending conflicts
@@ -129,7 +128,6 @@ Feature: Tests that impending conflicts are cleaned up in workspaces
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:
@@ -177,7 +175,6 @@ Feature: Tests that impending conflicts are cleaned up in workspaces
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
       | nodeAggregateId                      | "nodingers-cat"                                 |
-      | affectedOccupiedDimensionSpacePoints | [{"example": "source"}]                         |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
 
     When the command RebaseWorkspace is executed with payload:


### PR DESCRIPTION
Remove possibly incorrect or undefined `NodeAggregateWasRemoved::$affectedOccupiedDimensionSpacePoints`

Originally https://github.com/neos/neos-development-collection/commit/8bccb958b25c9946f3b8ecae7416751f4015f6c9 introduced `$affectedOccupiedDimensionSpacePoints` for the change projection

Now with soft removals we dont need to focus on `NodeAggregateWasRemoved` and could even ignore them. There is no need to difference between occupied and covered as soft removals cant do this either (https://github.com/neos/neos-development-collection/issues/5507).
This change thus marks removal events in all `affectedCoveredDimensionSpacePoints` instead. They will not be shown in the workspace module either way and its more of a debug tool.

Previously `removeNodeInDimensionSpacePointSet` issued not necessarily occupied points and also when removing a root node aggregate it might be surprising to find out that `$affectedOccupiedDimensionSpacePoints` is empty because the root node doesnt occupy a special point.

 To simplify the discussion for now we remove this now unused feature

 Well have to revise the question for affected vs source dimension space points either way in a professional manner for other events, see https://github.com/neos/neos-development-collection/issues/4265#issuecomment-2711187915 but that is not for now.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
