### PR TITLE
BUGFIX: Reload node if hidden state is updated via inspector

### DIFF
--- a/Neos.Neos/NodeTypes/Mixin/Hidable.yaml
+++ b/Neos.Neos/NodeTypes/Mixin/Hidable.yaml
@@ -14,6 +14,7 @@
       type: boolean
       ui:
         label: i18n
+        reloadIfChanged: true
         inspector:
           group: 'visibility'
           position: 30


### PR DESCRIPTION
With this change nodes are updated in the guest frame when the hidden state is updated in the inspector.

Resolves: #5601