### PR TITLE
PATCH: Allow `symfony/serializer` in version 7

### DIFF
--- a/Neos.ContentRepository.Core/composer.json
+++ b/Neos.ContentRepository.Core/composer.json
@@ -18,7 +18,7 @@
         "neos/utility-objecthandling": "*",
         "neos/utility-arrays": "*",
         "doctrine/dbal": "^3.1.4",
-        "symfony/serializer": "^6.3",
+        "symfony/serializer": "^6.3 || ^7.0",
         "psr/clock": "^1",
         "behat/transliterator": "~1.0",
         "ramsey/uuid": "^3.0 || ^4.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "neos/error-messages": "*",
         "neos/utility-objecthandling": "*",
         "neos/utility-arrays": "*",
-        "symfony/serializer": "^6.3",
+        "symfony/serializer": "^6.3 || ^7.0",
         "psr/clock": "^1",
         "behat/transliterator": "~1.0",
         "ramsey/uuid": "^3.0 || ^4.0",


### PR DESCRIPTION
7 is a breaking change see https://github.com/symfony/serializer/blob/7.3/CHANGELOG.md#70


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
