### PR TITLE
BUGFIX: Prevent sharing splitString between node routings

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -141,8 +141,6 @@ use Psr\Http\Message\UriInterface;
  * if needed.
  *
  * Then, the {@see DimensionResolverInterface} of the target site is called for adjusting the URL.
- *
- * @Flow\Scope("singleton")
  */
 final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart implements
     DynamicRoutePartInterface,


### PR DESCRIPTION
This change makes sure that each route has its own handler instance and prevents accidental sharing of instance properties. An optimal solution wouldn't need the `splitString` as instance variable anymore, but this would require a change in Flow.

Resolves: #5571
