### PR TITLE
TASK: WIP: Add method to find deleted node aggregate ids to change finder

### DIFF
--- a/Neos.Neos/Classes/PendingChangesProjection/ChangeFinder.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/ChangeFinder.php
@@ -15,7 +15,10 @@ declare(strict_types=1);
 namespace Neos\Neos\PendingChangesProjection;
 
 use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\Flow\Annotations as Flow;
 
@@ -31,6 +34,23 @@ final class ChangeFinder implements ProjectionStateInterface
         private readonly Connection $dbal,
         private readonly string $tableName,
     ) {
+    }
+
+    public function findNodeAggregateIdsForDeletedNodes(ContentStreamId $contentStreamId, OriginDimensionSpacePoint $originDimensionSpacePoint): NodeAggregateIds
+    {
+        $deletedRows = $this->dbal->executeQuery(
+            <<<SQL
+                SELECT nodeAggregateId FROM {$this->tableName}
+                WHERE contentStreamId = :contentStreamId
+                AND deleted IS TRUE
+                AND originDimensionSpacePointHash = :originDimensionSpacePointHash
+            SQL,
+            [
+                'contentStreamId' => $contentStreamId->value,
+                'originDimensionSpacePointHash' => $originDimensionSpacePoint->hash
+            ]
+        )->fetchAllAssociative();
+        return NodeAggregateIds::fromArray(array_map(fn(array $row) => $row['nodeAggregateId'], $deletedRows));
     }
 
     public function findByContentStreamId(ContentStreamId $contentStreamId): Changes

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/PendingChangesTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/PendingChangesTrait.php
@@ -17,6 +17,7 @@ use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\Common\EmbedsNodeAggregateId;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
@@ -49,6 +50,55 @@ trait PendingChangesTrait
      * @return T
      */
     abstract private function getObject(string $className): object;
+
+    /**
+     * @Then I expect to have the following deleted nodeAggregateIds in workspace :workspace for dimension :dimensionSpacePoint:
+     */
+    public function iExpectTheChangeProjectionToHaveTheFollowingDeletionsForContentStream(TableNode $table, string $workspace, string $dimensionSpacePoint)
+    {
+        // forwards compatible adjustment, we make the test assertions on workspace names even tough we store the data in content streams
+        $workspaceInstance = $this->currentContentRepository->findWorkspaceByName(WorkspaceName::fromString($workspace));
+        Assert::assertNotNull($workspaceInstance, 'workspace doesnt exist');
+
+        $changeFinder = $this->currentContentRepository->projectionState(ChangeFinder::class);
+        $deletedNodeAggregateIde = $changeFinder->findNodeAggregateIdsForDeletedNodes(
+            $workspaceInstance->currentContentStreamId,
+            OriginDimensionSpacePoint::fromJsonString($dimensionSpacePoint),
+        );
+
+        $expectedNodeAggregateIds = NodeAggregateIds::fromArray(
+            array_map(
+                fn (array $row) => $row['nodeAggregateId'],
+                $table->getHash()
+            )
+        );
+
+        $deletedNodeAggregateIdsJson = $deletedNodeAggregateIde->toStringArray();
+        $expectedNodeAggregateIdsJson = $expectedNodeAggregateIds->toStringArray();
+
+        sort($expectedNodeAggregateIdsJson);
+        sort($deletedNodeAggregateIdsJson);
+
+        Assert::assertEquals($expectedNodeAggregateIdsJson, $deletedNodeAggregateIdsJson, 'Mismatch of changes');
+    }
+
+    /**
+     * @Then I expect to have no deletions in workspace :workspace for dimension :dimensionSpacePoint
+     */
+    public function iExpectTheChangeProjectionToHaveNoDeletionsForContentStreamAndDimension(string $workspace, string $dimensionSpacePoint)
+    {
+        // forwards compatible adjustment, we make the test assertions on workspace names even tough we store the data in content streams
+        $workspaceInstance = $this->currentContentRepository->findWorkspaceByName(WorkspaceName::fromString($workspace));
+        Assert::assertNotNull($workspaceInstance, 'workspace doesnt exist');
+
+        $changeFinder = $this->currentContentRepository->projectionState(ChangeFinder::class);
+        $deletedNodeAggregateIde = $changeFinder->findNodeAggregateIdsForDeletedNodes(
+            $workspaceInstance->currentContentStreamId,
+            OriginDimensionSpacePoint::fromJsonString($dimensionSpacePoint),
+        );
+
+        Assert::assertEquals(0, $deletedNodeAggregateIde->count(), 'Mismatch of changes');
+    }
 
     /**
      * @Then I expect to have the following changes in workspace :workspace:

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/01-SoftRemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/01-SoftRemoveNodeAggregate_WithoutDimensions.feature
@@ -57,7 +57,11 @@ Feature: Soft remove node aggregate with node without dimensions
     Then I expect to have the following changes in workspace "user-workspace":
       | nodeAggregateId  | created | changed | moved | deleted | originDimensionSpacePoint |
       | nody-mc-nodeface | 0       | 0       | 0     | 1       | {}                        |
+    And I expect to have the following deleted nodeAggregateIds in workspace "user-workspace" for dimension "{}":
+      | nodeAggregateId  |
+      | nody-mc-nodeface |
     And I expect to have no changes in workspace "live"
+    And I expect to have no deletions in workspace "live" for dimension "{}"
 
   Scenario: Soft remove node aggregate in live workspace
     Given the command TagSubtree is executed with payload:
@@ -70,6 +74,8 @@ Feature: Soft remove node aggregate with node without dimensions
 
     Then I expect to have no changes in workspace "live"
     And I expect to have no changes in workspace "user-workspace"
+    And I expect to have no deletions in workspace "live" for dimension "{}"
+    And I expect to have no deletions in workspace "user-workspace" for dimension "{}"
 
   Scenario: Soft remove node aggregate with children in user workspace
     Given the command TagSubtree is executed with payload:
@@ -84,6 +90,10 @@ Feature: Soft remove node aggregate with node without dimensions
       | nodeAggregateId        | created | changed | moved | deleted | originDimensionSpacePoint |
       | sir-david-nodenborough | 0       | 0       | 0     | 1       | {}                        |
     And I expect to have no changes in workspace "live"
+    And I expect to have the following deleted nodeAggregateIds in workspace "user-workspace" for dimension "{}":
+      | nodeAggregateId        |
+      | sir-david-nodenborough |
+    And I expect to have no deletions in workspace "live" for dimension "{}"
 
   Scenario: Soft remove node aggregate with children in live workspace
     Given the command TagSubtree is executed with payload:
@@ -96,6 +106,8 @@ Feature: Soft remove node aggregate with node without dimensions
 
     Then I expect to have no changes in workspace "live"
     And I expect to have no changes in workspace "user-workspace"
+    And I expect to have no deletions in workspace "live" for dimension "{}"
+    And I expect to have no deletions in workspace "user-workspace" for dimension "{}"
 
   Scenario: Soft remove node aggregate in user workspace which was already modified
     Given the command SetNodeProperties is executed with payload:
@@ -117,3 +129,7 @@ Feature: Soft remove node aggregate with node without dimensions
       | nodeAggregateId        | created | changed | moved | deleted | originDimensionSpacePoint |
       | sir-david-nodenborough | 0       | 1       | 0     | 1       | {}                        |
     And I expect to have no changes in workspace "live"
+    And I expect to have the following deleted nodeAggregateIds in workspace "user-workspace" for dimension "{}":
+      | nodeAggregateId        |
+      | sir-david-nodenborough |
+    And I expect to have no deletions in workspace "live" for dimension "{}":

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/02-SoftRemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/02-SoftRemoveNodeAggregate_WithDimensions.feature
@@ -113,6 +113,14 @@ Feature: Soft remove node aggregate with node
       | nodeAggregateId | created | changed | moved | deleted | originDimensionSpacePoint |
       | other-removal   | 0       | 0       | 0     | 1       | {"language": "de"}        |
       | other-removal   | 0       | 0       | 0     | 1       | {"language": "gsw"}       |
+    And I expect to have the following deleted nodeAggregateIds in workspace "user-workspace" for dimension '{"language": "de"}':
+      | nodeAggregateId  |
+      | other-removal    |
+    And I expect to have the following deleted nodeAggregateIds in workspace "user-workspace" for dimension '{"language": "gsw"}':
+      | nodeAggregateId  |
+      | other-removal    |
+    And I expect to have no deletions in workspace "live" for dimension '{"language": "de"}'
+    And I expect to have no deletions in workspace "live" for dimension '{"language": "gsw"}'
 
   Scenario: Soft remove node aggregate in user-workspace with "allSpecializations"
     Given the command TagSubtree is executed with payload:


### PR DESCRIPTION
This is to be used by the pagetree to visualize not yet published deletions.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
