### PR TITLE
FEATURE: Backport Neos.Site Helper

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/SiteHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/SiteHelper.php
@@ -17,6 +17,9 @@ namespace Neos\Neos\Fusion\Helper;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Neos\Domain\Model\Site;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Domain\Service\SiteService;
+use Neos\Flow\Annotations as Flow;
 
 /**
  * ForwardCompatibility Neos 9.0
@@ -24,10 +27,15 @@ use Neos\Neos\Domain\Model\Site;
  */
 class SiteHelper implements ProtectedContextAwareInterface
 {
+    #[Flow\Inject]
+    protected SiteRepository $siteRepository;
 
     public function findBySiteNode(NodeInterface $siteNode): ?Site
     {
-        return $siteNode->getContext()->getCurrentSite();
+        if ($siteNode->getParentPath() !== SiteService::SITES_ROOT_PATH) {
+            return null; // not a side node
+        }
+        return $this->siteRepository->findOneByNodeName($siteNode->getName());
     }
 
     /**

--- a/Neos.Neos/Classes/Fusion/Helper/SiteHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/SiteHelper.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Fusion\Helper;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Neos\Domain\Model\Site;
+
+/**
+ * ForwardCompatibility Neos 9.0
+ * Eel helper for accessing the Site object
+ */
+class SiteHelper implements ProtectedContextAwareInterface
+{
+
+    public function findBySiteNode(NodeInterface $siteNode): ?Site
+    {
+        return $siteNode->getContext()->getCurrentSite();
+    }
+
+    /**
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -592,6 +592,7 @@ Neos:
       Neos.Rendering: Neos\Neos\Fusion\Helper\RenderingHelper
       Neos.Caching: Neos\Neos\Fusion\Helper\CachingHelper
       Neos.Backend: Neos\Neos\Fusion\Helper\BackendHelper
+      Neos.Site: Neos\Neos\Fusion\Helper\SiteHelper
 
   # DocTools is a tool used by Neos Developers to help with a variety of documentation tasks.
   # These settings are only used in generating Documentation.

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/EelHelper.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/EelHelper.feature
@@ -3,6 +3,7 @@ Feature: Tests for the EEL helpers interacting with the CR
 
   Background:
     Given I have the site "a"
+    Given I have the site "b"
     And I have the following NodeTypes configuration:
     """yaml
     'unstructured': {}
@@ -54,6 +55,7 @@ Feature: Tests for the EEL helpers interacting with the CR
       | a1b3       | /sites/a/a1/a1b/a1b3       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1b3", "title": "Node a1b3"}   | false           |
       | a1c        | /sites/a/a1/a1c            | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1c", "title": "Node a1c"}     | true            |
       | a1c1       | /sites/a/a1/a1c/a1c1       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1c1", "title": "Node a1c1"}   | false           |
+      | b          | /sites/b                   | Neos.Neos:Test.Site           | {"uriPathSegment": "b", "title": "Node b"}         | false           |
     And the Fusion context request URI is "http://localhost"
     And I have the following Fusion setup:
     """fusion
@@ -69,6 +71,8 @@ Feature: Tests for the EEL helpers interacting with the CR
       siteEntity_title = ${Neos.Site.findBySiteNode(node).name}
       siteEntity_packageKey = ${Neos.Site.findBySiteNode(node).siteResourcesPackageKey}
 
+      foreignSiteEntity = ${Neos.Site.findBySiteNode(q(node).find('#b').get(0)).nodeName}
+
       notASiteNode = ${Neos.Site.findBySiteNode(q(node).children().get(0))}
       @process.render = ${Json.stringify(value, ['JSON_PRETTY_PRINT'])}
     }
@@ -79,6 +83,7 @@ Feature: Tests for the EEL helpers interacting with the CR
         "siteEntity_nodeName": "a",
         "siteEntity_title": "Untitled Site",
         "siteEntity_packageKey": "Neos.Demo",
+        "foreignSiteEntity": "b",
         "notASiteNode": null
     }
     """

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/EelHelper.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/EelHelper.feature
@@ -1,0 +1,84 @@
+@fixtures
+Feature: Tests for the EEL helpers interacting with the CR
+
+  Background:
+    Given I have the site "a"
+    And I have the following NodeTypes configuration:
+    """yaml
+    'unstructured': {}
+    'Neos.Neos:FallbackNode': {}
+    'Neos.Neos:Document':
+      properties:
+        title:
+          type: string
+        uriPathSegment:
+          type: string
+    'Neos.Neos:Content':
+      properties:
+        title:
+          type: string
+    'Neos.Neos:Test.Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Test.DocumentType1':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Test.DocumentType2':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Test.DocumentType2a':
+      superTypes:
+        'Neos.Neos:Test.DocumentType2': true
+    'Neos.Neos:Test.Content':
+      superTypes:
+        'Neos.Neos:Content': true
+    """
+    And I have the following nodes:
+      | Identifier | Path                       | Node Type                     | Properties                                         | Hidden in index |
+      | root       | /sites                     | unstructured                  |                                                    | false           |
+      | a          | /sites/a                   | Neos.Neos:Test.Site           | {"uriPathSegment": "a", "title": "Node a"}         | false           |
+      | a1         | /sites/a/a1                | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1", "title": "Node a1"}       | false           |
+      | a1a        | /sites/a/a1/a1a            | Neos.Neos:Test.DocumentType2a | {"uriPathSegment": "a1a", "title": "Node a1a"}     | false           |
+      | a1a1       | /sites/a/a1/a1a/a1a1       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1a1", "title": "Node a1a1"}   | false           |
+      | a1a2       | /sites/a/a1/a1a/a1a2       | Neos.Neos:Test.DocumentType2  | {"uriPathSegment": "a1a2", "title": "Node a1a2"}   | false           |
+      | a1a3       | /sites/a/a1/a1a/a1a3       | Neos.Neos:Test.DocumentType2a | {"uriPathSegment": "a1a3", "title": "Node a1a3"}   | false           |
+      | a1a4       | /sites/a/a1/a1a/a1a4       | Neos.Neos:Test.DocumentType2a | {"uriPathSegment": "a1a4", "title": "Node a1a4"}   | false           |
+      | a1a5       | /sites/a/a1/a1a/a1a5       | Neos.Neos:Test.DocumentType2a | {"uriPathSegment": "a1a5", "title": "Node a1a5"}   | false           |
+      | a1a6       | /sites/a/a1/a1a/a1a6       | Neos.Neos:Test.DocumentType2  | {"uriPathSegment": "a1a6", "title": "Node a1a6"}   | false           |
+      | a1a7       | /sites/a/a1/a1a/a1a7       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1a7", "title": "Node a1a7"}   | false           |
+      | a1b        | /sites/a/a1/a1b            | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1b", "title": "Node a1b"}     | false           |
+      | a1b1       | /sites/a/a1/a1b/a1b1       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1b1", "title": "Node a1b1"}   | false           |
+      | a1b1a      | /sites/a/a1/a1b/a1b1/a1b1a | Neos.Neos:Test.DocumentType2a | {"uriPathSegment": "a1b1a", "title": "Node a1b1a"} | false           |
+      | a1b1b      | /sites/a/a1/a1b/a1b1/a1b1b | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1b1b", "title": "Node a1b1b"} | false           |
+      | a1b2       | /sites/a/a1/a1b/a1b2       | Neos.Neos:Test.DocumentType2  | {"uriPathSegment": "a1b2", "title": "Node a1b2"}   | false           |
+      | a1b3       | /sites/a/a1/a1b/a1b3       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1b3", "title": "Node a1b3"}   | false           |
+      | a1c        | /sites/a/a1/a1c            | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1c", "title": "Node a1c"}     | true            |
+      | a1c1       | /sites/a/a1/a1c/a1c1       | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a1c1", "title": "Node a1c1"}   | false           |
+    And the Fusion context request URI is "http://localhost"
+    And I have the following Fusion setup:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    """
+
+  Scenario: Neos.Site.findBySiteNode()
+    When the Fusion context node is "a"
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Fusion:DataStructure {
+      siteEntity_nodeName = ${Neos.Site.findBySiteNode(node).nodeName}
+      siteEntity_title = ${Neos.Site.findBySiteNode(node).name}
+      siteEntity_packageKey = ${Neos.Site.findBySiteNode(node).siteResourcesPackageKey}
+
+      notASiteNode = ${Neos.Site.findBySiteNode(q(node).children().get(0))}
+      @process.render = ${Json.stringify(value, ['JSON_PRETTY_PRINT'])}
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    {
+        "siteEntity_nodeName": "a",
+        "siteEntity_title": "Untitled Site",
+        "siteEntity_packageKey": "Neos.Demo",
+        "notASiteNode": null
+    }
+    """


### PR DESCRIPTION
Backport of Neos.Site Eel Helper to provide forward compatibility in Neos 8.4.

```
prototype(Acme.Site:Document) {
   name = ${Neos.Site.findBySiteNode(site).siteResourcesPackageKey}
}

```

Fixes #5629 
