### PR TITLE
TASK: Implement performance tracing for CatchUpHooks

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -98,6 +98,7 @@ final class ContentRepositoryFactory
             $contentDimensionSource,
             $this->interDimensionalVariationGraph,
             $this->propertyConverter,
+            $this->performanceTracer
         );
         $subscribers = [];
         $additionalProjectionStates = [];
@@ -123,6 +124,7 @@ final class ContentRepositoryFactory
                 $this->nodeTypeManager,
                 $this->contentDimensionSource,
                 $this->interDimensionalVariationGraph,
+                $this->performanceTracer
             )),
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Factory/ProjectionSubscriberFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ProjectionSubscriberFactory.php
@@ -49,6 +49,7 @@ final readonly class ProjectionSubscriberFactory
             $dependencies->nodeTypeManager,
             $dependencies->contentDimensionSource,
             $dependencies->interDimensionalVariationGraph,
+            $dependencies->performanceTracer,
         ));
 
         return new ProjectionSubscriber(

--- a/Neos.ContentRepository.Core/Classes/Factory/SubscriberFactoryDependencies.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/SubscriberFactoryDependencies.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Factory;
 
 use Neos\ContentRepository\Core\Dimension\ContentDimensionSourceInterface;
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
@@ -31,6 +32,7 @@ final readonly class SubscriberFactoryDependencies
         public ContentDimensionSourceInterface $contentDimensionSource,
         public InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private PropertyConverter $propertyConverter,
+        public PerformanceTracerInterface|null $performanceTracer,
     ) {
     }
 
@@ -42,14 +44,16 @@ final readonly class SubscriberFactoryDependencies
         NodeTypeManager $nodeTypeManager,
         ContentDimensionSourceInterface $contentDimensionSource,
         InterDimensionalVariationGraph $interDimensionalVariationGraph,
-        PropertyConverter $propertyConverter
+        PropertyConverter $propertyConverter,
+        PerformanceTracerInterface|null $performanceTracer,
     ): self {
         return new self(
             $contentRepositoryId,
             $nodeTypeManager,
             $contentDimensionSource,
             $interDimensionalVariationGraph,
-            $propertyConverter
+            $propertyConverter,
+            $performanceTracer,
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/CatchUpHookFactories.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/CatchUpHookFactories.php
@@ -59,6 +59,6 @@ final class CatchUpHookFactories implements CatchUpHookFactoryInterface
     public function build(CatchUpHookFactoryDependencies $dependencies): CatchUpHookInterface
     {
         $catchUpHooks = array_map(static fn(CatchUpHookFactoryInterface $catchUpHookFactory) => $catchUpHookFactory->build($dependencies), $this->catchUpHookFactories);
-        return new DelegatingCatchUpHook(...$catchUpHooks);
+        return new DelegatingCatchUpHook($dependencies->performanceTracer, ...$catchUpHooks);
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/CatchUpHookFactoryDependencies.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/CatchUpHookFactoryDependencies.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Projection\CatchUpHook;
 
 use Neos\ContentRepository\Core\Dimension\ContentDimensionSourceInterface;
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ProjectionStateInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
@@ -36,7 +37,8 @@ final readonly class CatchUpHookFactoryDependencies
         public ProjectionStateInterface $projectionState,
         public NodeTypeManager $nodeTypeManager,
         public ContentDimensionSourceInterface $contentDimensionSource,
-        public InterDimensionalVariationGraph $variationGraph
+        public InterDimensionalVariationGraph $variationGraph,
+        public PerformanceTracerInterface|null $performanceTracer,
     ) {
     }
 
@@ -51,14 +53,16 @@ final readonly class CatchUpHookFactoryDependencies
         ProjectionStateInterface $projectionState,
         NodeTypeManager $nodeTypeManager,
         ContentDimensionSourceInterface $contentDimensionSource,
-        InterDimensionalVariationGraph $variationGraph
+        InterDimensionalVariationGraph $variationGraph,
+        PerformanceTracerInterface|null $performanceTracer,
     ): self {
         return new self(
             $contentRepositoryId,
             $projectionState,
             $nodeTypeManager,
             $contentDimensionSource,
-            $variationGraph
+            $variationGraph,
+            $performanceTracer,
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/DelegatingCatchUpHook.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/CatchUpHook/DelegatingCatchUpHook.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Projection\CatchUpHook;
 
 use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\EventStore\Model\EventEnvelope;
 
@@ -22,6 +23,7 @@ final readonly class DelegatingCatchUpHook implements CatchUpHookInterface
     private array $catchUpHooks;
 
     public function __construct(
+        private PerformanceTracerInterface|null $performanceTracer,
         CatchUpHookInterface ...$catchUpHooks
     ) {
         $this->catchUpHooks = $catchUpHooks;
@@ -79,6 +81,7 @@ final readonly class DelegatingCatchUpHook implements CatchUpHookInterface
         foreach ($this->catchUpHooks as $catchUpHook) {
             try {
                 $closure($catchUpHook);
+                $this->performanceTracer?->mark('CatchUpHook::' . $hookName, ['hook' => get_class($catchUpHook)]);
             } catch (\Throwable $e) {
                 $firstError ??= $e;
                 $failedCatchupHookName = substr(strrchr($catchUpHook::class, '\\') ?: '', 1);


### PR DESCRIPTION
Before this change, it was really hard to figure out why Neos was slow if CatchUpHooks (f.e. added by community packages) had a negative impact on write performance.
With this change, it is really easy to see. The change is non-breaking.
