### PR TITLE
BUGFIX: Prevent render error if asset is not set in ImageTag

### DIFF
--- a/Neos.Media/Classes/Eel/ImageHelper.php
+++ b/Neos.Media/Classes/Eel/ImageHelper.php
@@ -41,7 +41,7 @@ class ImageHelper implements ProtectedContextAwareInterface
      * @throws ThumbnailServiceException
      */
     public function createThumbnail(
-        AssetInterface $asset,
+        ?AssetInterface $asset,
         ?string $preset = null,
         ?int $width = null,
         ?int $maximumWidth = null,

--- a/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageTag.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Prototypes/ImageTag.fusion
@@ -10,7 +10,7 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
   async = false
   quality = NULL
   preset = NULL
-  @context.thumbnail = ${Neos.Media.Image.createThumbnail(
+  @context.thumbnail = ${this.asset ? Neos.Media.Image.createThumbnail(
     this.asset,
     this.preset,
     this.width,
@@ -22,7 +22,7 @@ prototype(Neos.Neos:ImageTag) < prototype(Neos.Fusion:Tag) {
     this.async,
     this.quality,
     this.format
-  )}
+  ) : null}
 
   tagName = 'img'
   attributes {


### PR DESCRIPTION
As the thumbnail is generated within „context“ conditions don’t apply yet which could prevent the rendering and therefore the error.

The new method was introduced with Neos 8.4.