### PR TITLE
TASK: Allow variation of tethered root children

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
@@ -10,6 +10,10 @@ Feature: Create node variant
       | language   | de, gsw | gsw->de         |
     And using the following node types:
     """yaml
+    'Neos.ContentRepository:Root':
+      childNodes:
+        tethered:
+          type: 'Neos.ContentRepository.Testing:Tethered'
     'Neos.ContentRepository.Testing:Document':
       childNodes:
         tethered:
@@ -20,14 +24,15 @@ Feature: Create node variant
     And I am in content repository "default"
     And I am user identified by "initiating-user-identifier"
     And the command CreateRootWorkspace is executed with payload:
-      | Key                  | Value                |
-      | workspaceName        | "live"               |
-      | newContentStreamId   | "cs-identifier"      |
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
     And I am in workspace "live" and dimension space point {"market":"DE", "language":"gsw"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
-      | Key             | Value                         |
-      | nodeAggregateId | "lady-eleonode-rootford"      |
-      | nodeTypeName    | "Neos.ContentRepository:Root" |
+      | Key                                | Value                             |
+      | nodeAggregateId                    | "lady-eleonode-rootford"          |
+      | nodeTypeName                       | "Neos.ContentRepository:Root"     |
+      | tetheredDescendantNodeAggregateIds | {"tethered": "nodimer-tetherton"} |
     # We have to add another node since root nodes have no dimension space points and thus cannot be varied
     # Node /document
     And the following CreateNodeAggregateWithNode commands are executed:
@@ -73,7 +78,7 @@ Feature: Create node variant
       | targetOrigin    | {"market":"DE", "language":"de"}  |
     Then the last command should have thrown an exception of type "NodeAggregateIsRoot"
 
-  Scenario: Try to create a variant in a tethered node aggregate
+  Scenario: Try to create a variant in a tethered node aggregate which is not a child of a root node aggregate
     When the command CreateNodeVariant is executed with payload and exceptions are caught:
       | Key             | Value                             |
       | nodeAggregateId | "nodewyn-tetherton"               |
@@ -120,3 +125,11 @@ Feature: Create node variant
       | sourceOrigin    | {"market":"DE", "language":"gsw"} |
       | targetOrigin    | {"market":"DE", "language":"de"}  |
     Then the last command should have thrown an exception of type "NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint"
+
+  Scenario: Creating variants of tethered root children is allowed
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value                             |
+      | nodeAggregateId | "nodimer-tetherton"               |
+      | sourceOrigin    | {"market":"DE", "language":"de"}  |
+      | targetOrigin    | {"market":"DE", "language":"gsw"} |
+    # no exceptions


### PR DESCRIPTION
This allows variation of nodes that are tethered to a root node.

**Upgrade instructions**

none

**Review instructions**

In general, tethered nodes must not be varied independently from their parent.
At the same time, it is possible (and sensible, e.g. for the Taxonomies package or enforcing the presence of certain sites in a project) to define tethered children of a root node. Root nodes, again, cannot be varied, meaning that their tethered children can never be varied either.

This fixes this by allowing variation of tethered nodes if and only if they are tethered to a root node.

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
