### PR TITLE
BUGFIX: move paratest to require-dev, as it is not required for using the CR (only for developing it)

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/composer.json
+++ b/Neos.ContentRepository.BehavioralTests/composer.json
@@ -11,8 +11,10 @@
     ],
     "require": {
         "neos/contentrepository-core": "self.version",
-        "brianium/paratest": "^6.11",
         "phpunit/phpunit": "^9.6"
+    },
+    "require-dev": {
+        "brianium/paratest": "^6.11"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "neos/flow-development-collection": "9.0.x-dev",
         "doctrine/dbal": "^3.1.4",
         "doctrine/migrations": "*",
-        "brianium/paratest": "^6.11",
         "phpunit/phpunit": "^9.6",
         "neos/eventstore": "^1",
         "php": "^8.2",
@@ -296,6 +295,7 @@
         }
     },
     "require-dev": {
+        "brianium/paratest": "^6.11",
         "roave/security-advisories": "dev-latest",
         "phpstan/phpstan": "^1.11",
         "squizlabs/php_codesniffer": "^3.6",


### PR DESCRIPTION
This helps me with a version conflict I am currently encountering, and should have no negative side-effects. I want to try out PestPHP with Neos, especially Browser Testing: https://pestphp.com/docs/pest-v4-is-here-now-with-browser-testing#content-pest-v4-is-here-now-with-browser-testing