### PR TITLE
BUGFIX: Translate label for childNodes

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
@@ -14,6 +14,7 @@ namespace Neos\ContentRepository\Domain\Model;
 use Neos\Eel\EelEvaluatorInterface;
 use Neos\Eel\Utility;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\EelHelper\TranslationHelper;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 
 /**
@@ -33,6 +34,12 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
      * @var array
      */
     protected $defaultContextConfiguration;
+
+    /**
+     * @Flow\Inject
+     * @var TranslationHelper
+     */
+    protected $translationHelper;
 
     /**
      * @var string
@@ -73,6 +80,7 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
     public function getLabel(\Neos\ContentRepository\Domain\Projection\Content\NodeInterface $node): string
     {
         $expression = $this->getExpression();
+
         if ($node->isAutoCreated()) {
             $parentNode = $node->getParent();
             $property = 'childNodes.' . $node->getName() . '.label';
@@ -80,7 +88,11 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
                 $expression = $parentNode->getNodeType()->getConfiguration($property);
             }
         }
+
         if (Utility::parseEelExpression($expression) === null) {
+            if($node->isAutoCreated()) {
+                return $this->translationHelper->translate($expression);
+            }
             return $expression;
         }
         return (string)Utility::evaluateEelExpression($expression, $this->eelEvaluator, ['node' => $node], $this->defaultContextConfiguration);

--- a/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/ExpressionBasedNodeLabelGenerator.php
@@ -90,7 +90,7 @@ class ExpressionBasedNodeLabelGenerator implements NodeLabelGeneratorInterface
         }
 
         if (Utility::parseEelExpression($expression) === null) {
-            if($node->isAutoCreated()) {
+            if ($node->isAutoCreated()) {
                 return $this->translationHelper->translate($expression);
             }
             return $expression;

--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -78,7 +78,6 @@ class NodeTypeConfigurationEnrichmentAspect
             $this->setPropertyLabels($nodeTypeName, $configuration, $declaredSuperTypes);
         }
 
-        //\Neos\Flow\var_dump($this->translator->translateById(labelId: "childNodes.column0", sourceName: "", packageKey: "Neos.Demo"));
         if (isset($configuration['childNodes'])) {
             $this->setChildNodeLabels($nodeTypeName, $configuration, $declaredSuperTypes);
         }

--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -57,9 +57,9 @@ class NodeTypeConfigurationEnrichmentAspect
         $declaredSuperTypes = $joinPoint->getMethodArgument('declaredSuperTypes');
         $configuration = $joinPoint->getMethodArgument('configuration');
         $nodeTypeName = $joinPoint->getMethodArgument('name');
-
+        //\Neos\Flow\var_dump("---------------------------------------");
         $this->addLabelsToNodeTypeConfiguration($nodeTypeName, $configuration, $declaredSuperTypes);
-
+        //\Neos\Flow\var_dump(json_encode($configuration));
         $joinPoint->setMethodArgument('configuration', $configuration);
         $joinPoint->getAdviceChain()->proceed($joinPoint);
     }
@@ -78,6 +78,27 @@ class NodeTypeConfigurationEnrichmentAspect
 
         if (isset($configuration['properties'])) {
             $this->setPropertyLabels($nodeTypeName, $configuration, $declaredSuperTypes);
+        }
+
+        if (isset($configuration['childNodes'])) {
+            $this->setChildNodeLabels($nodeTypeName, $configuration, $declaredSuperTypes);
+        }
+    }
+
+
+    /**
+     * @param $nodeTypeName
+     * @param array $configuration
+     * @param array $declaredSuperTypes
+     * @return void
+     */
+    protected function setChildNodeLabels($nodeTypeName, array &$configuration, array $declaredSuperTypes)
+    {
+        $nodeTypeLabelIdPrefix = $this->generateNodeTypeLabelIdPrefix($nodeTypeName);
+        foreach ($configuration['childNodes'] as $childNodeName => &$childNodeConfiguration) {
+            if ($this->shouldFetchTranslation($childNodeConfiguration)) {
+                $childNodeConfiguration['label'] = $this->getChildNodeLabelTranslationId($nodeTypeLabelIdPrefix, $childNodeName);
+            }
         }
     }
 
@@ -298,6 +319,18 @@ class NodeTypeConfigurationEnrichmentAspect
     protected function getPropertyLabelTranslationId($nodeTypeSpecificPrefix, $propertyName)
     {
         return $nodeTypeSpecificPrefix . 'properties.' . $propertyName;
+    }
+
+    /**
+     * Generates a childNode label with the given $nodeTypeSpecificPrefix.
+     *
+     * @param string $nodeTypeSpecificPrefix
+     * @param string $childNodeName
+     * @return string
+     */
+    protected function getChildNodeLabelTranslationId($nodeTypeSpecificPrefix, $childNodeName)
+    {
+        return $nodeTypeSpecificPrefix . 'childNodes.' . $childNodeName;
     }
 
     /**

--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -85,11 +85,11 @@ class NodeTypeConfigurationEnrichmentAspect
 
 
     /**
-     * @param $nodeTypeName
+     * @param string $nodeTypeName
      * @param array $configuration
      * @return void
      */
-    protected function setChildNodeLabels($nodeTypeName, array &$configuration)
+    protected function setChildNodeLabels(string $nodeTypeName, array &$configuration)
     {
         $nodeTypeLabelIdPrefix = $this->generateNodeTypeLabelIdPrefix($nodeTypeName);
         foreach ($configuration['childNodes'] as $childNodeName => &$childNodeConfiguration) {
@@ -325,7 +325,7 @@ class NodeTypeConfigurationEnrichmentAspect
      * @param string $childNodeName
      * @return string
      */
-    protected function getChildNodeLabelTranslationId($nodeTypeSpecificPrefix, $childNodeName)
+    protected function getChildNodeLabelTranslationId(string $nodeTypeSpecificPrefix, string $childNodeName)
     {
         return $nodeTypeSpecificPrefix . 'childNodes.' . $childNodeName;
     }

--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -57,9 +57,7 @@ class NodeTypeConfigurationEnrichmentAspect
         $declaredSuperTypes = $joinPoint->getMethodArgument('declaredSuperTypes');
         $configuration = $joinPoint->getMethodArgument('configuration');
         $nodeTypeName = $joinPoint->getMethodArgument('name');
-        //\Neos\Flow\var_dump("---------------------------------------");
         $this->addLabelsToNodeTypeConfiguration($nodeTypeName, $configuration, $declaredSuperTypes);
-        //\Neos\Flow\var_dump(json_encode($configuration));
         $joinPoint->setMethodArgument('configuration', $configuration);
         $joinPoint->getAdviceChain()->proceed($joinPoint);
     }
@@ -80,6 +78,7 @@ class NodeTypeConfigurationEnrichmentAspect
             $this->setPropertyLabels($nodeTypeName, $configuration, $declaredSuperTypes);
         }
 
+        //\Neos\Flow\var_dump($this->translator->translateById(labelId: "childNodes.column0", sourceName: "", packageKey: "Neos.Demo"));
         if (isset($configuration['childNodes'])) {
             $this->setChildNodeLabels($nodeTypeName, $configuration, $declaredSuperTypes);
         }

--- a/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Neos.Neos/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -79,7 +79,7 @@ class NodeTypeConfigurationEnrichmentAspect
         }
 
         if (isset($configuration['childNodes'])) {
-            $this->setChildNodeLabels($nodeTypeName, $configuration, $declaredSuperTypes);
+            $this->setChildNodeLabels($nodeTypeName, $configuration);
         }
     }
 
@@ -87,14 +87,13 @@ class NodeTypeConfigurationEnrichmentAspect
     /**
      * @param $nodeTypeName
      * @param array $configuration
-     * @param array $declaredSuperTypes
      * @return void
      */
-    protected function setChildNodeLabels($nodeTypeName, array &$configuration, array $declaredSuperTypes)
+    protected function setChildNodeLabels($nodeTypeName, array &$configuration)
     {
         $nodeTypeLabelIdPrefix = $this->generateNodeTypeLabelIdPrefix($nodeTypeName);
         foreach ($configuration['childNodes'] as $childNodeName => &$childNodeConfiguration) {
-            if ($this->shouldFetchTranslation($childNodeConfiguration)) {
+            if ($childNodeConfiguration && $this->shouldFetchTranslation($childNodeConfiguration)) {
                 $childNodeConfiguration['label'] = $this->getChildNodeLabelTranslationId($nodeTypeLabelIdPrefix, $childNodeName);
             }
         }


### PR DESCRIPTION
Added translation support for labels of autocreated childNodes

## Example:

yaml-File:
```yaml
'Neos.Demo:Content.Columns.Two':
  ...
  childNodes:
    column0:
      type: 'Neos.Demo:Collection.Content.Column'
      label: i18n
    column1:
      type: 'Neos.Demo:Collection.Content.Column'
      label: i18n
```

xlf-file:
```xlf
...
<trans-unit id="childNodes.column0" xml:space="preserve">
	<source>Left Column</source>
</trans-unit>
<trans-unit id="childNodes.column1" xml:space="preserve">
	<source>Right Column</source>
</trans-unit>
...
```

## Changes:
Added childNode labels in addLabelsToNodeTypeConfiguration in NodeConfigurationEnrichmentAspect and implemented function for transforming i18n to a later translated id

Implemented translating of said id to the actual translation in ExpressionBasedNodeLabelGenerator in function getLabel

resolved: https://github.com/neos/neos-development-collection/issues/5643

## Environment
```
- Flow: 8.4
- Neos: 8.4
- PHP: 8.3
```

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
