### PR TITLE
BUGFIX: Adjust uri path segment for copied documents

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
@@ -206,9 +206,7 @@ final class NodeDuplicationService
         NodeAggregateId $targetParentNodeAggregateId,
         ContentSubgraphInterface $subgraph
     ): string {
-        $alreadyClaimedUriPathSegments = [
-            $originalUriPathSegment
-        ];
+        $alreadyClaimedUriPathSegments = [];
         foreach (
             $subgraph->findChildNodes(
                 $targetParentNodeAggregateId,

--- a/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\NodeReferencesToWrit
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\NodeReferenceToWrite;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\TagSubtree;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\References;
@@ -109,7 +110,26 @@ final class NodeDuplicationService
             $nodeAggregateIdMapping
         );
 
+        $isFirstCommand = true;
         foreach ($commands as $command) {
+            if ($isFirstCommand) {
+                if (
+                    $command instanceof CreateNodeAggregateWithNode
+                    && array_key_exists('uriPathSegment', $command->initialPropertyValues->values)
+                ){
+                    $command = $command->withInitialPropertyValues(
+                        newInitialPropertyValues: $command->initialPropertyValues->withValue(
+                            valueName: 'uriPathSegment',
+                            value: $this->resolveUriPathSegmentForCopy(
+                                originalUriPathSegment: $command->initialPropertyValues->values['uriPathSegment'],
+                                targetParentNodeAggregateId: $targetParentNodeAggregateId,
+                                subgraph: $subgraph,
+                            ),
+                        )
+                    );
+                }
+                $isFirstCommand = false;
+            }
             $contentRepository->handle($command);
         }
     }
@@ -177,6 +197,36 @@ final class NodeDuplicationService
         }
 
         return $commands;
+    }
+
+    private function resolveUriPathSegmentForCopy(
+        string $originalUriPathSegment,
+        NodeAggregateId $targetParentNodeAggregateId,
+        ContentSubgraphInterface $subgraph
+    ): string {
+        $alreadyClaimedUriPathSegments = [
+            $originalUriPathSegment
+        ];
+        foreach (
+            $subgraph->findChildNodes(
+                $targetParentNodeAggregateId,
+                FindChildNodesFilter::create(),
+            ) as $futureSibling
+        ) {
+            $siblingUriPathSegment = $futureSibling->getProperty('uriPathSegment');
+            if (is_string($siblingUriPathSegment)) {
+                $alreadyClaimedUriPathSegments[$siblingUriPathSegment] = true;
+            }
+        }
+
+        $uriPathSegment = $originalUriPathSegment;
+        $i = 1;
+        while (array_key_exists($uriPathSegment, $alreadyClaimedUriPathSegments)) {
+            $uriPathSegment = $originalUriPathSegment . '-' . $i;
+            $i++;
+        }
+
+        return $uriPathSegment;
     }
 
     private function commandsForSubtreeRecursively(TransientNodeCopy $transientParentNode, Subtree $subtree, ContentSubgraphInterface $subgraph, Commands $commands): Commands

--- a/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
@@ -115,8 +115,10 @@ final class NodeDuplicationService
             if ($isFirstCommand) {
                 if (
                     $command instanceof CreateNodeAggregateWithNode
+                    && $contentRepository->getNodeTypeManager()->getNodeType($command->nodeTypeName)
+                        ?->isOfType('Neos.Neos:Document')
                     && array_key_exists('uriPathSegment', $command->initialPropertyValues->values)
-                ){
+                ) {
                     $command = $command->withInitialPropertyValues(
                         newInitialPropertyValues: $command->initialPropertyValues->withValue(
                             valueName: 'uriPathSegment',

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_UriPathSegment.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_UriPathSegment.feature
@@ -1,0 +1,109 @@
+Feature: Copying a document node will adjust its uriPathSegment
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Sites':
+      superTypes:
+        Neos.ContentRepository:Root: true
+    'Neos.Neos:Site': []
+    'Neos.Neos:Document':
+      properties:
+        uriPathSegment:
+          type: string
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    When I am in workspace "live" and dimension space point {}
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | nodeTypeName    | "Neos.Neos:Sites"        |
+
+    When the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId            | parentNodeAggregateId      | nodeTypeName       | initialPropertyValues                |
+      | sir-david-nodenborough     | lady-eleonode-rootford     | Neos.Neos:Site     | {}                                   |
+      | nody-mc-nodeface           | sir-david-nodenborough     | Neos.Neos:Document | {"uriPathSegment": "document"}       |
+      | nodimus-mediocre           | nody-mc-nodeface           | Neos.Neos:Document | {"uriPathSegment": "child-document"} |
+      | sir-nodeward-nodington-iii | sir-david-nodenborough     | Neos.Neos:Document | {"uriPathSegment": "other-document"} |
+      | sir-nodeward-nodington-iv  | sir-nodeward-nodington-iii | Neos.Neos:Document | {"uriPathSegment": "document"}       |
+
+  Scenario: Copying a document node as a sibling adjusts its uri path segment
+    When copy nodes recursively is executed with payload:
+      | Key                         | Value                                                                                          |
+      | sourceDimensionSpacePoint   | {}                                                                                             |
+      | sourceNodeAggregateId       | "nody-mc-nodeface"                                                                             |
+      | targetDimensionSpacePoint   | {}                                                                                             |
+      | targetParentNodeAggregateId | "sir-david-nodenborough"                                                                       |
+      | nodeAggregateIdMapping      | {"nody-mc-nodeface": "nody-mc-nodeface-copied", "nodimus-mediocre": "nodimus-mediocre-copied"} |
+
+    Then I expect node aggregate identifier "nody-mc-nodeface-copied" to lead to node cs-identifier;nody-mc-nodeface-copied;{}
+    And I expect this node to have the following properties:
+      | Key            | Value      |
+      | uriPathSegment | document-1 |
+
+    And I expect node aggregate identifier "nodimus-mediocre-copied" to lead to node cs-identifier;nodimus-mediocre-copied;{}
+    And I expect this node to have the following properties:
+      | Key            | Value          |
+      | uriPathSegment | child-document |
+
+    When copy nodes recursively is executed with payload:
+      | Key                         | Value                                                                                              |
+      | sourceDimensionSpacePoint   | {}                                                                                                 |
+      | sourceNodeAggregateId       | "nody-mc-nodeface"                                                                                 |
+      | targetDimensionSpacePoint   | {}                                                                                                 |
+      | targetParentNodeAggregateId | "sir-david-nodenborough"                                                                           |
+      | nodeAggregateIdMapping      | {"nody-mc-nodeface": "nody-mc-nodeface-copied-2", "nodimus-mediocre": "nodimus-mediocre-copied-2"} |
+
+    Then I expect node aggregate identifier "nody-mc-nodeface-copied-2" to lead to node cs-identifier;nody-mc-nodeface-copied-2;{}
+    And I expect this node to have the following properties:
+      | Key            | Value      |
+      | uriPathSegment | document-2 |
+
+    And I expect node aggregate identifier "nodimus-mediocre-copied-2" to lead to node cs-identifier;nodimus-mediocre-copied-2;{}
+    And I expect this node to have the following properties:
+      | Key            | Value          |
+      | uriPathSegment | child-document |
+
+  Scenario: Copying a document node to another adjusts its uri path segment
+    When copy nodes recursively is executed with payload:
+      | Key                         | Value                                                                                          |
+      | sourceDimensionSpacePoint   | {}                                                                                             |
+      | sourceNodeAggregateId       | "nody-mc-nodeface"                                                                             |
+      | targetDimensionSpacePoint   | {}                                                                                             |
+      | targetParentNodeAggregateId | "sir-nodeward-nodington-iii"                                                                   |
+      | nodeAggregateIdMapping      | {"nody-mc-nodeface": "nody-mc-nodeface-copied", "nodimus-mediocre": "nodimus-mediocre-copied"} |
+
+    Then I expect node aggregate identifier "nody-mc-nodeface-copied" to lead to node cs-identifier;nody-mc-nodeface-copied;{}
+    And I expect this node to have the following properties:
+      | Key            | Value      |
+      | uriPathSegment | document-1 |
+
+    And I expect node aggregate identifier "nodimus-mediocre-copied" to lead to node cs-identifier;nodimus-mediocre-copied;{}
+    And I expect this node to have the following properties:
+      | Key            | Value          |
+      | uriPathSegment | child-document |
+
+    When copy nodes recursively is executed with payload:
+      | Key                         | Value                                                                                              |
+      | sourceDimensionSpacePoint   | {}                                                                                                 |
+      | sourceNodeAggregateId       | "nody-mc-nodeface"                                                                                 |
+      | targetDimensionSpacePoint   | {}                                                                                                 |
+      | targetParentNodeAggregateId | "sir-nodeward-nodington-iii"                                                                       |
+      | nodeAggregateIdMapping      | {"nody-mc-nodeface": "nody-mc-nodeface-copied-2", "nodimus-mediocre": "nodimus-mediocre-copied-2"} |
+
+    Then I expect node aggregate identifier "nody-mc-nodeface-copied-2" to lead to node cs-identifier;nody-mc-nodeface-copied-2;{}
+    And I expect this node to have the following properties:
+      | Key            | Value      |
+      | uriPathSegment | document-2 |
+
+    And I expect node aggregate identifier "nodimus-mediocre-copied-2" to lead to node cs-identifier;nodimus-mediocre-copied-2;{}
+    And I expect this node to have the following properties:
+      | Key            | Value          |
+      | uriPathSegment | child-document |


### PR DESCRIPTION
When copying document nodes, the uri path segment was not adjusted which lead to issues, as described in #5657 

This now is done in the NodeDuplicationService by checking all future siblings.

**Upgrade instructions**

none

**Review instructions**

please check the tests for completeness

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
