### PR TITLE
TASK: Stabilise pure dbal repository truncations during behat tests

### DIFF
--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
  */
 
 use Behat\Gherkin\Node\TableNode;
-use Doctrine\DBAL\Connection;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\Neos\AssetUsage\AssetUsageIndexingProcessor;
@@ -37,13 +37,9 @@ trait AssetUsageTrait
      */
     abstract private function getObject(string $className): object;
 
-    /**
-     * @BeforeScenario
-     */
-    final public function pruneAssetUsage(): void
+    final public function pruneAssetUsage(ContentRepositoryId $contentRepositoryId): void
     {
-        /** Flushes the pure dbal @see AssetUsageRepository which is not trucated via the @flowEntities hook. */
-        $this->getObject(Connection::class)->exec('TRUNCATE TABLE neos_asset_usage');
+        $this->getObject(\Neos\Neos\AssetUsage\Domain\AssetUsageRepository::class)->removeAll($contentRepositoryId);
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 
 use Behat\Gherkin\Node\TableNode;
+use Doctrine\DBAL\Connection;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -41,9 +42,8 @@ trait AssetUsageTrait
      */
     final public function pruneAssetUsage(): void
     {
-        foreach (static::$alreadySetUpContentRepositories as $contentRepositoryId) {
-            $this->getObject(\Neos\Neos\AssetUsage\Domain\AssetUsageRepository::class)->removeAll($contentRepositoryId);
-        }
+        /** Flushes the pure dbal @see AssetUsageRepository which is not trucated via the @flowEntities hook. */
+        $this->getObject(Connection::class)->exec('TRUNCATE TABLE neos_asset_usage');
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -115,6 +115,8 @@ class FeatureContext implements BehatContext
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         FakeContentDimensionSourceFactory::reset();
         FakeNodeTypeManagerFactory::reset();
+        $this->pruneAssetUsage($contentRepositoryId);
+        $this->pruneWorkspaceService($contentRepositoryId);
 
         return $contentRepository;
     }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 
 use Behat\Gherkin\Node\TableNode;
+use Doctrine\DBAL\Connection;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
@@ -54,10 +55,9 @@ trait WorkspaceServiceTrait
      */
     final public function pruneWorkspaceService(): void
     {
-        foreach (static::$alreadySetUpContentRepositories as $contentRepositoryId) {
-            $this->getObject(\Neos\Neos\Domain\Repository\WorkspaceMetadataAndRoleRepository::class)->pruneWorkspaceMetadata($contentRepositoryId);
-            $this->getObject(\Neos\Neos\Domain\Repository\WorkspaceMetadataAndRoleRepository::class)->pruneRoleAssignments($contentRepositoryId);
-        }
+        /** Flushes the pure dbal @see WorkspaceMetadataAndRoleRepository which is not trucated via the @flowEntities hook. */
+        $this->getObject(Connection::class)->exec('TRUNCATE TABLE neos_neos_workspace_metadata');
+        $this->getObject(Connection::class)->exec('TRUNCATE TABLE neos_neos_workspace_role');
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/WorkspaceServiceTrait.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
  */
 
 use Behat\Gherkin\Node\TableNode;
-use Doctrine\DBAL\Connection;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -50,14 +50,10 @@ trait WorkspaceServiceTrait
      */
     abstract private function getObject(string $className): object;
 
-    /**
-     * @BeforeScenario
-     */
-    final public function pruneWorkspaceService(): void
+    final public function pruneWorkspaceService(ContentRepositoryId $contentRepositoryId): void
     {
-        /** Flushes the pure dbal @see WorkspaceMetadataAndRoleRepository which is not trucated via the @flowEntities hook. */
-        $this->getObject(Connection::class)->exec('TRUNCATE TABLE neos_neos_workspace_metadata');
-        $this->getObject(Connection::class)->exec('TRUNCATE TABLE neos_neos_workspace_role');
+        $this->getObject(\Neos\Neos\Domain\Repository\WorkspaceMetadataAndRoleRepository::class)->pruneWorkspaceMetadata($contentRepositoryId);
+        $this->getObject(\Neos\Neos\Domain\Repository\WorkspaceMetadataAndRoleRepository::class)->pruneRoleAssignments($contentRepositoryId);
     }
 
     /**


### PR DESCRIPTION
These repositories are listed (correctly) in

```
flow configuration:show --path Neos.Flow.persistence.doctrine.migrations.ignoredTables
```

which causes doctrine to ignore them when creating new migrations for new entities.

Also the FlowEntities trait for doctrine in behat use does not truncate these tables as they are foreign matter.

Now previously we uses the php apis of the respective repositories to empty the tables but the apis require the CR-Id to be handed in.

We can get a hold of the tested CR by using `$alreadySetUpContentRepositories` - checking the CR-Registry for available CRs would be wrong as one can dynamically define a CR in testing. This dynamic definition of a CR will only happen after the first Scenario is run. Before `$alreadySetUpContentRepositories` would be empty. This means that when running a first behat test which uses the WorkspaceService the test will likely fail as the database still contains values.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
