### PR TITLE
TASK: Avoid prototype injection in constructors

### DIFF
--- a/Neos.Neos/Classes/AssetUsage/Domain/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Domain/AssetUsageRepository.php
@@ -16,12 +16,14 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\Flow\Annotations\Scope;
 use Neos\Neos\AssetUsage\Dto\AssetUsageFilter;
 use Neos\Neos\AssetUsage\Dto\AssetUsages;
 
 /**
  * @internal Not meant to be used in user land code. In order to look up asset usages the AssetUsageService or GlobalAssetUsageService can be used
  */
+#[Scope("singleton")]
 final class AssetUsageRepository
 {
     public const TABLE = 'neos_asset_usage';

--- a/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
+++ b/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
@@ -15,6 +15,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
+use Neos\Flow\Annotations\Scope;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\AssetVariantInterface;
@@ -34,6 +35,7 @@ use Neos\Utility\TypeHandling;
  * 2. Which cache entries do I need to flush on a change to an asset (this requires an additional traversal over all
  *    dependent workspaces).
  */
+#[Scope("singleton")]
 final class AssetUsageIndexingService
 {
     /** @var array <string, string> */

--- a/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/ImpendingHardRemovalConflictRepository.php
+++ b/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/ImpendingHardRemovalConflictRepository.php
@@ -19,8 +19,10 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\Flow\Annotations\Scope;
 
 /** @internal */
+#[Scope("singleton")]
 final readonly class ImpendingHardRemovalConflictRepository
 {
     private const CONFLICT_TABLE_NAME = 'neos_neos_impending_hard_removal_conflict';


### PR DESCRIPTION
This removes occurances of constructor injection with prototypes, the modified classes are all injected via constructor and should therefore be singletons.

Related: neos/flow-development-collection#3494
