### PR TITLE
BUGFIX: Fix AFX AST positions to fix fusion migrations

### DIFF
--- a/Neos.Fusion.Afx/Classes/Parser/Expression/Node.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Expression/Node.php
@@ -48,9 +48,9 @@ class Node
                     if ($lexer->isOpeningBrace()) {
                         $attributes[] = [
                             'type' => 'spread',
-                            'from' => $lexer->getCharacterPosition(),
+                            'from' => $lexer->getCharacterPosition() + 4,
                             'payload' => Spread::parse($lexer),
-                            'to' => $lexer->getCharacterPosition()
+                            'to' => $lexer->getCharacterPosition() - 2
                         ];
                     } else {
                         $attributes[] = [

--- a/Neos.Fusion.Afx/Classes/Parser/Expression/NodeList.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Expression/NodeList.php
@@ -73,9 +73,9 @@ class NodeList
 
                 $contents[] = [
                     'type' => 'expression',
-                    'from' => $lexer->getCharacterPosition(),
+                    'from' => $lexer->getCharacterPosition() + 1,
                     'payload' => Expression::parse($lexer),
-                    'to' => $lexer->getCharacterPosition(),
+                    'to' => $lexer->getCharacterPosition() - ($lexer->isEnd() ? 1 : 2),
                 ];
                 $currentText = '';
                 continue;

--- a/Neos.Fusion.Afx/Classes/Parser/Expression/Prop.php
+++ b/Neos.Fusion.Afx/Classes/Parser/Expression/Prop.php
@@ -46,9 +46,9 @@ class Prop
                 case $lexer->isOpeningBrace():
                     $value = [
                         'type' => 'expression',
-                        'from' => $lexer->getCharacterPosition(),
+                        'from' => $lexer->getCharacterPosition() + 1,
                         'payload' => Expression::parse($lexer),
-                        'to' => $lexer->getCharacterPosition(),
+                        'to' => $lexer->getCharacterPosition() - 2,
                         'identifier' => $identifier
                     ];
                     break;

--- a/Neos.Fusion.Afx/Tests/Functional/ParserTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/ParserTest.php
@@ -41,6 +41,26 @@ class ParserTest extends TestCase
     /**
      * @test
      */
+    public function shouldParseASingleExpression(): void
+    {
+        $parser = new Parser('{String.uppercase("test")}');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'expression',
+                    'payload' => 'String.uppercase("test")',
+                    'from' => 1,
+                    'to' => 24
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function shouldParseSingleTag(): void
     {
         $parser = new Parser('<div></div>');
@@ -107,8 +127,8 @@ class ParserTest extends TestCase
                             0 => [
                                 'type' => 'expression',
                                 'payload' => 'String.uppercase("test")',
-                                'from' => 5,
-                                'to' => 31
+                                'from' => 6,
+                                'to' => 29
                             ]
                         ],
                         'selfClosing' => false
@@ -268,8 +288,8 @@ class ParserTest extends TestCase
                                     'type' => 'expression',
                                     'payload' => '"value" + "a"',
                                     'identifier' => 'prop',
-                                    'from' => 10,
-                                    'to' => 25
+                                    'from' => 11,
+                                    'to' => 23
                                 ]
                             ]
                         ],
@@ -494,8 +514,8 @@ class ParserTest extends TestCase
                                     'type' => 'expression',
                                     'payload' => 'item'
                                 ],
-                                'from' => 5,
-                                'to' => 14
+                                'from' => 9,
+                                'to' => 12
                             ]
                         ],
                         'children' => [],
@@ -535,8 +555,8 @@ class ParserTest extends TestCase
                                     'type' => 'expression',
                                     'payload' => 'item',
                                 ],
-                                'from' => 18,
-                                'to' => 27,
+                                'from' => 22,
+                                'to' => 25,
                             ],
                             [
                                 'type' => 'prop',
@@ -544,8 +564,8 @@ class ParserTest extends TestCase
                                     'type' => 'expression',
                                     'payload' => 'expression',
                                     'identifier' => 'bar',
-                                    'from' => 32,
-                                    'to' => 44,
+                                    'from' => 33,
+                                    'to' => 42,
                                 ]
                             ]
                         ],

--- a/Neos.Fusion/Classes/Migrations/EelExpression/EelExpressionTransformer.php
+++ b/Neos.Fusion/Classes/Migrations/EelExpression/EelExpressionTransformer.php
@@ -186,8 +186,8 @@ final class EelExpressionTransformer
             // We found an Eel expression in a spread operation
             $result[] = new EelExpressionPosition(
                 $afxElement['payload']['payload'],
-                $afxElement['from'] + 5, // advance beyond '{...'
-                $afxElement['to'],
+                $afxElement['from'] + 1,
+                $afxElement['to'] + 2,
                 null
             );
             return;
@@ -197,8 +197,8 @@ final class EelExpressionTransformer
             // We found an Eel expression
             $result[] = new EelExpressionPosition(
                 $afxElement['payload'],
-                $afxElement['from'] + 2, // advance beyond '{'
-                $afxElement['to'],
+                $afxElement['from'] + 1,
+                $afxElement['to'] + 2,
                 null
             );
         }

--- a/Neos.Fusion/Tests/Unit/Migrations/EelExpressionTransformerTest.php
+++ b/Neos.Fusion/Tests/Unit/Migrations/EelExpressionTransformerTest.php
@@ -181,6 +181,39 @@ class EelExpressionTransformerTest extends TestCase
             Fusion,
         ];
 
+        // bugfix preserve output of single EEL expression in afx
+        yield 'L ' . __LINE__ => [
+            fn (string $eelExpression) => $eelExpression,
+            <<<'Fusion'
+            prototype(Neos.Fusion.Test:Value) < prototype(Neos.Fusion:Value) {
+                value = afx`{props.value}`
+            }
+            Fusion,
+            <<<'Fusion'
+            prototype(Neos.Fusion.Test:Value) < prototype(Neos.Fusion:Value) {
+                value = afx`{props.value}`
+            }
+            Fusion,
+        ];
+
+        yield 'L ' . __LINE__ => [
+            fn (string $eelExpression) => str_replace('someVariable', 'myNewVariable', $eelExpression),
+            <<<'Fusion'
+            prototype(Neos.Fusion.Test:Value) < prototype(Neos.Fusion:Value) {
+                value = afx`
+                    <span>{someVariable}</span>
+                    {someVariable}`
+            }
+            Fusion,
+            <<<'Fusion'
+            prototype(Neos.Fusion.Test:Value) < prototype(Neos.Fusion:Value) {
+                value = afx`
+                    <span>{myNewVariable}</span>
+                    {myNewVariable}`
+            }
+            Fusion,
+        ];
+
         yield 'L ' . __LINE__ => [
             fn (string $eelExpression) => str_replace('someVariable', 'myNewVariable', $eelExpression),
             <<<'Fusion'


### PR DESCRIPTION
positions in the AFX AST are now calculated properly:

```
{abc}
 1 3
```

`abc` starts at character `1` (`a`) and goes to character `3` (`c`) position `0` and `4` are the outer braces.

This is also done correctly for spreads or when the expression is in a tag content
```
foo={abc}
     5 7

{...abc}
    4 6
```

The `EelExpressionTransformer` works with the positions differently and thus we offset them. But the semantic we now hold for the afx parser and the tests should ideally apply to all ast positions we use.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
