### PR TITLE
BUGFIX: Allow moving of nodes to a parent with an already covered child name…

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
@@ -206,7 +206,7 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | relationDistributionStrategy | "scatter"                |
     Then the last command should have thrown an exception of type "NodeNameIsAlreadyCovered"
 
-  Scenario: Using the gatherSpecializations strategy, try to move a node to a parent that already has a child node of the same name in a specialization
+  Scenario: Using the gatherSpecializations strategy, try to move a node to a parent that already has a child node of the same name and different aggregate id in a specialization
     Given the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | originDimensionSpacePoint | nodeTypeName                            | parentNodeAggregateId      | nodeName        |
       | nody-mc-nodeface | {"example": "source"}     | Neos.ContentRepository.Testing:Document | sir-nodeward-nodington-iii | target-document |
@@ -219,7 +219,7 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | relationDistributionStrategy | "gatherSpecializations"  |
     Then the last command should have thrown an exception of type "NodeNameIsAlreadyCovered"
 
-  Scenario: Using the gatherAll strategy, try to move a node to a parent that already has a child node of the same name in a generalization
+  Scenario: Using the gatherAll strategy, try to move a node to a parent that already has a child node of the same name and different aggregate id in a generalization
     Given the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | originDimensionSpacePoint | nodeTypeName                            | parentNodeAggregateId | nodeName        |
       | rival-destinode  | {"example": "general"}    | Neos.ContentRepository.Testing:Document | general-nodesworth    | target-document |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
@@ -19,9 +19,9 @@ Feature: Move a node with content dimensions
     And using identifier "default", I define a content repository
     And I am in content repository "default"
     And the command CreateRootWorkspace is executed with payload:
-      | Key                  | Value                |
-      | workspaceName        | "live"               |
-      | newContentStreamId   | "cs-identifier"      |
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
     And I am in workspace "live" and dimension space point {"example": "general"}
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -2074,3 +2074,38 @@ Feature: Move a node with content dimensions
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     And I expect node aggregate identifier "nody-mc-nodeface-ii" to lead to node cs-identifier;nody-mc-nodeface-ii;{"example": "general"}
+
+  Scenario: Move a node variant back and forth
+    # should bypass the constraint checks for unique names
+    # because this already is the variant the name should otherwise be reserved for
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "nody-mc-nodeface"       |
+      | newParentNodeAggregateId     | "sir-david-nodenborough" |
+      | dimensionSpacePoint          | {"example": "source"}    |
+      | relationDistributionStrategy | "scatter"                |
+    And the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | nodeAggregateId              | "nody-mc-nodeface"           |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+      | dimensionSpacePoint          | {"example": "source"}        |
+      | relationDistributionStrategy | "scatter"                    |
+
+    Then I expect exactly 14 events to be published on stream "ContentStream:cs-identifier"
+    And event at index 12 is of type "NodeAggregateWasMoved" with payload:
+      | Key                           | Expected                                                              |
+      | contentStreamId               | "cs-identifier"                                                       |
+      | nodeAggregateId               | "nody-mc-nodeface"                                                    |
+      | newParentNodeAggregateId      | "sir-david-nodenborough"                                              |
+      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null}] |
+    And event at index 13 is of type "NodeAggregateWasMoved" with payload:
+      | Key                           | Expected                                                              |
+      | contentStreamId               | "cs-identifier"                                                       |
+      | nodeAggregateId               | "nody-mc-nodeface"                                                    |
+      | newParentNodeAggregateId      | "sir-nodeward-nodington-iii"                                          |
+      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null}] |
+
+    When I am in workspace "live" and dimension space point {"example": "source"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
@@ -599,12 +599,16 @@ trait ConstraintChecks
     }
 
     /**
+     * @param ?NodeAggregateId $exclusivelyAllowedNodeAggregateId in some cases, aggregates of a given ID
+     *      are allowed to cover this name. E.g. in the move case, if a node is moved (back) to its other variants,
+     *      the name does not need to be reserved for future variants because the moved node already is that exact one
      * @throws NodeNameIsAlreadyCovered
      */
     protected function requireNodeNameToBeUncovered(
         ContentGraphInterface $contentGraph,
         ?NodeName $nodeName,
         NodeAggregateId $parentNodeAggregateId,
+        ?NodeAggregateId $exclusivelyAllowedNodeAggregateId = null,
     ): void {
         if ($nodeName === null) {
             return;
@@ -614,7 +618,10 @@ trait ConstraintChecks
             $parentNodeAggregateId,
             $nodeName
         );
-        if ($childNodeAggregate instanceof NodeAggregate) {
+        if (
+            $childNodeAggregate instanceof NodeAggregate
+            && ($exclusivelyAllowedNodeAggregateId === null || !$childNodeAggregate->nodeAggregateId->equals($exclusivelyAllowedNodeAggregateId))
+        ) {
             throw new NodeNameIsAlreadyCovered(
                 'Node name "' . $nodeName->value . '" is already covered by node aggregate "'
                     . $childNodeAggregate->nodeAggregateId->value . '".'

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/NodeMove.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/NodeMove.php
@@ -119,6 +119,7 @@ trait NodeMove
                 $contentGraph,
                 $nodeAggregate->nodeName,
                 $command->newParentNodeAggregateId,
+                $command->nodeAggregateId,
             );
             if ($nodeAggregate->nodeName) {
                 $this->requireNodeTypeNotToDeclareTetheredChildNodeName($newParentNodeAggregate->nodeTypeName, $nodeAggregate->nodeName);


### PR DESCRIPTION
… in case the name is covered by variants of the to-be-moved node.

Previously, we rejected moving a node to a new parent that already had a child node aggregate of the same name, even if the requested dimension space point was yet uncovered.
This was necessary to reserve that name for future variants of the node already residing there.

In the special case that the node to be moved is already said variant, i.e. it shares the node aggregate id with the node aggregate already covering the name, the move operation is safe though.

This is especially demonstrated in #5663 when simply moving a node variant back and forth.

With this, the constraint checks have been relaxed just enough to let the respective command pass.

**Upgrade instructions**

none required

**Review instructions**

This seemed almost too easy and I may have overlooked something.

The only reason why we are so strict regarding names when moving that came to my mind was that we want to reserve the name for future variants, though, which is not necessary in this case.

Does anyone remember other reasons?

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions

Resolves: #5663 