### PR TITLE
BUGFIX: Update browser history in workspace ui

### DIFF
--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -16,7 +16,6 @@ namespace Neos\Workspace\Ui\Controller;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Dimension\ContentDimensionId;
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlreadyExists;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\ConflictingEvent;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewActions.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewActions.fusion
@@ -57,6 +57,7 @@ prototype(Neos.Workspace.Ui:Component.ReviewActions) < prototype(Neos.Fusion:Com
             label={props.i18n.id('back')}
             attributes.hx-get={private.indexWorkspaceUri}
             attributes.hx-replace-url={private.indexWorkspaceUri}
+            attributes.hx-push-url={private.indexWorkspaceUri}
             attributes.hx-select="#workspace-module-content"
             attributes.hx-target="#workspace-module-content"
             attributes.hx-swap="outerHTML"
@@ -107,7 +108,6 @@ prototype(Neos.Workspace.Ui:Component.ReviewActions) < prototype(Neos.Fusion:Com
               attributes.hx-on--after-request={'document.getElementById("' + private.publishSelectedChangesPopoverId + '").showPopover()'}
             />
           </div>
-
         </div>
       </div>
   `

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Components/WorkspaceTableRow.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Components/WorkspaceTableRow.fusion
@@ -117,6 +117,7 @@ prototype(Neos.Workspace.Ui:Component.WorkspaceTableRow) < prototype(Neos.Fusion
           disabled={props.workspaceListItem.pendingChanges.total == 0}
           attributes.hx-get={private.reviewWorkspaceUri}
           attributes.hx-replace-url={private.reviewWorkspaceUri}
+          attributes.hx-push-url={private.reviewWorkspaceUri}
           attributes.hx-target="#workspace-module-content"
           attributes.hx-select="#workspace-module-content"
           attributes.hx-swap="outerHTML"


### PR DESCRIPTION
Before this change pressing back in the browser would lead to the previous Neos module instead of the previous view in the workspace ui itself, even though the url was correctly updated in the navigation bar.