### PR TITLE
TASK: Update enshrined/svg-sanitize to ^0.22.0

### DIFF
--- a/Neos.Media.Browser/composer.json
+++ b/Neos.Media.Browser/composer.json
@@ -24,7 +24,7 @@
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
         "doctrine/orm": "^2.6",
-        "enshrined/svg-sanitize": "^0.17.0"
+        "enshrined/svg-sanitize": "^0.22.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "neos/utility-mediatypes": "*",
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
-        "enshrined/svg-sanitize": "^0.17.0",
+        "enshrined/svg-sanitize": "^0.22.0",
         "neos/imagine": "^3.1.0",
         "imagine/imagine": "*",
         "doctrine/dbal": "^2.8",


### PR DESCRIPTION
Upgraded the enshrined/svg-sanitize dependency from ^0.17.0 to ^0.22.0 in composer.json due to CVE-2025-55166

Relates to: #4812