### PR TITLE
BUGFIX: Ensure workspace module can correctly handle workspace name a…

### DIFF
--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
@@ -31,11 +31,8 @@ final class WorkspaceName implements \JsonSerializable
     public const WORKSPACE_NAME_LIVE = 'live';
 
     /**
-     * @todo fix the annotation below once flow can either
-     *   - understand types for array keys
-     *   - ignores static properties
+     * phpstan prefix because https://github.com/neos/flow-development-collection/issues/3464
      * @phpstan-var array<string,self>
-     * @var array<self>
      */
     private static array $instances = [];
 

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceName.php
@@ -31,7 +31,11 @@ final class WorkspaceName implements \JsonSerializable
     public const WORKSPACE_NAME_LIVE = 'live';
 
     /**
-     * @var array<string,self>
+     * @todo fix the annotation below once flow can either
+     *   - understand types for array keys
+     *   - ignores static properties
+     * @phpstan-var array<string,self>
+     * @var array<self>
      */
     private static array $instances = [];
 


### PR DESCRIPTION
Because flow does not understand the type annotation `array<string,self>` yet.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
