### PR TITLE
FEATURE: Introduce `SubscriptionEngine::reactivate`

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
@@ -13,6 +13,7 @@ use Neos\ContentRepository\Core\Subscription\Engine\Error;
 use Neos\ContentRepository\Core\Subscription\Engine\Errors;
 use Neos\ContentRepository\Core\Subscription\Engine\ProcessedResult;
 use Neos\ContentRepository\Core\Subscription\Engine\Result;
+use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngineCriteria;
 use Neos\ContentRepository\Core\Subscription\Exception\CatchUpHadErrors;
 use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionError;
@@ -23,6 +24,68 @@ use Neos\EventStore\Model\EventEnvelope;
 
 final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
 {
+    /** @test */
+    public function projectionWithErrorCanBeReactivated()
+    {
+        $this->eventStore->setup();
+        $this->fakeProjection->expects(self::once())->method('setUp');
+        $this->subscriptionEngine->setup();
+        $this->fakeProjection->expects(self::any())->method('status')->willReturn(ProjectionStatus::ok());
+        $result = $this->subscriptionEngine->boot();
+        self::assertEquals(ProcessedResult::success(0), $result);
+        $this->expectOkayStatus('contentGraph', SubscriptionStatus::ACTIVE, SequenceNumber::none());
+        $this->expectOkayStatus('Vendor.Package:FakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::none());
+
+        // commit an event
+        $this->commitExampleContentStreamEvent();
+
+        // catchup active tries to apply the commited event
+        $exception = new \RuntimeException('This projection is kaputt.');
+        $this->fakeProjection->expects($i = self::exactly(2))->method('apply')->willReturnCallback(function ($_, EventEnvelope $eventEnvelope) use ($i, $exception) {
+            match($i->getInvocationCount()) {
+                1 => [
+                    self::assertEquals(1, $eventEnvelope->sequenceNumber->value),
+                    throw $exception
+                ],
+                2 => [
+                    // on second call is repaired:
+                    self::assertEquals(1, $eventEnvelope->sequenceNumber->value),
+                ]
+            };
+        });
+        $expectedStatusForFailedProjection = ProjectionSubscriptionStatus::create(
+            subscriptionId: SubscriptionId::fromString('Vendor.Package:FakeProjection'),
+            subscriptionStatus: SubscriptionStatus::ERROR,
+            subscriptionPosition: SequenceNumber::none(),
+            subscriptionError: SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception),
+            setupStatus: ProjectionStatus::ok(),
+        );
+
+        $result = $this->subscriptionEngine->catchUpActive();
+        self::assertEquals(ProcessedResult::failed(1, Errors::fromArray([Error::create(
+            SubscriptionId::fromString('Vendor.Package:FakeProjection'),
+            $exception->getMessage(),
+            $exception,
+            SequenceNumber::fromInteger(1)
+        )])), $result);
+
+        self::assertEquals(
+            $expectedStatusForFailedProjection,
+            $this->subscriptionStatus('Vendor.Package:FakeProjection')
+        );
+        $this->expectOkayStatus('contentGraph', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
+
+        //
+        // fix projection and catchup
+        //
+
+        // reactivate and catchup
+        $result = $this->subscriptionEngine->reactivate(SubscriptionEngineCriteria::create([SubscriptionId::fromString('Vendor.Package:FakeProjection')]));
+        self::assertNull($result->errors);
+
+        $this->expectOkayStatus('Vendor.Package:FakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
+    }
+
     /** @test */
     public function fixFailedProjectionViaReset()
     {
@@ -125,6 +188,23 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
         $result = $this->subscriptionEngine->setup();
         self::assertEquals(Result::success(), $result);
         self::assertEquals($expectedFailure, $this->subscriptionStatus('Vendor.Package:SecondFakeProjection'));
+
+        // reactivation will attempt to retry fix this, but can only work if the projection is repaired and will lead to an error otherwise:
+        $result = $this->subscriptionEngine->reactivate();
+        self::assertEquals(1, $result->numberOfProcessedEvents);
+        self::assertEquals('Must not happen! Debug projection detected duplicate event 1 of type ContentStreamWasCreated', $result->errors->first()?->message);
+
+        self::assertEquals(
+            ProjectionSubscriptionStatus::create(
+                subscriptionId: SubscriptionId::fromString('Vendor.Package:SecondFakeProjection'),
+                subscriptionStatus: SubscriptionStatus::ERROR,
+                subscriptionPosition: SequenceNumber::none(),
+                // previous state is now an error too also error:
+                subscriptionError: SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ERROR, $result->errors->first()->throwable),
+                setupStatus: ProjectionStatus::ok(),
+            ),
+            $this->subscriptionStatus('Vendor.Package:SecondFakeProjection')
+        );
 
         // expect the subscriptionError to be reset to null
         $result = $this->subscriptionEngine->reset();

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/SubscriptionDetachedStatusTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/SubscriptionDetachedStatusTest.php
@@ -111,7 +111,7 @@ final class SubscriptionDetachedStatusTest extends AbstractSubscriptionEngineTes
     }
 
     /** @test */
-    public function projectionIsDetachedOnSetup()
+    public function projectionIsDetachedOnSetupAndReattachedIfPossible()
     {
         $this->fakeProjection->expects(self::once())->method('setUp');
         $this->fakeProjection->expects(self::once())->method('apply');
@@ -159,6 +159,12 @@ final class SubscriptionDetachedStatusTest extends AbstractSubscriptionEngineTes
             ),
             $this->subscriptionStatus('Vendor.Package:FakeProjection')
         );
+
+        // reactivate does re-attach as the projection if its found again
+        $result = $this->subscriptionEngine->reactivate(SubscriptionEngineCriteria::create([SubscriptionId::fromString('Vendor.Package:FakeProjection')]));
+        self::assertNull($result->errors);
+
+        $this->expectOkayStatus('Vendor.Package:FakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
     }
 
     /** @test */

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -92,6 +92,14 @@ final class SubscriptionEngine
         );
     }
 
+    public function reactivate(SubscriptionEngineCriteria|null $criteria = null, ?\Closure $progressCallback = null, ?int $batchSize = null): ProcessedResult
+    {
+        $criteria ??= SubscriptionEngineCriteria::noConstraints();
+        return $this->processExclusively(
+            fn () => $this->catchUpSubscriptions($criteria, SubscriptionStatusFilter::fromArray([SubscriptionStatus::ERROR, SubscriptionStatus::DETACHED]), $progressCallback, $batchSize)
+        );
+    }
+
     public function reset(SubscriptionEngineCriteria|null $criteria = null): Result
     {
         $criteria ??= SubscriptionEngineCriteria::noConstraints();


### PR DESCRIPTION
Followup to the subscription engine: https://github.com/neos/neos-development-collection/pull/5321
by reintroducing the initial `reactivate` implementation: 525fcc49a2521d0eacf565c11b2710517986d0ca

when introducing the subscription engine we discussed whether to have `reactivate` as feature or not. At the end we settled with not having it sorely to reduce the API surface for now, and also because attempting to reactivate might not fix a projection after all if it cannot handle the same event twice: https://github.com/neos/neos-development-collection/pull/5321#issuecomment-2544873938

Now we noticed that during catchup a rare condition might cause a deadlock which leads into the content graph being in error state.
> Failed to insert hierarchy relation: An exception occurred while executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction

This is really unfortunate and we attempted to reproduce this again via tests but failed (https://github.com/neos/neos-development-collection/pull/5513). But to allow fixing this condition simply if any project ever runs into this again we want to provide the reactivate api as a tool. The race condition in question occurred before any other results were committed and for this special case it was testet that a reactivation works.

This change provides and internal cli command to make reactivation possible without modifing the subscription table and hack some php code.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
