### PR TITLE
BUGFIX: Allow possible translation value to be null

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Configuration/NodeTypeEnrichmentService.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Configuration/NodeTypeEnrichmentService.php
@@ -354,7 +354,7 @@ class NodeTypeEnrichmentService
     {
         $fieldValue = array_key_exists($fieldName, $parentConfiguration) ? $parentConfiguration[$fieldName] : '';
 
-        return (trim($fieldValue) === 'i18n');
+        return ($fieldValue !== null && trim($fieldValue) === 'i18n');
     }
 
     /**


### PR DESCRIPTION
If the value of a potential translateable field is null, the trim function complains about a non-string value. So we check now upfront, if the value is null.

```
trim(): Argument #1 ($string) must be of type string, null given
```