### PR TITLE
!!! FEATURE: Allow workspaces to be deactivated, leaving them unusable until being activated again

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -23,6 +23,7 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceIsDeactivated;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStream;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
@@ -65,6 +66,9 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         }
         if ($row === false) {
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);
+        }
+        if ($row['currentContentStreamId'] === null) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspaceName);
         }
         $currentContentStreamId = ContentStreamId::fromString($row['currentContentStreamId']);
         return new ContentGraph($this->dbal, $this->nodeFactory, $this->contentRepositoryId, $this->nodeTypeManager, $this->tableNames, $workspaceName, $currentContentStreamId);
@@ -144,7 +148,7 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         return $queryBuilder
             ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.hasChanges, cs.sourceContentStreamVersion = scs.version as upToDateWithBase')
             ->from($this->tableNames->workspace(), 'ws')
-            ->join('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
+            ->leftJoin('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
             ->leftJoin('cs', $this->tableNames->contentStream(), 'scs', 'scs.id = cs.sourceContentStreamId');
     }
 
@@ -153,9 +157,13 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
      */
     private static function workspaceFromDatabaseRow(array $row): Workspace
     {
+        $workspaceName = WorkspaceName::fromString($row['name']);
         $baseWorkspaceName = $row['baseWorkspaceName'] !== null ? WorkspaceName::fromString($row['baseWorkspaceName']) : null;
 
-        if ($baseWorkspaceName === null) {
+        if ($row['currentContentStreamId'] === null) {
+            // no currentContentStreamId, workspace is deactivated
+            $status = WorkspaceStatus::DEACTIVATED;
+        } elseif ($baseWorkspaceName === null) {
             // no base workspace, a root is always up-to-date
             $status = WorkspaceStatus::UP_TO_DATE;
         } elseif ($row['upToDateWithBase'] === 1) {
@@ -167,9 +175,9 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         }
 
         return Workspace::create(
-            WorkspaceName::fromString($row['name']),
+            $workspaceName,
             $baseWorkspaceName,
-            ContentStreamId::fromString($row['currentContentStreamId']),
+            $row['currentContentStreamId'] ? ContentStreamId::fromString($row['currentContentStreamId']) : null,
             $status,
             $baseWorkspaceName === null
                 ? false

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -51,6 +51,8 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregate
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTags;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event\WorkspaceWasActivated;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event\WorkspaceWasDeactivated;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\WorkspaceWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceBaseWorkspaceWasChanged;
@@ -167,9 +169,11 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             WorkspaceBaseWorkspaceWasChanged::class => $this->whenWorkspaceBaseWorkspaceWasChanged($event),
             WorkspaceRebaseFailed::class => $this->whenWorkspaceRebaseFailed($event),
             WorkspaceWasCreated::class => $this->whenWorkspaceWasCreated($event),
+            WorkspaceWasActivated::class => $this->whenWorkspaceWasActivated($event),
             WorkspaceWasDiscarded::class => $this->whenWorkspaceWasDiscarded($event),
             WorkspaceWasPublished::class => $this->whenWorkspaceWasPublished($event),
             WorkspaceWasRebased::class => $this->whenWorkspaceWasRebased($event),
+            WorkspaceWasDeactivated::class => $this->whenWorkspaceWasDeactivated($event),
             WorkspaceWasRemoved::class => $this->whenWorkspaceWasRemoved($event),
             default => null,
         };
@@ -681,6 +685,16 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     private function whenWorkspaceBaseWorkspaceWasChanged(WorkspaceBaseWorkspaceWasChanged $event): void
     {
         $this->updateBaseWorkspace($event->workspaceName, $event->baseWorkspaceName, $event->newContentStreamId);
+    }
+
+    private function whenWorkspaceWasActivated(WorkspaceWasActivated $event): void
+    {
+        $this->updateWorkspaceContentStreamId($event->workspaceName, $event->newContentStreamId);
+    }
+
+    private function whenWorkspaceWasDeactivated(WorkspaceWasDeactivated $event): void
+    {
+        $this->updateWorkspaceContentStreamId($event->workspaceName, null);
     }
 
     private function whenWorkspaceRebaseFailed(WorkspaceRebaseFailed $event): void

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -109,7 +109,7 @@ class DoctrineDbalContentGraphSchemaBuilder
         $workspaceTable = self::createTable($this->tableNames->workspace(), [
             DbalSchemaFactory::columnForWorkspaceName('name', $platform)->setNotnull(true),
             DbalSchemaFactory::columnForWorkspaceName('baseWorkspaceName', $platform)->setNotnull(false),
-            DbalSchemaFactory::columnForContentStreamId('currentContentStreamId', $platform)->setNotNull(true),
+            DbalSchemaFactory::columnForContentStreamId('currentContentStreamId', $platform)->setNotNull(false),
         ]);
 
         $workspaceTable->addUniqueIndex(['currentContentStreamId']);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/Workspace.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/Workspace.php
@@ -45,10 +45,10 @@ trait Workspace
 
     private function updateWorkspaceContentStreamId(
         WorkspaceName $workspaceName,
-        ContentStreamId $contentStreamId,
+        ?ContentStreamId $contentStreamId,
     ): void {
         $this->dbal->update($this->tableNames->workspace(), [
-            'currentContentStreamId' => $contentStreamId->value,
+            'currentContentStreamId' => $contentStreamId?->value,
         ], [
             'name' => $workspaceName->value
         ]);

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W12-DeactivateWorkspace/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W12-DeactivateWorkspace/01-ConstraintChecks.feature
@@ -1,0 +1,73 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Deactivate/Activate workspace constraints
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Content':
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        child1:
+          type: 'Neos.ContentRepository.Testing:Content'
+        child2:
+          type: 'Neos.ContentRepository.Testing:Content'
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+  Scenario: Deactivating the workspace is not allowed for workspaces with other workspaces depending on it
+    When the command DeactivateWorkspace is executed with payload and exceptions are caught:
+      | Key               | Value   |
+      | workspaceName     | "live" |
+
+    Then the last command should have thrown an exception of type "WorkspaceHasWorkspacesDependingOnIt"
+
+  Scenario: Activating the workspace is not allowed for active workspaces
+    When the command ActivateWorkspace is executed with payload and exceptions are caught:
+      | Key                | Value                    |
+      | workspaceName      | "user-test"              |
+      | newContentStreamId | "new-user-cs-identifier" |
+
+    Then the last command should have thrown an exception of type "WorkspaceIsActivated" with code 1766069245 and message:
+    """
+    The workspace "user-test" is activated
+    """
+
+  Scenario: Deactivating the workspace is not allowed if there are pending changes
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "user-test"                              |
+      | nodeAggregateId           | "holy-nody"                              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "New node in shared"}           |
+
+    Given I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "holy-nody" to lead to node user-cs-identifier;holy-nody;{}
+
+    When the command DeactivateWorkspace is executed with payload and exceptions are caught:
+      | Key                | Value                        |
+      | workspaceName      | "user-test"                  |
+
+    Then the last command should have thrown an exception of type "WorkspaceContainsPublishableChanges"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W12-DeactivateWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W12-DeactivateWorkspace/02-BasicFeatures.feature
@@ -1,0 +1,76 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Deactivate and Activate a Workspace
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Content':
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        child1:
+          type: 'Neos.ContentRepository.Testing:Content'
+        child2:
+          type: 'Neos.ContentRepository.Testing:Content'
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                    |
+      | workspaceName             | "live"                                   |
+      | nodeAggregateId           | "nody-mc-nodeface"                       |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | originDimensionSpacePoint | {}                                       |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | initialPropertyValues     | {"text": "Original text"}                |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+  Scenario: Deactivating a workspace with no pending changes
+    When the command DeactivateWorkspace is executed with payload:
+      | Key               | Value       |
+      | workspaceName     | "user-test" |
+    Then workspace user-test has status DEACTIVATED
+
+  Scenario: Deactivating an already deactivated Workspace fails
+    And the command DeactivateWorkspace is executed with payload and exceptions are caught:
+      | Key               | Value       |
+      | workspaceName     | "user-test" |
+    When the command DeactivateWorkspace is executed with payload and exceptions are caught:
+      | Key               | Value       |
+      | workspaceName     | "user-test" |
+    Then the last command should have thrown an exception of type "WorkspaceIsDeactivated" with code 1765977861 and message:
+    """
+    The workspace "user-test" is deactivated
+    """
+
+  Scenario: Activating a deactivated workspace
+    When the command DeactivateWorkspace is executed with payload:
+      | Key               | Value       |
+      | workspaceName     | "user-test" |
+    And the command ActivateWorkspace is executed with payload:
+      | Key                | Value                    |
+      | workspaceName      | "user-test"              |
+      | newContentStreamId | "user-new-cs-identifier" |
+    Then workspace user-test has status UP_TO_DATE
+
+    Given I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-new-cs-identifier;nody-mc-nodeface;{}
+

--- a/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
+++ b/Neos.ContentRepository.Core/Classes/EventStore/EventNormalizer.php
@@ -27,6 +27,8 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregate
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregateWithNodeWasCreated;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event\WorkspaceWasActivated;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event\WorkspaceWasDeactivated;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\WorkspaceWasCreated;
 use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceBaseWorkspaceWasChanged;
@@ -107,6 +109,8 @@ final readonly class EventNormalizer
             WorkspaceWasRemoved::class,
             WorkspaceOwnerWasChanged::class,
             WorkspaceBaseWorkspaceWasChanged::class,
+            WorkspaceWasActivated::class,
+            WorkspaceWasDeactivated::class,
         ];
 
         $fullClassNameToShortEventType = [];

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
@@ -49,7 +49,14 @@ trait WorkspaceConstraintChecks
             throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspaceName);
         }
 
-        return $workspace;
+        // DANGEROUS error of type return.type ignored
+        // This is done due to phpstan being unable to deduce that the returned workspace actually fulfills all
+        // required conditions. This is guaranteed by `$workspace->isActive()` returning true:
+        // isActive() is annotated with
+        // @ phpstan-assert-if-true ContentStreamId $this->currentContentStreamId
+        // @ phpstan-assert-if-true WorkspaceStatus::UP_TO_DATE|WorkspaceStatus::OUTDATED $this->status
+        // which are the same guarantees this method makes, but in a syntactical different way.
+        return $workspace; // @phpstan-ignore return.type
     }
 
     /**
@@ -70,7 +77,9 @@ trait WorkspaceConstraintChecks
             // TODO: if this happens, something is seriously wrong in the database, handle differently?
             throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspace->baseWorkspaceName);
         }
-        return $baseWorkspace;
+
+        // @phpstan-ignore-next-line
+        return $baseWorkspace; // @phpstan-ignore return.type
     }
 
     private function requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): void

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
@@ -16,6 +16,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasNoBaseWorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasWorkspacesDependingOnIt;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceIsDeactivated;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
@@ -25,13 +26,25 @@ trait WorkspaceConstraintChecks
 {
     /**
      * @throws WorkspaceDoesNotExist
+     * @phpstan-return Workspace
      */
-    private function requireActiveWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): Workspace
+    private function requireWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): Workspace
     {
         $workspace = $commandHandlingDependencies->findWorkspaceByName($workspaceName);
         if (is_null($workspace)) {
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);
         }
+
+        return $workspace;
+    }
+
+    /**
+     * @throws WorkspaceDoesNotExist|WorkspaceIsDeactivated
+     * @phpstan-return object{ currentContentStreamId: ContentStreamId, status: WorkspaceStatus::UP_TO_DATE|WorkspaceStatus::OUTDATED } & Workspace
+     */
+    private function requireActiveWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): Workspace
+    {
+        $workspace = $this->requireWorkspace($workspaceName, $commandHandlingDependencies);
         if (!$workspace->isActive()) {
             throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspaceName);
         }
@@ -42,6 +55,7 @@ trait WorkspaceConstraintChecks
     /**
      * @throws WorkspaceHasNoBaseWorkspaceName
      * @throws BaseWorkspaceDoesNotExist
+     * @phpstan-return object{ currentContentStreamId: ContentStreamId, status: WorkspaceStatus::UP_TO_DATE|WorkspaceStatus::OUTDATED } & Workspace
      */
     private function requireBaseWorkspace(Workspace $workspace, CommandHandlingDependencies $commandHandlingDependencies): Workspace
     {
@@ -51,6 +65,10 @@ trait WorkspaceConstraintChecks
         $baseWorkspace = $commandHandlingDependencies->findWorkspaceByName($workspace->baseWorkspaceName);
         if (is_null($baseWorkspace)) {
             throw BaseWorkspaceDoesNotExist::butWasSupposedTo($workspace->workspaceName);
+        } elseif (!$baseWorkspace->isActive()) {
+            // should never happen!
+            // TODO: if this happens, something is seriously wrong in the database, handle differently?
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspace->baseWorkspaceName);
         }
         return $baseWorkspace;
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
@@ -14,20 +14,26 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceContainsPublishableChanges;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasNoBaseWorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasWorkspacesDependingOnIt;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceIsDeactivated;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
 
 trait WorkspaceConstraintChecks
 {
     /**
      * @throws WorkspaceDoesNotExist
      */
-    private function requireWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): Workspace
+    private function requireActiveWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): Workspace
     {
         $workspace = $commandHandlingDependencies->findWorkspaceByName($workspaceName);
         if (is_null($workspace)) {
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);
+        }
+        if (!$workspace->isActive()) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspaceName);
         }
 
         return $workspace;
@@ -51,12 +57,29 @@ trait WorkspaceConstraintChecks
 
     private function requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): void
     {
-        $workspace = $this->requireWorkspace($workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($workspaceName, $commandHandlingDependencies);
         if (!$workspace->isRootWorkspace()) {
             $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
             if (!$baseWorkspace->isRootWorkspace()) {
                 throw InvalidDimensionAdjustmentTargetWorkspace::becauseWorkspaceMustBeRootOrRootBased($workspace->workspaceName);
             }
+        }
+    }
+
+    private function requireWorkspaceToNotBeBaseForAnyOtherWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): void
+    {
+        $workspaces = $commandHandlingDependencies->findAllWorkspaces();
+        $conflictingWorkspaceNames = [];
+        foreach ($workspaces as $workspace) {
+            if ($workspace->baseWorkspaceName === $workspaceName) {
+                $conflictingWorkspaceNames[] = $workspace->workspaceName;
+            }
+        }
+        if ($conflictingWorkspaceNames !== []) {
+            throw WorkspaceHasWorkspacesDependingOnIt::butWasNotSupposedTo(
+                $workspaceName,
+                ...$conflictingWorkspaceNames
+            );
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Command/ActivateWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Command/ActivateWorkspace.php
@@ -44,7 +44,7 @@ final readonly class ActivateWorkspace implements CommandInterface
     {
         return new self(
             WorkspaceName::fromString($array['workspaceName']),
-            ContentStreamId::fromString($array['contentStreamId'])
+            ContentStreamId::fromString($array['newContentStreamId'])
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Command/ActivateWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Command/ActivateWorkspace.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * Activate a workspace
+ *
+ * @api commands are the write-API of the ContentRepository
+ */
+final readonly class ActivateWorkspace implements CommandInterface
+{
+    /**
+     * @param WorkspaceName $workspaceName Name of the workspace that should be activated
+     * @param ContentStreamId $newContentStreamId The id of the new content stream which is created during the activation
+     */
+    private function __construct(
+        public WorkspaceName $workspaceName,
+        public ContentStreamId $newContentStreamId,
+    ) {
+    }
+
+    public static function create(WorkspaceName $workspaceName): self
+    {
+        return new self($workspaceName, ContentStreamId::create());
+    }
+
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            WorkspaceName::fromString($array['workspaceName']),
+            ContentStreamId::fromString($array['contentStreamId'])
+        );
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Command/DeactivateWorkspace.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Command/DeactivateWorkspace.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command;
+
+use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * Deactivate a workspace
+ *
+ * @api commands are the write-API of the ContentRepository
+ */
+final readonly class DeactivateWorkspace implements CommandInterface
+{
+    /**
+     * @param WorkspaceName $workspaceName Name of the workspace that should be deactivated
+     */
+    private function __construct(public WorkspaceName $workspaceName)
+    {
+    }
+
+    public static function create(WorkspaceName $workspaceName): self
+    {
+        return new self($workspaceName);
+    }
+
+    public static function fromArray(array $array): self
+    {
+        return new self(WorkspaceName::fromString($array['workspaceName']));
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Event/WorkspaceWasActivated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Event/WorkspaceWasActivated.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event;
+
+use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\EventStore\Model\Event\SequenceNumber;
+
+/**
+ * @api events are the persistence-API of the content repository
+ */
+final readonly class WorkspaceWasActivated implements EventInterface, EmbedsWorkspaceName
+{
+    public function __construct(
+        public WorkspaceName $workspaceName,
+        /**
+         * The new content stream ID
+         */
+        public ContentStreamId $newContentStreamId,
+    ) {
+    }
+
+    public function getWorkspaceName(): WorkspaceName
+    {
+        return $this->workspaceName;
+    }
+
+    public static function fromArray(array $values): self
+    {
+        return new self(
+            WorkspaceName::fromString($values['workspaceName']),
+            ContentStreamId::fromString($values['newContentStreamId']),
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'workspaceName' => $this->workspaceName,
+            'newContentStreamId' => $this->newContentStreamId
+        ];
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Event/WorkspaceWasDeactivated.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceActivation/Event/WorkspaceWasDeactivated.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event;
+
+use Neos\ContentRepository\Core\EventStore\EventInterface;
+use Neos\ContentRepository\Core\Feature\Common\EmbedsWorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * @api events are the persistence-API of the content repository
+ */
+final readonly class WorkspaceWasDeactivated implements EventInterface, EmbedsWorkspaceName
+{
+    public function __construct(public WorkspaceName $workspaceName)
+    {
+    }
+
+    public function getWorkspaceName(): WorkspaceName
+    {
+        return $this->workspaceName;
+    }
+
+    public static function fromArray(array $values): self
+    {
+        return new self(WorkspaceName::fromString($values['workspaceName']));
+    }
+
+    public function jsonSerialize(): array
+    {
+        return ['workspaceName' => $this->workspaceName];
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -65,6 +65,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasNoBaseWorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceContainsPublishableChanges;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceIsActivated;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceIsDeactivated;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -135,6 +136,9 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->baseWorkspaceName->value,
                 $command->workspaceName->value
             ), 1513890708);
+        }
+        if (!$baseWorkspace->isActive()) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($command->baseWorkspaceName);
         }
         $sourceContentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($baseWorkspace->currentContentStreamId);
         $this->requireContentStreamToNotBeClosed($baseWorkspace->currentContentStreamId, $commandHandlingDependencies);
@@ -291,6 +295,13 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         Version $baseWorkspaceContentStreamVersion,
         ContentStreamId $newContentStreamId
     ): \Generator {
+        if (!$baseWorkspace->isActive()) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($baseWorkspace->workspaceName);
+        }
+        if (!$workspace->isActive()) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspace->workspaceName);
+        }
+
         yield $this->forkContentStream(
             $newContentStreamId,
             $baseWorkspace->currentContentStreamId,
@@ -703,6 +714,13 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         Version $baseWorkspaceContentStreamVersion,
         ContentStreamId $newContentStream
     ): \Generator {
+        if (!$baseWorkspace->isActive()) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($baseWorkspace->workspaceName);
+        }
+        if (!$workspace->isActive()) {
+            throw WorkspaceIsDeactivated::butWasSupposedToBeActivated($workspace->workspaceName);
+        }
+
         yield $this->forkContentStream(
             $newContentStream,
             $baseWorkspace->currentContentStreamId,
@@ -785,18 +803,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         DeleteWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $contentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
+        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
 
-        yield new EventsToPublish(
-            ContentStreamEventStreamName::fromContentStreamId($workspace->currentContentStreamId)->getEventStreamName(),
-            Events::with(
-                new ContentStreamWasRemoved(
-                    $workspace->currentContentStreamId,
+        if ($workspace->isActive()) {
+            $contentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
+
+            yield new EventsToPublish(
+                ContentStreamEventStreamName::fromContentStreamId($workspace->currentContentStreamId)->getEventStreamName(),
+                Events::with(
+                    new ContentStreamWasRemoved(
+                        $workspace->currentContentStreamId,
+                    ),
                 ),
-            ),
-            ExpectedVersion::fromVersion($contentStreamVersion)
-        );
+                ExpectedVersion::fromVersion($contentStreamVersion)
+            );
+        }
 
         yield new EventsToPublish(
             WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName(),
@@ -932,6 +953,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         ), 1715341085);
     }
 
+    /**
+     * @param Workspace&object{ currentContentStreamId: ContentStreamId } $workspace
+     * @param CommandHandlingDependencies $commandHandlingDependencies
+     * @return Version
+     */
     private function requireOpenContentStreamAndVersion(Workspace $workspace, CommandHandlingDependencies $commandHandlingDependencies): Version
     {
         if ($commandHandlingDependencies->isContentStreamClosed($workspace->currentContentStreamId)) {

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -30,6 +30,10 @@ use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStream
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasReopened;
 use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Event\ContentStreamWasCreated;
 use Neos\ContentRepository\Core\Feature\ContentStreamRemoval\Event\ContentStreamWasRemoved;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\ActivateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\DeactivateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event\WorkspaceWasActivated;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Event\WorkspaceWasDeactivated;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Event\RootWorkspaceWasCreated;
@@ -60,6 +64,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamIsClosed;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceHasNoBaseWorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceContainsPublishableChanges;
+use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceIsActivated;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -99,12 +104,14 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         /** @phpstan-ignore-next-line */
         return match ($command::class) {
             CreateWorkspace::class => $this->handleCreateWorkspace($command, $commandHandlingDependencies),
+            ActivateWorkspace::class => $this->handleActivateWorkspace($command, $commandHandlingDependencies),
             CreateRootWorkspace::class => $this->handleCreateRootWorkspace($command, $commandHandlingDependencies),
             PublishWorkspace::class => $this->handlePublishWorkspace($command, $commandHandlingDependencies),
             RebaseWorkspace::class => $this->handleRebaseWorkspace($command, $commandHandlingDependencies),
             PublishIndividualNodesFromWorkspace::class => $this->handlePublishIndividualNodesFromWorkspace($command, $commandHandlingDependencies),
             DiscardIndividualNodesFromWorkspace::class => $this->handleDiscardIndividualNodesFromWorkspace($command, $commandHandlingDependencies),
             DiscardWorkspace::class => $this->handleDiscardWorkspace($command, $commandHandlingDependencies),
+            DeactivateWorkspace::class => $this->handleDeactivateWorkspace($command, $commandHandlingDependencies),
             DeleteWorkspace::class => $this->handleDeleteWorkspace($command, $commandHandlingDependencies),
             ChangeBaseWorkspace::class => $this->handleChangeBaseWorkspace($command, $commandHandlingDependencies),
         };
@@ -192,7 +199,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         PublishWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
         if (!$workspace->hasPublishableChanges()) {
             throw WorkspaceCommandSkipped::becauseWorkspaceToPublishIsEmpty($command->workspaceName);
@@ -340,7 +347,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         RebaseWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
 
         $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace, $commandHandlingDependencies);
@@ -443,7 +450,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         PublishIndividualNodesFromWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
 
         if (!$workspace->hasPublishableChanges()) {
@@ -567,7 +574,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         DiscardIndividualNodesFromWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
 
         if (!$workspace->hasPublishableChanges()) {
@@ -669,7 +676,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         DiscardWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
 
         if (!$workspace->hasPublishableChanges()) {
@@ -731,7 +738,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         ChangeBaseWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $currentBaseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
 
         $this->requireContentStreamToNotBeClosed($workspace->currentContentStreamId, $commandHandlingDependencies);
@@ -744,7 +751,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             throw WorkspaceContainsPublishableChanges::butWasNotSupposedToForBaseWorkspaceChange($workspace->workspaceName);
         }
 
-        $newBaseWorkspace = $this->requireWorkspace($command->baseWorkspaceName, $commandHandlingDependencies);
+        $newBaseWorkspace = $this->requireActiveWorkspace($command->baseWorkspaceName, $commandHandlingDependencies);
         $this->requireNonCircularRelationBetweenWorkspaces($workspace, $newBaseWorkspace, $commandHandlingDependencies);
 
         $newBaseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($newBaseWorkspace, $commandHandlingDependencies);
@@ -778,7 +785,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         DeleteWorkspace $command,
         CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
         $contentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
 
         yield new EventsToPublish(
@@ -798,6 +805,83 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $command->workspaceName,
                 )
             ),
+            ExpectedVersion::ANY()
+        );
+    }
+
+    /**
+     * @throws WorkspaceDoesNotExist
+     * @throws ContentStreamAlreadyExists
+     */
+    private function handleActivateWorkspace(
+        ActivateWorkspace $command,
+        CommandHandlingDependencies $commandHandlingDependencies,
+    ): \Generator {
+        $workspace = $commandHandlingDependencies->findWorkspaceByName($command->workspaceName);
+        if (is_null($workspace)) {
+            throw WorkspaceDoesNotExist::butWasSupposedTo($command->workspaceName);
+        }
+        if ($workspace->isActive()) {
+            throw WorkspaceIsActivated::butWasSupposedToBeDeactivated($command->workspaceName);
+        }
+        $baseWorkspace = $this->requireActiveWorkspace($workspace->baseWorkspaceName, $commandHandlingDependencies);
+        $contentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($baseWorkspace->currentContentStreamId);
+
+        $this->requireContentStreamToNotExistYet($command->newContentStreamId, $commandHandlingDependencies);
+
+        yield $this->forkContentStream(
+            $command->newContentStreamId,
+            $baseWorkspace->currentContentStreamId,
+            $contentStreamVersion,
+            sprintf('Activate workspace %s based on %s', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value)
+        );
+
+        yield new EventsToPublish(
+            WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName(),
+            Events::with(
+                new WorkspaceWasActivated(
+                    $command->workspaceName,
+                    $command->newContentStreamId,
+                )
+            ),
+            ExpectedVersion::ANY()
+        );
+    }
+
+    /**
+     * @throws WorkspaceDoesNotExist
+     * @throws WorkspaceContainsPublishableChanges
+     */
+    private function handleDeactivateWorkspace(
+        DeactivateWorkspace $command,
+        CommandHandlingDependencies $commandHandlingDependencies,
+    ): \Generator {
+        $workspace = $this->requireActiveWorkspace($command->workspaceName, $commandHandlingDependencies);
+        //$contentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
+
+        if ($workspace->hasPublishableChanges()) {
+            throw WorkspaceContainsPublishableChanges::butWasNotSupposedToForDeactivating($workspace->workspaceName);
+        }
+        $this->requireWorkspaceToNotBeBaseForAnyOtherWorkspace($command->workspaceName, $commandHandlingDependencies);
+
+        // TODO: Discuss order of deletion/deactivation
+        yield new EventsToPublish(
+            WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName(),
+            Events::with(
+                new WorkspaceWasDeactivated($command->workspaceName)
+            ),
+            ExpectedVersion::ANY()
+        );
+
+        yield new EventsToPublish(
+            ContentStreamEventStreamName::fromContentStreamId($workspace->currentContentStreamId)->getEventStreamName(),
+            Events::with(
+                new ContentStreamWasRemoved(
+                    $workspace->currentContentStreamId,
+                ),
+            ),
+            // content stream is unused by now and deletion is idempotent. There is no possible gain from a version
+            // check at this point.
             ExpectedVersion::ANY()
         );
     }

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceContainsPublishableChanges.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceContainsPublishableChanges.php
@@ -13,6 +13,11 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
  */
 final class WorkspaceContainsPublishableChanges extends \RuntimeException
 {
+    public static function butWasNotSupposedToForDeactivating(WorkspaceName $workspaceName): self
+    {
+        throw new self(sprintf('The workspace %s needs to be empty before being deactivated.', $workspaceName->value), 1765979146);
+    }
+
     public static function butWasNotSupposedToForBaseWorkspaceChange(WorkspaceName $workspaceName): self
     {
         throw new self(sprintf('The workspace %s needs to be empty before switching the base workspace.', $workspaceName->value), 1681455989);

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceHasWorkspacesDependingOnIt.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceHasWorkspacesDependingOnIt.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Exception;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * @api because exception is thrown during invariant checks on command execution
+ */
+final class WorkspaceHasWorkspacesDependingOnIt extends \DomainException
+{
+    public static function butWasNotSupposedTo(
+        WorkspaceName $workspaceName,
+        WorkspaceName ...$dependingWorkspaceNames
+    ): self {
+        return new self(sprintf(
+            'The workspaces %s depend on workspace %s.',
+            implode(
+                ',',
+                array_map(
+                    fn (WorkspaceName $workspaceName): string => $workspaceName->value,
+                    $dependingWorkspaceNames
+                )
+            ),
+            $workspaceName,
+        ), 1766070671);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceIsActivated.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceIsActivated.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Exception;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * @api because exception is thrown during invariant checks on command execution or when attempting to query a deactivated workspace
+ */
+final class WorkspaceIsActivated extends \DomainException
+{
+    public static function butWasSupposedToBeDeactivated(WorkspaceName $name): self
+    {
+        return new self(sprintf(
+            'The workspace "%s" is activated',
+            $name->value
+        ), 1766069245);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceIsDeactivated.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Exception/WorkspaceIsDeactivated.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Exception;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+
+/**
+ * @api because exception is thrown during invariant checks on command execution or when attempting to query a deactivated workspace
+ */
+final class WorkspaceIsDeactivated extends \DomainException
+{
+    public static function butWasSupposedToBeActivated(WorkspaceName $name): self
+    {
+        return new self(sprintf(
+            'The workspace "%s" is deactivated',
+            $name->value
+        ), 1765977861);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
@@ -24,18 +24,22 @@ final readonly class Workspace
     /**
      * @param WorkspaceName $workspaceName Workspace identifier, unique within one Content Repository instance
      * @param WorkspaceName|null $baseWorkspaceName Workspace identifier of the base workspace (i.e. the target when publishing changes) – if null this instance is considered a root (aka public) workspace
-     * @param ContentStreamId $currentContentStreamId The Content Stream this workspace currently points to – usually it is set to a new, empty content stream after publishing/rebasing the workspace
+     * @param ContentStreamId|null $currentContentStreamId The Content Stream this workspace currently points to if it is active – usually it is set to a new, empty content stream after publishing/rebasing the workspace
      * @param WorkspaceStatus $status The current status of this workspace
      */
     private function __construct(
         public WorkspaceName $workspaceName,
         public ?WorkspaceName $baseWorkspaceName,
-        public ContentStreamId $currentContentStreamId,
+        // TODO: ist allowing null here a problem? (strict phpstan?)
+        public ?ContentStreamId $currentContentStreamId,
         public WorkspaceStatus $status,
         private bool $hasPublishableChanges
     ) {
         if ($this->isRootWorkspace() && $this->hasPublishableChanges) {
             throw new \InvalidArgumentException('Root workspaces cannot have changes', 1730371566);
+        }
+        if ($this->isActive() && $this->currentContentStreamId === null) {
+            throw new \InvalidArgumentException('Active workspaces must have a non null content stream ID', 1730371566);
         }
     }
 
@@ -45,7 +49,7 @@ final readonly class Workspace
     public static function create(
         WorkspaceName $workspaceName,
         ?WorkspaceName $baseWorkspaceName,
-        ContentStreamId $currentContentStreamId,
+        ?ContentStreamId $currentContentStreamId,
         WorkspaceStatus $status,
         bool $hasPublishableChanges
     ): self {
@@ -58,6 +62,14 @@ final readonly class Workspace
     public function hasPublishableChanges(): bool
     {
         return $this->hasPublishableChanges;
+    }
+
+    /**
+     * Indicates if the workspace is active.
+     */
+    public function isActive(): bool
+    {
+        return $this->status !== WorkspaceStatus::DEACTIVATED;
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/Workspace.php
@@ -38,8 +38,11 @@ final readonly class Workspace
         if ($this->isRootWorkspace() && $this->hasPublishableChanges) {
             throw new \InvalidArgumentException('Root workspaces cannot have changes', 1730371566);
         }
-        if ($this->isActive() && $this->currentContentStreamId === null) {
+        if ($this->currentContentStreamId === null && $this->isActive()) {
             throw new \InvalidArgumentException('Active workspaces must have a non null content stream ID', 1730371566);
+        }
+        if ($this->isRootWorkspace() && !$this->isActive()) {
+            throw new \InvalidArgumentException('Root Workspaces cannot be deactivated', 1768571925);
         }
     }
 
@@ -66,6 +69,10 @@ final readonly class Workspace
 
     /**
      * Indicates if the workspace is active.
+     *
+     * @phpstan-assert-if-true ContentStreamId $this->currentContentStreamId
+     * @phpstan-assert-if-true WorkspaceStatus::UP_TO_DATE|WorkspaceStatus::OUTDATED $this->status
+     * @phpstan-assert-if-false WorkspaceName $this->baseWorkspaceName
      */
     public function isActive(): bool
     {

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceStatus.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceStatus.php
@@ -47,6 +47,13 @@ enum WorkspaceStatus: string implements \JsonSerializable
      */
     case OUTDATED = 'OUTDATED';
 
+    /**
+     * A non-base workspace can be deactivated on purpose. A deactivated workspace has no current content stream.
+     * Before a deactivated workspace can be used it has to be activated again, which will result in its content stream
+     * to become a new fork of its base workspace content stream.
+     */
+    case DEACTIVATED = 'DEACTIVATED';
+
     public function equals(self $other): bool
     {
         return $this->value === $other->value;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -44,6 +44,8 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeA
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\UpdateRootNodeAggregateDimensions;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\TagSubtree;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\UntagSubtree;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\ActivateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\DeactivateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\ChangeBaseWorkspace;
@@ -313,6 +315,24 @@ trait GenericCommandExecutionAndEventPublication
     }
 
     /**
+     * @When the command DeactivateWorkspace is executed with payload:
+     */
+    public function theCommandDeactivateWorkspaceIsExecutedWithPayload(TableNode $payloadTable): void
+    {
+        $commandArguments = $this->readPayloadTable($payloadTable);
+        $this->handleCommand(DeactivateWorkspace::class, $commandArguments);
+    }
+
+    /**
+     * @When the command ActivateWorkspace is executed with payload:
+     */
+    public function theCommandActivateWorkspaceIsExecutedWithPayload(TableNode $payloadTable): void
+    {
+        $commandArguments = $this->readPayloadTable($payloadTable);
+        $this->handleCommand(ActivateWorkspace::class, $commandArguments);
+    }
+
+    /**
      * @When the command :shortCommandName is executed with payload and exceptions are caught:
      */
     public function theCommandIsExecutedWithPayloadAndExceptionsAreCaught(string $shortCommandName, TableNode $payloadTable): void
@@ -477,6 +497,8 @@ trait GenericCommandExecutionAndEventPublication
             CreateRootWorkspace::class,
             CreateWorkspace::class,
             DeleteWorkspace::class,
+            ActivateWorkspace::class,
+            DeactivateWorkspace::class,
             DisableNodeAggregate::class,
             DiscardIndividualNodesFromWorkspace::class,
             DiscardWorkspace::class,

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Command;
 
+use DateInterval;
+use DateInvalidOperationException;
+use Neos\ContentRepository\Core\Feature\Security\Exception\AccessDenied;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\DeactivateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlreadyExists;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\WorkspaceRebaseFailed;
@@ -26,6 +30,10 @@ use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Security\Account;
+use Neos\Flow\Utility\Now;
+use Neos\Neos\Domain\Model\User;
+use Neos\Neos\Domain\Model\UserId;
 use Neos\Neos\Domain\Model\WorkspaceClassification;
 use Neos\Neos\Domain\Model\WorkspaceDescription;
 use Neos\Neos\Domain\Model\WorkspaceRole;
@@ -55,6 +63,9 @@ class WorkspaceCommandController extends CommandController
 
     #[Flow\Inject]
     protected WorkspaceService $workspaceService;
+
+    #[Flow\Inject]
+    protected Now $now;
 
     /**
      * Publish changes of a workspace
@@ -524,6 +535,92 @@ class WorkspaceCommandController extends CommandController
         ]);
     }
 
+    /**
+     * Deactivate a single workspace by name.
+     *
+     * A workspace can only be deactivated if it has no pending changes and no other workspace depends on it.
+     *
+     * @param string $workspace Name of the workspace to deactivate.
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @throws StopCommandException
+     * @throws AccessDenied
+     */
+    public function deactivateCommand(string $workspace, string $contentRepository = 'default'): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
+
+        $workspaceName = WorkspaceName::fromString($workspace);
+        $workspaceInstance = $contentRepositoryInstance->findWorkspaceByName($workspaceName);
+        if ($workspaceInstance === null) {
+            $this->outputLine('Workspace "%s" not found.', [$workspaceName->value]);
+            $this->quit();
+        }
+        if ($workspaceInstance->hasPublishableChanges()) {
+            $this->outputLine('Workspace "%s" cannot be deactivated, it has publishable changes.', [$workspaceName->value]);
+            $this->quit();
+        }
+        $dependentWorkspaces = $contentRepositoryInstance->findWorkspaces()
+            ->filter(fn(Workspace $workspace) => $workspace->baseWorkspaceName === $workspaceName)
+            ->map(fn (Workspace $workspace) => $workspace->workspaceName->value);
+        if (count($dependentWorkspaces) > 0) {
+            $this->outputLine('Workspace "%s" cannot be deactivated, the following workspaces depend on it: "%s".', [
+                $workspaceName->value,
+                implode('", "', $dependentWorkspaces)
+            ]);
+            $this->quit();
+        }
+
+        $contentRepositoryInstance->handle(DeactivateWorkspace::create($workspaceName));
+    }
+
+    /**
+     * Deactivate all stale personal workspaces.
+     *
+     * A personal workspace is considered stale if it has no pending changes, no other workspace uses it as a base
+     * workspace and the owner of the workspace did not log in for the time specified.
+     *
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @param string $dateInterval The time interval a user had to be inactive for its workspaces to be considered stale. (Default: '7 days')
+     * @throws AccessDenied
+     * @throws DateInvalidOperationException
+     */
+    public function deactivateStaleCommand(string $contentRepository = 'default', string $dateInterval = '7 days'): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
+
+        $interval = DateInterval::createFromDateString($dateInterval);
+
+        $workspaces = $contentRepositoryInstance->findWorkspaces();
+        $baseWorkspaces = $this->splObjectStoreFromIterable($workspaces->map(fn($workspace) => $workspace->baseWorkspaceName));
+
+        $probablyStaleWorkspaceNames = $this->splObjectStoreFromIterable(
+            $workspaces
+                ->filter(fn($workspace) => !$workspace->hasPublishableChanges() &&
+                    !$baseWorkspaces->contains($workspace->workspaceName))
+                ->map(fn($workspace) => $workspace->workspaceName)
+        );
+
+        $inactiveUserIds = $this->splObjectStoreFromIterable($this->userService->findUserIdsNotLoggedInBefore($this->now->sub($interval)));
+
+        $personalWorkspaces = $this->workspaceService->getPersonalWorkspaces($contentRepositoryId);
+        $workspacesToDeactivate = [];
+        foreach ($personalWorkspaces as $userId => $personalWorkspace) {
+            /**  @var UserId $userId */
+            if (
+                $probablyStaleWorkspaceNames->contains($personalWorkspace) &&
+                $inactiveUserIds->contains($userId)
+            ) {
+                $workspacesToDeactivate[] = $personalWorkspace;
+            }
+        }
+
+        foreach ($workspacesToDeactivate as $workspace) {
+            $contentRepositoryInstance->handle(DeactivateWorkspace::create($workspace));
+        }
+    }
+
     // -----------------------
 
     private function buildWorkspaceRoleSubject(WorkspaceRoleSubjectType $subjectType, string $usernameOrRoleIdentifier): WorkspaceRoleSubject
@@ -539,5 +636,14 @@ class WorkspaceCommandController extends CommandController
             $roleSubject = WorkspaceRoleSubject::createForGroup($usernameOrRoleIdentifier);
         }
         return $roleSubject;
+    }
+
+    private function splObjectStoreFromIterable(iterable $iterable): \SplObjectStorage
+    {
+        $result = new \SplObjectStorage();
+        foreach ($iterable as $workspace) {
+            $result->attach($workspace);
+        }
+        return $result;
     }
 }

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -17,6 +17,7 @@ namespace Neos\Neos\Command;
 use DateInterval;
 use DateInvalidOperationException;
 use Neos\ContentRepository\Core\Feature\Security\Exception\AccessDenied;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\ActivateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\DeactivateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlreadyExists;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Dto\RebaseErrorHandlingStrategy;
@@ -630,6 +631,32 @@ class WorkspaceCommandController extends CommandController
         foreach ($workspacesToDeactivate as $workspace) {
             $contentRepositoryInstance->handle(DeactivateWorkspace::create($workspace));
         }
+    }
+    /**
+     * Activate a single - previously deactivated - workspace by name.
+     *
+     * @param string $workspace Name of the workspace to deactivate.
+     * @param string $contentRepository The name of the content repository. (Default: 'default')
+     * @throws StopCommandException
+     * @throws AccessDenied
+     */
+    public function activateCommand(string $workspace, string $contentRepository = 'default'): void
+    {
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
+
+        $workspaceName = WorkspaceName::fromString($workspace);
+        $workspaceInstance = $contentRepositoryInstance->findWorkspaceByName($workspaceName);
+        if ($workspaceInstance === null) {
+            $this->outputLine('Workspace "%s" not found.', [$workspaceName->value]);
+            $this->quit();
+        }
+        if ($workspaceInstance->isActive()) {
+            $this->outputLine('Workspace "%s" is already active.', [$workspaceName->value]);
+            $this->quit();
+        }
+
+        $contentRepositoryInstance->handle(ActivateWorkspace::create($workspaceName));
     }
 
     // -----------------------

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -582,7 +582,7 @@ class WorkspaceCommandController extends CommandController
      *
      * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @param string $dateInterval The time interval a user had to be inactive for its workspaces to be considered stale. (Default: '7 days')
-     * @throws AccessDenied|DateInvalidOperationException
+     * @throws AccessDenied
      */
     public function deactivateStaleCommand(string $contentRepository = 'default', string $dateInterval = '7 days'): void
     {
@@ -595,6 +595,15 @@ class WorkspaceCommandController extends CommandController
             return;
         }
 
+        try {
+            $cutoffTime = $this->now->sub($interval);
+            // DateInvalidOperationException is introduced in php 8.3, therefore phpstan can't find it and complains
+            // about the next line in php 8.2
+        } catch (\DateInvalidOperationException) { // @phpstan-ignore class.notFound,catch.neverThrown
+            $this->outputLine('Invalid date interval "%s".', [$interval]);
+            return;
+        }
+
         $workspaces = $contentRepositoryInstance->findWorkspaces();
         $baseWorkspaces = $this->splObjectStoreFromIterable($workspaces->map(fn($workspace) => $workspace->baseWorkspaceName));
 
@@ -604,8 +613,7 @@ class WorkspaceCommandController extends CommandController
                     !$baseWorkspaces->contains($workspace->workspaceName))
                 ->map(fn($workspace) => $workspace->workspaceName)
         );
-
-        $inactiveUserIds = $this->splObjectStoreFromIterable($this->userService->findUserIdsNotLoggedInBefore($this->now->sub($interval)));
+        $inactiveUserIds = $this->splObjectStoreFromIterable($this->userService->findUserIdsNotLoggedInBefore($cutoffTime));
 
         $personalWorkspaces = $this->workspaceService->getPersonalWorkspaces($contentRepositoryId);
         $workspacesToDeactivate = [];

--- a/Neos.Neos/Classes/Command/WorkspaceCommandController.php
+++ b/Neos.Neos/Classes/Command/WorkspaceCommandController.php
@@ -478,7 +478,7 @@ class WorkspaceCommandController extends CommandController
                 $workspaceMetadata->title->value,
                 $workspaceMetadata->description->value,
                 $workspace->status->value,
-                $workspace->currentContentStreamId->value,
+                $workspace->currentContentStreamId?->value,
             ];
         }
         $this->output->outputTable($tableRows, $headerRow);
@@ -515,7 +515,7 @@ class WorkspaceCommandController extends CommandController
         $this->outputFormatted('Title: <b>%s</b>', [$workspaceMetadata->title->value]);
         $this->outputFormatted('Description: <b>%s</b>', [$workspaceMetadata->description->value]);
         $this->outputFormatted('Status: <b>%s</b>', [$workspacesInstance->status->value]);
-        $this->outputFormatted('Content Stream: <b>%s</b>', [$workspacesInstance->currentContentStreamId->value]);
+        $this->outputFormatted('Content Stream: <b>%s</b>', [$workspacesInstance->currentContentStreamId?->value]);
 
         $workspaceRoleAssignments = $this->workspaceService->getWorkspaceRoleAssignments($contentRepositoryId, $workspaceName);
         $this->outputLine();
@@ -582,8 +582,7 @@ class WorkspaceCommandController extends CommandController
      *
      * @param string $contentRepository The name of the content repository. (Default: 'default')
      * @param string $dateInterval The time interval a user had to be inactive for its workspaces to be considered stale. (Default: '7 days')
-     * @throws AccessDenied
-     * @throws DateInvalidOperationException
+     * @throws AccessDenied|DateInvalidOperationException
      */
     public function deactivateStaleCommand(string $contentRepository = 'default', string $dateInterval = '7 days'): void
     {
@@ -591,6 +590,10 @@ class WorkspaceCommandController extends CommandController
         $contentRepositoryInstance = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         $interval = DateInterval::createFromDateString($dateInterval);
+        if ($interval === false) {
+            $this->outputLine('Invalid date interval "%s".', [$dateInterval]);
+            return;
+        }
 
         $workspaces = $contentRepositoryInstance->findWorkspaces();
         $baseWorkspaces = $this->splObjectStoreFromIterable($workspaces->map(fn($workspace) => $workspace->baseWorkspaceName));
@@ -638,11 +641,19 @@ class WorkspaceCommandController extends CommandController
         return $roleSubject;
     }
 
+    /**
+     * @template TObject of object
+     * @param iterable<TObject|null> $iterable
+     * @return \SplObjectStorage<TObject,mixed>
+     */
     private function splObjectStoreFromIterable(iterable $iterable): \SplObjectStorage
     {
+        /** @var \SplObjectStorage<TObject,mixed> $result */
         $result = new \SplObjectStorage();
-        foreach ($iterable as $workspace) {
-            $result->attach($workspace);
+        foreach ($iterable as $value) {
+            if ($value !== null) {
+                $result->attach($value);
+            }
         }
         return $result;
     }

--- a/Neos.Neos/Classes/Domain/Repository/WorkspaceMetadataAndRoleRepository.php
+++ b/Neos.Neos/Classes/Domain/Repository/WorkspaceMetadataAndRoleRepository.php
@@ -386,6 +386,30 @@ final readonly class WorkspaceMetadataAndRoleRepository
     }
 
     /**
+     * @return \Traversable<UserId,WorkspaceName>
+     */
+    public function findAllPersonalWorkspaceNamesByContentRepositoryId(ContentRepositoryId $contentRepositoryId): \Traversable
+    {
+        $tableMetadata = self::TABLE_NAME_WORKSPACE_METADATA;
+        $query = <<<SQL
+            SELECT
+                owner_user_id, content_repository_id, workspace_name
+            FROM
+                {$tableMetadata}
+            WHERE
+                classification = :personalWorkspaceClassification
+                AND content_repository_id = :contentRepositoryId
+        SQL;
+        $rows = $this->dbal->fetchAllAssociative($query, [
+            'personalWorkspaceClassification' => WorkspaceClassification::PERSONAL->value,
+            'contentRepositoryId' => $contentRepositoryId->value,
+        ]);
+        foreach ($rows as $row) {
+            yield UserId::fromString($row['owner_user_id']) => WorkspaceName::fromString($row['workspace_name']);
+        }
+    }
+
+    /**
      * @param \Closure(): void $fn
      * @return void
      */

--- a/Neos.Neos/Classes/Domain/Service/SiteExportService.php
+++ b/Neos.Neos/Classes/Domain/Service/SiteExportService.php
@@ -59,6 +59,10 @@ final readonly class SiteExportService
         if ($liveWorkspace === null) {
             throw new \RuntimeException('Failed to find live workspace', 1716652280);
         }
+        if (!$liveWorkspace->isActive()) {
+            //TODO: should be impossible
+            throw new \RuntimeException('Live workspace was deactivated', 1768577266);
+        }
 
         $processors = Processors::fromArray([
             'Exporting events' => $this->contentRepositoryRegistry->buildService(

--- a/Neos.Neos/Classes/Domain/Service/UserService.php
+++ b/Neos.Neos/Classes/Domain/Service/UserService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Domain\Service;
 
+use DateTimeInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
@@ -773,6 +774,30 @@ class UserService
         }
 
         return $roles;
+    }
+
+    /**
+     * @param DateTimeInterface $dateTime
+     * @return \Traversable<UserId>
+     */
+    public function findUserIdsNotLoggedInBefore(DateTimeInterface $dateTime): \Traversable
+    {
+        /** @var User $user */
+        foreach ($this->getUsers() as $user) {
+            $accounts = $user->getAccounts();
+            $loggedIn = false;
+            foreach ($accounts as $account) {
+                $lastSuccessfulAuthenticationDate = $account->getLastSuccessfulAuthenticationDate();
+                if ($lastSuccessfulAuthenticationDate != null && $lastSuccessfulAuthenticationDate > $dateTime) {
+                    $loggedIn = true;
+                    break;
+                }
+            }
+
+            if (!$loggedIn) {
+                yield $user->getId();
+            }
+        }
     }
 
     /**

--- a/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
@@ -371,13 +371,17 @@ final class WorkspacePublishingService
     private function pendingWorkspaceChangesInternal(ContentRepository $contentRepository, WorkspaceName $workspaceName): Changes
     {
         $crWorkspace = $this->requireContentRepositoryWorkspace($contentRepository, $workspaceName);
-        return $contentRepository->projectionState(ChangeFinder::class)->findByContentStreamId($crWorkspace->currentContentStreamId);
+        return $crWorkspace->isActive()
+            ? $contentRepository->projectionState(ChangeFinder::class)->findByContentStreamId($crWorkspace->currentContentStreamId)
+            : Changes::fromArray([]);
     }
 
     private function countPendingWorkspaceChangesInternal(ContentRepository $contentRepository, WorkspaceName $workspaceName): int
     {
         $crWorkspace = $this->requireContentRepositoryWorkspace($contentRepository, $workspaceName);
-        return $contentRepository->projectionState(ChangeFinder::class)->countByContentStreamId($crWorkspace->currentContentStreamId);
+        return $crWorkspace->isActive()
+            ? $contentRepository->projectionState(ChangeFinder::class)->countByContentStreamId($crWorkspace->currentContentStreamId)
+            : 0;
     }
 
     private function isChangePublishableWithinAncestorScope(

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace Neos\Neos\Domain\Service;
 
 use Neos\ContentRepository\Core\Feature\Security\Exception\AccessDenied;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\ActivateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceActivation\Command\DeactivateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlreadyExists;
@@ -215,6 +217,44 @@ final readonly class WorkspaceService
             WorkspaceName::forLive(),
             $user->getId(),
         );
+    }
+
+    public function isWorkspaceActive(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): bool
+    {
+        return $this->requireWorkspace($contentRepositoryId, $workspaceName)->isActive();
+    }
+
+    public function activatePersonalWorkspaceForUserIfDeactivated(ContentRepositoryId $contentRepositoryId, User $user): void
+    {
+        $existingWorkspaceName = $this->metadataAndRoleRepository->findWorkspaceNameByUser($contentRepositoryId, $user->getId());
+        if ($existingWorkspaceName === null) {
+            throw new \RuntimeException(sprintf('No workspace is assigned to the user with id "%s")', $user->getId()->value), 1766049866);
+        }
+
+        $workspaceIsActive = $this->isWorkspaceActive($contentRepositoryId, $existingWorkspaceName);
+        if ($workspaceIsActive) {
+            return;
+        }
+
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepository->handle(ActivateWorkspace::create($existingWorkspaceName));
+    }
+
+    // TODO: required? If not remove
+    public function deactivatePersonalWorkspaceForUserIfActive(ContentRepositoryId $contentRepositoryId, User $user): void
+    {
+        $existingWorkspaceName = $this->metadataAndRoleRepository->findWorkspaceNameByUser($contentRepositoryId, $user->getId());
+        if ($existingWorkspaceName === null) {
+            throw new \RuntimeException(sprintf('No workspace is assigned to the user with id "%s")', $user->getId()->value), 1766049866);
+        }
+
+        $workspaceIsActive = $this->isWorkspaceActive($contentRepositoryId, $existingWorkspaceName);
+        if (!$workspaceIsActive) {
+            return;
+        }
+
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepository->handle(DeactivateWorkspace::create($existingWorkspaceName));
     }
 
     /**

--- a/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspaceService.php
@@ -341,6 +341,14 @@ final readonly class WorkspaceService
         throw new \RuntimeException(sprintf('Failed to find unique workspace name for "%s" after %d attempts.', $candidate, $attempt - 1), 1725975479);
     }
 
+    /**
+     * @return \Traversable<UserId,WorkspaceName>
+     */
+    public function getPersonalWorkspaces(ContentRepositoryId $contentRepository): \Traversable
+    {
+        return $this->metadataAndRoleRepository->findAllPersonalWorkspaceNamesByContentRepositoryId($contentRepository);
+    }
+
     // ------------------
 
     /**

--- a/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
+++ b/Neos.Workspace.Ui/Classes/Controller/WorkspaceController.php
@@ -466,10 +466,9 @@ class WorkspaceController extends AbstractModuleController
         $nodesCount = 0;
 
         try {
-            $nodesCount = $contentRepository->projectionState(ChangeFinder::class)
-                ->countByContentStreamId(
-                    $workspace->currentContentStreamId
-                );
+            $nodesCount = $workspace->currentContentStreamId === null ? 0 :
+                $contentRepository->projectionState(ChangeFinder::class)
+                    ->countByContentStreamId($workspace->currentContentStreamId);
         } catch (\Exception $exception) {
             $message = $this->getModuleLabel(
                 'workspaces.notDeletedErrorWhileFetchingUnpublishedNodes',
@@ -996,7 +995,7 @@ class WorkspaceController extends AbstractModuleController
         ContentRepository $contentRepository,
     ): ContentChangeItems {
         $currentWorkspace = $contentRepository->findWorkspaces()->find(
-            fn (Workspace $potentialWorkspace) => $potentialWorkspace->currentContentStreamId->equals($contentStreamIdOfOriginalNode)
+            fn (Workspace $potentialWorkspace) => $potentialWorkspace->currentContentStreamId?->equals($contentStreamIdOfOriginalNode) ?? false
         );
         $originalNode = null;
         if ($currentWorkspace !== null) {
@@ -1327,6 +1326,10 @@ class WorkspaceController extends AbstractModuleController
     }
 
     protected function getChangesFromWorkspace(Workspace $selectedWorkspace,ContentRepository $contentRepository ): Changes{
+        if (!$selectedWorkspace->isActive()) {
+            // since there is no content stream associated to them, inactive workspaces cannot contain changes
+            return Changes::fromArray([]);
+        }
         return $contentRepository->projectionState(ChangeFinder::class)
             ->findByContentStreamId(
                 $selectedWorkspace->currentContentStreamId


### PR DESCRIPTION
**This is meant to address Neos performance issues when publishing changes.**

**This change modifies the database (`workspace::currentContentStreamId` becomes nullable) -> that's why it is marked as BREAKING**

# Basic Idea

Each Neos account has its own workspace and each workspace its own content stream. These content streams result in a potentially large number of entries in the content repositories `hierarchyrelation` table, which in turn, will make the fork operation slower. 

**Core Observation:** In a lot of cases only a small amount of these accounts is actually actively used, i.e. have unpublished changes.

The basic idea of this PR is to remove the unnecessary lines from the `hierarchyrelation` table:

- **Workspaces can be deactivated,**  which will remove the associated content stream, but leave the workspace itself in the database.
  - This can only be done if the workspace is both up to date and not used as a base workspace for another workspace. 
- This will *reduce the time a fork operation requires* and therefore speed up the publish process.
- When **activated** again, a new content stream is forked from the base workspace and associated to the workspace. This can be done on login, opaque to the user logging in.

# Implementation Details

The feature is exposed through commands in the `WorkspaceCommandController`:
- `./flow workspace:deactivate`: deactivate a workspace (only if contains no changes + no other one depending on it)
- `./flow workspace:activate`: re-activate a workspace
- `./flow workspace:deactivateStale`: deactivate all **stale** user workspaces. A workspace is stale if:
  - it is a user workspace
  - contains no pending changes
  - has no other workspace depending on it
  - and the user the workspace belongs to did not log in for a given amount of time (by default 7 days).

The last command is meant to be used in a cron job or similar to minimize the amount of active workspaces without the need to manually deactivate workspaces.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
 
Related: https://github.com/neos/neos-development-collection/issues/4388