### PR TITLE
BUGFIX: Nodes show action does not handle `\JsonSerializable` objects and crashes if object is not StringAble

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -127,7 +127,7 @@ class NodesController extends ActionController
 
         $convertedNodeProperties = $this->nodePropertyConverterService->getPropertiesArray($node);
         array_walk($convertedNodeProperties, function (&$value) {
-            if (is_array($value)) {
+            if (is_array($value) || $value instanceof \JsonSerializable) {
                 $value = json_encode($value);
             }
         });


### PR DESCRIPTION
With https://github.com/neos/neos-ui/pull/3723 and https://github.com/neos/neos-ui/pull/3723 the `NodePropertyConverterService` returns `\JsonSerializable` objects directly in the expectation that they are serialized directly. This is also true for the usages within the Neos Ui.

But this legacy endpoint here in Neos doesnt do it. And throws

"Object of class Sitegeist\Archaeopteryx\Link could not be converted to string"

on some occasions whenever the endoint is used. Funnely the Neos Ui really does not care about the node properties rendered here via fluid in html so we could also return "nudelsuppe" here. Its just important that it not crashes.

https://github.com/neos/neos-development-collection/blob/1aeef6c02142b41e4626ea32434f06cd0f84e9bd/Neos.Neos/Resources/Private/Templates/Service/Nodes/Show.html#L30-L35

In the future we should have this whole thing killed :D

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
