### PR TITLE
BUGFIX: Use cached node uris

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHook.php
+++ b/Neos.Neos/Classes/FrontendRouting/CatchUpHook/RouterCacheHook.php
@@ -12,6 +12,7 @@ use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemove
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Projection\CatchUpHook\CatchUpHookInterface;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\EventStore\Model\EventEnvelope;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
@@ -117,7 +118,11 @@ final class RouterCacheHook implements CatchUpHookInterface
         }
 
         $newPropertyValues = $event->propertyValues->getPlainValues();
-        if (!isset($newPropertyValues['uriPathSegment'])) {
+        $unsetPropertyValues = array_flip(array_map(
+            fn (PropertyName $propertyName) => $propertyName->value,
+            iterator_to_array($event->propertiesToUnset)
+        ));
+        if (!isset($newPropertyValues['uriPathSegment']) && !isset($unsetPropertyValues['uriPathSegment'])) {
             return;
         }
 

--- a/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeUriBuilder.php
@@ -135,7 +135,7 @@ final readonly class NodeUriBuilder
         }
 
         $routeValues = $options->routingArguments;
-        $routeValues['node'] = $nodeAddress;
+        $routeValues['node'] = $nodeAddress->toJson();
         $routeValues['@action'] = strtolower('show');
         $routeValues['@controller'] = strtolower('Frontend\Node');
         $routeValues['@package'] = strtolower('Neos.Neos');


### PR DESCRIPTION
By providing a node address as string, the `RouterCachingService` does not return null anymore for the given RouteValue.

Though this leads to the address being serialised and deserialised for each built uri. This could be further optimised in the future by also accepting the nodeaddress as array in `\Neos\Neos\FrontendRouting\EventSourcedFrontendNodeRoutePartHandler::resolveWithParameters`

Resolves: #5568
