### PR TITLE
TASK: Prune asset usage index before catchup when subscription is booting.

### DIFF
--- a/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
+++ b/Neos.Neos/Classes/AssetUsage/CatchUpHook/AssetUsageCatchUpHook.php
@@ -44,6 +44,10 @@ final class AssetUsageCatchUpHook implements CatchUpHookInterface
 
     public function onBeforeCatchUp(SubscriptionStatus $subscriptionStatus): void
     {
+        if ($subscriptionStatus == SubscriptionStatus::BOOTING) {
+            // Prune index before projection gets replayed.
+            $this->assetUsageIndexingService->pruneIndex($this->contentRepositoryId);
+        }
     }
 
     public function onBeforeEvent(EventInterface $eventInstance, EventEnvelope $eventEnvelope): void


### PR DESCRIPTION
We need to cleanup the asset usage before the projection gets replayed to prevent wrong index entries.