### PR TITLE
BUGFIX: Improve error for wrong default dsp in routing

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -215,6 +215,12 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
                 $contentRepository
             );
         } catch (NodeNotFoundException $exception) {
+            if (
+                !$contentRepository->getVariationGraph()->getDimensionSpacePoints()->contains($dimensionSpacePoint)
+            ) {
+                // initialise variation graph for non-happy case to improve errors if configuration was faulty
+                throw new \RuntimeException(sprintf('Resolved (default) dimension %s for route path "%s" is not a valid combination', $dimensionSpacePoint->toJson(), $dimensionResolvingResult->remainingUriPath), 1743334596);
+            }
             // we silently swallow the Node Not Found case, as you'll see this in the server log if it interests you
             // (and other routes could still handle this).
             return false;


### PR DESCRIPTION
Missing the `defaultDimensionSpacePoint` will just be ignored silently as we then use the default dsp `{}` which will not find any nodes in a multi language cr.

```
Neos:
  Neos:
    sites:
      'your-site':
        contentRepository: 'default'
        contentDimensions:
          defaultDimensionSpacePoint: {language: de}
          resolver:
            factoryClassName: Neos\Neos\FrontendRouting\DimensionResolution\Resolver\AutoUriPathResolverFactory

```

A non helpful error is shown: 

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/522761e4-6548-4774-a0bb-fa48fc2ce52e" />

Instead we throw a raw exception to raise attention.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
