### PR TITLE
BUGFIX: Fix publishing for `Neos.Neos:RestrictedEditor` from 3rd level workspace

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -406,8 +406,11 @@ class WorkspacesController extends AbstractModuleController
         }
         switch ($action) {
             case 'publish':
+                if (($targetWorkspace = $selectedWorkspace->getBaseWorkspace()) === null) {
+                    $targetWorkspace = $this->workspaceRepository->findOneByName('live');
+                }
                 foreach ($nodes as $node) {
-                    $this->publishingService->publishNode($node);
+                    $this->publishingService->publishNode($node, $targetWorkspace);
                 }
                 $this->addFlashMessage(
                     $this->translator->translateById('workspaces.selectedChangesHaveBeenPublished', [], null, null, 'Modules', 'Neos.Neos')

--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -619,8 +619,8 @@ class WorkspacesController extends AbstractModuleController
                         'diff' => $diffArray
                     ];
                 }
-            // The && in belows condition is on purpose as creating a thumbnail for comparison only works if actually
-            // BOTH are ImageInterface (or NULL).
+                // The && in belows condition is on purpose as creating a thumbnail for comparison only works if actually
+                // BOTH are ImageInterface (or NULL).
             } elseif (
                 ($originalPropertyValue instanceof ImageInterface || $originalPropertyValue === null)
                 && ($changedPropertyValue instanceof ImageInterface || $changedPropertyValue === null)


### PR DESCRIPTION
**Changes I made:**
- `WorkspacesController`: explicitly define the target workspace for case `publish` in `publishOrDiscardNodesAction()`

**Why I'm changing this:**
Our project has a workspace setup like `Workspace A -> Workspace B -> Live`. Users, who are not allowed to publish to Live (like `Neos.Neos:RestrictedEditor`) cannot publish nodes with childNodes from Workspace A to Workspace B, because it wrongly assumes that the targetWorkspace for the childNodes is Live. This fix sets the target workspace explicitly to prevent the system from assuming the wrong target workspace. The problem is more fully explained in the linked issue. 

resolved: https://github.com/neos/neos-development-collection/issues/5373


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
