### PR TITLE
BUGFIX: Skip reference properties in AssetExportProcessor

### DIFF
--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/AssetExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/AssetExportProcessor.php
@@ -51,9 +51,13 @@ final class AssetExportProcessor implements ProcessorInterface
                 continue;
             }
             foreach ($properties as $propertyName => $propertyValue) {
+                if ($nodeType->hasReference($propertyName)) {
+                    $context->dispatch(Severity::NOTICE, "Skipped node data processing for the property \"{$propertyName}\". The property is a reference. (Node: {$nodeDataRow['identifier']})");
+                    continue;
+                }
                 try {
                     $propertyType = $nodeType->getPropertyType($propertyName);
-                } catch (\InvalidArgumentException $e) {
+                } catch (\InvalidArgumentException) {
                     $context->dispatch(Severity::WARNING, "Skipped node data processing for the property \"{$propertyName}\". The property name is not part of the NodeType schema for the NodeType \"{$nodeType->name->value}\". (Node: {$nodeDataRow['identifier']})");
                     continue;
                 }


### PR DESCRIPTION
The `AssetExportProcessor` loops over properties found in the raw node data.

For reference(s) properties the `NodeType` complains when asked for the _property_ type, since references are not longer properties as before.

This thus skips references, as the cannot hold an asset anyway, thus solving warnings about

`Warning: Skipped node data processing for the property "foo". The property name is not part of the NodeType schema for the NodeType "Acme.Acmeom:Document.Page"`

which are very misleading (as the property exists).

**Review instructions**

Export legacy content having a `references`property…

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
