### PR TITLE
BUGFIX: Boot media module flash-messages correctly if rendered outside Neos module

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Layouts/Default.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/Default.html
@@ -23,7 +23,7 @@
         </div>
         <div class="neos-media-content{f:if(condition: '{tags -> f:count()} > 25', then: ' neos-media-aside-condensed')}">
             <div class="neos-media-assets">
-                <div id="neos-notification-container" class="neos-notification-container">
+                <div id="neos-notification-container">
                     <f:render partial="FlashMessages"/>
                 </div>
                 <f:render section="Content"/>

--- a/Neos.Media.Browser/Resources/Private/Layouts/EditImage.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/EditImage.html
@@ -9,9 +9,10 @@
 	</f:for>
 </head>
 <body class="{settings.bodyClasses} media-browser-inspector">
-    <f:render partial="FlashMessages"/>
-
-    <f:render section="Content"/>
+	<div id="neos-notification-container">
+		<f:render partial="FlashMessages"/>
+	</div>
+	<f:render section="Content"/>
 	<script src="{f:uri.resource(path: 'resource://Neos.Media.Browser/Public/JavaScript/pdf.js')}"></script>
 	<f:for each="{settings.scripts}" as="script">
 		<script src="{f:uri.resource(path: script)}"></script>

--- a/Neos.Media.Browser/Resources/Private/Layouts/UploadImage.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/UploadImage.html
@@ -10,8 +10,9 @@
 </head>
 <body class="{settings.bodyClasses} media-browser-inspector">
 <div class="neos-row-fluid">
-	<f:render partial="FlashMessages" />
-
+	<div id="neos-notification-container">
+		<f:render partial="FlashMessages"/>
+	</div>
 	<f:render section="Content" />
 </div>
 <f:for each="{settings.scripts}" as="script">


### PR DESCRIPTION
Solves the bug described in https://github.com/neos/neos-development-collection/issues/5379#issuecomment-2701041702

Previously only flashmessages in the Default template (e.g. on show) where shown but neither for editing or uploading

Flashmessages in the media module are not shown for all actions if the media module is booted within the Neos ui.
The current error for `edit` or `new` action is that `this.container` (`#neos-notification-container`) is null and thus no flashmessages can be rendered in the dom:

https://github.com/neos/neos-development-collection/blob/c7be41ac865e096b62a019f3cf700222834b29f6/Neos.Neos/Resources/Public/JavaScript/Components/Notification/Toast.ts#L39

The mentioned container is normally created by js itself as child to `#neos-application`

https://github.com/neos/neos-development-collection/blob/c7be41ac865e096b62a019f3cf700222834b29f6/Neos.Neos/Resources/Public/JavaScript/Components/Notification/Toast.ts#L24

But the `#neos-application` is only rendered by the Backend Module Index template from Neos:

https://github.com/neos/neos-development-collection/blob/89d4c84c5640a49867d56592b6def1a2c6e5db0d/Neos.Neos/Resources/Private/Templates/Backend/Module/Index.html#L90


As the Media Ui provides a layout for the case of being rendered in the Neos backend module and for plain rendering as in the neos ui iframe (added via https://github.com/neos/neos-development-collection/pull/2171), the non module layouts must ensure that the shared javascript works by providing the desired dom structure.

- Module/Default.html
- Module/UploadImage.html
- Module/EditImage.html
- Default.html
- UploadImage.html
- EditImage.html


The flashmessages for `showAction` (e.g. default layout) work already in the neos ui as two changes https://github.com/neos/neos-development-collection/pull/5133 and https://github.com/neos/neos-development-collection/pull/5117 provided a fix to make the flashmessages work by ensuring `<div id="neos-notification-container">` is present.


This pull request extends the fix of providing an `#neos-notification-container` container for the `UploadImage` and `EditImage` template:


<img width="1179" alt="image" src="https://github.com/user-attachments/assets/53d17902-a6ae-40f3-8449-0cc7194ae589" />




**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
