### PR TITLE
BUGFIX: Prevent "security Context cannot be initialized" in CLI when using `getContentSubgraph()`

### DIFF
--- a/Neos.Neos/Classes/Security/ContentRepositoryAuthProvider/ContentRepositoryAuthProvider.php
+++ b/Neos.Neos/Classes/Security/ContentRepositoryAuthProvider/ContentRepositoryAuthProvider.php
@@ -42,6 +42,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Neos\Domain\Model\WorkspacePermissions;
 use Neos\Neos\Domain\Service\UserService;
+use Neos\Neos\Domain\SubtreeTagging\NeosVisibilityConstraints;
 use Neos\Neos\Security\Authorization\ContentRepositoryAuthorizationService;
 use Neos\Neos\Security\Authorization\Privilege\EditNodePrivilege;
 
@@ -73,6 +74,9 @@ final readonly class ContentRepositoryAuthProvider implements AuthProviderInterf
 
     public function getVisibilityConstraints(WorkspaceName $workspaceName): VisibilityConstraints
     {
+        if ($this->securityContext->areAuthorizationChecksDisabled()) {
+            return NeosVisibilityConstraints::excludeRemoved();
+        }
         return $this->authorizationService->getVisibilityConstraints($this->contentRepositoryId, $this->securityContext->getRoles());
     }
 


### PR DESCRIPTION
`canReadNodesFromWorkspace()` correctly uses this check but `$this->securityContext->getRoles()` fails in CLI when the subgraph is fetched during asking for the `getVisibilityConstraints()`

CLI is invoked in a `$this->securityContext->withoutAuthorizationChecks()` closure but its up to us as developers to check `areAuthorizationChecksDisabled()` as there is no best-effort return value generation like empty array for `getRoles()`

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
