### PR TITLE
BUGFIX: Fix checking workspaces when move nodes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeData.php
@@ -883,7 +883,7 @@ class NodeData extends AbstractNodeData
     {
         $sourceNodeData = $this;
         $originalPath = $this->path;
-        if ($originalPath === $targetPath && $this->workspace->getName() === $targetWorkspace) {
+        if ($originalPath === $targetPath && $this->workspace->getName() === $targetWorkspace->getName()) {
             return $this;
         }
 


### PR DESCRIPTION
**Upgrade instructions**

While fixing the move of nodes in #5561 I also noticed, that the workspace itself has not been checked correctly, as the workspaceName was checked against the Workspace (class) in the [beginning of the move()-Method](https://github.com/neos/neos-development-collection/blob/65cbf7b7e0aeedcaea68eae4332d15b719a694c9/Neos.ContentRepository/Classes/Domain/Model/NodeData.php#L886). This PR fixes this and correctly compares the workspaces at the beginning of the `NodaData::move()` method.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
