### PR TITLE
FEATURE: Hacky backport of the 9.0 `renderingMode` in Fusion

### DIFF
--- a/Neos.Fusion/Classes/Core/Runtime.php
+++ b/Neos.Fusion/Classes/Core/Runtime.php
@@ -691,6 +691,16 @@ class Runtime
         }
         $contextVariables['this'] = $contextObject;
 
+        if (class_exists(\Neos\Neos\Domain\Model\Neos9NodeBasedRenderingModeStub::class)) {
+            // Temporary hack, discard with Neos 9.0 with the proper implementation of renderingMode and Fusion Globals.
+            $anyLikelyNode = $contextVariables['site'] ?? $contextVariables['documentNode'] ?? $contextVariables['node'] ?? null;
+            if ($anyLikelyNode instanceof \Neos\ContentRepository\Domain\Model\Node) {
+                $contextVariables['renderingMode'] = \Neos\Neos\Domain\Model\Neos9NodeBasedRenderingModeStub::createFromLegacyNodeContentContext(
+                    $anyLikelyNode->getContext()
+                );
+            }
+        }
+
         /** may have to be phpstan-ignore-next-line'd: the mind of the great phpstan can and will not comprehend this */
         if ($this->eelEvaluator instanceof \Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy) {
             $this->eelEvaluator->_activateDependency();

--- a/Neos.Neos/Classes/Domain/Model/Neos9NodeBasedRenderingModeStub.php
+++ b/Neos.Neos/Classes/Domain/Model/Neos9NodeBasedRenderingModeStub.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Model;
+
+use Neos\Neos\Domain\Service\ContentContext;
+
+/**
+ * Describes the mode in which the Neos interface is rendering currently,
+ * mainly distinguishing between edit and preview modes currently.
+ */
+final readonly class Neos9NodeBasedRenderingModeStub
+{
+    public const FRONTEND = 'frontend';
+
+    /**
+     * @param array<string,mixed> $options
+     */
+    private function __construct(
+        public string $name,
+        public bool $isEdit,
+        public bool $isPreview,
+        public string $title,
+        public string $fusionPath,
+        public array $options
+    ) {
+    }
+
+    public static function createFromLegacyNodeContentContext(ContentContext $contentContext): Neos9NodeBasedRenderingModeStub
+    {
+        if (!$contentContext->isInBackend()) {
+            return self::createFrontend();
+        }
+        return self::createFromLegacy($contentContext->getCurrentRenderingMode());
+    }
+
+    public static function createFromLegacy(UserInterfaceMode $userInterfaceMode): Neos9NodeBasedRenderingModeStub
+    {
+        return new self(
+            $userInterfaceMode->getName(),
+            $userInterfaceMode->isEdit(),
+            $userInterfaceMode->isPreview(),
+            $userInterfaceMode->getTitle(),
+            $userInterfaceMode->getFusionPath(),
+            $userInterfaceMode->getOptions() ?? []
+        );
+    }
+
+    /**
+     * Creates the system integrated rendering mode 'frontend' (in Neos 8 referred to as 'live')
+     */
+    public static function createFrontend(): Neos9NodeBasedRenderingModeStub
+    {
+        return new self(
+            Neos9NodeBasedRenderingModeStub::FRONTEND,
+            false,
+            false,
+            'Frontend',
+            '',
+            []
+        );
+    }
+}

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -14,6 +14,7 @@ namespace Neos\Neos\Tests\Functional\Fusion;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Fusion\Tests\Functional\FusionObjects\AbstractFusionObjectTest;
+use Neos\Neos\Domain\Service\ContentContext;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -120,7 +121,7 @@ class NodeHelperTest extends AbstractFusionObjectTest
 
         $textNode = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['hasProperty', 'getProperty', 'getNodeType', 'isAutoCreated'])
+            ->setMethods(['hasProperty', 'getProperty', 'getNodeType', 'isAutoCreated', 'getContext'])
             ->disableOriginalConstructor()
             ->getMock();
         $textNode
@@ -145,6 +146,11 @@ class NodeHelperTest extends AbstractFusionObjectTest
         $textNode
             ->method('getNodeType')
             ->willReturn($nodeType);
+
+        $fakeContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
+        $textNode
+            ->method('getContext')
+            ->willReturn($fakeContext);
 
         $this->textNode = $textNode;
     }


### PR DESCRIPTION
Neos 9.0 contains the introduction of FusionGlobals https://github.com/neos/neos-development-collection/pull/4425 which allowed to introduce `renderingMode` https://github.com/neos/neos-development-collection/pull/4505 as global like `request`.

We evaluated to fully back-port these features but this would require lots of effort and might be not agreeable as it certainly would break APIs across Fusion and Neos.

But herby we introduce a super slim backport which disregards any architecture and makes `${renderingMode}` magically possible in Fusion when Neos is installed and nodes are rendered.

The `renderingMode` attempts to align to the new 9.0 specification as close as possible - but the implementation is limited in two regards:

- `site`, `documentNode` or `node` have to be available in the current fusion context which can be tampered with in fusion by forgetting to register those in a cached segment. This would lead to `renderingMode` not being available but in 9.0 it would as its ever-present.
- when nodes from the "live" workspace are rendered the renderingMode will switch to `frontend` which results in `renderingMode.isEdit` being false. In Neos 9 the rendering mode and the rendered nodes are decoupled from each other. With this backport a decoupling is not possible and using `q().context()` on a node and replacing that fusion variable might thus have implications on the `renderingMode`.


Also users of the herby introduced 8.4 `renderingMode` and its 9.0 brother should be aware its not behaving exactly as `node.context.currentRenderingMode`.
The rendering mode of the `context` returns for every logged in users its current rendering mode. This leads to `edit` being true for the frontend and for the backend in the neos ui. Only if logged out or when using a private window the frontend behaviour aligns to the Neos 9 specification and `edit` is false.
 
The rector migration [`FusionContextCurrentRenderingModeRector`](https://github.com/neos/rector/blob/e397f70ed1340c5a62b9d20b0b70253b87201617/src/ContentRepository90/Rules/FusionContextCurrentRenderingModeRector.php#L27-L28) still migrates it as an exact replacement to improve the current situation.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
