### PR TITLE
TASK: Cleanup `Neos.Fusion:GlobalCacheIdentifiers` by removing `workspaceChain`

### DIFF
--- a/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
+++ b/Neos.Neos/Classes/Fusion/Helper/CachingHelper.php
@@ -17,7 +17,6 @@ namespace Neos\Neos\Fusion\Helper;
 use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
-use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\ProtectedContextAwareInterface;
@@ -160,35 +159,6 @@ class CachingHelper implements ProtectedContextAwareInterface
             CacheTagSet::forDescendantOfNodesFromNodesWithoutWorkspace($nodesCollection)->toStringArray(),
             CacheTagSet::forWorkspaceNameFromNodes($nodesCollection)->toStringArray(),
         );
-    }
-
-    /**
-     * @param Node|null $node
-     * @return array<string,Workspace>
-     */
-    public function getWorkspaceChain(?Node $node): array
-    {
-        if ($node === null) {
-            return [];
-        }
-
-        $contentRepository = $this->contentRepositoryRegistry->get(
-            $node->contentRepositoryId
-        );
-
-        $currentWorkspace = $contentRepository->findWorkspaceByName(
-            $node->workspaceName
-        );
-        $workspaceChain = [];
-        // TODO: Maybe write CTE here
-        while ($currentWorkspace !== null) {
-            $workspaceChain[$currentWorkspace->workspaceName->value] = $currentWorkspace;
-            $currentWorkspace = $currentWorkspace->baseWorkspaceName
-                ? $contentRepository->findWorkspaceByName($currentWorkspace->baseWorkspaceName)
-                : null;
-        }
-
-        return $workspaceChain;
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Fusion/Override/GlobalCacheIdentifiers.fusion
+++ b/Neos.Neos/Resources/Private/Fusion/Override/GlobalCacheIdentifiers.fusion
@@ -1,10 +1,5 @@
 # Extension of the GlobalCacheIdentifiers prototype
 #
-# We add the names of workspaces of the current workspace chain (for example, "user-john,some-workspace,live") to the list
-# of entry identifier pieces in order to make sure that a specific combination of workspaces has its own content cache entry.
-#
 prototype(Neos.Fusion:GlobalCacheIdentifiers) {
-  workspaceChain = ${Array.join(Array.keys(Neos.Caching.getWorkspaceChain(documentNode)), ',')}
-  workspaceChain.@if.has = ${!!documentNode}
   renderingMode = ${renderingMode.name}
 }


### PR DESCRIPTION
in Neos 9 (ESCR) the workspace is no longer a fallback but a full copy of the base workspace content stream from a certain point. Any changes like base workspace change or publish or discard will lead to a full workspace cache flush (which is a new cache tag) There is no shine through from the base workspace and to explicitly request the new contents synchronise is uses (which is a RebaseWorkspaces and flushes the full workspace)

cleanup to https://github.com/neos/neos-development-collection/pull/5221 which introduces `Workspace` content cache tags (`\Neos\Neos\Fusion\Cache\CacheTag::forWorkspaceName()`)

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
