### PR TITLE
BUGFIX: Preview modes do not display hidden nodes

### DIFF
--- a/Neos.Neos/Classes/Controller/Frontend/NodeController.php
+++ b/Neos.Neos/Classes/Controller/Frontend/NodeController.php
@@ -132,6 +132,12 @@ class NodeController extends ActionController
         $nodeAddress = NodeAddress::fromJsonString($node);
 
         $subgraph = $contentRepository->getContentSubgraph($nodeAddress->workspaceName, $nodeAddress->dimensionSpacePoint);
+        if ($renderingMode->isPreview) {
+            $visibilityConstraints = $this->contentRepositoryAuthorizationService->getVisibilityConstraints($contentRepository->id, $this->securityContext->getRoles());
+            $visibilityConstraints = $visibilityConstraints->merge(NeosVisibilityConstraints::excludeDisabled());
+            $subgraph = $contentRepository->getContentGraph($nodeAddress->workspaceName)
+                ->getSubgraph($nodeAddress->dimensionSpacePoint, $visibilityConstraints);
+        }
 
         $nodeInstance = $subgraph->findNodeById($nodeAddress->aggregateId);
 


### PR DESCRIPTION
This makes the preview more realistic and helps editors better estimate how the end result will look like.
