### PR TITLE
BUGFIX: 8.x Stabilise workspace -> rootNodeData relation

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
@@ -91,7 +91,7 @@ class Workspace
      * Root node data of this workspace
      *
      * @var NodeData
-     * @ORM\ManyToOne
+     * @ORM\ManyToOne(cascade={"persist"})
      * @ORM\JoinColumn(referencedColumnName="id")
      */
     protected $rootNodeData;
@@ -160,7 +160,6 @@ class Workspace
     {
         if ($initializationCause === ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED) {
             $this->rootNodeData = new NodeData('/', $this);
-            $this->nodeDataRepository->add($this->rootNodeData);
 
             if ($this->owner instanceof UserInterface) {
                 $this->setOwner($this->owner);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -11,13 +11,11 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * source code.
  */
 
-use Neos\ContentRepository\Exception\WorkspaceException;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
-use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Exception\WorkspaceException;
+use Neos\Flow\Tests\UnitTestCase;
 
 /**
  * Test case for the "Workspace" domain model
@@ -35,23 +33,6 @@ class WorkspaceTest extends UnitTestCase
         $workspace = new Workspace('MyWorkspace', $baseWorkspace);
         self::assertSame('MyWorkspace', $workspace->getName());
         self::assertSame($baseWorkspace, $workspace->getBaseWorkspace());
-    }
-
-    /**
-     * @test
-     */
-    public function onInitializationANewlyCreatedWorkspaceCreatesItsOwnRootNode()
-    {
-        $workspace = $this->getAccessibleMock(Workspace::class, ['dummy'], [], '', false);
-
-        $mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['add'])->getMock();
-        $mockNodeDataRepository->expects(self::once())->method('add');
-
-        $workspace->_set('nodeDataRepository', $mockNodeDataRepository);
-
-        $workspace->initializeObject(ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED);
-
-        self::assertInstanceOf(NodeData::class, $workspace->getRootNodeData());
     }
 
     /**


### PR DESCRIPTION
While running the behat or functional tests locally i got the error

> The object of type "Neos\ContentRepository\Domain\Model\Workspace" (identifier: "user-admin") which was passed to EntityManager->add() is not a new object.

The code part of this seems particularly hacky and odd. But really it should still work. We found that a cache hickup is really the reason for this https://github.com/neos/flow-development-collection/issues/3496

so we might not need this cleanup as it would just disguise more fundamental problems

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
