### PR TITLE
FEATURE: Backport Neos.Caching Helper

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Fusion\Cache;
+
+use Neos\Cache\CacheAwareInterface;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * ForwardCompatibility for Neos 9.0
+ *
+ * The cache entry identifier data transfer object for nodes
+ *
+ * @Flow\Proxy(false)
+ * @internal
+ */
+final readonly class NodeCacheEntryIdentifier implements CacheAwareInterface
+{
+    private function __construct(
+        private string $value
+    ) {
+    }
+
+    public static function fromNode(NodeInterface $node): self
+    {
+        return new self('Node_' . $node->getWorkspace()->getName()
+            . '_' . $node->getNodeData()->getDimensionsHash()
+            . '_' .  $node->getIdentifier());
+    }
+
+    public function getCacheEntryIdentifier(): string
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -16,6 +16,7 @@ use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Neos\Exception;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Neos\Fusion\Cache\NodeCacheEntryIdentifier;
 
 /**
  * Caching helper to make cache tag generation easier.
@@ -166,6 +167,21 @@ class CachingHelper implements ProtectedContextAwareInterface
     public function renderWorkspaceTagForContextNode(string $workspaceName)
     {
         return '%' . md5($workspaceName) . '%';
+    }
+
+    /**
+     * ForwardCompatiblity for Neos 9.0
+     *
+     * Generate a `@cache` entry identifier for a given node:
+     *
+     *     entryIdentifier {
+     *       documentNode = ${Neos.Caching.entryIdentifierForNode(documentNode)}
+     *     }
+     *
+     */
+    public function entryIdentifierForNode(NodeInterface $node): NodeCacheEntryIdentifier
+    {
+        return NodeCacheEntryIdentifier::fromNode($node);
     }
 
     /**


### PR DESCRIPTION
Backport of Neos.Caching Eel Helper to provide forward compatibility in Neos 8.4.
```
prototype(Acme.Site:Document) {
    @cache {
        mode = "cached"
        entryIdentifier {
            documentNode = ${Neos.Caching.entryIdentifierForNode(documentNode)}
        }
     }
}
```
Fixes #5628 