### PR TITLE
BUGFIX: ensure PHPUnit exists only as dev dependency

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/composer.json
+++ b/Neos.ContentRepository.BehavioralTests/composer.json
@@ -10,10 +10,10 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "neos/contentrepository-core": "self.version",
-        "phpunit/phpunit": "^9.6"
+        "neos/contentrepository-core": "self.version"
     },
     "require-dev": {
+        "phpunit/phpunit": "^9.6",
         "brianium/paratest": "^6.11"
     },
     "autoload": {

--- a/Neos.ContentRepository.Core/composer.json
+++ b/Neos.ContentRepository.Core/composer.json
@@ -25,7 +25,7 @@
         "roave/security-advisories": "dev-latest",
         "phpstan/phpstan": "^1.11",
         "squizlabs/php_codesniffer": "^3.6",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Fusion.Afx/composer.json
+++ b/Neos.Fusion.Afx/composer.json
@@ -16,7 +16,7 @@
     "neos/fusion": "self.version"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0"
+    "phpunit/phpunit": "^9.6"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "neos/flow-development-collection": "9.0.x-dev",
         "doctrine/dbal": "^3.1.4",
         "doctrine/migrations": "*",
-        "phpunit/phpunit": "^9.6",
         "neos/eventstore": "^1",
         "php": "^8.2",
         "neos/error-messages": "*",
@@ -88,6 +87,7 @@
         "league/flysystem-ziparchive": "to export zip archives",
         "neos/media": "to import Assets",
         "neos/escr-asset-usage": "to export used assets",
+        "phpunit/phpunit": "to run assertions in the steps (>=9.6 <13)",
         "neos/contentrepository-structureadjustment": "for certain steps",
         "neos/contentrepository-nodemigration": "for certain steps",
         "phpbench/phpbench": "For running performance benchmarks of the Fusion runtime",
@@ -295,6 +295,7 @@
         }
     },
     "require-dev": {
+        "phpunit/phpunit": "^9.6",
         "brianium/paratest": "^6.11",
         "roave/security-advisories": "dev-latest",
         "phpstan/phpstan": "^1.11",


### PR DESCRIPTION
I am currently experimenting with Pest PHP (and specially Playwright based Browser testing)  - and this prevents me from installing Pest :-)
