### PR TITLE
BUGFIX: Replace skip migrations with simple return

### DIFF
--- a/Neos.ContentRepository/Migrations/Mysql/Version20230430183156.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20230430183156.php
@@ -23,10 +23,11 @@ final class Version20230430183156 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MysqlPlatform'."
         );
 
-        $this->skipIf(!$schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('IDX_CE6515692D45FE4D')
-            && $schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('UNIQ_CE6515692D45FE4D'),
-            "Skipped index renaming because they are already named properly"
-        );
+        if(!$schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('IDX_CE6515692D45FE4D')
+            && $schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('UNIQ_CE6515692D45FE4D')
+        ){
+            return;
+        }
 
         $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP INDEX IDX_CE6515692D45FE4D, ADD UNIQUE INDEX UNIQ_CE6515692D45FE4D (movedto)');
     }
@@ -38,10 +39,11 @@ final class Version20230430183156 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MysqlPlatform'."
         );
 
-        $this->skipIf($schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('IDX_CE6515692D45FE4D')
-            && !$schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('UNIQ_CE6515692D45FE4D'),
-            "Skipped index renaming because they are already named properly"
-        );
+        if($schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('IDX_CE6515692D45FE4D')
+            && !$schema->getTable('neos_contentrepository_domain_model_nodedata')->hasIndex('UNIQ_CE6515692D45FE4D')
+        ) {
+            return;
+        }
 
         $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP INDEX UNIQ_CE6515692D45FE4D, ADD INDEX IDX_CE6515692D45FE4D (movedto)');
     }

--- a/Neos.ContentRepository/Migrations/Postgresql/Version20150524151134.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20150524151134.php
@@ -13,13 +13,15 @@ class Version20150524151134 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function up(Schema $schema): void 
+    public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
         if ($this->connection->getWrappedConnection() instanceof \Doctrine\DBAL\Driver\ServerInfoAwareConnection) {
             $version = $this->connection->getWrappedConnection()->getServerVersion();
             // This means we are using a jsonb field (see Version20150324210627) and this already stores unescaped unicode, so we can skip here.
-            $this->skipIf(version_compare($version, '9.4', '>='), 'Node properties stored in a JSONB column, no migration necessary.');
+            if (version_compare($version, '9.4', '>=')) {
+                return;
+            }
         }
 
         $select = $this->connection->query("SELECT persistence_object_identifier, properties FROM typo3_typo3cr_domain_model_nodedata");
@@ -39,13 +41,15 @@ class Version20150524151134 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
         if ($this->connection->getWrappedConnection() instanceof \Doctrine\DBAL\Driver\ServerInfoAwareConnection) {
             $version = $this->connection->getWrappedConnection()->getServerVersion();
             // This means we are using a jsonb field (see Version20150324210627) and this already stores unescaped unicode, so we can skip here.
-            $this->skipIf(version_compare($version, '9.4', '>='), 'Node properties stored in a JSONB column, no migration necessary.');
+            if(version_compare($version, '9.4', '>=')) {
+                return;
+            }
         }
 
         $select = $this->connection->query("SELECT persistence_object_identifier, properties FROM typo3_typo3cr_domain_model_nodedata");


### PR DESCRIPTION
If we use the skip migrations feature of doctrine, the migrations never get marked as applied. Which leads to situations, where your migration status will never be clean. So I replaced all skipif with a simple return.

See also: https://github.com/doctrine/migrations/issues/1179