### PR TITLE
BUGFIX: Add Missing ChangePropertyTypeFromScalarToBackedEnum transformation

### DIFF
--- a/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
+++ b/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
@@ -126,6 +126,7 @@ Neos:
         AddNewProperty: Neos\ContentRepository\NodeMigration\Transformation\AddNewPropertyConverterAwareTransformationFactory
         ChangeNodeType: Neos\ContentRepository\NodeMigration\Transformation\ChangeNodeTypeTransformationFactory
         ChangePropertyValue: Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyValueConverterAwareTransformationFactory
+        ChangePropertyTypeFromScalarToBackedEnum: Neos\ContentRepository\NodeMigration\Transformation\ChangePropertyTypeFromScalarToBackedEnumTransformationFactory
         MoveDimensionSpacePoint: Neos\ContentRepository\NodeMigration\Transformation\MoveDimensionSpacePointTransformationFactory
         RemoveNode: Neos\ContentRepository\NodeMigration\Transformation\RemoveNodeTransformationFactory
         RemoveProperty: Neos\ContentRepository\NodeMigration\Transformation\RemovePropertyTransformationFactory

--- a/Neos.Neos/Documentation/References/NodeMigrations.rst
+++ b/Neos.Neos/Documentation/References/NodeMigrations.rst
@@ -14,6 +14,7 @@ The Content Repository comes with a number of common transformations:
 - ``AddDimensionShineThrough``
 - ``AddNewProperty``
 - ``ChangeNodeType``
+- ``ChangePropertyTypeFromScalarToBackedEnum``
 - ``ChangePropertyValue``
 - ``MoveDimensionSpacePoint``
 - ``RemoveNode``
@@ -120,6 +121,41 @@ Options Reference:
   This flag allows to enforce the migration. In case of child constraint conflicts the conflicting child nodes get deleted.
 
   Default is `false`.
+
+ChangePropertyTypeFromScalarToBackedEnum
+~~~~~~~~~~~~~~
+
+Change a node property value from a scalar to a backed enum.
+
+Since Neos 9.1, backed enums are fully supported in both the CR and Neos UI.
+This transformation changes previously stored backing values (properties of type int or string) to the actual enums
+after the property type has been changed to the enum's fully qualified classname in the node type config.
+
+Example:
+First, change
+
+.. code-block:: yaml
+
+  'Acme.Site:MyNodeType':
+    properties:
+      someValue:
+        type: string
+
+to
+
+.. code-block:: yaml
+
+  'Acme.Site:MyNodeType':
+    properties:
+      someValue:
+        type: Acme\Site\SomeStringEnum
+
+, then run the transformation with property ``someValue``.
+
+Options Reference:
+
+``property`` (string)
+  The name of the property to be transformed.
 
 ChangePropertyValue
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This was simply missing in the default settings

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.1 branch where this was introduced
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
