### PR TITLE
Fix moving nodes to a different parent node

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -925,7 +925,7 @@ class NodeData extends AbstractNodeData
                 $movedNodeData->createShadow($originalPath);
             }
         } else {
-            $referencedShadowNode = $this->nodeDataRepository->findOneByMovedTo($sourceNodeData);
+            $referencedShadowNode = $this->nodeDataRepository->findOneByMovedTo($sourceNodeData->getMovedTo());
             if ($targetPathShadowNodeData === null) {
                 if ($referencedShadowNode === null) {
                     // There is no shadow node on the original or target path, so the current node data will be turned to a shadow node and a new node data will be created for the moved node.


### PR DESCRIPTION
**Upgrade instructions**

Currently, when moving nodes to a different parent node, the publishing fails, as the referenced shadow node can not be found. This happens, because `NodeData::move()` method [tries to find the node data by the source node](https://github.com/neos/neos-development-collection/blob/65cbf7b7e0aeedcaea68eae4332d15b719a694c9/Neos.ContentRepository/Classes/Domain/Model/NodeData.php#L928) instead of the `movedTo`-property. 

**Review instructions**

Try to move a node to a different parent node (move page inside another page for example) without this PR. Then try it again with this fix (mainly  replace `findOneByMovedTo($sourceNodeData)` with `findOneByMovedTo($sourceNodeData->getMovedTo())`). 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions

** Thanks **

Thanks to @robinroloff for also digging into this.