### PR TITLE
BUGFIX: Improve nodetype checks performance

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/NodeType.php
@@ -99,6 +99,8 @@ class NodeType
      */
     protected $initialized = false;
 
+    private static $isOfTypeCache = [];
+
     /**
      * Constructs this node type
      *
@@ -303,14 +305,22 @@ class NodeType
         if ($nodeType === $this->name) {
             return true;
         }
-        if (array_key_exists($nodeType, $this->declaredSuperTypes) && $this->declaredSuperTypes[$nodeType] === null) {
-            return false;
+        if (!isset(self::$isOfTypeCache[$this->name])) {
+            self::$isOfTypeCache[$this->name] = [];
+            foreach ($this->declaredSuperTypes as $superTypeName => $superType) {
+                self::$isOfTypeCache[$this->name][$superTypeName] = $superType !== null;
+            }
+        }
+        if (isset(self::$isOfTypeCache[$this->name][$nodeType])) {
+            return self::$isOfTypeCache[$this->name][$nodeType];
         }
         foreach ($this->declaredSuperTypes as $superType) {
-            if ($superType !== null && $superType->isOfType($nodeType) === true) {
+            if ($superType?->isOfType($nodeType)) {
+                self::$isOfTypeCache[$this->name][$nodeType] = true;
                 return true;
             }
         }
+        self::$isOfTypeCache[$this->name][$nodeType] = false;
         return false;
     }
 

--- a/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
+++ b/Neos.ContentRepository/Classes/Domain/Service/NodeTypeManager.php
@@ -100,7 +100,7 @@ class NodeTypeManager
             $filteredNodeTypes = [];
             /** @var NodeType $nodeType */
             foreach ($this->cachedNodeTypes as $nodeTypeName => $nodeType) {
-                if ($nodeType->isOfType($superTypeName) && $nodeTypeName !== $superTypeName) {
+                if ($nodeTypeName !== $superTypeName && $nodeType->isOfType($superTypeName)) {
                     $filteredNodeTypes[$nodeTypeName] = $nodeType;
                 }
             }
@@ -108,7 +108,7 @@ class NodeTypeManager
         }
 
         if ($includeAbstractNodeTypes === false) {
-            return array_filter($this->cachedSubNodeTypes[$superTypeName], function (NodeType $nodeType) {
+            return array_filter($this->cachedSubNodeTypes[$superTypeName], static function (NodeType $nodeType) {
                 return !$nodeType->isAbstract();
             });
         }


### PR DESCRIPTION
This change is based on a patch I use in larger Neos instances to speed up the `isOfType` checks which can occur thousands of times for a single request and goes recursively through all `superTypes` of a node for each check.

TODO: Add some example and show improvement in numbers

**Upgrade instructions**

Nothing to do

**Review instructions**

All tests stay green

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
