### PR TITLE
BUGFIX: Handle null values in node cache helper

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -43,11 +43,14 @@ class CachingHelper implements ProtectedContextAwareInterface
      * A cache entry with this tag will be flushed whenever one of the
      * given nodes (for any variant) is updated.
      *
-     * @param iterable<Node>|Node $nodes (A single Node or array or \Traversable of Nodes)
+     * @param iterable<Node>|Node|null $nodes (A single Node or array or \Traversable of Nodes or null)
      * @return array<int,string>,
      */
-    public function nodeTag(iterable|Node $nodes): array
+    public function nodeTag(iterable|Node|null $nodes): array
     {
+        if (!$nodes) {
+            return [];
+        }
         if (!is_iterable($nodes)) {
             $nodes = [$nodes];
         } else {
@@ -70,20 +73,21 @@ class CachingHelper implements ProtectedContextAwareInterface
      *     }
      *
      */
-    public function entryIdentifierForNode(Node $node): NodeCacheEntryIdentifier
+    public function entryIdentifierForNode(Node|null $node): ?NodeCacheEntryIdentifier
     {
-        return NodeCacheEntryIdentifier::fromNode($node);
+        return $node ? NodeCacheEntryIdentifier::fromNode($node) : null;
     }
 
     /**
      * Generate a `@cache` entry tag for a single node identifier.
      *
-     * @param string $identifier
-     * @param Node $contextNode
      * @return string[]
      */
-    public function nodeTagForIdentifier(string $identifier, Node $contextNode): array
+    public function nodeTagForIdentifier(string|null $identifier, Node|null $contextNode): array
     {
+        if (!$identifier || !$contextNode) {
+            return [];
+        }
         return [
             CacheTag::forNodeAggregate(
                 $contextNode->contentRepositoryId,
@@ -108,11 +112,14 @@ class CachingHelper implements ProtectedContextAwareInterface
      * (for any variant) that is of the given node type name(s)
      * (including inheritance) is updated.
      *
-     * @param iterable<string>|string $nodeTypes
+     * @param iterable<string>|string|null $nodeTypes
      * @return array<int,string>
      */
-    public function nodeTypeTag(string|iterable $nodeTypes, Node $contextNode): array
+    public function nodeTypeTag(string|iterable|null $nodeTypes, Node $contextNode): array
     {
+        if (!$nodeTypes) {
+            return [];
+        }
         if (!is_iterable($nodeTypes)) {
             $nodeTypes = [$nodeTypes];
         } else {
@@ -143,11 +150,14 @@ class CachingHelper implements ProtectedContextAwareInterface
      * (for any variant) that is a descendant (child on any level) of one of
      * the given nodes is updated.
      *
-     * @param iterable<Node>|Node $nodes (A single Node or array or \Traversable of Nodes)
+     * @param iterable<Node>|Node|null $nodes (A single Node or array or \Traversable of Nodes or null)
      * @return array<int,string>
      */
-    public function descendantOfTag(iterable|Node $nodes): array
+    public function descendantOfTag(iterable|Node|null $nodes): array
     {
+        if (!$nodes) {
+            return [];
+        }
         if (!is_iterable($nodes)) {
             $nodes = [$nodes];
         } else {

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -82,6 +82,7 @@ class CachingHelperTest extends UnitTestCase
                     'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
                 ]
             ],
+            [null, []],
         ];
     }
 
@@ -136,7 +137,8 @@ class CachingHelperTest extends UnitTestCase
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'Node_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
                 'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
-            ]]
+            ]],
+            [null, []],
         ];
     }
 
@@ -224,7 +226,8 @@ class CachingHelperTest extends UnitTestCase
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_ca511a55-c5c0-f7d7-8d71-8edeffc75306',
                 'DescendantOf_7505d64a54e061b7acd54ccd58b49dc43500b635_7005c7cf-4d19-ce36-0873-476b6cadb71a',
                 'Workspace_364cfc8e70b2baa23dbd14503d2bd00e063829e7',
-            ]]
+            ]],
+            [null, []],
         ];
     }
 


### PR DESCRIPTION
This was supported in previous Neos versions and is hard to solve in a clean way in Fusion, so it’s better if the helper deals with it.

Example from neos.io:

```
    footerContainer = ${q(site).property('footerContentContainer')}

    @cache {
        mode = 'cached'
        entryIdentifier {
            site = ${Neos.Caching.entryIdentifierForNode(site)}
        }
        entryTags {
            footerContainer = ${Neos.Caching.nodeTag(q(site).property('footerContentContainer'))}
            childNodes = ${Neos.Caching.descendantOfTag(q(site).property('footerContentContainer'))}
        }
    }
```