### PR TITLE
BUGFIX: Reimplement missing node route handler options from previous Neos versions

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -300,7 +300,7 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
             if ($resolveResult === false) {
                 return false;
             }
-        } catch (NodeNotFoundException|TargetSiteNotFoundException|InvalidShortcutException $exception) {
+        } catch (NodeNotFoundException | TargetSiteNotFoundException | InvalidShortcutException $exception) {
             // TODO log exception ... yes todo
             return false;
         }
@@ -433,21 +433,24 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
     private function nodeTypeIsAllowed(
         DocumentNodeInfo $nodeInfo,
         ContentRepository $contentRepository,
-    ): bool
-    {
+    ): bool {
         $nodeTypeManager = $contentRepository->getNodeTypeManager();
 
         $allowedNodeTypeName = $this->options['nodeType'] ?? null;
-        if ($allowedNodeTypeName && !$nodeTypeManager
+        if (
+            $allowedNodeTypeName && !$nodeTypeManager
             ->getNodeType($nodeInfo->getNodeTypeName())
-            ?->isOfType($allowedNodeTypeName)) {
+            ?->isOfType($allowedNodeTypeName)
+        ) {
             return false;
         }
 
         $onlyMatchSiteNodes = $this->options['onlyMatchSiteNodes'] ?? false;
-        if ($onlyMatchSiteNodes && !$nodeTypeManager
+        if (
+            $onlyMatchSiteNodes && !$nodeTypeManager
                 ->getNodeType($nodeInfo->getNodeTypeName())
-                ?->isOfType('Neos.Neos:Site')) {
+                ?->isOfType('Neos.Neos:Site')
+        ) {
             return false;
         }
         return true;

--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -425,19 +425,27 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
     }
 
     /**
-     * Whether the given node is allowed according to the "nodeType" option
+     * Whether the given node is allowed according to the "nodeType" option and the "onlyMatchSiteNodes" option.
      */
     private function nodeTypeIsAllowed(
         DocumentNodeInfo $nodeInfo,
         ContentRepository $contentRepository,
     ): bool
     {
-        if (isset($this->options['nodeType'])) {
-            $nodeTypeName = $this->options['nodeType'];
-            $nodeTypeManager = $contentRepository->getNodeTypeManager();
-            return (bool)$nodeTypeManager
+        $nodeTypeManager = $contentRepository->getNodeTypeManager();
+
+        $allowedNodeTypeName = $this->options['nodeType'] ?? null;
+        if ($allowedNodeTypeName && !$nodeTypeManager
+            ->getNodeType($nodeInfo->getNodeTypeName())
+            ?->isOfType($allowedNodeTypeName)) {
+            return false;
+        }
+
+        $onlyMatchSiteNodes = $this->options['onlyMatchSiteNodes'] ?? false;
+        if ($onlyMatchSiteNodes && !$nodeTypeManager
                 ->getNodeType($nodeInfo->getNodeTypeName())
-                ?->isOfType($nodeTypeName);
+                ?->isOfType('Neos.Neos:Site')) {
+            return false;
         }
         return true;
     }

--- a/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.Neos/Classes/FrontendRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -238,7 +238,7 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
     /**
      * @param string $uriPath
      * @param DimensionSpacePoint $dimensionSpacePoint
-     * @return MatchResult|false
+     * @return MatchResult|false returns the MatchResult that represents the node that matched the given $uriPath – or false if the found node does not match the constraints
      * @throws NodeNotFoundException
      */
     private function matchUriPath(
@@ -378,6 +378,9 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
     }
 
 
+    /**
+     * @return string|false the remaining request path or false if the splitString was not found in the $requestPath
+     */
     private function truncateRequestPathAndReturnRemainder(string &$requestPath, string $uriPathSuffix): false|string
     {
         if ($uriPathSuffix !== '') {


### PR DESCRIPTION
Re-adds support for the `nodeType` and  `onlyMatchSiteNodes` options for the default `FrontendNodeRoutePartHandlerInterface` implementation