### PR TITLE
BUGFIX: Fix subtree tagging after move

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -25,34 +25,36 @@ trait SubtreeTagging
     private function addSubtreeTag(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
     {
         $addTagToDescendantsStatement = <<<SQL
-            UPDATE {$this->tableNames->hierarchyRelation()} h
+        UPDATE {$this->tableNames->hierarchyRelation()} h
+            JOIN (
+                WITH RECURSIVE cte (id, dsp) AS (
+                    SELECT ch.childnodeanchor, ch.dimensionspacepointhash
+                    FROM {$this->tableNames->hierarchyRelation()} ch
+                    INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ch.parentnodeanchor
+                    WHERE
+                      n.nodeaggregateid = :nodeAggregateId
+                      AND ch.contentstreamid = :contentStreamId
+                      AND ch.dimensionspacepointhash in (:dimensionSpacePointHashes)
+                      AND NOT JSON_CONTAINS_PATH(ch.subtreetags, 'one', :tagPath)
+                    UNION ALL
+                    SELECT
+                      dh.childnodeanchor,
+                      dh.dimensionspacepointhash
+                    FROM
+                      cte
+                      JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.id
+                        AND dh.contentstreamid = :contentStreamId
+                        AND dh.dimensionspacepointhash = cte.dsp
+                    WHERE
+                      NOT JSON_CONTAINS_PATH(dh.subtreetags, 'one', :tagPath)
+                )
+                SELECT * FROM cte
+            ) subquery ON h.dimensionspacepointhash = subquery.dsp
+                AND h.childnodeanchor = subquery.id
             SET h.subtreetags = JSON_INSERT(h.subtreetags, :tagPath, null)
-            WHERE h.childnodeanchor IN (
-              WITH RECURSIVE cte (id) AS (
-                SELECT ch.childnodeanchor
-                FROM {$this->tableNames->hierarchyRelation()} ch
-                INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ch.parentnodeanchor
-                WHERE
-                  n.nodeaggregateid = :nodeAggregateId
-                  AND ch.contentstreamid = :contentStreamId
-                  AND ch.dimensionspacepointhash in (:dimensionSpacePointHashes)
-                  AND NOT JSON_CONTAINS_PATH(ch.subtreetags, 'one', :tagPath)
-                UNION ALL
-                SELECT
-                  dh.childnodeanchor
-                FROM
-                  cte
-                  JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.id
-                    AND dh.contentstreamid = :contentStreamId
-                    AND dh.dimensionspacepointhash in (:dimensionSpacePointHashes)
-                WHERE
-                  NOT JSON_CONTAINS_PATH(dh.subtreetags, 'one', :tagPath)
-              )
-              SELECT DISTINCT id FROM cte
-            )
-              AND h.contentstreamid = :contentStreamId
-              AND h.dimensionspacepointhash in (:dimensionSpacePointHashes)
+            WHERE h.contentstreamid = :contentStreamId
         SQL;
+
         try {
             $this->dbal->executeStatement($addTagToDescendantsStatement, [
                 'contentStreamId' => $contentStreamId->value,
@@ -63,7 +65,7 @@ trait SubtreeTagging
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479749, $e);
+            throw new \RuntimeException(sprintf('1: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479749, $e);
         }
 
         $addTagToNodeStatement = <<<SQL
@@ -85,7 +87,7 @@ trait SubtreeTagging
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479840, $e);
+            throw new \RuntimeException(sprintf('2: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479840, $e);
         }
     }
 
@@ -93,23 +95,9 @@ trait SubtreeTagging
     {
         $removeTagStatement = <<<SQL
             UPDATE {$this->tableNames->hierarchyRelation()} h
-            SET subtreetags = IF((
-              SELECT containsTag FROM (SELECT
-                JSON_CONTAINS_PATH(gph.subtreetags, 'one', :tagPath) as containsTag
-              FROM
-                {$this->tableNames->hierarchyRelation()} gph
-                INNER JOIN {$this->tableNames->hierarchyRelation()} ph ON ph.parentnodeanchor = gph.childnodeanchor
-                INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
-              WHERE
-                ph.parentnodeanchor = gph.childnodeanchor
-                AND n.nodeaggregateid = :nodeAggregateId
-                AND gph.contentstreamid = :contentStreamId
-                AND gph.dimensionspacepointhash in (:dimensionSpacePointHashes)
-              LIMIT 1) as containsTagSubQuery
-            ), JSON_SET(subtreetags, :tagPath, null), JSON_REMOVE(subtreetags, :tagPath))
-            WHERE childnodeanchor IN (
-              WITH RECURSIVE cte (id) AS (
-                SELECT ph.childnodeanchor
+            JOIN (
+              WITH RECURSIVE cte (id, dsp) AS (
+                SELECT ph.childnodeanchor, ph.dimensionspacepointhash
                 FROM {$this->tableNames->hierarchyRelation()} ph
                 INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
                 WHERE
@@ -118,19 +106,35 @@ trait SubtreeTagging
                   AND ph.dimensionspacepointhash in (:dimensionSpacePointHashes)
                 UNION ALL
                 SELECT
-                  dh.childnodeanchor
+                  dh.childnodeanchor,
+                  dh.dimensionspacepointhash
                 FROM
                   cte
                   JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.id
                     AND dh.contentstreamid = :contentStreamId
-                    AND dh.dimensionspacepointhash in (:dimensionSpacePointHashes)
+                    AND dh.dimensionspacepointhash = cte.dsp
                 WHERE
                   JSON_EXTRACT(dh.subtreetags, :tagPath) != TRUE
               )
-              SELECT DISTINCT id FROM cte
-            )
-              AND contentstreamid = :contentStreamId
-              AND dimensionspacepointhash in (:dimensionSpacePointHashes)
+              SELECT * FROM cte
+            ) subquery ON h.dimensionspacepointhash = subquery.dsp
+                AND h.childnodeanchor = subquery.id
+                SET subtreetags = IF(
+                (
+                    SELECT containsTag FROM (SELECT
+                        JSON_CONTAINS_PATH(gph.subtreetags, 'one', :tagPath) as containsTag
+                  FROM
+                    {$this->tableNames->hierarchyRelation()} gph
+                    INNER JOIN {$this->tableNames->hierarchyRelation()} ph ON ph.parentnodeanchor = gph.childnodeanchor
+                    INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
+                  WHERE
+                    ph.parentnodeanchor = gph.childnodeanchor
+                    AND n.nodeaggregateid = :nodeAggregateId
+                    AND gph.contentstreamid = :contentStreamId
+                  LIMIT 1) as containsTagSubQuery
+                ), JSON_SET(subtreetags, :tagPath, null), JSON_REMOVE(subtreetags, :tagPath)
+              )
+              WHERE contentstreamid = :contentStreamId
         SQL;
         try {
             $this->dbal->executeStatement($removeTagStatement, [

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
@@ -201,7 +201,7 @@ Feature: Tag and untag nodes after moving their children in or out
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"example": "source"}    |
-      | nodeVariantSelectionStrategy | "scatter"                |
+      | nodeVariantSelectionStrategy | "allVariants"            |
       | tag                          | "my-tag"                 |
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -534,10 +534,10 @@ Feature: Tag and untag nodes after moving their children in or out
 
     And I am in dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
     And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
 
     And I am in dimension space point {"example": "source"}
@@ -550,10 +550,10 @@ Feature: Tag and untag nodes after moving their children in or out
 
     And I am in dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
     And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
 
     And I am in dimension space point {"example": "spec"}
@@ -843,7 +843,7 @@ Feature: Tag and untag nodes after moving their children in or out
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {"example": "source"}    |
-      | nodeVariantSelectionStrategy | "scatter"                |
+      | nodeVariantSelectionStrategy | "allVariants"            |
       | tag                          | "my-tag"                 |
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
@@ -1164,7 +1164,7 @@ Feature: Tag and untag nodes after moving their children in or out
       | Key                          | Value                        |
       | dimensionSpacePoint          | {"example": "source"}        |
       | nodeAggregateId              | "nody-mc-nodeface"           |
-      | relationDistributionStrategy | "gatherSpecializations"      |
+      | relationDistributionStrategy | "gatherAll"                  |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
 
     And the command TagSubtree is executed with payload:
@@ -1244,10 +1244,10 @@ Feature: Tag and untag nodes after moving their children in or out
 
     And I am in dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
     And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
 
     And I am in dimension space point {"example": "peer"}
@@ -1260,10 +1260,10 @@ Feature: Tag and untag nodes after moving their children in or out
 
     And I am in dimension space point {"example": "spec"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
     And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
-    And I expect this node to exactly inherit the tags ""
+    And I expect this node to exactly inherit the tags "my-tag"
     And I expect this node to be exactly explicitly tagged ""
 
   Scenario: Move a child node in via gatherAll strategy, then untag the parent and all its variants

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
@@ -14,6 +14,23 @@ Feature: Tag and untag nodes after moving their children in or out
   the parent in
   - allSpecializations
   - allVariants
+  Idea for testing TAGGING ("... then tag the parent ..."):
+  - lady-eleonode-rootford
+  -- sir-david-nodenborough  <-- (2) Tag
+  --- nody-mc-nodeface       <-- (1) Move Source
+  ---- nodimus-mediocre
+  -- sir-nodeward-nodington-iii
+  --- nodimus-prime
+  --- .....................  <-- (1) Move Target
+
+  Idea for testing UNTAGGING ("... then untag the parent ..."):
+  - lady-eleonode-rootford
+  -- sir-david-nodenborough  <-- (1) Tag         (3) untag
+  --- nody-mc-nodeface       <-- (1) Move Source
+  ---- nodimus-mediocre
+  -- sir-nodeward-nodington-iii <-- (1) Tag
+  --- nodimus-prime
+  --- .....................  <-- (1) Move Target
 
   Background:
     Given using the following content dimensions:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
@@ -1,0 +1,1327 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Tag and untag nodes after moving their children in or out
+
+  As a user of the CR I want to
+  - move child nodes were out
+  - move nodes in as new children
+  using the
+  - scatter
+  - gatherSpecializations
+  - gatherAll
+  strategy and then
+  - tag
+  - untag
+  the parent in
+  - allSpecializations
+  - allVariants
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values                      | Generalizations                      |
+      | example    | general, source, peer, spec | spec->source->general, peer->general |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Document': []
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {"example": "general"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId            | parentNodeAggregateId      | nodeTypeName                            | nodeName        |
+      | sir-david-nodenborough     | lady-eleonode-rootford     | Neos.ContentRepository.Testing:Document | parent-document |
+      | nody-mc-nodeface           | sir-david-nodenborough     | Neos.ContentRepository.Testing:Document | document        |
+      | nodimus-mediocre           | nody-mc-nodeface           | Neos.ContentRepository.Testing:Document | child-document  |
+      | sir-nodeward-nodington-iii | lady-eleonode-rootford     | Neos.ContentRepository.Testing:Document | esquire         |
+      | nodimus-prime              | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:Document | esquire-child   |
+
+  Scenario: Move a child node out via scatter strategy, then tag the parent and all its specializations
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via scatter strategy, then tag the parent and all its variants
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via scatter strategy, then untag the parent and all its specializations
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via scatter strategy, then untag the parent and all its variants
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "scatter"                |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherSpecializations strategy, then tag the parent and all its specializations
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherSpecializations strategy, then tag the parent and all its variants
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherSpecializations strategy, then untag the parent and all its specializations
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherSpecializations strategy, then untag the parent and all its variants
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherAll strategy, then tag the parent and all its specializations
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherAll strategy, then tag the parent and all its variants
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherAll strategy, then untag the parent and all its specializations
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node out via gatherAll strategy, then untag the parent and all its variants
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via scatter strategy, then tag the parent and all its specializations
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allSpecializations"         |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via scatter strategy, then tag the parent and all its variants
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via scatter strategy, then untag the parent and all its specializations
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allSpecializations"         |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via scatter strategy, then untag the parent and all its variants
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "scatter"                |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "scatter"                    |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherSpecializations strategy, then tag the parent and all its specializations
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allSpecializations"         |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherSpecializations strategy, then tag the parent and all its variants
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherSpecializations strategy, then untag the parent and all its specializations
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allSpecializations"         |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherSpecializations strategy, then untag the parent and all its variants
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherAll strategy, then tag the parent and all its specializations
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allSpecializations"         |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherAll strategy, then tag the parent and all its variants
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherSpecializations"      |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherAll strategy, then untag the parent and all its specializations
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+      | tag                          | "my-tag"                 |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags "my-tag"
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+  Scenario: Move a child node in via gatherAll strategy, then untag the parent and all its variants
+    When the command TagSubtree is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example": "source"}    |
+      | nodeVariantSelectionStrategy | "allVariants"            |
+      | tag                          | "my-tag"                 |
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+
+    And the command UntagSubtree is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
+      | coveredDimensionSpacePoint   | {"example": "source"}        |
+      | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "my-tag"                     |
+
+    And I am in dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+
+    And I am in dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to exactly inherit the tags ""
+    And I expect this node to be exactly explicitly tagged ""


### PR DESCRIPTION
Resolves: #5618

Previously, when cascading subtree tags (both add and remove), the whole set of affected DSPs was evaluated on each level.

This affected also hierarchy relations not connected to the tagged node in their DSP (see #5618)

Visualization:
<img width="1302" height="1160" alt="TagAfterMove" src="https://github.com/user-attachments/assets/925cd135-baa4-4d35-91ab-437789d77490" />

**Upgrade instructions**

Neos uses subtree tags (for disabling and soft removal) always in "allSpecializations" mode, i.e. generalizations and peer variants are unaffected.

Thus, if (and only if) a project has specialization variants, it is affected by the underlying bug anyway. In that case, a replay of the content graph projection is advised.

**Review instructions**

I've done an edge case analysis for the new test cases, please check them for completeness and that the step definitions match the respective parameters.

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
