### PR TITLE
FEATURE: Document new link editor for readthedocs

### DIFF
--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -314,7 +314,20 @@ The following options are allowed for defining a NodeType:
           key would create soft line breaks instead (equivalent to configuring an editable on a span tag).
 
         ``linking``
-          A way to configure additional options available for a link, e.g. target or rel attributes.
+          Options for the link editor (Note that ``formatting.a`` must be enabled).
+
+          Advanced Options Reference:
+
+          ``title`` (boolean)
+            Enabling "Title" allows to set the `title` attribute of the resulting `<a>`-Tag
+          ``targetBlank`` (boolean)
+            Enabling "Open in new window" allows to set the `target` attribute of the resulting `<a>`-Tag to `_blank`
+          ``relNofollow`` (boolean)
+            Enabling "No follow (SEO)" allows to set the `rel` attribute of the resulting `<a>`-Tag to `nofollow`
+          ``download`` (boolean)
+            Enabling "Force download" allows to set the `download` attribute of the resulting `<a>`-Tag
+
+          Additionally the configuration in ``linkTypes`` allows to further configure the types of link, see :ref:`property-editor-reference-linkeditor`.
 
         ``formatting``
           Various formatting options (see example below for all available options).
@@ -326,7 +339,6 @@ The following options are allowed for defining a NodeType:
             placeholder: i18n
             autoparagraph: true
             linking:
-              anchor: true
               title: true
               relNofollow: true
               targetBlank: true

--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -382,8 +382,6 @@ Options Reference:
 ``linkTypes``
   Configure the link types (see below).
 
-Neos comes with the following built-in link types.
-
 All link types can be configured via ``editorOptions.linkTypes.<id of link type>``:
 
 Example:
@@ -405,6 +403,8 @@ Example:
 
 .. note:: When using the link editor inline all options are specified inside ``inline.editorOptions.linking``.
 
+You can find the available link types and their configuration options below.
+
 Web (configuration ``linkTypes.Web``):
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -412,7 +412,7 @@ The Web Link Type handles external links, so links that begin with `http://` or 
 
 Link Type Options Reference:
 ``enabled`` (boolean)
-	If ``true``, disables this link type.
+	If ``false``, disables this link type.
 ``position`` (string|integer)
 	Defines order of this link type. E.g. ``"before <id of link type>"``.
 
@@ -423,18 +423,15 @@ The `Document` Link Type handles internal links. The editor offers you a documen
 
 The `Document` Link Type can be configured as follows:
 
-# @deprecated legacy options
-              startingPoint: '/<Neos.Neos:Sites>/my-site/'
-
 Link Type Options Reference:
 ``enabled`` (boolean)
-	If ``true``, disables this link type.
+	If ``false``, disables this link type.
 ``position`` (string|integer)
 	Defines order of this link type. E.g. ``"before <id of link type>"``.
 ``startingPoint`` (string)
   Starting point for the node tree, by default the current site node
 ``baseNodeType`` (string)
-  Base NodeType for the node tree by default behaves like the document tree and follows all child hierachies for nodes of type ``Neos.Neos:Document``.
+  Base NodeType for the node tree by default behaves like the document tree and follows all child hierarchies for nodes of type ``Neos.Neos:Document``.
 ``loadingDepth`` (integer)
   Loading depth for the node tree by default behaves like the document tree and lists nodes up to a depth of ``4``.
 ``allowedNodeTypes`` (array of strings)
@@ -462,7 +459,7 @@ The `Asset` Link Type handles links to files from the Media Module. The editor w
 
 Link Type Options Reference:
 ``enabled`` (boolean)
-	If ``true``, disables this link type.
+	If ``false``, disables this link type.
 ``position`` (string|integer)
 	Defines order of this link type. E.g. ``"before <id of link type>"``.
 
@@ -478,7 +475,7 @@ The `MailTo` Link Type can be configured as follows:
 
 Link Type Options Reference:
 ``enabled`` (boolean)
-	If ``true``, disables this link type.
+	If ``false``, disables this link type.
 ``position`` (string|integer)
 	Defines order of this link type. E.g. ``"before <id of link type>"``.
 ``enabledFields`` (object)
@@ -506,7 +503,7 @@ The `Phone` link type handles phone links, which start with `tel:` and allow to 
 
 Link Type Options Reference:
 ``enabled`` (boolean)
-	If ``true``, disables this link type.
+	If ``false``, disables this link type.
 ``position`` (string|integer)
 	Defines order of this link type. E.g. ``"before <id of link type>"``.
 

--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -118,7 +118,6 @@ It takes all the same configuration options as the inline rich text editor under
               placeholder: '<p>placeholder</p>'
               autoparagraph: true
               linking:
-                anchor: true
                 title: true
                 relNofollow: true
                 targetBlank: true
@@ -369,48 +368,198 @@ Options Reference:
 ``disabled`` (boolean)
 	If ``true``, disables the SelectBoxEditor.
 
+.. _property-editor-reference-linkeditor:
 
-Property Type: string ``LinkEditor`` -- Link Editor for internal, external and asset links
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Property Type: string or object Neos\\Neos\\Domain\\Link\\Link ``LinkEditor`` -- Link Editor for all types of links
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If internal links to other nodes, external links or asset links shall be editable at some point, the
-``LinkEditor`` can be used to edit a link::
-
-    myLink:
-      type: string
-      ui:
-        inspector:
-          editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
-
-The searchbox will accept:
-
-* node document titles
-* asset titles and tags
-* valid URLs
-* valid email addresses
-
-By default, links to generic ``Neos.Neos:Document`` nodes are allowed; but by setting the ``nodeTypes`` option,
-this can be further restricted (like with the ``reference`` editor). Additionally, links to assets can be disabled
-by setting ``assets`` to ``FALSE``. Links to external URLs are always possible. If you need a reference towards
-only an asset, use the ``asset`` property type; for a reference to another node, use the ``reference`` property type.
-Furthermore, the placeholder text can be customized by setting the ``placeholder`` option::
-
-
-    myExternalLink:
-      type: string
-      ui:
-        inspector:
-          group: 'document'
-          editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
-          editorOptions:
-            assets: FALSE
-            nodeTypes: ['Neos.Neos:Shortcut']
-            placeholder: 'Paste a link, or type to search for nodes'
+Editor to create links for nodes, assets, mails, phone or general http links.
 
 Options Reference:
 
 ``disabled`` (boolean)
-	If ``true``, disables the LinkEditor.
+	If ``true``, disables the link editor.
+``linkTypes``
+  Configure the link types (see below).
+
+Neos comes with the following built-in link types.
+
+All link types can be configured via ``editorOptions.linkTypes.<id of link type>``:
+
+Example:
+
+.. code-block:: yaml
+
+    Vendor.Site:LinkEditor:
+      # ...
+      properties:
+        myLink:
+          type: string
+          ui:
+            inspector:
+              editor: 'Neos.Neos/Inspector/Editors/LinkEditor'
+              editorOptions:
+                linkTypes:
+                  Node:
+                    position: 'before Web'
+
+.. note:: When using the link editor inline all options are specified inside ``inline.editorOptions.linking``.
+
+Web (configuration ``linkTypes.Web``):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Web Link Type handles external links, so links that begin with `http://` or `https://`.
+
+Link Type Options Reference:
+``enabled`` (boolean)
+	If ``true``, disables this link type.
+``position`` (string|integer)
+	Defines order of this link type. E.g. ``"before <id of link type>"``.
+
+Document (configuration ``linkTypes.Document``):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `Document` Link Type handles internal links. The editor offers you a document tree from which you can select documents from within your site. It also offers a search and a node type filter similar to the main document tree in the left side bar of the Neos UI.
+
+The `Document` Link Type can be configured as follows:
+
+# @deprecated legacy options
+              startingPoint: '/<Neos.Neos:Sites>/my-site/'
+
+Link Type Options Reference:
+``enabled`` (boolean)
+	If ``true``, disables this link type.
+``position`` (string|integer)
+	Defines order of this link type. E.g. ``"before <id of link type>"``.
+``startingPoint`` (string)
+  Starting point for the node tree, by default the current site node
+``baseNodeType`` (string)
+  Base NodeType for the node tree by default behaves like the document tree and follows all child hierachies for nodes of type ``Neos.Neos:Document``.
+``loadingDepth`` (integer)
+  Loading depth for the node tree by default behaves like the document tree and lists nodes up to a depth of ``4``.
+``allowedNodeTypes`` (array of strings)
+  A list of allowed linkable node types or super types.
+
+Example:
+
+.. code-block:: yaml
+
+    editorOptions:
+      # ..
+      linking:
+        linkTypes:
+          Node:
+            startingPoint: '/<Neos.Neos:Sites>/my-site/some-feature'
+            baseNodeType: 'Vendor.Site:Document'
+            loadingDepth: 8
+            allowedNodeTypes: ['Vendor.Site:Mixin.ReferenceableDocument']
+
+
+Asset (configuration ``linkTypes.Asset``):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `Asset` Link Type handles links to files from the Media Module. The editor will offer you a media browser from which you can select any asset from within your site.
+
+Link Type Options Reference:
+``enabled`` (boolean)
+	If ``true``, disables this link type.
+``position`` (string|integer)
+	Defines order of this link type. E.g. ``"before <id of link type>"``.
+
+
+Mail To (configuration ``linkTypes.MailTo``):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `MailTo` Link Type handles e-mail links, so links that start with `mailto:`. Links with the `mailto:` protocol allow not only to specify a recipient, but also to configure a subject, a message body, carbon copy (CC) recipients and blind carbon copy (BCC) recipients for the outgoing e-mail.
+
+The editor for the `MailTo` Link Type will offer all of those fields. Each field can be deactivated via configuration.
+
+The `MailTo` Link Type can be configured as follows:
+
+Link Type Options Reference:
+``enabled`` (boolean)
+	If ``true``, disables this link type.
+``position`` (string|integer)
+	Defines order of this link type. E.g. ``"before <id of link type>"``.
+``enabledFields`` (object)
+  Allows to disable the optional fields, by default they are enabled.
+
+Example:
+
+.. code-block:: yaml
+
+    editorOptions:
+      # ..
+      linking:
+        linkTypes:
+          MailTo:
+            enabledFields:
+              subject: false
+              cc: false
+              bcc: false
+              body: false
+
+Phone (configuration ``linkTypes.Phone``):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `Phone` link type handles phone links, which start with `tel:` and allow to start a call.
+
+Link Type Options Reference:
+``enabled`` (boolean)
+	If ``true``, disables this link type.
+``position`` (string|integer)
+	Defines order of this link type. E.g. ``"before <id of link type>"``.
+
+
+Value Object support of ``Neos\\Neos\\Domain\\Link\\Link``:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Additionally to the simple ``string`` type the link editor allows to store the link in a value object.
+To enable that specify ``type: Neos\\Neos\\Domain\\Link\\Link`` for the property.
+
+The value object can serialize more than just the `href`. We can allow to edit other link related options like `title` and the `target`.
+
+Advanced Options Reference:
+
+``title`` (boolean)
+  Enabling "Title" allows to set the `$title` property of the resulting `Link`-object
+``targetBlank`` (boolean)
+  Enabling "Open in new window" allows to set the `$target` property of the resulting `Link`-object to `"_blank"`
+``relNofollow`` (boolean)
+  Enabling "No follow (SEO)" allows to set the `$rel` property of the resulting `Link`-object to `["nofollow"]`
+``download`` (boolean)
+  Enabling "Force download" allows to set the `$download` property of the resulting `Link`-object
+
+Example:
+
+.. code-block:: yaml
+
+    Vendor.Site:LinkEditor:
+      # ...
+      properties:
+        myLinkObject:
+          type: Neos\\Neos\\Domain\\Link\\Link
+          ui:
+            inspector:
+              # editor is automatically set to LinkEditor
+              editorOptions:
+                title: true
+                targetBlank: true
+                relNofollow: true
+                download: true
+                linkTypes:
+                  # ...
+
+The link value object can be queried as usual. An example rendering would look the following:
+
+Example::
+
+    link = ${q(node).property("myLinkObject")}
+    renderer = afx`
+        <a href={props.link.href} title={props.link.title} target={props.link.target} rel={props.link.rel} rel.@if={props.link.rel != []}>
+            My Text
+        </a>
+    `
 
 Property Type: integer ``TextFieldEditor``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -455,22 +604,22 @@ Options Reference:
 
 ``min`` (integer)
 	The lowest value in the range of permitted values. This value must be less than or equal to the value of the max attribute.
-  
+
 ``max`` (integer)
 	The greatest value in the range of permitted values. This value must be greater than or equal to the value of the min attribute.
-  
+
 ``step`` (integer)
 	The step attribute is a number that specifies the granularity that the value must adhere to.
-  
+
 ``unit`` (string)
   The value gets displayed beside the current value, as well after the minimal value (only if ``minLabel`` is not set) and after the maximal value (only if ``maxLabel`` is not set). (The unit is just a visual indicator and will not be added to the resulting property value.)
 
 ``minLabel`` (string)
 	If set, this value is displayed instead of the minimum value.
-  
+
 ``maxLabel`` (string)
 	If set, this value is displayed instead of the maximum value.
- 
+
 ``disabled`` (boolean)
 	If set to ``true``, the range editor gets disabled.
 


### PR DESCRIPTION
The Neos UI ships with https://github.com/neos/neos-ui/pull/3996 a new link editor. Its backwards-compatible to already set links and also supports the same options though in a different structure (see documentation).

Following legacy options should be rewritten to use the declaration in `linkTypes` instead. They will be upcasted (via https://github.com/neos/neos-ui/pull/4037) at runtime if no new declaration in `linkTypes` is made. Using new and old syntax simultaneously will lead to old syntax being ignored fully.

- `assets` use `linkTypes.Asset.enabled: false` instead to disabled asset links
- `nodes` use `linkTypes.Node.enabled: false` instead to disabled asset links
- `nodeTypes` use `linkTypes.Node.baseNodeType` with a NodeType filter string instead
- `startingPoint` use `linkTypes.Node.startingPoint` instead
- `placeholder` obsolete finds no application in the new link editor can be safely removed

The `anchor` option for the inline editor to enable anchor support was removed. Instead anchors can be set via the "Advanced Options" to both Asset and Node links. For Web links the anchor is naturally part of the full link input at all times.

```diff
  inline:
    editorOptions:
      linking:
-       anchor: true
        title: true
        relNofollow: true
        targetBlank: true
```

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
