### PR TITLE
Revert "BUGFIX: Reload node if hidden state is updated via inspector"

### DIFF
--- a/Neos.Neos/NodeTypes/Mixin/Hidable.yaml
+++ b/Neos.Neos/NodeTypes/Mixin/Hidable.yaml
@@ -14,7 +14,6 @@
       type: boolean
       ui:
         label: i18n
-        reloadIfChanged: true
         inspector:
           group: 'visibility'
           position: 30


### PR DESCRIPTION
Reverts neos/neos-development-collection#5602 as it raises issues while using the toolbar actions to hide and show nodes.

See: #5615 