### PR TITLE
BUGFIX: Do not throw exception when assigning tag to reuploaded image

### DIFF
--- a/Neos.Media.Browser/Classes/Controller/AssetController.php
+++ b/Neos.Media.Browser/Classes/Controller/AssetController.php
@@ -35,6 +35,7 @@ use Neos\Media\Browser\Domain\Session\BrowserState;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\ImageVariant;
 use Neos\Media\Domain\Model\AssetSource\AssetNotFoundExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyRepositoryInterface;
@@ -591,6 +592,10 @@ class AssetController extends ActionController
      */
     public function uploadAction(Asset $asset): string
     {
+        if ($this->persistenceManager->isNewObject($asset) === false && $asset instanceof ImageVariant) {
+            $asset = $asset->getOriginalAsset();
+        }
+
         if (($tag = $this->browserState->get('activeTag')) !== null) {
             $asset->addTag($tag);
         }


### PR DESCRIPTION
This pull request is related too: neos/neos-development-collection#5693

When an image already exists in the media library and there is an image variant with the same image dimensions, re-uploading the image to a tag does not work. This ensures image variants are replaced with the original asset during re-upload.

resolved:#5693

