### PR TITLE
BUGFIX: MediaBrowser's upload action shows empty flash message if file is too big

### DIFF
--- a/Neos.Media.Browser/Resources/Private/Layouts/EditImage.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/EditImage.html
@@ -7,6 +7,10 @@
 	<f:for each="{settings.styles}" as="style">
 		<link rel="stylesheet" href="{f:uri.resource(path: style)}" />
 	</f:for>
+	<link
+		rel="neos-xliff"
+		href="{f:uri.action(action: 'xliffAsJson', arguments: {locale: '{neos:backend.interfaceLanguage()}', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'Neos.Neos', absolute: true) -> f:format.raw()}"
+	/>
 </head>
 <body class="{settings.bodyClasses} media-browser-inspector">
 	<div id="neos-notification-container">

--- a/Neos.Media.Browser/Resources/Private/Layouts/UploadImage.html
+++ b/Neos.Media.Browser/Resources/Private/Layouts/UploadImage.html
@@ -7,6 +7,10 @@
 	<f:for each="{settings.styles}" as="style">
 		<link rel="stylesheet" href="{f:uri.resource(path: style)}" />
 	</f:for>
+	<link
+		rel="neos-xliff"
+		href="{f:uri.action(action: 'xliffAsJson', arguments: {locale: '{neos:backend.interfaceLanguage()}', version: '{neos:backend.xliffCacheVersion()}'}, controller: 'Backend\Backend', package: 'Neos.Neos', absolute: true) -> f:format.raw()}"
+	/>
 </head>
 <body class="{settings.bodyClasses} media-browser-inspector">
 <div class="neos-row-fluid">


### PR DESCRIPTION
expected (like in the standalone media browser)

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/bcb151bf-c240-409e-803e-36693f604fe8" />

actual (media browser insider neos ui):

<img width="873" alt="image" src="https://github.com/user-attachments/assets/bbc5de87-0133-47f3-b932-c6718b693d3b" />

interestingly the error works in the neos ui when one uses the media browsers drag and drop

<img width="747" alt="image" src="https://github.com/user-attachments/assets/312b2cc8-79b6-4fb0-bb5b-4fd1a4f125a1" />

-------

The existence of this bug was uncovered via https://github.com/neos/neos-development-collection/pull/5528 because previously no validation error was shown and on upload the server just died:

<img width="670" alt="image" src="https://github.com/user-attachments/assets/95b5a2ec-0c5c-4c12-8d66-2d9bcf874b0a" />

> Could not convert target type "Neos\Media\Domain\Model\Asset": Missing constructor argument "resource" for object of type "Neos\Media\Domain\Model\Asset".




**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

This bug was uncovered because translate() simply returns undefined, if not initialised. No error no fallback, nuthing.
Also while `I18n.init()` _IS_ called, it doesnt actually initialise anything. For that 

https://github.com/neos/neos-development-collection/blob/847e4647d761249b5c48ade07fe08ad7d1db58c5/Neos.Neos/Resources/Public/JavaScript/index.js#L23-L27

has to be invoked and that is done by adding the link.

------------------

Notice also that ist not particularly keen of us to initialise I18n once in the host (neos.ui) and then in the iframe too. This is just extra work for the browser, and we dump the iframe after selecting the image.
Now my pr doenst improve that but there are ideas outlined here https://github.com/neos/neos-ui/issues/3119 and the first step for a global translate api was already introduced via https://github.com/neos/neos-ui/pull/3804.
Nothing for a bugfix to build up on though.

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
