### PR TITLE
BUGFIX: Prevent premature connection to database in `WorkspaceMetadataAndRoleRepository`

### DIFF
--- a/Neos.Neos/Classes/Domain/Repository/WorkspaceMetadataAndRoleRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/WorkspaceMetadataAndRoleRepository.php
@@ -42,15 +42,17 @@ use Neos\Neos\Security\Authorization\ContentRepositoryAuthorizationService;
  * @internal Neos users should not need to deal with this low level repository. No security is imposed here. Please use the {@see WorkspaceService}!
  */
 #[Flow\Scope('singleton')]
-final readonly class WorkspaceMetadataAndRoleRepository
+final class WorkspaceMetadataAndRoleRepository
 {
     private const TABLE_NAME_WORKSPACE_METADATA = 'neos_neos_workspace_metadata';
     private const TABLE_NAME_WORKSPACE_ROLE = 'neos_neos_workspace_role';
 
-    public function __construct(
-        private Connection $dbal
-    ) {
-    }
+    /**
+     * Lazy inject to prevent connection to database if object is loaded
+     * @var Connection
+     */
+    #[Flow\Inject(lazy: true)]
+    protected $dbal;
 
     /**
      * The public and documented API is {@see WorkspaceService::assignWorkspaceRole}


### PR DESCRIPTION
Im currently experimenting with a faster node controller which takes the resolved node address (which is cached via flows routing cache) and then looks up the cache entry for the document and outputs that. (For the component engine ^^)

Now because we nowadays prever eager injections via constructor or typed property a database connection is created already only because the NodeController injects the `ContentRepositoryAuthorizationService` eagerly even it is not asked a question.

This pr ensures the repository fetches the connection only on use. Alternatively we can move the lazy injection to the node controller by using:

```
/**
 * @var ContentRepositoryAuthorizationService
 * @Flow\Inject
 */
protected $contentRepositoryAuthorizationService;
```


<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
