### PR TITLE
BUGFIX: Update svg-sanitize to latest version to fix security issue

### DIFF
--- a/Neos.Media.Browser/composer.json
+++ b/Neos.Media.Browser/composer.json
@@ -24,7 +24,7 @@
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
         "doctrine/orm": "^2.6",
-        "enshrined/svg-sanitize": "^0.17.0"
+        "enshrined/svg-sanitize": "^0.22.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
**Upgrade instructions**

The used svg sanitizer has a security vulnerability (see https://github.com/advisories/GHSA-22wq-q86m-83fh). Therefore, we need to update our composer dependencies to require the latest version of the used dependency ([enshrined/svg-sanitize](https://github.com/darylldoyle/svg-sanitizer)).

To update, simply run `composer update`.

**Review instructions**

[enshrined/svg-sanitize](https://github.com/darylldoyle/svg-sanitizer/tags) has following updates, which will be included with the version bump:

- [0.18.0](https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.18.0): Allow the enabling of loading large files
- [0.19.0](https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.19.0): Preserve libxml errors after failed parsing
- [0.20.0](https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.20.0): Support PHP 8.4
- [0.21.0](https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.21.0): Update AllowedAttributes.php
- [0.22.0](https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.22.0): Fix SVG Sanitizer

**Checklist**

- [x] Code follows the PSR-2 coding style --> only dependency updates
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
