### PR TITLE
FEATURE: Add node migration transformation to change properties from scalar to BackedEnum

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyTypeFromScalarToBackedEnum_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyTypeFromScalarToBackedEnum_Dimensions.feature
@@ -78,12 +78,10 @@ Feature: Change property type from scalar to backed enum
             type: 'ChangePropertyTypeFromScalarToBackedEnum'
             settings:
               property: 'myString'
-              newType: '\Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek'
           -
             type: 'ChangePropertyTypeFromScalarToBackedEnum'
             settings:
               property: 'myInt'
-              newType: '\Neos\ContentRepository\Core\Tests\Behavior\Fixtures\ArbitraryNumber'
     """
 
     # the original content stream has not been touched

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyTypeFromScalarToBackedEnum_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyTypeFromScalarToBackedEnum_Dimensions.feature
@@ -1,0 +1,145 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Change property type from scalar to backed enum
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values                      | Generalizations                      |
+      | example    | general, source, peer, spec | spec->source->general, peer->general |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root':
+      constraints:
+        nodeTypes:
+          'Neos.ContentRepository.Testing:Document': true
+          'Neos.ContentRepository.Testing:OtherDocument': true
+    'Neos.ContentRepository.Testing:Document':
+      properties:
+        myString:
+          type: string
+        myInt:
+          type: int
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                                     |
+      | nodeAggregateId           | "nody-mc-nodeface"                                  |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Document"                 |
+      | originDimensionSpacePoint | {"example": "general"}                                    |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                                  |
+      | initialPropertyValues     | {"myString": "https://schema.org/Wednesday", "myInt": 42} |
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "nody-mc-nodeface" |
+      | sourceOrigin    | {"example":"general"}    |
+      | targetOrigin    | {"example":"source"}     |
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "nody-mc-nodeface" |
+      | sourceOrigin    | {"example":"general"}    |
+      | targetOrigin    | {"example":"peer"}       |
+
+
+  Scenario: Change property type from scalar to backed enum creating a new target workspace
+    When I change the node types in content repository "default" to:
+    """yaml
+    'Neos.ContentRepository:Root':
+      constraints:
+        nodeTypes:
+          'Neos.ContentRepository.Testing:Document': true
+          'Neos.ContentRepository.Testing:OtherDocument': true
+    'Neos.ContentRepository.Testing:Document':
+      properties:
+        myString:
+          type: \Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek
+        myInt:
+          type: \Neos\ContentRepository\Core\Tests\Behavior\Fixtures\ArbitraryNumber
+    """
+    And I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
+    """yaml
+    migration:
+      -
+        filters:
+          -
+            type: 'NodeType'
+            settings:
+              nodeType: 'Neos.ContentRepository.Testing:Document'
+        transformations:
+          -
+            type: 'ChangePropertyTypeFromScalarToBackedEnum'
+            settings:
+              property: 'myString'
+              newType: '\Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek'
+          -
+            type: 'ChangePropertyTypeFromScalarToBackedEnum'
+            settings:
+              property: 'myInt'
+              newType: '\Neos\ContentRepository\Core\Tests\Behavior\Fixtures\ArbitraryNumber'
+    """
+
+    # the original content stream has not been touched
+    When I am in workspace "live" and dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have the following properties:
+      | Key      | Value                        |
+      | myString | https://schema.org/Wednesday |
+      | myInt    | 42                           |
+
+    When I am in workspace "live" and dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "source"}
+    And I expect this node to have the following properties:
+      | Key      | Value                        |
+      | myString | https://schema.org/Wednesday |
+      | myInt    | 42                           |
+
+    When I am in workspace "live" and dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "peer"}
+    And I expect this node to have the following properties:
+      | Key      | Value                        |
+      | myString | https://schema.org/Wednesday |
+      | myInt    | 42                           |
+
+    When I am in workspace "live" and dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "source"}
+    And I expect this node to have the following properties:
+      | Key      | Value                        |
+      | myString | https://schema.org/Wednesday |
+      | myInt    | 42                           |
+
+    # the node was changed in the new content stream, in all variants
+    When I am in workspace "migration-workspace" and dimension space point {"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have the following properties:
+      | Key      | Value                                  |
+      | myString | DayOfWeek:https://schema.org/Wednesday |
+      | myInt    | ArbitraryNumber:42                     |
+
+    When I am in workspace "migration-workspace" and dimension space point {"example": "source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"example": "source"}
+    And I expect this node to have the following properties:
+      | Key      | Value                                  |
+      | myString | DayOfWeek:https://schema.org/Wednesday |
+      | myInt    | ArbitraryNumber:42                     |
+
+    When I am in workspace "migration-workspace" and dimension space point {"example": "peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"example": "peer"}
+    And I expect this node to have the following properties:
+      | Key      | Value                                  |
+      | myString | DayOfWeek:https://schema.org/Wednesday |
+      | myInt    | ArbitraryNumber:42                     |
+
+    When I am in workspace "migration-workspace" and dimension space point {"example": "spec"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"example": "source"}
+    And I expect this node to have the following properties:
+      | Key      | Value                                  |
+      | myString | DayOfWeek:https://schema.org/Wednesday |
+      | myInt    | ArbitraryNumber:42                     |

--- a/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/ArbitraryNumber.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/ArbitraryNumber.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.Core package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Behavior\Fixtures;
+
+/**
+ * An arbitrary number enumeration
+ */
+enum ArbitraryNumber: int
+{
+    case NUMBER_42 = 42;
+    case NUMBER_8472 = 8472;
+}

--- a/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/DayOfWeek.php
+++ b/Neos.ContentRepository.Core/Tests/Behavior/Fixtures/DayOfWeek.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Tests\Behavior\Fixtures;
 
 /**
- * A day of week enumeratoion
+ * A day of week enumeration
  *
  * @see https://schema.org/DayOfWeek
  */

--- a/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/NodeMigrationServiceFactory.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\NodeMigration\Filter\PropertyValueFilterFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\AddDimensionShineThroughTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyConverterAwareTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\ChangeNodeTypeTransformationFactory;
+use Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyTypeFromScalarToBackedEnumTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyValueConverterAwareTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\MoveDimensionSpacePointTransformationFactory;
 use Neos\ContentRepository\NodeMigration\Transformation\PropertyConverterAwareTransformationFactoryInterface;
@@ -58,6 +59,7 @@ final readonly class NodeMigrationServiceFactory implements ContentRepositorySer
                 'AddNewProperty' => AddNewPropertyConverterAwareTransformationFactory::class,
                 'ChangeNodeType' => ChangeNodeTypeTransformationFactory::class,
                 'ChangePropertyValue' => ChangePropertyValueConverterAwareTransformationFactory::class,
+                'ChangePropertyTypeFromScalarToBackedEnum' => ChangePropertyTypeFromScalarToBackedEnumTransformationFactory::class,
                 'MoveDimensionSpacePoint' => MoveDimensionSpacePointTransformationFactory::class,
                 'RemoveNode' => RemoveNodeTransformationFactory::class,
                 'RemoveProperty' => RemovePropertyTransformationFactory::class,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyTypeFromScalarToBackedEnumTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyTypeFromScalarToBackedEnumTransformationFactory.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\CommandHandler\Commands;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -27,7 +28,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 class ChangePropertyTypeFromScalarToBackedEnumTransformationFactory implements TransformationFactoryInterface
 {
     /**
-     * @param array{property: string, newType: class-string<\BackedEnum>} $settings
+     * @param array{property: string} $settings
      */
     public function build(
         array $settings,
@@ -36,19 +37,15 @@ class ChangePropertyTypeFromScalarToBackedEnumTransformationFactory implements T
     {
         return new class (
             $settings['property'],
-            $settings['newType'],
+            $contentRepository->getNodeTypeManager(),
         ) implements NodeAggregateBasedTransformationInterface {
             public function __construct(
                 /**
                  * Name of the property to be transformed
                  */
                 private readonly string $property,
-                /**
-                 * New type of the property
-                 *
-                 * @var class-string<\BackedEnum>
-                 */
-                private readonly string $newType,
+
+                private readonly NodeTypeManager $nodeTypeManager,
             )
             {
             }
@@ -56,8 +53,10 @@ class ChangePropertyTypeFromScalarToBackedEnumTransformationFactory implements T
             public function execute(
                 NodeAggregate $nodeAggregate,
                 WorkspaceName $workspaceNameForWriting
-            ): TransformationStep
-            {
+            ): TransformationStep {
+                /** @var class-string<\BackedEnum> $newType */
+                $newType = $this->nodeTypeManager->getNodeType($nodeAggregate->nodeTypeName)
+                    ?->getPropertyType($this->property);
                 $commands = [];
                 foreach ($nodeAggregate->getNodes() as $node) {
                     $propertyValue = $node->properties[$this->property];
@@ -69,7 +68,7 @@ class ChangePropertyTypeFromScalarToBackedEnumTransformationFactory implements T
                         $node->aggregateId,
                         $node->originDimensionSpacePoint,
                         PropertyValuesToWrite::fromArray([
-                            $this->property => $this->newType::from($propertyValue),
+                            $this->property => $newType::from($propertyValue),
                         ]),
                     );
                 }

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyTypeFromScalarToBackedEnumTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyTypeFromScalarToBackedEnumTransformationFactory.php
@@ -27,7 +27,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 class ChangePropertyTypeFromScalarToBackedEnumTransformationFactory implements TransformationFactoryInterface
 {
     /**
-     * @param array<string,string> $settings
+     * @param array{property: string, newType: class-string<\BackedEnum>} $settings
      */
     public function build(
         array $settings,

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyTypeFromScalarToBackedEnumTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangePropertyTypeFromScalarToBackedEnumTransformationFactory.php
@@ -14,17 +14,17 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\NodeMigration\Transformation;
 
+use Neos\ContentRepository\Core\CommandHandler\Commands;
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\NodeModification\Command\SetNodeProperties;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
- * Rename a node property
+ * Change a node property value from a scalar to a backed enum
  */
-class RenamePropertyTransformationFactory implements TransformationFactoryInterface
+class ChangePropertyTypeFromScalarToBackedEnumTransformationFactory implements TransformationFactoryInterface
 {
     /**
      * @param array<string,string> $settings
@@ -35,43 +35,46 @@ class RenamePropertyTransformationFactory implements TransformationFactoryInterf
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface
     {
         return new class (
-            $settings['from'],
-            $settings['to'],
-        ) implements NodeBasedTransformationInterface {
+            $settings['property'],
+            $settings['newType'],
+        ) implements NodeAggregateBasedTransformationInterface {
             public function __construct(
                 /**
-                 * Property name to change
+                 * Name of the property to be transformed
                  */
-                private readonly string $from,
+                private readonly string $property,
                 /**
-                 * New name of property
+                 * New type of the property
+                 *
+                 * @var class-string<\BackedEnum>
                  */
-                private readonly string $to,
+                private readonly string $newType,
             )
             {
             }
 
             public function execute(
-                Node $node,
-                DimensionSpacePointSet $coveredDimensionSpacePoints,
+                NodeAggregate $nodeAggregate,
                 WorkspaceName $workspaceNameForWriting
             ): TransformationStep
             {
-                $propertyValue = $node->properties[$this->from];
-                if ($propertyValue === null) {
-                    return TransformationStep::createEmpty();
-                }
-                return TransformationStep::fromCommand(
-                    SetNodeProperties::create(
+                $commands = [];
+                foreach ($nodeAggregate->getNodes() as $node) {
+                    $propertyValue = $node->properties[$this->property];
+                    if ($propertyValue === null) {
+                        continue;
+                    }
+                    $commands[] = SetNodeProperties::create(
                         $workspaceNameForWriting,
                         $node->aggregateId,
                         $node->originDimensionSpacePoint,
                         PropertyValuesToWrite::fromArray([
-                            $this->to => $propertyValue,
-                            $this->from => null,
+                            $this->property => $this->newType::from($propertyValue),
                         ]),
-                    )
-                );
+                    );
+                }
+
+                return TransformationStep::fromCommands(Commands::fromArray($commands));
             }
         };
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -32,6 +32,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
+use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\ArbitraryNumber;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress;
 use Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PriceSpecification;
@@ -379,7 +380,7 @@ trait ProjectedNodeTrait
         });
     }
 
-    private function resolvePropertyValue(string $serializedPropertyValue)
+    private function resolvePropertyValue(string $serializedPropertyValue): mixed
     {
         switch ($serializedPropertyValue) {
             case 'PostalAddress:dummy':
@@ -399,6 +400,8 @@ trait ProjectedNodeTrait
                     return new Uri(\mb_substr($serializedPropertyValue, 4));
                 } elseif (\str_starts_with($serializedPropertyValue, 'DayOfWeek:')) {
                     return DayOfWeek::from(\mb_substr($serializedPropertyValue, 10));
+                } elseif (\str_starts_with($serializedPropertyValue, 'ArbitraryNumber:')) {
+                    return ArbitraryNumber::from((int)\mb_substr($serializedPropertyValue, 16));
                 }
         }
 


### PR DESCRIPTION
this is a followup feature for https://github.com/neos/flow-development-collection/pull/3523#issuecomment-3587053387

Since now we have fully fledged enum support for node properties, this now adds a node transformation that retroactively changes previously set strings (or ints) to their \BackedEnum counterparts - given the NodeType configuration has been adjusted beforehand.

**Upgrade instructions**

none

**Review instructions**

see tests

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.1 branch as this is a new feature
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
