### PR TITLE
BUGFIX: prevent dangling content stream if switching base workspace

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -50,7 +50,7 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     Okay. No pruneable streams in the event stream
     """
 
-  Scenario: no longer in use content streams will be properly cleaned from the graph projection.
+  Scenario: RebaseWorkspace - no longer in use content streams will be properly cleaned from the graph projection
     When the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
@@ -72,6 +72,35 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     When I am in workspace "user-test" and dimension space point {}
     # todo test that the graph projection really is cleaned up and that no hierarchy stil exist?
     Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier-rebased;root-node;{}
+
+  Scenario: ChangeBaseWorkspace - no longer in use content streams will be properly cleaned from the graph projection.
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                   |
+      | workspaceName      | "review1"               |
+      | baseWorkspaceName  | "live"                  |
+      | newContentStreamId | "review1-cs-identifier" |
+
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+    When I am in workspace "user-test" and dimension space point {}
+    # Ensure that we are in content user-cs-identifier
+    Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier;root-node;{}
+
+    When the command ChangeBaseWorkspace is executed with payload:
+      | Key                | Value                    |
+      | workspaceName      | "user-test"              |
+      | baseWorkspaceName  | "review1"                |
+      | newContentStreamId | "user-cs-identifier-new" |
+    # now, we have one unused content stream (the old content stream of the user-test workspace)
+    # -> this needs to be auto-cleaned-up
+
+    Then I expect the content stream "user-cs-identifier" to not exist
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier-new;root-node;{}
 
   Scenario: no longer in use content streams can be cleaned up completely (simple case)
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -767,6 +767,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             ),
             ExpectedVersion::ANY()
         );
+
+        yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
     }
 
     /**


### PR DESCRIPTION
This change helps with performance, because we do not want the list of content streams to grow unbounded.

Resolves: #5670 