### PR TITLE
BUGFIX: Convert selectbox group labels i18n values

### DIFF
--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -182,6 +182,9 @@ class NodeTypeConfigurationEnrichmentAspect
                     if ($this->shouldFetchTranslation($optionConfiguration)) {
                         $optionConfiguration['label'] = $translationIdGenerator('selectBoxEditor.values.' . $value);
                     }
+                    if ($this->shouldFetchTranslation($optionConfiguration, 'group')) {
+                        $optionConfiguration['group'] = $translationIdGenerator('selectBoxEditor.groups.' . $value);
+                    }
                 }
                 break;
             case 'Neos.Neos/Inspector/Editors/CodeEditor':


### PR DESCRIPTION
**Review instructions**

This change converts `i18n` values of group labels to shorthand strings like `Neos.Demo:NodeTypes.Content.Headline:properties.tagName.selectBoxEditor.groups.h1`.
This works together with https://github.com/neos/neos-ui/pull/3955 to make it possible to localise group labels for select box values like in the following example:

```yaml
    tagName:
      type: string
      defaultValue: 'h2'
      ui:
        label: i18n
        reloadIfChanged: true
        inspector:
          group: settings
          position: 10
          editor: Neos.Neos/Inspector/Editors/SelectBoxEditor
          editorOptions:
            values:
              h1:
                label: h1
                group: i18n
              h2:
                label: h2
                group: i18n
              h3:
                label: h3
                group: 'Neos.Demo:Main:group.label'
              h4:
                label: h4
                group: Just some text
              h5:
                label: h5
                group: 'Neos.Demo:Main:group.label'
```
