### PR TITLE
BUGFIX: Use the resolved target to replace the origin target

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/NodeShortcutResolver.php
+++ b/Neos.Neos/Classes/FrontendRouting/NodeShortcutResolver.php
@@ -74,7 +74,7 @@ class NodeShortcutResolver
         if ($resolvedTarget === $documentNodeInfo) {
             return $nodeAddress;
         }
-        return $nodeAddress->withAggregateId($documentNodeInfo->getNodeAggregateId());
+        return $nodeAddress->withAggregateId($resolvedTarget->getNodeAggregateId());
     }
 
     /**


### PR DESCRIPTION
The resolved target wasn't used to build the new target node address. 

Fixes #5677 

**Review instructions**

- Create a ShortCut node with target "parent" and publish
- Manuelly open the URL of the ShortCut node 
- Expected: Redirect to the parent node