### PR TITLE
BUGFIX: Adjust fusion-form dependency

### DIFF
--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -21,7 +21,7 @@
         "neos/contentrepository-export": "self.version",
         "neos/fusion": "self.version",
         "neos/fusion-afx": "self.version",
-        "neos/fusion-form": "^1.0 || ^2.0",
+        "neos/fusion-form": "^2.1 || ^3.0",
         "neos/fluid-adaptor": "~9.0.0",
         "neos/media": "self.version",
         "neos/workspace-ui": "self.version",


### PR DESCRIPTION
The fusion form in version below 2.1 is incompatible with Neos 9.0. Therefore, we have to modify the constraint and disable versions prior to 2.1. Additionally, we should include 3.0 as it supports Symfony Mailer.

**Review instructions**

Just check dependencies in the setup.
