### PR TITLE
FEATURE: Site nodetype

### DIFF
--- a/Neos.ContentRepository/NodeTypes/Root.yaml
+++ b/Neos.ContentRepository/NodeTypes/Root.yaml
@@ -1,0 +1,2 @@
+'Neos.ContentRepository:Root':
+  abstract: true

--- a/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
+++ b/Neos.Neos/Classes/Command/NodeCommandControllerPlugin.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\Command;
  */
 
 use Neos\ContentRepository\Command\EventDispatchingNodeCommandControllerPluginInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\Eel\Exception as EelException;
 use Neos\Eel\FlowQuery\FlowQuery;
@@ -65,6 +66,12 @@ class NodeCommandControllerPlugin implements EventDispatchingNodeCommandControll
      * @var NodeDataRepository
      */
     protected $nodeDataRepository;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
 
     /**
      * @Flow\Inject
@@ -207,7 +214,7 @@ HELPTEXT;
         if ($sitesNode === null) {
             $taskDescription = sprintf('Create missing site node "<i>%s</i>"', SiteService::SITES_ROOT_PATH);
             $taskClosure = function () use ($rootNode) {
-                $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
+                $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH), $this->nodeTypeManager->getNodeType('Neos.Neos:Sites'));
                 $this->persistenceManager->persistAll();
             };
             $this->dispatch(self::EVENT_TASK, $taskDescription, $taskClosure);

--- a/Neos.Neos/Classes/Command/SiteCommandController.php
+++ b/Neos.Neos/Classes/Command/SiteCommandController.php
@@ -170,7 +170,7 @@ class SiteCommandController extends CommandController
         $this->persistenceManager->persistAll();
         $sitesNode = $rootNode->getNode(SiteService::SITES_ROOT_PATH);
         if ($sitesNode === null) {
-            $sitesNode = $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
+            $sitesNode = $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH), $this->nodeTypeManager->getNodeType('Neos.Neos:Sites'));
         }
 
         $siteNode = $sitesNode->createNode($nodeName, $siteNodeType);

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -397,7 +397,7 @@ class SitesController extends AbstractModuleController
         $this->persistenceManager->persistAll();
         $sitesNode = $rootNode->getNode(SiteService::SITES_ROOT_PATH);
         if ($sitesNode === null) {
-            $sitesNode = $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
+            $sitesNode = $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH), $this->nodeTypeManager->getNodeType('Neos.Neos:Sites'));
         }
         $siteNode = $sitesNode->createNode($nodeName, $siteNodeType);
         $siteNode->setProperty('title', $siteName);

--- a/Neos.Neos/Classes/Domain/Service/SiteImportService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteImportService.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Domain\Service;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\Exception\InvalidPackageStateException;
@@ -61,6 +62,12 @@ class SiteImportService
      * @var NodeImportService
      */
     protected $nodeImportService;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
 
     /**
      * @Flow\Inject
@@ -206,7 +213,7 @@ class SiteImportService
 
             $sitesNode = $rootNode->getNode(SiteService::SITES_ROOT_PATH);
             if ($sitesNode === null) {
-                $sitesNode = $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH));
+                $sitesNode = $rootNode->createNode(NodePaths::getNodeNameFromPath(SiteService::SITES_ROOT_PATH), $this->nodeTypeManager->getNodeType('Neos.Neos:Sites'));
             }
 
             $this->nodeImportService->import($xmlReader, $sitesNode->getPath(), dirname($pathAndFilename) . '/Resources');

--- a/Neos.Neos/NodeTypes/Mixin/Site.yaml
+++ b/Neos.Neos/NodeTypes/Mixin/Site.yaml
@@ -1,0 +1,10 @@
+#
+# Abstract NodeType for a Neos.Neos site.
+# Each homepage must extend this NodeType.
+# Nodes of this type must be direct children of the Neos.Neos:Site Root
+# and must not be created at any other place in the tree.
+#
+'Neos.Neos:Site':
+  abstract: true
+  superTypes:
+    'Neos.Neos:Document': true

--- a/Neos.Neos/NodeTypes/Root/Sites.yaml
+++ b/Neos.Neos/NodeTypes/Root/Sites.yaml
@@ -1,0 +1,11 @@
+#
+# Root NodeType for a Neos.Neos content repository.
+# Any Neos Site node must be its direct child.
+#
+'Neos.Neos:Sites':
+  superTypes:
+    'Neos.ContentRepository:Root': true
+  constraints:
+    nodeTypes:
+      '*': false
+      'Neos.Neos:Site': true

--- a/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Configuration/NodeTypes.Document.Homepage.yaml
+++ b/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Configuration/NodeTypes.Document.Homepage.yaml
@@ -1,0 +1,9 @@
+# This is a custom document node type which has been auto-generated for your site package
+# by Neos. You can customize this to your needs.
+'{packageKey}:Document.Homepage':
+  superTypes:
+    'Neos.Neos:Site': true
+    '{packageKey}:Document.Page': true
+  ui:
+    icon: home
+    label: '{packageKey} Homepage'

--- a/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Configuration/NodeTypes.Document.Page.yaml
+++ b/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Configuration/NodeTypes.Document.Page.yaml
@@ -9,3 +9,6 @@
   childNodes:
     main:
       type: 'Neos.Neos:ContentCollection'
+  constraints:
+    nodeTypes:
+      '{packageKey}:Document.Homepage': true

--- a/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Content/Sites.xml
+++ b/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Content/Sites.xml
@@ -3,7 +3,7 @@
  <site name="{siteName}" state="1" siteResourcesPackageKey="{packageKey}" siteNodeName="{siteNodeName}">
   <nodes formatVersion="2.0">
    <node nodeName="{siteNodeName}">
-    <variant workspace="live" nodeType="{packageKey}:Document.Page" sortingIndex="100" version="1" removed="" hidden="" hiddenInIndex="">
+    <variant workspace="live" nodeType="{packageKey}:Document.Homepage" sortingIndex="100" version="1" removed="" hidden="" hiddenInIndex="">
      <dimensions>
      <f:for each="{dimensions}" as="dimension">
       <{dimension.identifier}>{dimension.default}</{dimension.identifier}>

--- a/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Fusion/Document/Homepage.fusion
+++ b/Neos.SiteKickstarter/Resources/Private/AfxGenerator/Fusion/Document/Homepage.fusion
@@ -1,0 +1,1 @@
+prototype({packageKey}:Document.Homepage) < prototype({packageKey}:Document.Page)


### PR DESCRIPTION
Resolves: #5617

**Upgrade instructions**

Add the abstract nodetype `Neos.Neos:Site` to your homepage nodetype like this:

```yaml
'My.SitePackage:Document.Homepage':
  superTypes:
    'Neos.Neos:Site': true
```

**Review instructions**

Newly generated sites and empty content repository should be initialised with the new sites nodetype and use the site mixing in the generated homepage.
