### PR TITLE
FEATURE: Restrict site creation module to site nodetype and hide legacy options

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -256,7 +256,8 @@ class SitesController extends AbstractModuleController
             'documentNodeTypes' => $documentNodeTypes,
             'site' => $site,
             'generatorServiceIsAvailable' => $generatorServiceIsAvailable,
-            'generatorServices' => $generatorServices
+            'generatorServices' => $generatorServices,
+            'settings' => $this->moduleConfiguration['settings'],
         ]);
     }
 

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -234,7 +234,7 @@ class SitesController extends AbstractModuleController
     public function newSiteAction(?Site $site = null)
     {
         $sitePackages = $this->packageManager->getFilteredPackages('available', 'neos-site');
-        $documentNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.Neos:Site', false);
+        $documentNodeTypes = $this->nodeTypeManager->getSubNodeTypes($this->moduleConfiguration['settings']['baseNodeType'] ?? 'Neos.Neos:Site', false);
 
         $generatorServiceIsAvailable = $this->packageManager->isPackageAvailable('Neos.SiteKickstarter');
         $generatorServices = [];

--- a/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Administration/SitesController.php
@@ -234,7 +234,7 @@ class SitesController extends AbstractModuleController
     public function newSiteAction(?Site $site = null)
     {
         $sitePackages = $this->packageManager->getFilteredPackages('available', 'neos-site');
-        $documentNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.Neos:Document', false);
+        $documentNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.Neos:Site', false);
 
         $generatorServiceIsAvailable = $this->packageManager->isPackageAvailable('Neos.SiteKickstarter');
         $generatorServices = [];

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -390,6 +390,10 @@ Neos:
               newSite:
                 label: 'Neos.Neos:Modules:sites.actions.newSite.label'
                 title: 'Neos.Neos:Modules:sites.actions.newSite.title'
+            settings:
+              # Options are disabled by default with Neos 8.4 as these functionalities were removed in Neos 9.0
+              enableLegacyPackageImport: false
+              enableLegacyPackageCreation: false
           configuration:
             label: 'Neos.Neos:Modules:configuration.label'
             controller: 'Neos\Neos\Controller\Module\Administration\ConfigurationController'

--- a/Neos.Neos/Configuration/Settings.yaml
+++ b/Neos.Neos/Configuration/Settings.yaml
@@ -391,6 +391,7 @@ Neos:
                 label: 'Neos.Neos:Modules:sites.actions.newSite.label'
                 title: 'Neos.Neos:Modules:sites.actions.newSite.title'
             settings:
+              baseNodeType: 'Neos.Neos:Site'
               # Options are disabled by default with Neos 8.4 as these functionalities were removed in Neos 9.0
               enableLegacyPackageImport: false
               enableLegacyPackageCreation: false

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -38,7 +38,7 @@
               </div>
             </div>
             <div class="neos-control-group{f:validation.ifHasErrors(for: 'nodeType', then: ' neos-error')}">
-              <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.documentType', value: 'Select a document nodeType', source: 'Modules')}</label>
+              <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.documentType', value: 'Select a document nodeType', source: 'Modules')} <i>(based on Neos.Neos:Site)</i></label>
               <div class="neos-controls neos-select">
                 <f:form.select name="nodeType" options="{documentNodeTypes}" optionLabelField="name" optionValueField="name" id="node-type" class="neos-span12" />
               </div>

--- a/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Administration/Sites/NewSite.html
@@ -5,26 +5,28 @@
 	<h2>{neos:backend.translate(id: 'sites.new', value: 'New site', source: 'Modules')}</h2>
 
   <div class="neos-row-fluid">
-    <f:form action="importSite">
-      <fieldset class="neos-span3">
-        <legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site', source: 'Modules')}</legend>
-        <f:if condition="{sitePackages -> f:count()} > 0">
-          <f:then>
-            <div class="neos-control-group">
-              <label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package', source: 'Modules')}</label>
-              <div class="neos-controls neos-select">
-                <f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
-              </div>
-            </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.import', value: 'Import Site', source: 'Modules')}" class="neos-button neos-button-primary" />
-          </f:then>
-          <f:else>
-            <p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.', source: 'Modules')}
-            </p>
-          </f:else>
-        </f:if>
-      </fieldset>
-    </f:form>
+		<f:if condition="{settings.enableLegacyPackageImport}">
+			<f:form action="importSite">
+				<fieldset class="neos-span3">
+					<legend>{neos:backend.translate(id: 'sites.import', value: 'Import a site', source: 'Modules')}</legend>
+					<f:if condition="{sitePackages -> f:count()} > 0">
+						<f:then>
+							<div class="neos-control-group">
+								<label class="neos-control-label" for="site">{neos:backend.translate(id: 'sites.select', value: 'Select a site package', source: 'Modules')}</label>
+								<div class="neos-controls neos-select">
+									<f:form.select name="packageKey" options="{sitePackages}" optionLabelField="packageKey" optionValueField="packageKey" id="site" class="neos-span12" />
+								</div>
+							</div>
+							<f:form.submit value="{neos:backend.translate(id: 'sites.import', value: 'Import Site', source: 'Modules')}" class="neos-button neos-button-primary" />
+						</f:then>
+						<f:else>
+							<p>{neos:backend.translate(id: 'sites.noPackackeInfo', value: 'No site packages are available. Make sure you have an active site package.', source: 'Modules')}
+							</p>
+						</f:else>
+					</f:if>
+				</fieldset>
+			</f:form>
+		</f:if>
 
     <f:form action="createSiteNode">
       <fieldset class="neos-span3 neos-offset1">
@@ -60,39 +62,41 @@
       </fieldset>
     </f:form>
 
-    <f:form action="createSitePackage">
-      <fieldset class="neos-span3 neos-offset1">
-        <legend>{neos:backend.translate(id: 'sites.createPackage', value: 'Create a new site-package', source: 'Modules')}</legend>
-        <f:if condition="{generatorServiceIsAvailable}">
-          <f:then>
-            <div class="neos-control-group{f:validation.ifHasErrors(for: 'packageKey', then: ' neos-error')}">
-              <label class="neos-control-label" for="package-key">{neos:backend.translate(id: 'packageKey', value: 'Package key', source: 'Modules')}</label>
-              <div class="neos-controls">
-                <f:form.textfield name="packageKey" value="{packageKey}" id="package-key" class="neos-span12" placeholder="{neos:backend.translate(id: 'sites.validPackageKeyInfo', value: 'VendorName.MyPackageKey')}" />
-                <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'packageKey'}"/>
-              </div>
-            </div>
-            <div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
-              <label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name', source: 'Modules')}</label>
-              <div class="neos-controls">
-                <f:form.textfield name="siteName" value="{siteName}" id="site-name" />
-                <f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
-              </div>
-            </div>
-            <div class="neos-control-group{f:validation.ifHasErrors(for: 'generatorClass', then: ' neos-error')}">
-              <label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.generatorClass', value: 'Select a site generator', source: 'Modules')}</label>
-              <div class="neos-controls neos-select">
-                <f:form.select name="generatorClass" options="{generatorServices}" id="generator-class" class="neos-span12" />
-              </div>
-            </div>
-            <f:form.submit value="{neos:backend.translate(id: 'sites.createPackage', value: 'Create Site-Package', source: 'Modules')}" class="neos-button neos-button-primary" />
-          </f:then>
-          <f:else>
-            <p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.', source: 'Modules') -> f:format.raw()}</p>
-          </f:else>
-        </f:if>
-      </fieldset>
-    </f:form>
+		<f:if condition="{settings.enableLegacyPackageCreation}">
+			<f:form action="createSitePackage">
+				<fieldset class="neos-span3 neos-offset1">
+					<legend>{neos:backend.translate(id: 'sites.createPackage', value: 'Create a new site-package', source: 'Modules')}</legend>
+					<f:if condition="{generatorServiceIsAvailable}">
+						<f:then>
+							<div class="neos-control-group{f:validation.ifHasErrors(for: 'packageKey', then: ' neos-error')}">
+								<label class="neos-control-label" for="package-key">{neos:backend.translate(id: 'packageKey', value: 'Package key', source: 'Modules')}</label>
+								<div class="neos-controls">
+									<f:form.textfield name="packageKey" value="{packageKey}" id="package-key" class="neos-span12" placeholder="{neos:backend.translate(id: 'sites.validPackageKeyInfo', value: 'VendorName.MyPackageKey')}" />
+									<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'packageKey'}"/>
+								</div>
+							</div>
+							<div class="neos-control-group{f:validation.ifHasErrors(for: 'siteName', then: ' neos-error')}">
+								<label class="neos-control-label" for="site-name">{neos:backend.translate(id: 'sites.name', value: 'Site name', source: 'Modules')}</label>
+								<div class="neos-controls">
+									<f:form.textfield name="siteName" value="{siteName}" id="site-name" />
+									<f:render partial="Module/Shared/FieldValidationResults" arguments="{fieldname: 'siteName'}"/>
+								</div>
+							</div>
+							<div class="neos-control-group{f:validation.ifHasErrors(for: 'generatorClass', then: ' neos-error')}">
+								<label class="neos-control-label" for="node-type">{neos:backend.translate(id: 'sites.generatorClass', value: 'Select a site generator', source: 'Modules')}</label>
+								<div class="neos-controls neos-select">
+									<f:form.select name="generatorClass" options="{generatorServices}" id="generator-class" class="neos-span12" />
+								</div>
+							</div>
+							<f:form.submit value="{neos:backend.translate(id: 'sites.createPackage', value: 'Create Site-Package', source: 'Modules')}" class="neos-button neos-button-primary" />
+						</f:then>
+						<f:else>
+							<p>{neos:backend.translate(id: 'sites.noNeosKickstarterInfo', value: 'The <em>Neos Kickstarter</em> package is not installed, install it to kickstart new sites.', source: 'Modules') -> f:format.raw()}</p>
+						</f:else>
+					</f:if>
+				</fieldset>
+			</f:form>
+		</f:if>
   </div>
   <div class="neos-footer">
     <f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'cancel', value: 'Cancel')}</f:link.action>


### PR DESCRIPTION
Hide "Import a site" and "Create a new site-package" by default in Neos 8.4 and add settings to re-enable

these options were removed via Neos 9.0 but can be restored by settings:

```yaml
Neos.Neos.modules.administration.submodules.sites.settings.enableLegacyPackageImport: true
Neos.Neos.modules.administration.submodules.sites.settings.enableLegacyPackageCreation: true
```

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
