### PR TITLE
BUGFIX: Correct error in fusion code generated by site kickstarter

### DIFF
--- a/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Fusion/Document/AbstractPage.fusion
+++ b/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Fusion/Document/AbstractPage.fusion
@@ -24,8 +24,6 @@ prototype({packageKey}:Document.AbstractPage) < prototype(Neos.Neos:Page) {
   }
 
   body = {packageKey}:Component.Template.Default {
-    @context.node = ${this.node}
-
     # Define template properties
     menu = Neos.Neos:Menu
     content = Neos.Fusion:Component {


### PR DESCRIPTION
The previously generated code caused a type error in `@context.node = ${Neos.Node.nearestContentCollection(node, this.nodePath)}` because the context node was accidentally set to `null`.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
