### PR TITLE
FEATURE: Add option to emit warnings before handling node migrations

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
@@ -203,7 +203,7 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
 
 
   Scenario: matching only happens based on originDimensionSpacePoint, not on visibleDimensionSpacePoints - we try to change CH, but should not see any modification (includeSpecializations = FALSE - default)
-    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs" and exceptions are caught:
     """yaml
     migration:
       -
@@ -225,22 +225,14 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
               property: 'text'
               newSerializedValue: 'fixed value'
     """
-
-    # neither DE or CH is modified
-    When I am in workspace "migration-workspace" and dimension space point {"language": "de"}
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    And I expect this node to have the following properties:
-      | Key  | Value           |
-      | text | "Original text" |
-
-    When I am in workspace "migration-workspace" and dimension space point {"language": "ch"}
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    And I expect this node to have the following properties:
-      | Key  | Value           |
-      | text | "Original text" |
+    Then the last command should have thrown an exception of type "MigrationException" with message:
+    """
+    Migration did not issue any commands.
+    """
+    And I expect the content stream "migration-cs" to not exist
 
   Scenario: matching only happens based on originDimensionSpacePoint, not on visibleDimensionSpacePoints - we try to change CH, but should not see any modification (includeSpecializations = TRUE)
-    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs" and exceptions are caught:
     """yaml
     migration:
       -
@@ -263,16 +255,8 @@ Feature: Change Property Value across dimensions; and test DimensionSpacePoints 
               property: 'text'
               newSerializedValue: 'fixed value'
     """
-
-    # neither DE or CH is modified
-    When I am in workspace "migration-workspace" and dimension space point {"language": "de"}
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    And I expect this node to have the following properties:
-      | Key  | Value           |
-      | text | "Original text" |
-
-    When I am in workspace "migration-workspace" and dimension space point {"language": "ch"}
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    And I expect this node to have the following properties:
-      | Key  | Value           |
-      | text | "Original text" |
+    Then the last command should have thrown an exception of type "MigrationException" with message:
+    """
+    Migration did not issue any commands.
+    """
+    And I expect the content stream "migration-cs" to not exist

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
@@ -68,7 +68,7 @@ Feature: Change Property
       | text | "fixed value" |
 
   Scenario: Ignoring transformation if property does not exist on node
-    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs" and exceptions are caught:
     """yaml
     migration:
       -
@@ -84,12 +84,12 @@ Feature: Change Property
               property: 'notExisting'
               newSerializedValue: 'fixed value'
     """
-    # we did not change anything because notExisting does not exist
-    When I am in workspace "migration-workspace" and dimension space point {}
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{} to exist in the content graph
-    And I expect this node to have the following properties:
-      | Key  | Value           |
-      | text | "Original text" |
+
+    Then the last command should have thrown an exception of type "MigrationException" with message:
+    """
+    Migration did not issue any commands.
+    """
+    And I expect the content stream "migration-cs" to not exist
 
   Scenario: replacement using default currentValuePlaceholder
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
@@ -65,7 +65,7 @@ Feature: Remove Property
     And I expect this node to have no properties
 
   Scenario: Ignoring transformation if property does not exist on node
-    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs" and exceptions are caught:
     """yaml
     migration:
       -
@@ -80,9 +80,9 @@ Feature: Remove Property
             settings:
               property: 'notExisting'
     """
-    # we did not change anything because notExisting does not exist
-    When I am in workspace "migration-workspace" and dimension space point {}
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{} to exist in the content graph
-    And I expect this node to have the following properties:
-      | Key  | Value           |
-      | text | "Original text" |
+
+    Then the last command should have thrown an exception of type "MigrationException" with message:
+    """
+    Migration did not issue any commands.
+    """
+    And I expect the content stream "migration-cs" to not exist

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
@@ -110,7 +110,23 @@ Feature: Update root node aggregate dimensions
       | Identifier | Values      | Generalizations |
       | language   | mul, de, ch | ch->de->mul     |
 
-    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs" and exceptions are caught:
+    """yaml
+    migration:
+      -
+        transformations:
+          -
+            type: 'UpdateRootNodeAggregateDimensions'
+            settings:
+              nodeType: 'Neos.ContentRepository:Root'
+    """
+
+    Then the last command should have thrown an exception of type "NodeMigrationRequireConfirmationException" with message:
+    """
+    1 warnings: commands UpdateRootNodeAggregateDimensions require confirmation: Updating the dimensions of root node lady-eleonode-rootford will remove all its descendants in dimensions [{"language":"en"}]
+    """
+
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", with force and publishing on success:
     """yaml
     migration:
       -

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/Commands.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/Commands.php
@@ -60,6 +60,11 @@ final readonly class Commands implements \IteratorAggregate, \Countable
         yield from $this->items;
     }
 
+    public function isEmpty(): bool
+    {
+        return $this->items === [];
+    }
+
     public function count(): int
     {
         return count($this->items);

--- a/Neos.ContentRepository.NodeMigration/src/Command/ExecuteMigration.php
+++ b/Neos.ContentRepository.NodeMigration/src/Command/ExecuteMigration.php
@@ -20,14 +20,66 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 /**
  * Execute a Content Repository migration (which is defined in a YAML file)
  */
-final class ExecuteMigration
+final readonly class ExecuteMigration
 {
-    public function __construct(
-        public readonly MigrationConfiguration $migrationConfiguration,
-        public readonly WorkspaceName $sourceWorkspaceName,
-        public readonly WorkspaceName $targetWorkspaceName,
-        public readonly bool $publishOnSuccess,
-        public readonly ContentStreamId $contentStreamId,
+    private function __construct(
+        public MigrationConfiguration $migrationConfiguration,
+        public WorkspaceName $sourceWorkspaceName,
+        public WorkspaceName $targetWorkspaceName,
+        public ContentStreamId $contentStreamId,
+        public bool $publishOnSuccess,
+        public bool $requireConfirmation,
     ) {
+    }
+
+    public static function create(
+        MigrationConfiguration $migrationConfiguration,
+        WorkspaceName $sourceWorkspaceName,
+        WorkspaceName $targetWorkspaceName
+    ): self {
+        return new self(
+            $migrationConfiguration,
+            $sourceWorkspaceName,
+            $targetWorkspaceName,
+            ContentStreamId::create(),
+            publishOnSuccess: true,
+            requireConfirmation: true
+        );
+    }
+
+    public function withoutPublishOnSuccess(): self
+    {
+        return new self(
+            $this->migrationConfiguration,
+            $this->sourceWorkspaceName,
+            $this->targetWorkspaceName,
+            $this->contentStreamId,
+            false,
+            $this->requireConfirmation,
+        );
+    }
+
+    public function withoutRequiringConfirmation(): self
+    {
+        return new self(
+            $this->migrationConfiguration,
+            $this->sourceWorkspaceName,
+            $this->targetWorkspaceName,
+            $this->contentStreamId,
+            $this->publishOnSuccess,
+            false,
+        );
+    }
+
+    public function withContentStreamId(ContentStreamId $contentStreamId): self
+    {
+        return new self(
+            $this->migrationConfiguration,
+            $this->sourceWorkspaceName,
+            $this->targetWorkspaceName,
+            $contentStreamId,
+            $this->publishOnSuccess,
+            $this->requireConfirmation,
+        );
     }
 }

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationRequireConfirmationException.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationRequireConfirmationException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeMigration;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\NodeMigration\Transformation\TransformationSteps;
+
+final class NodeMigrationRequireConfirmationException extends \DomainException
+{
+    public static function becauseStepsRequireConfirmation(TransformationSteps $transformationSteps): self
+    {
+        $additionalInformation = [];
+        foreach ($transformationSteps as $transformationStep) {
+            $additionalInformation[] = sprintf(
+                'commands %s require confirmation: %s',
+                join(',', array_map(fn (CommandInterface $command) => substr(strrchr($command::class, '\\') ?: '', 1), iterator_to_array($transformationStep->commands))),
+                $transformationStep->confirmationReason,
+            );
+        }
+        return new self(
+            sprintf('%d warnings: %s', count($transformationSteps), join(";\n", $additionalInformation)),
+            1742060622
+        );
+    }
+}

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
@@ -46,6 +46,7 @@ class AddDimensionShineThroughTransformationFactory implements TransformationFac
             }
 
             public function execute(
+                WorkspaceName $workspaceNameForReading,
                 WorkspaceName $workspaceNameForWriting,
             ): TransformationStep {
                 return TransformationStep::fromCommand(

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddDimensionShineThroughTransformationFactory.php
@@ -38,19 +38,17 @@ class AddDimensionShineThroughTransformationFactory implements TransformationFac
         return new class (
             DimensionSpacePoint::fromArray($settings['from']),
             DimensionSpacePoint::fromArray($settings['to']),
-            $contentRepository
         ) implements GlobalTransformationInterface {
             public function __construct(
                 private readonly DimensionSpacePoint $from,
                 private readonly DimensionSpacePoint $to,
-                private readonly ContentRepository $contentRepository,
             ) {
             }
 
             public function execute(
                 WorkspaceName $workspaceNameForWriting,
-            ): void {
-                $this->contentRepository->handle(
+            ): TransformationStep {
+                return TransformationStep::fromCommand(
                     AddDimensionShineThrough::create(
                         $workspaceNameForWriting,
                         $this->from,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/AddNewPropertyConverterAwareTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/AddNewPropertyConverterAwareTransformationFactory.php
@@ -37,7 +37,6 @@ class AddNewPropertyConverterAwareTransformationFactory implements PropertyConve
             $settings['newPropertyName'],
             $settings['type'],
             $settings['serializedValue'],
-            $contentRepository,
             $propertyConverter,
         ) implements NodeBasedTransformationInterface {
             public function __construct(
@@ -50,7 +49,6 @@ class AddNewPropertyConverterAwareTransformationFactory implements PropertyConve
                  * Serialized Property value to be set.
                  */
                 private readonly mixed $serializedValue,
-                private readonly ContentRepository $contentRepository,
                 private readonly PropertyConverter $propertyConverter,
             ) {
             }
@@ -59,15 +57,15 @@ class AddNewPropertyConverterAwareTransformationFactory implements PropertyConve
                 Node $node,
                 DimensionSpacePointSet $coveredDimensionSpacePoints,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
+            ): TransformationStep {
                 if ($this->serializedValue === null) {
                     // we don't need to unset a non-existing property
-                    return;
+                    return TransformationStep::createEmpty();
                 }
                 $deserializedPropertyValue = $this->propertyConverter->deserializePropertyValue(SerializedPropertyValue::create($this->serializedValue, $this->type)); // @phpstan-ignore neos.cr.internal
 
                 if (!$node->hasProperty($this->newPropertyName)) {
-                    $this->contentRepository->handle(
+                    return TransformationStep::fromCommand(
                         SetNodeProperties::create(
                             $workspaceNameForWriting,
                             $node->aggregateId,
@@ -78,6 +76,8 @@ class AddNewPropertyConverterAwareTransformationFactory implements PropertyConve
                         )
                     );
                 }
+
+                return TransformationStep::createEmpty();
             }
         };
     }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
@@ -44,7 +44,6 @@ class ChangeNodeTypeTransformationFactory implements TransformationFactoryInterf
         return new class (
             $settings['newType'],
             $nodeAggregateTypeChangeChildConstraintConflictResolutionStrategy,
-            $contentRepository
         ) implements NodeAggregateBasedTransformationInterface {
             public function __construct(
                 /**
@@ -52,15 +51,14 @@ class ChangeNodeTypeTransformationFactory implements TransformationFactoryInterf
                  */
                 private readonly string $newType,
                 private readonly NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $strategy,
-                private readonly ContentRepository $contentRepository
             ) {
             }
 
             public function execute(
                 NodeAggregate $nodeAggregate,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
-                $this->contentRepository->handle(ChangeNodeAggregateType::create(
+            ): TransformationStep {
+                return TransformationStep::fromCommand(ChangeNodeAggregateType::create(
                     $workspaceNameForWriting,
                     $nodeAggregate->nodeAggregateId,
                     NodeTypeName::fromString($this->newType),

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyValueConverterAwareTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyValueConverterAwareTransformationFactory.php
@@ -69,7 +69,6 @@ class ChangePropertyValueConverterAwareTransformationFactory implements Property
             $search,
             $replace,
             $currentValuePlaceholder,
-            $contentRepository,
             $propertyConverter,
         ) implements NodeBasedTransformationInterface {
             public function __construct(
@@ -97,7 +96,6 @@ class ChangePropertyValueConverterAwareTransformationFactory implements Property
                  * current property value into the new value.
                  */
                 private readonly string $currentValuePlaceholder,
-                private readonly ContentRepository $contentRepository,
                 private readonly PropertyConverter $propertyConverter,
             ) {
             }
@@ -106,7 +104,7 @@ class ChangePropertyValueConverterAwareTransformationFactory implements Property
                 Node $node,
                 DimensionSpacePointSet $coveredDimensionSpacePoints,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
+            ): TransformationStep {
                 $currentProperty = $node->properties->serialized()->getProperty($this->propertyName);
                 if ($currentProperty !== null) {
                     $value = $currentProperty->value;
@@ -129,7 +127,7 @@ class ChangePropertyValueConverterAwareTransformationFactory implements Property
                     );
                     $deserializedPropertyValue = $this->propertyConverter->deserializePropertyValue(SerializedPropertyValue::create($newValueWithReplacedSearch, $currentProperty->type));  // @phpstan-ignore neos.cr.internal
 
-                    $this->contentRepository->handle(
+                    return TransformationStep::fromCommand(
                         SetNodeProperties::create(
                             $workspaceNameForWriting,
                             $node->aggregateId,
@@ -140,6 +138,8 @@ class ChangePropertyValueConverterAwareTransformationFactory implements Property
                         )
                     );
                 }
+
+                return TransformationStep::createEmpty();
             }
         };
     }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/GlobalTransformationInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/GlobalTransformationInterface.php
@@ -25,5 +25,5 @@ interface GlobalTransformationInterface
 {
     public function execute(
         WorkspaceName $workspaceNameForWriting,
-    ): void;
+    ): TransformationStep;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/GlobalTransformationInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/GlobalTransformationInterface.php
@@ -24,6 +24,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 interface GlobalTransformationInterface
 {
     public function execute(
+        WorkspaceName $workspaceNameForReading,
         WorkspaceName $workspaceNameForWriting,
     ): TransformationStep;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
@@ -36,19 +36,17 @@ class MoveDimensionSpacePointTransformationFactory implements TransformationFact
         return new class (
             $from,
             $to,
-            $contentRepository
         ) implements GlobalTransformationInterface {
             public function __construct(
                 private readonly DimensionSpacePoint $from,
                 private readonly DimensionSpacePoint $to,
-                private readonly ContentRepository $contentRepository,
             ) {
             }
 
             public function execute(
                 WorkspaceName $workspaceNameForWriting,
-            ): void {
-                $this->contentRepository->handle(
+            ): TransformationStep {
+                return TransformationStep::fromCommand(
                     MoveDimensionSpacePoint::create(
                         $workspaceNameForWriting,
                         $this->from,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/MoveDimensionSpacePointTransformationFactory.php
@@ -44,6 +44,7 @@ class MoveDimensionSpacePointTransformationFactory implements TransformationFact
             }
 
             public function execute(
+                WorkspaceName $workspaceNameForReading,
                 WorkspaceName $workspaceNameForWriting,
             ): TransformationStep {
                 return TransformationStep::fromCommand(

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/NodeAggregateBasedTransformationInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/NodeAggregateBasedTransformationInterface.php
@@ -27,5 +27,5 @@ interface NodeAggregateBasedTransformationInterface
     public function execute(
         NodeAggregate $nodeAggregate,
         WorkspaceName $workspaceNameForWriting
-    ): void;
+    ): TransformationStep;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/NodeBasedTransformationInterface.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/NodeBasedTransformationInterface.php
@@ -29,5 +29,5 @@ interface NodeBasedTransformationInterface
         Node $node,
         DimensionSpacePointSet $coveredDimensionSpacePoints,
         WorkspaceName $workspaceNameForWriting
-    ): void;
+    ): TransformationStep;
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RemoveNodeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RemoveNodeTransformationFactory.php
@@ -47,12 +47,10 @@ class RemoveNodeTransformationFactory implements TransformationFactoryInterface
         return new class (
             $strategy,
             $overriddenDimensionSpacePoint,
-            $contentRepository
         ) implements NodeBasedTransformationInterface {
             public function __construct(
                 private ?NodeVariantSelectionStrategy $strategy,
                 private readonly ?DimensionSpacePoint $overriddenDimensionSpacePoint,
-                private readonly ContentRepository $contentRepository
             ) {
             }
 
@@ -63,7 +61,7 @@ class RemoveNodeTransformationFactory implements TransformationFactoryInterface
                 Node $node,
                 DimensionSpacePointSet $coveredDimensionSpacePoints,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
+            ): TransformationStep {
                 if ($this->strategy === null) {
                     $this->strategy = NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS;
                 }
@@ -81,10 +79,10 @@ class RemoveNodeTransformationFactory implements TransformationFactoryInterface
                 if (!$coveredDimensionSpacePoints->contains($coveredDimensionSpacePoint)) {
                     // we are currently in a Node which has other covered dimension space points than the target ones,
                     // so we do not need to do anything.
-                    return;
+                    return TransformationStep::createEmpty();
                 }
 
-                $this->contentRepository->handle(RemoveNodeAggregate::create(
+                return TransformationStep::fromCommand(RemoveNodeAggregate::create(
                     $workspaceNameForWriting,
                     $node->aggregateId,
                     $coveredDimensionSpacePoint,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RemovePropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RemovePropertyTransformationFactory.php
@@ -36,23 +36,21 @@ class RemovePropertyTransformationFactory implements TransformationFactoryInterf
         $propertyName = $settings['property'];
         return new class (
             $propertyName,
-            $contentRepository
         ) implements NodeBasedTransformationInterface {
             public function __construct(
                 /**
                  * the name of the property to be removed.
                  */
                 private readonly string $propertyName,
-                private readonly ContentRepository $contentRepository
             ) {
             }
             public function execute(
                 Node $node,
                 DimensionSpacePointSet $coveredDimensionSpacePoints,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
+            ): TransformationStep {
                 if ($node->hasProperty($this->propertyName)) {
-                    $this->contentRepository->handle(
+                    return TransformationStep::fromCommand(
                         SetNodeProperties::create(
                             $workspaceNameForWriting,
                             $node->aggregateId,
@@ -63,6 +61,7 @@ class RemovePropertyTransformationFactory implements TransformationFactoryInterf
                         )
                     );
                 }
+                return TransformationStep::createEmpty();
             }
         };
     }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RenameNodeAggregateTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RenameNodeAggregateTransformationFactory.php
@@ -33,22 +33,20 @@ class RenameNodeAggregateTransformationFactory implements TransformationFactoryI
 
         return new class (
             $newNodeName,
-            $contentRepository
         ) implements NodeAggregateBasedTransformationInterface {
             public function __construct(
                 /**
                  * The new Node Name to use as a string
                  */
                 private readonly string $newNodeName,
-                private readonly ContentRepository $contentRepository
             ) {
             }
 
             public function execute(
                 NodeAggregate $nodeAggregate,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
-                $this->contentRepository->handle(ChangeNodeAggregateName::create(
+            ): TransformationStep {
+                return TransformationStep::fromCommand(ChangeNodeAggregateName::create(
                     $workspaceNameForWriting,
                     $nodeAggregate->nodeAggregateId,
                     NodeName::fromString($this->newNodeName),

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/RenamePropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/RenamePropertyTransformationFactory.php
@@ -37,7 +37,6 @@ class RenamePropertyTransformationFactory implements TransformationFactoryInterf
         return new class (
             $settings['from'],
             $settings['to'],
-            $contentRepository
         ) implements NodeBasedTransformationInterface {
             public function __construct(
                 /**
@@ -48,7 +47,6 @@ class RenamePropertyTransformationFactory implements TransformationFactoryInterf
                  * New name of property
                  */
                 private readonly string $to,
-                private readonly ContentRepository $contentRepository
             )
             {
             }
@@ -57,13 +55,13 @@ class RenamePropertyTransformationFactory implements TransformationFactoryInterf
                 Node $node,
                 DimensionSpacePointSet $coveredDimensionSpacePoints,
                 WorkspaceName $workspaceNameForWriting
-            ): void
+            ): TransformationStep
             {
                 $propertyValue = $node->properties[$this->from];
                 if ($propertyValue === null) {
-                    return;
+                    return TransformationStep::createEmpty();
                 }
-                $this->contentRepository->handle(
+                return TransformationStep::fromCommand(
                     SetNodeProperties::create(
                         $workspaceNameForWriting,
                         $node->aggregateId,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/StripTagsOnPropertyTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/StripTagsOnPropertyTransformationFactory.php
@@ -35,14 +35,12 @@ class StripTagsOnPropertyTransformationFactory implements TransformationFactoryI
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         return new class (
             $settings['property'],
-            $contentRepository
         ) implements NodeBasedTransformationInterface {
             public function __construct(
                 /**
                  * the name of the property to work on.
                  */
                 private readonly string $propertyName,
-                private readonly ContentRepository $contentRepository
             ) {
             }
 
@@ -50,10 +48,10 @@ class StripTagsOnPropertyTransformationFactory implements TransformationFactoryI
                 Node $node,
                 DimensionSpacePointSet $coveredDimensionSpacePoints,
                 WorkspaceName $workspaceNameForWriting
-            ): void {
+            ): TransformationStep {
                 $propertyValue = $node->properties[$this->propertyName];
                 if ($propertyValue === null) {
-                    return;
+                    return TransformationStep::createEmpty();
                 }
                 if (!is_string($propertyValue)) {
                     throw new \Exception(
@@ -62,7 +60,7 @@ class StripTagsOnPropertyTransformationFactory implements TransformationFactoryI
                     );
                 }
                 $newValue = strip_tags($propertyValue);
-                $this->contentRepository->handle(
+                return TransformationStep::fromCommand(
                     SetNodeProperties::create(
                         $workspaceNameForWriting,
                         $node->aggregateId,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationStep.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationStep.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeMigration\Transformation;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\CommandHandler\Commands;
+
+final class TransformationStep
+{
+    private function __construct(
+        public Commands $commands,
+        // todo public bool $requireConfirmation
+    ) {
+    }
+
+    public static function createEmpty(): self
+    {
+        return new self(Commands::createEmpty());
+    }
+
+    public static function fromCommand(CommandInterface $command): self
+    {
+        return new self(Commands::create($command));
+    }
+
+    public static function fromCommands(Commands $commands): self
+    {
+        return new self($commands);
+    }
+}

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationStep.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationStep.php
@@ -11,22 +11,35 @@ final class TransformationStep
 {
     private function __construct(
         public Commands $commands,
-        // todo public bool $requireConfirmation
+        public bool $requireConfirmation,
+        public string $confirmationReason
     ) {
     }
 
     public static function createEmpty(): self
     {
-        return new self(Commands::createEmpty());
+        return new self(Commands::createEmpty(), false, '');
     }
 
     public static function fromCommand(CommandInterface $command): self
     {
-        return new self(Commands::create($command));
+        return new self(Commands::create($command), false, '');
     }
 
     public static function fromCommands(Commands $commands): self
     {
-        return new self($commands);
+        return new self($commands, false, '');
+    }
+
+    public function withRequiredConfirmation(string $reason): self
+    {
+        if ($this->commands->isEmpty()) {
+            throw new \InvalidArgumentException('Cannot make a noop step confirmation required.');
+        }
+        return new self(
+            $this->commands,
+            requireConfirmation: true,
+            confirmationReason: $reason
+        );
     }
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationSteps.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationSteps.php
@@ -15,14 +15,19 @@ final readonly class TransformationSteps implements \IteratorAggregate, \Countab
     private function __construct(
         TransformationStep ...$items
     ) {
-        $this->items = $items;
+        $notEmpty = [];
+        foreach ($items as $item) {
+            if (!$item->commands->isEmpty()) {
+                $notEmpty[] = $item;
+            }
+        }
+        $this->items = $notEmpty;
     }
 
     public static function create(TransformationStep ...$items): self
     {
         return new self(...$items);
     }
-
 
     public static function createEmpty(): self
     {

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationSteps.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationSteps.php
@@ -39,9 +39,19 @@ final readonly class TransformationSteps implements \IteratorAggregate, \Countab
         return new self(...[...$this->items, $transformationStep]);
     }
 
+    public function filterConfirmationRequired(): self
+    {
+        return new self(...array_filter($this->items, fn (TransformationStep $step) => $step->requireConfirmation));
+    }
+
     public function getIterator(): \Traversable
     {
         yield from $this->items;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->items === [];
     }
 
     public function count(): int

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationSteps.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/TransformationSteps.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\NodeMigration\Transformation;
+
+/**
+ * @implements \IteratorAggregate<TransformationStep>
+ */
+final readonly class TransformationSteps implements \IteratorAggregate, \Countable
+{
+    /** @var array<TransformationStep> */
+    private array $items;
+
+    private function __construct(
+        TransformationStep ...$items
+    ) {
+        $this->items = $items;
+    }
+
+    public static function create(TransformationStep ...$items): self
+    {
+        return new self(...$items);
+    }
+
+
+    public static function createEmpty(): self
+    {
+        return new self();
+    }
+
+    public function merge(TransformationSteps $other): self
+    {
+        return new self(...[...$this->items, ...$other->items]);
+    }
+
+    public function withAppended(TransformationStep $transformationStep): self
+    {
+        return new self(...[...$this->items, $transformationStep]);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->items;
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
@@ -91,28 +91,40 @@ final class Transformations
 
     public function executeGlobal(
         WorkspaceName $workspaceNameForWriting,
-    ): void {
+    ): TransformationSteps {
+        $transformationSteps = TransformationSteps::createEmpty();
         foreach ($this->globalTransformations as $globalTransformation) {
-            $globalTransformation->execute($workspaceNameForWriting);
+            $transformationSteps = $transformationSteps->withAppended(
+                $globalTransformation->execute($workspaceNameForWriting)
+            );
         }
+        return $transformationSteps;
     }
 
     public function executeNodeAggregateBased(
         NodeAggregate $nodeAggregate,
         WorkspaceName $workspaceNameForWriting
-    ): void {
+    ): TransformationSteps {
+        $transformationSteps = TransformationSteps::createEmpty();
         foreach ($this->nodeAggregateBasedTransformations as $nodeAggregateBasedTransformation) {
-            $nodeAggregateBasedTransformation->execute($nodeAggregate, $workspaceNameForWriting);
+            $transformationSteps = $transformationSteps->withAppended(
+                $nodeAggregateBasedTransformation->execute($nodeAggregate, $workspaceNameForWriting)
+            );
         }
+        return $transformationSteps;
     }
 
     public function executeNodeBased(
         Node $node,
         DimensionSpacePointSet $coveredDimensionSpacePoints,
         WorkspaceName $workspaceNameForWriting
-    ): void {
+    ): TransformationSteps {
+        $transformationSteps = TransformationSteps::createEmpty();
         foreach ($this->nodeBasedTransformations as $nodeBasedTransformation) {
-            $nodeBasedTransformation->execute($node, $coveredDimensionSpacePoints, $workspaceNameForWriting);
+            $transformationSteps = $transformationSteps->withAppended(
+                $nodeBasedTransformation->execute($node, $coveredDimensionSpacePoints, $workspaceNameForWriting)
+            );
         }
+        return $transformationSteps;
     }
 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/Transformations.php
@@ -90,12 +90,13 @@ final class Transformations
     }
 
     public function executeGlobal(
+        WorkspaceName $workspaceNameForReading,
         WorkspaceName $workspaceNameForWriting,
     ): TransformationSteps {
         $transformationSteps = TransformationSteps::createEmpty();
         foreach ($this->globalTransformations as $globalTransformation) {
             $transformationSteps = $transformationSteps->withAppended(
-                $globalTransformation->execute($workspaceNameForWriting)
+                $globalTransformation->execute($workspaceNameForReading, $workspaceNameForWriting)
             );
         }
         return $transformationSteps;

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
@@ -45,10 +45,11 @@ class UpdateRootNodeAggregateDimensionsTransformationFactory implements Transfor
             }
 
             public function execute(
+                WorkspaceName $workspaceNameForReading,
                 WorkspaceName $workspaceNameForWriting,
             ): TransformationStep {
 
-                $rootNodeAggregate = $this->contentRepository->getContentGraph($workspaceNameForWriting)->findRootNodeAggregateByType($this->nodeTypeName);
+                $rootNodeAggregate = $this->contentRepository->getContentGraph($workspaceNameForReading)->findRootNodeAggregateByType($this->nodeTypeName);
 
                 if (!$rootNodeAggregate) {
                     throw new MigrationException(

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
@@ -57,12 +57,22 @@ class UpdateRootNodeAggregateDimensionsTransformationFactory implements Transfor
                     );
                 }
 
-                return TransformationStep::fromCommand(
+                $transformationStep = TransformationStep::fromCommand(
                     UpdateRootNodeAggregateDimensions::create(
                         $workspaceNameForWriting,
                         $rootNodeAggregate->nodeAggregateId
                     )
                 );
+
+                $allowedDimensionSubspace = $this->contentRepository->getVariationGraph()->getDimensionSpacePoints();
+                $toBeRemovedDimensionSpacePoints = $rootNodeAggregate->coveredDimensionSpacePoints->getDifference($allowedDimensionSubspace);
+                if (!$toBeRemovedDimensionSpacePoints->isEmpty()) {
+                    return $transformationStep->withRequiredConfirmation(
+                        sprintf('Updating the dimensions of root node %s will remove all its descendants in dimensions %s', $rootNodeAggregate->nodeAggregateId->value, $toBeRemovedDimensionSpacePoints->toJson())
+                    );
+                }
+
+                return $transformationStep;
             }
         };
     }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/UpdateRootNodeAggregateDimensionsTransformationFactory.php
@@ -46,7 +46,7 @@ class UpdateRootNodeAggregateDimensionsTransformationFactory implements Transfor
 
             public function execute(
                 WorkspaceName $workspaceNameForWriting,
-            ): void {
+            ): TransformationStep {
 
                 $rootNodeAggregate = $this->contentRepository->getContentGraph($workspaceNameForWriting)->findRootNodeAggregateByType($this->nodeTypeName);
 
@@ -57,7 +57,7 @@ class UpdateRootNodeAggregateDimensionsTransformationFactory implements Transfor
                     );
                 }
 
-                $this->contentRepository->handle(
+                return TransformationStep::fromCommand(
                     UpdateRootNodeAggregateDimensions::create(
                         $workspaceNameForWriting,
                         $rootNodeAggregate->nodeAggregateId


### PR DESCRIPTION
While fixing `UpdateRootNodeAggregateDimensions` in https://github.com/neos/neos-development-collection/pull/5514 and making it more dangerous by REMOVING all content in a dimension, we thought there should be a warning / require option.

this pr archives exactly that by making migrations return recipes instead of handling the commands themselves:

> 1 warnings: commands UpdateRootNodeAggregateDimensions require confirmation: Updating the dimensions of root node lady-eleonode-rootford will remove all its descendants in dimensions [{"language":"en"}]

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
