### PR TITLE
BUGFIX: Handle WorkspaceBaseWorkspaceWasChanged in ContentStreamPruner

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -102,6 +102,15 @@ Feature: If content streams are not in use anymore by the workspace, they can be
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "root-node" to lead to node user-cs-identifier-new;root-node;{}
 
+    Then I expect the content stream pruner status output:
+    """
+    Okay. No dangling streams found
+
+    Removed content streams that can be pruned from the event stream
+      id: user-cs-identifier previous state: no longer in use
+    To prune the removed streams from the event stream run ./flow contentStream:pruneRemovedFromEventstream
+    """
+
   Scenario: no longer in use content streams can be cleaned up completely (simple case)
 
     When the command CreateWorkspace is executed with payload:

--- a/Neos.ContentRepository.Core/Classes/Service/ContentStreamPruner.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentStreamPruner.php
@@ -14,6 +14,7 @@ use Neos\ContentRepository\Core\Feature\ContentStreamRemoval\Event\ContentStream
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\WorkspaceWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspaceEventStreamName;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceBaseWorkspaceWasChanged;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasPublished;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceRebaseFailed;
@@ -286,15 +287,12 @@ class ContentStreamPruner implements ContentRepositoryServiceInterface
                 case ContentStreamWasCreated::class:
                     $cs[$domainEvent->contentStreamId->value] = ContentStreamForPruning::create(
                         $domainEvent->contentStreamId,
-                        ContentStreamStatus::CREATED,
-                        null,
                         $eventEnvelope->recordedAt
                     );
                     break;
                 case ContentStreamWasForked::class:
-                    $cs[$domainEvent->newContentStreamId->value] = ContentStreamForPruning::create(
+                    $cs[$domainEvent->newContentStreamId->value] = ContentStreamForPruning::createForked(
                         $domainEvent->newContentStreamId,
-                        ContentStreamStatus::FORKED,
                         $domainEvent->sourceContentStreamId,
                         $eventEnvelope->recordedAt
                     );
@@ -324,6 +322,7 @@ class ContentStreamPruner implements ContentRepositoryServiceInterface
                     EventType::fromString('WorkspaceWasRebased'),
                     EventType::fromString('WorkspaceRebaseFailed'),
                     // we don't need to track WorkspaceWasRemoved as a ContentStreamWasRemoved event would be emitted before
+                    EventType::fromString('WorkspaceBaseWorkspaceWasChanged'),
                 )
             )
         );
@@ -334,43 +333,43 @@ class ContentStreamPruner implements ContentRepositoryServiceInterface
                 case RootWorkspaceWasCreated::class:
                     if (isset($cs[$domainEvent->newContentStreamId->value])) {
                         $cs[$domainEvent->newContentStreamId->value] = $cs[$domainEvent->newContentStreamId->value]
-                                ->withStatus(ContentStreamStatus::IN_USE_BY_WORKSPACE);
+                                ->withWorkspace($domainEvent->workspaceName);
                     }
                     break;
                 case WorkspaceWasCreated::class:
                     if (isset($cs[$domainEvent->newContentStreamId->value])) {
                         $cs[$domainEvent->newContentStreamId->value] = $cs[$domainEvent->newContentStreamId->value]
-                                ->withStatus(ContentStreamStatus::IN_USE_BY_WORKSPACE);
+                                ->withWorkspace($domainEvent->workspaceName);
                     }
                     break;
                 case WorkspaceWasDiscarded::class:
                     if (isset($cs[$domainEvent->newContentStreamId->value])) {
                         $cs[$domainEvent->newContentStreamId->value] = $cs[$domainEvent->newContentStreamId->value]
-                            ->withStatus(ContentStreamStatus::IN_USE_BY_WORKSPACE);
+                            ->withWorkspace($domainEvent->workspaceName);
                     }
                     if (isset($cs[$domainEvent->previousContentStreamId->value])) {
                         $cs[$domainEvent->previousContentStreamId->value] = $cs[$domainEvent->previousContentStreamId->value]
-                            ->withStatus(ContentStreamStatus::NO_LONGER_IN_USE);
+                            ->withNoLongerInUse();
                     }
                     break;
                 case WorkspaceWasPublished::class:
                     if (isset($cs[$domainEvent->newSourceContentStreamId->value])) {
                         $cs[$domainEvent->newSourceContentStreamId->value] = $cs[$domainEvent->newSourceContentStreamId->value]
-                            ->withStatus(ContentStreamStatus::IN_USE_BY_WORKSPACE);
+                            ->withWorkspace($domainEvent->sourceWorkspaceName);
                     }
                     if (isset($cs[$domainEvent->previousSourceContentStreamId->value])) {
                         $cs[$domainEvent->previousSourceContentStreamId->value] = $cs[$domainEvent->previousSourceContentStreamId->value]
-                            ->withStatus(ContentStreamStatus::NO_LONGER_IN_USE);
+                            ->withNoLongerInUse();
                     }
                     break;
                 case WorkspaceWasRebased::class:
                     if (isset($cs[$domainEvent->newContentStreamId->value])) {
                         $cs[$domainEvent->newContentStreamId->value] = $cs[$domainEvent->newContentStreamId->value]
-                            ->withStatus(ContentStreamStatus::IN_USE_BY_WORKSPACE);
+                            ->withWorkspace($domainEvent->workspaceName);
                     }
                     if (isset($cs[$domainEvent->previousContentStreamId->value])) {
                         $cs[$domainEvent->previousContentStreamId->value] = $cs[$domainEvent->previousContentStreamId->value]
-                            ->withStatus(ContentStreamStatus::NO_LONGER_IN_USE);
+                            ->withNoLongerInUse();
                     }
                     break;
                 case WorkspaceRebaseFailed::class:
@@ -378,6 +377,24 @@ class ContentStreamPruner implements ContentRepositoryServiceInterface
                     if (isset($cs[$domainEvent->candidateContentStreamId->value])) {
                         $cs[$domainEvent->candidateContentStreamId->value] = $cs[$domainEvent->candidateContentStreamId->value]
                             ->withRemoved();
+                    }
+                    break;
+                case WorkspaceBaseWorkspaceWasChanged::class:
+                    $previousContentStreamId = null;
+                    // the event does not contain the $previousContentStreamId so we look into the build up state
+                    foreach ($cs as $contentStreamForPruning) {
+                        if ($contentStreamForPruning->workspaceName === $domainEvent->workspaceName) {
+                            $previousContentStreamId = $contentStreamForPruning->id;
+                            break;
+                        }
+                    }
+                    if (isset($cs[$domainEvent->newContentStreamId->value])) {
+                        $cs[$domainEvent->newContentStreamId->value] = $cs[$domainEvent->newContentStreamId->value]
+                            ->withWorkspace($domainEvent->workspaceName);
+                    }
+                    if ($previousContentStreamId) {
+                        $cs[$previousContentStreamId->value] = $cs[$previousContentStreamId->value]
+                            ->withNoLongerInUse();
                     }
                     break;
                 default:

--- a/Neos.ContentRepository.Core/Classes/Service/ContentStreamPruner/ContentStreamForPruning.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentStreamPruner/ContentStreamForPruning.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Service\ContentStreamPruner;
 
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
  * This model reflects if content streams are currently in use or not. Each content stream
@@ -61,6 +62,7 @@ final readonly class ContentStreamForPruning
     private function __construct(
         public ContentStreamId $id,
         public ContentStreamStatus $status,
+        public ?WorkspaceName $workspaceName,
         public ?ContentStreamId $sourceContentStreamId,
         public \DateTimeImmutable $created,
         public bool $removed,
@@ -69,24 +71,51 @@ final readonly class ContentStreamForPruning
 
     public static function create(
         ContentStreamId $id,
-        ContentStreamStatus $status,
-        ?ContentStreamId $sourceContentStreamId,
         \DateTimeImmutable $created,
     ): self {
         return new self(
             $id,
-            $status,
+            ContentStreamStatus::CREATED,
+            null,
+            null,
+            $created,
+            false
+        );
+    }
+
+    public static function createForked(
+        ContentStreamId $id,
+        ContentStreamId $sourceContentStreamId,
+        \DateTimeImmutable $created,
+    ): self {
+        return new self(
+            $id,
+            ContentStreamStatus::FORKED,
+            null,
             $sourceContentStreamId,
             $created,
             false
         );
     }
 
-    public function withStatus(ContentStreamStatus $status): self
+    public function withNoLongerInUse(): self
     {
         return new self(
             $this->id,
-            $status,
+            ContentStreamStatus::NO_LONGER_IN_USE,
+            null,
+            $this->sourceContentStreamId,
+            $this->created,
+            $this->removed
+        );
+    }
+
+    public function withWorkspace(WorkspaceName $workspaceName): self
+    {
+        return new self(
+            $this->id,
+            ContentStreamStatus::IN_USE_BY_WORKSPACE,
+            $workspaceName,
             $this->sourceContentStreamId,
             $this->created,
             $this->removed
@@ -98,6 +127,7 @@ final readonly class ContentStreamForPruning
         return new self(
             $this->id,
             $this->status,
+            $this->workspaceName,
             $this->sourceContentStreamId,
             $this->created,
             true


### PR DESCRIPTION
Solves: #5670

the previousContentStreamId is not included in the event thus we build up the ContentStreamForPruning state with workspace names

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
