### PR TITLE
BUGFIX: Creating valid „more“ url in history module

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/HistoryController.php
@@ -53,7 +53,7 @@ class HistoryController extends AbstractModuleController
                 ->controllerContext
                 ->getUriBuilder()
                 ->setCreateAbsoluteUri(true)
-                ->uriFor('Index', ['offset' => $offset + $limit], 'History', 'Neos.Neos');
+                ->uriFor('index', ['offset' => $offset + $limit]);
         }
 
         $eventsByDate = [];

--- a/Neos.Neos/Resources/Private/Templates/Module/Management/History/Index.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/History/Index.html
@@ -48,7 +48,7 @@
 	window.addEventListener('DOMContentLoaded', (event) => {
 		jQuery(function($) {
 
-			var nextPage = '{nextPage}';
+			var nextPage = jQuery('div.loadMore').data('neos-history-nextpage');
 			var historyContainer = $('.neos-history');
 			$('.loadMore button').click(function() {
 


### PR DESCRIPTION
With this change the uri to load more history entries is correctly generated again and all history entries can be browsed.

Resolves: #5702
