### PR TITLE
BUGFIX: Neos backend login autofocus username

### DIFF
--- a/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Backend/Views/Login.fusion
@@ -121,6 +121,8 @@ prototype(Neos.Neos:Component.Login.Form) < prototype(Neos.Fusion:Component) {
                     attributes.id="username"
                     attributes.placeholder={I18n.id('username').value('Username').package('Neos.Neos').source('Main')}
                     attributes.class="neos-span12"
+                    attributes.autofocus="autofocus"
+                    attributes.autofocus.@if.usernameNotSet={!props.username}
                     attributes.aria-label={I18n.id('username').value('Username').package('Neos.Neos').source('Main')}
                 />
             </div>


### PR DESCRIPTION
When loading the backend login screen, one have to either TAB or click in the username field to input the login.

Increase accessibility (and convenience) by autofocusing the field upon loading.

**Note**: The password field already gets autofocus if the username is already filled (i.e. after a failed password attempt), which is why we have the `@if` here.