### PR TITLE
FEATURE: New link value object for new link editor (inspector)

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -296,7 +296,7 @@ trait CRTestSuiteTrait
     {
         return PropertyValuesToWrite::fromArray(
             array_map(
-                static fn (mixed $value) => is_array($value) && isset($value['__type']) ? new $value['__type']($value['value']) : $value,
+                static fn (mixed $value) => is_array($value) && isset($value['__type']) ? (is_array($value['value']) ? $value['__type']::fromArray($value['value']) : new $value['__type']($value['value'])) : $value,
                 $properties
             )
         );

--- a/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
+++ b/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
@@ -24,6 +24,7 @@ use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Neos\AssetUsage\Domain\AssetUsageRepository;
 use Neos\Neos\AssetUsage\Dto\AssetIdAndOriginalAssetId;
 use Neos\Neos\AssetUsage\Dto\AssetIdsByProperty;
+use Neos\Neos\Domain\Link\Link;
 use Neos\Utility\TypeHandling;
 
 /**
@@ -217,6 +218,14 @@ final class AssetUsageIndexingService
             preg_match_all('/asset:\/\/(?<assetId>[\w-]*)/i', $value, $matches, PREG_SET_ORDER);
             return array_map(static fn (array $match) => $match['assetId'], $matches);
         }
+
+        if ($value instanceof Link) {
+            if ($value->href->getScheme() === 'asset') {
+                return [$value->href->getHost() . $value->href->getPath()];
+            }
+            return [];
+        }
+
         if (is_subclass_of($type, ResourceBasedInterface::class)) {
             return [$this->persistenceManager->getIdentifierByObject($value)];
         }

--- a/Neos.Neos/Classes/Domain/Link/Link.php
+++ b/Neos.Neos/Classes/Domain/Link/Link.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Domain\Link;
+
+use GuzzleHttp\Psr7\Uri;
+use Neos\Flow\Annotations as Flow;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Link value object modeled partially after the html spec for <a> tags.
+ *
+ * Note that currently the link editor can only handle and write to
+ * the property {@see Link::$target} "_blank" | null
+ * and to {@see Link::$rel} ["noopener"] | null
+ *
+ * The Link values can be accessed in Fusion the following:
+ *
+ * ```fusion
+ * href = ${q(node).property("link").href}
+ * title = ${q(node).property("link").title}
+ * # ...
+ * ```
+ *
+ * In case you need to cast the uri in {@see Link::$href} explicitly to a string
+ * you can use: `String.toString(link.href)`
+ *
+ * @Flow\Proxy(false)
+ */
+final readonly class Link implements \JsonSerializable
+{
+    /**
+     * A selection of frequently used target attribute values
+     */
+    public const TARGET_SELF = '_self';
+    public const TARGET_BLANK = '_blank';
+
+    /**
+     * A selection of frequently used rel attribute values
+     */
+    public const REL_NOOPENER = 'noopener';
+    public const REL_NOFOLLOW = 'nofollow';
+
+    /**
+     * @param array<int, string> $rel
+     */
+    private function __construct(
+        public UriInterface $href,
+        public ?string $title,
+        public ?string $target,
+        public array $rel,
+        public bool $download
+    ) {
+    }
+
+    /**
+     * @param array<int, string> $rel
+     */
+    public static function create(
+        UriInterface $href,
+        ?string $title,
+        ?string $target,
+        array $rel,
+        bool $download,
+    ): self {
+        $relMap = [];
+        foreach ($rel as $value) {
+            $relMap[trim(strtolower($value))] = true;
+        }
+        $trimmedTarget = $target !== null ? trim($target) : '';
+        return new self(
+            $href,
+            $title,
+            $trimmedTarget !== '' ? strtolower($trimmedTarget) : null,
+            array_keys($relMap),
+            $download
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return self::create(
+            new Uri($array['href']),
+            $array['title'] ?? null,
+            $array['target'] ?? null,
+            $array['rel'] ?? [],
+            $array['download'] ?? false,
+        );
+    }
+
+    public static function fromString(string $string): self
+    {
+        return self::create(
+            new Uri($string),
+            null,
+            null,
+            [],
+            false,
+        );
+    }
+
+    public function withTitle(?string $title): self
+    {
+        return self::create(
+            $this->href,
+            $title,
+            $this->target,
+            $this->rel,
+            $this->download,
+        );
+    }
+
+    public function withTarget(?string $target): self
+    {
+        return self::create(
+            $this->href,
+            $this->title,
+            $target,
+            $this->rel,
+            $this->download,
+        );
+    }
+
+    /**
+     * @param array<int, string> $rel
+     */
+    public function withRel(array $rel): self
+    {
+        return self::create(
+            $this->href,
+            $this->title,
+            $this->target,
+            $rel,
+            $this->download,
+        );
+    }
+
+    public function withDownload(bool $download): self
+    {
+        return self::create(
+            $this->href,
+            $this->title,
+            $this->target,
+            $this->rel,
+            $download,
+        );
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'href' => $this->href->__toString(),
+            'title' => $this->title,
+            'target' => $this->target,
+            'rel' => $this->rel,
+            'download' => $this->download,
+        ];
+    }
+}

--- a/Neos.Neos/Classes/Domain/Link/Link.php
+++ b/Neos.Neos/Classes/Domain/Link/Link.php
@@ -65,24 +65,26 @@ final readonly class Link implements \JsonSerializable
     }
 
     /**
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     *
      * @param array<int, string> $rel
      */
     public static function create(
         UriInterface $href,
-        ?string $title,
-        ?string $target,
-        array $rel,
-        bool $download,
+        ?string $title = null,
+        ?string $target = null,
+        array $rel = [],
+        bool $download = false,
     ): self {
         $relMap = [];
         foreach ($rel as $value) {
-            $relMap[trim(strtolower($value))] = true;
+            $relMap[strtolower($value)] = true;
         }
-        $trimmedTarget = $target !== null ? trim($target) : '';
         return new self(
             $href,
-            $title,
-            $trimmedTarget !== '' ? strtolower($trimmedTarget) : null,
+            ($title === '' || $title === null) ? null : $title,
+            ($target === '' || $target === null) ? null : strtolower($target),
             array_keys($relMap),
             $download
         );
@@ -105,58 +107,29 @@ final readonly class Link implements \JsonSerializable
     public static function fromString(string $string): self
     {
         return self::create(
-            new Uri($string),
-            null,
-            null,
-            [],
-            false,
-        );
-    }
-
-    public function withTitle(?string $title): self
-    {
-        return self::create(
-            $this->href,
-            $title,
-            $this->target,
-            $this->rel,
-            $this->download,
-        );
-    }
-
-    public function withTarget(?string $target): self
-    {
-        return self::create(
-            $this->href,
-            $this->title,
-            $target,
-            $this->rel,
-            $this->download,
+            href: new Uri($string)
         );
     }
 
     /**
-     * @param array<int, string> $rel
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     *
+     * @param array<int, string>|null $rel
      */
-    public function withRel(array $rel): self
-    {
+    public function with(
+        ?UriInterface $href = null,
+        ?string $title = null,
+        ?string $target = null,
+        ?array $rel = null,
+        ?bool $download = null,
+    ): self {
         return self::create(
-            $this->href,
-            $this->title,
-            $this->target,
-            $rel,
-            $this->download,
-        );
-    }
-
-    public function withDownload(bool $download): self
-    {
-        return self::create(
-            $this->href,
-            $this->title,
-            $this->target,
-            $this->rel,
-            $download,
+            $href ?? $this->href,
+            $title ?? $this->title,
+            $target ?? $this->target,
+            $rel ?? $this->rel,
+            $download ?? $this->download,
         );
     }
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -10,6 +10,10 @@ Feature: Create node aggregate with node without dimensions
       properties:
         text:
           type: string
+        assetLinkString:
+          type: string
+        assetLinkObject:
+          type: Neos\Neos\Domain\Link\Link
         asset:
           type: Neos\Media\Domain\Model\Asset
         assets:
@@ -35,6 +39,8 @@ Feature: Create node aggregate with node without dimensions
     When an asset exists with id "asset-1"
     And an asset exists with id "asset-2"
     And an asset exists with id "asset-3"
+    And an asset exists with id "asset-4"
+    And an asset exists with id "asset-5"
 
     When the command CreateWorkspace is executed with payload:
       | Key                | Value            |
@@ -46,16 +52,20 @@ Feature: Create node aggregate with node without dimensions
     Given I am in workspace "live"
 
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId            | nodeName   | parentNodeAggregateId  | nodeTypeName                                           | initialPropertyValues                |
-      | sir-david-nodenborough     | node       | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"asset": "Asset:asset-1"}           |
-      | nody-mc-nodeface           | child-node | sir-david-nodenborough | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assets": ["Asset:asset-2"]}        |
-      | sir-nodeward-nodington-iii | esquire    | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"text": "Link to asset://asset-3."} |
+      | nodeAggregateId            | nodeName   | parentNodeAggregateId  | nodeTypeName                                           | initialPropertyValues                                                                                             |
+      | sir-david-nodenborough     | node       | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"asset": "Asset:asset-1"}                                                                                        |
+      | nody-mc-nodeface           | child-node | sir-david-nodenborough | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assets": ["Asset:asset-2"]}                                                                                     |
+      | sir-nodeward-nodington-iii | esquire    | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"text": "Link to asset://asset-3."}                                                                              |
+      | sir-nodeward-lincoln       |            | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assetLinkString": "asset://asset-4"}                                                                            |
+      | sir-objectward-lincoln     |            | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assetLinkObject": {"__type": "Neos\\\\Neos\\\\Domain\\\\Link\\\\Link", "value": { "href": "asset://asset-5" }}} |
 
     Then I expect the AssetUsageService to have the following AssetUsages:
-      | assetId | nodeAggregateId            | propertyName | workspaceName | originDimensionSpacePoint |
-      | asset-1 | sir-david-nodenborough     | asset        | live          | {}                        |
-      | asset-2 | nody-mc-nodeface           | assets       | live          | {}                        |
-      | asset-3 | sir-nodeward-nodington-iii | text         | live          | {}                        |
+      | assetId | nodeAggregateId            | propertyName    | workspaceName | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset           | live          | {}                        |
+      | asset-2 | nody-mc-nodeface           | assets          | live          | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text            | live          | {}                        |
+      | asset-4 | sir-nodeward-lincoln       | assetLinkString | live          | {}                        |
+      | asset-5 | sir-objectward-lincoln     | assetLinkObject | live          | {}                        |
 
   Scenario: Nodes on user workspace have been created
     Given I am in workspace "user-workspace"

--- a/Neos.Neos/Tests/Unit/Domain/Link/LinkTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Link/LinkTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Tests\Unit\Domain\Link;
+
+use GuzzleHttp\Psr7\Uri;
+use Neos\Neos\Domain\Link\Link;
+use PHPUnit\Framework\TestCase;
+
+class LinkTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function emptyLink()
+    {
+        $link = Link::create(
+            href: new Uri('#')
+        );
+        self::assertEquals('', (string)$link->href);
+        self::assertEquals(null, $link->title);
+        self::assertEquals(null, $link->target);
+        self::assertEquals([], $link->rel);
+        self::assertEquals(false, $link->download);
+
+        // another way to create it
+        self::assertEquals(
+            $link,
+            Link::fromString('#')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function linkWithAttributes()
+    {
+        $link = Link::create(
+            href: new Uri('/bar'),
+            title: 'My link',
+            target: Link::TARGET_BLANK,
+            rel: [Link::REL_NOFOLLOW],
+            download: true
+        );
+
+        self::assertEquals('/bar', (string)$link->href);
+        self::assertEquals('My link', $link->title);
+        self::assertEquals('_blank', $link->target);
+        self::assertEquals(['nofollow'], $link->rel);
+        self::assertEquals(true, $link->download);
+    }
+
+    /**
+     * @test
+     */
+    public function linkWithAttributesViaWither()
+    {
+        $emptyLink = Link::create(
+            href: new Uri('#')
+        );
+
+        $link = $emptyLink->with(
+            href: new Uri('/bar'),
+            title: 'My link',
+            target: Link::TARGET_BLANK,
+            rel: [Link::REL_NOFOLLOW],
+            download: true
+        );
+
+        self::assertEquals('/bar', (string)$link->href);
+        self::assertEquals('My link', $link->title);
+        self::assertEquals('_blank', $link->target);
+        self::assertEquals(['nofollow'], $link->rel);
+        self::assertEquals(true, $link->download);
+    }
+
+    /**
+     * @test
+     */
+    public function linkWithAttributesOneUpdated()
+    {
+        $link = Link::create(
+            href: new Uri('/bar'),
+            title: 'My link',
+            target: Link::TARGET_BLANK,
+            rel: [Link::REL_NOFOLLOW],
+            download: true
+        )->with(
+            title: 'My updated link'
+        );
+
+        self::assertEquals('/bar', (string)$link->href);
+        self::assertEquals('My updated link', $link->title);
+        self::assertEquals('_blank', $link->target);
+        self::assertEquals(['nofollow'], $link->rel);
+        self::assertEquals(true, $link->download);
+    }
+
+    /**
+     * @test
+     */
+    public function linkWithAttributesCanBeResetViaWith()
+    {
+        $link = Link::create(
+            href: new Uri('/bar'),
+            title: 'My link',
+            target: Link::TARGET_BLANK,
+            rel: [Link::REL_NOFOLLOW],
+            download: true
+        )->with(
+            title: '',
+            target: '',
+            rel: [],
+            download: false
+        );
+
+        self::assertEquals('/bar', (string)$link->href);
+        self::assertEquals(null, $link->title);
+        self::assertEquals(null, $link->target);
+        self::assertEquals([], $link->rel);
+        self::assertEquals(false, $link->download);
+    }
+}


### PR DESCRIPTION
In the Neos Ui https://github.com/neos/neos-ui/pull/3996 will introduce a new LinkEditor based on the Archaeopteryx.

With https://github.com/sitegeist/Sitegeist.Archaeopteryx/pull/44 the Archaeopteryx allowed not only to use the inspector editor for simple string values but also to use the `Sitegeist\Archaeopteryx\Link` value object which allows to store additional data from the LinkEditor like title,rel target and further.

Adapted to Neos this would look like:

```yaml
My.Content:
  properties:
    link:
      type: 'Neos\Neos\Domain\Link\Link'
      ui:
        inspector:
          editorOptions:
            anchor: true
            title: true
            targetBlank: true
            relNofollow: true
            download: true
```

The link value object can be queried as usual. An example rendering would look the following:

```
link = ${q(node).property("link")}
renderer = afx`
    <a href={props.link.href} title={props.link.title} target={props.link.target} rel={props.link.rel} rel.@if={props.link.rel != []}>
        My Text
    </a>
`
```

As the Archaeopteryx will now be part of the core we must discuss how or if we should also support this new feature in Neos 9.1 already.

The reason this discussion/PR is opened here in Neos.Neos is that the value object is part of the NodeType definition and thus existential part of the content repository and nodes. Writing an importer would require to use the value object as well and depending on the Neos Ui package - which has no PHP API - is not correct.

### Discussion

This change is not finished. With Neos 9 we have the asset usage for example which inspects all node properties to keep track of assets. This code would also need to be extended to look into this new value object.

When we think of relations from a node to another node - which is at the current form a link via `node://` protocol well also quickly realise that this is flawed as we have no simple way to validate that all outgoing links still work or cannot warn or notify when deleting a target node. This is true for the ckeditor blob but for links as a simple property it doesnt have to be this way. Neos 9 introduced references with properties on the edge. A node to node link with properties like title,rel or target can FULLY be implemented via a reference instead. And its way easier to work with real reference nodes instead of fiddling with plain `node://` strings or node strings that are encapsulated in a shiny `Link` object but just magic strings at the end still. The link editor obviously shines in that it allows to _either_ reference a node or an external website or asset. References cannot to external websites but might be able to learn assets at one point. The question is if we should introduce the concept of an apparent shiny link value object to the core when we already know it's not the holy grail?

As well probably continue to face the issue of inline links in ckeditor text blobs and cannot define that primary usecase away ^^ well have to find a solution for this already. On the Dresden sprint the idea was to possibly introduce on every node a reference blob which contains entries for all used node links on that node especially regarding text blobs. But that reference blog could also track the references used in the inspector link editor and this way we could continue and be happy with a stupid `Link` object? :)

Also for handling this new object and correctly serialising that for the Neos Ui we need to merge https://github.com/neos/neos-ui/pull/3723

-> We discussed that the primary use case is that one wants to define a link to somewhere. That might be an external page or internal. Either way the fact that its an internal node is usually not relevant to the integration as the node schema will be converted to an actual http link during rendering via `ConvertUris`. One rarely wants to have a node instance at hand here and thus actual reference edges might not be important except for the tracking of content. And for tracking node ids an idea is outlined above or we introduce an indexer like the `AssetUsage`

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
