### PR TITLE
BUGFIX: Allow boolean values for hidden properties in nodetype schema

### DIFF
--- a/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
+++ b/Neos.Neos/Resources/Private/Schema/NodeTypes.schema.yaml
@@ -52,7 +52,7 @@ additionalProperties:
                         additionalProperties: false
                         properties:
 
-                          'hidden': { type: ['string', 'null'], description: 'Option to hide a property.' }
+                          'hidden': { type: ['string', 'null', 'boolean'], description: 'Option to hide a property.' }
 
                           'group': { type: ['string', 'null'], description: 'Identifier of the inspector group in which this property should be edited. If not set, will not appear in inspector at all.' }
 


### PR DESCRIPTION
This prevents matching warnings in the configuration module or when verifying nodetypes via cli.

Resolves: #5520