### PR TITLE
BUGFIX: Inject persistence manager where necessary

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -26,6 +26,7 @@ use Neos\Flow\Mvc\View\JsonView;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\FluidAdaptor\View\TemplateView;
@@ -148,6 +149,12 @@ class AssetController extends ActionController
      * @var AssetVariantGenerator
      */
     protected $assetVariantGenerator;
+
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
     /**
      * @var AssetSourceInterface[]

--- a/Neos.Media/Tests/Functional/Fixtures/Controller/ImageController.php
+++ b/Neos.Media/Tests/Functional/Fixtures/Controller/ImageController.php
@@ -15,6 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\View\ViewInterface;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\FluidAdaptor\View\TemplateView;
 use Neos\Media\Domain\Model\Image;
@@ -39,6 +40,12 @@ class ImageController extends ActionController
      * @var AssetRepository
      */
     protected $assetRepository;
+
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
     /**
      * @param ViewInterface $view


### PR DESCRIPTION
In [#3450](https://github.com/neos/flow-development-collection/pull/3450), the persistence manager was removed from the AbstractController with the hint:

`In case you rely on $this->persistenceManager in your ActionController and didnt declare the PersistenceManagerInterface explicitly you have to do so now:`

Due to `# todo lint whole media browser package, now we only lint the parts that interact with the CR`

we forgot to do this in the Media Browser package, which leads to assets no longer being uploadable.

This PR fixes that.

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
