### PR TITLE
BUGFIX: Handle numeric node aggregate ids when building `NodeAggregates`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -333,6 +333,9 @@ final class NodeFactory
             throw new \RuntimeException(sprintf('Failed to JSON-decode subtree tags from JSON string %s: %s', $subtreeTagsJson, $e->getMessage()), 1716476904, $e);
         }
         foreach ($subtreeTagsArray as $tagValue => $explicit) {
+            if (!is_string($tagValue)) {
+                throw new \RuntimeException(sprintf('Fatal: SubtreeTags are never purely numeric. Got %d', $tagValue), 1768047428);
+            }
             if ($explicit) {
                 $explicitTags[] = $tagValue;
             } else {

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -296,11 +296,10 @@ final class NodeFactory
         }
 
         foreach ($nodesByOccupiedDimensionSpacePointsByNodeAggregate as $rawNodeAggregateId => $nodes) {
-            /** @var string $rawNodeAggregateId */
             $nodeAggregates[] = NodeAggregate::create(
                 $this->contentRepositoryId,
                 $workspaceName,
-                NodeAggregateId::fromString($rawNodeAggregateId),
+                NodeAggregateId::fromString((string)$rawNodeAggregateId),
                 $classificationByNodeAggregate[$rawNodeAggregateId],
                 $nodeTypeNames[$rawNodeAggregateId],
                 $nodeNames[$rawNodeAggregateId],

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -76,6 +76,7 @@ Feature: Find nodes using the findNodeById query
       | a2a2            | a2a2     | Neos.ContentRepository.Testing:Page        | a2a                    | {"text": "a2a2"}      | {}                                       |
       | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}         | {}                                       |
       | b1              | b1       | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}        | {}                                       |
+      | 123             | 123      | Neos.ContentRepository.Testing:Page        | home                   | {"text": "123"}       | {}                                       |
     And the command DisableNodeAggregate is executed with payload:
       | Key                          | Value         |
       | nodeAggregateId              | "a2a1"        |
@@ -94,6 +95,10 @@ Feature: Find nodes using the findNodeById query
 
     When I execute the findNodesByIds query for node aggregate id "home,a2a2,a2a1,non-existing" I expect the nodes "home,a2a2" to be returned
 
+    # special case numeric node ids
+    When I execute the findNodeById query for node aggregate id "123" I expect the node "123" to be returned
+    When I execute the findNodesByIds query for node aggregate id "123" I expect the nodes "123" to be returned
+
   Scenario:
     Contentgraph queries
     When I execute the findNodeAggregateById query for node aggregate id "a" I expect the following node aggregates to be returned:
@@ -106,3 +111,11 @@ Feature: Find nodes using the findNodeById query
       | a2a1            | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
       | a               | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
       | home            | Neos.ContentRepository.Testing:Homepage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+
+    # special case numeric node ids
+    When I execute the findNodeAggregateById query for node aggregate id "123" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      | 123             | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |
+    When I execute the findNodeAggregatesByIds query for node aggregate id "123" I expect the following node aggregates to be returned:
+      | nodeAggregateId | nodeTypeName                        | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions |
+      | 123             | Neos.ContentRepository.Testing:Page | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                           |

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
@@ -36,7 +36,7 @@ final class SubtreeTag implements \JsonSerializable
 
     private function __construct(public string $value)
     {
-        $regexPattern = '/^[a-z0-9_.-]{1,36}$/';
+        $regexPattern = '/^[a-z_.-][a-z0-9_.-]{0,35}$/';
         if (preg_match($regexPattern, $value) !== 1) {
             throw new \InvalidArgumentException(sprintf('The SubtreeTag value "%s" does not adhere to the regular expression "%s"', $value, $regexPattern), 1695467813);
         }

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTag.php
@@ -36,9 +36,12 @@ final class SubtreeTag implements \JsonSerializable
 
     private function __construct(public string $value)
     {
-        $regexPattern = '/^[a-z_.-][a-z0-9_.-]{0,35}$/';
+        $regexPattern = '/^[a-z0-9_.-]{1,36}$/';
         if (preg_match($regexPattern, $value) !== 1) {
             throw new \InvalidArgumentException(sprintf('The SubtreeTag value "%s" does not adhere to the regular expression "%s"', $value, $regexPattern), 1695467813);
+        }
+        if (is_numeric($this->value)) {
+            throw new \InvalidArgumentException(sprintf('The SubtreeTag value "%s" must not be fully numeric', $value), 1779911018);
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/NodeAggregateIds.php
@@ -20,25 +20,22 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Nodes;
 /**
  * An immutable collection of NodeAggregateIds, indexed by their value
  *
- * @implements \IteratorAggregate<string,NodeAggregateId>
+ * @implements \IteratorAggregate<NodeAggregateId>
  * @api
  */
 final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSerializable
 {
     /**
-     * @var array<string,NodeAggregateId>
+     * @param array<string|int,NodeAggregateId> $nodeAggregateIds
      */
-    private array $nodeAggregateIds;
-
-    private function __construct(NodeAggregateId ...$nodeAggregateIds)
-    {
-        /** @var array<string,NodeAggregateId> $nodeAggregateIds */
-        $this->nodeAggregateIds = $nodeAggregateIds;
+    private function __construct(
+        private array $nodeAggregateIds
+    ) {
     }
 
     public static function createEmpty(): self
     {
-        return new self();
+        return new self([]);
     }
 
     public static function create(NodeAggregateId ...$nodeAggregateIds): self
@@ -60,7 +57,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
             }
         }
 
-        return new self(...$nodeAggregateIds);
+        return new self($nodeAggregateIds);
     }
 
     public static function fromJsonString(string $jsonString): self
@@ -77,7 +74,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
 
     public function merge(self $other): self
     {
-        return new self(...array_merge(
+        return new self(array_merge(
             $this->nodeAggregateIds,
             $other->nodeAggregateIds
         ));
@@ -89,7 +86,7 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
     }
 
     /**
-     * @return array<string,NodeAggregateId>
+     * @return array<NodeAggregateId>
      */
     public function jsonSerialize(): array
     {
@@ -106,12 +103,12 @@ final class NodeAggregateIds implements \IteratorAggregate, \Countable, \JsonSer
      */
     public function toStringArray(): array
     {
-        return array_keys($this->nodeAggregateIds);
+        return array_map(strval(...), array_keys($this->nodeAggregateIds));
     }
 
     public function getIterator(): \Traversable
     {
-        yield from $this->nodeAggregateIds;
+        yield from array_values($this->nodeAggregateIds);
     }
 
     /**

--- a/Neos.ContentRepository.Core/Tests/Unit/Feature/SubtreeTagging/Dto/SubtreeTagTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Feature/SubtreeTagging/Dto/SubtreeTagTest.php
@@ -12,6 +12,7 @@ class SubtreeTagTest extends TestCase
      */
     public function fromStringSupportsUUIDs(): void
     {
+        // leading and trailing digits are allowed!
         $uuid = '2281f529-d769-4084-9bdb-ea0f89356667';
         self::assertSame($uuid, SubtreeTag::fromString($uuid)->value);
     }
@@ -32,6 +33,24 @@ class SubtreeTagTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         SubtreeTag::fromString('invalidTag');
+    }
+
+    /**
+     * @test
+     */
+    public function fromStringFailsIfStringContainsOnlyNumericCharacters(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        SubtreeTag::fromString('12345');
+    }
+
+    /**
+     * @test
+     */
+    public function fromStringFailsIfStringContainsOnlyNumericWithLeadingZeroCharacters(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        SubtreeTag::fromString('007');
     }
 
     /**

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAggregateIdsTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/NodeAggregateIdsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\SharedModel\Node;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
+use PHPUnit\Framework\TestCase;
+
+class NodeAggregateIdsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function constructWithNumericIds()
+    {
+        $ids = NodeAggregateIds::fromArray(['123']);
+        self::assertSame(['123'], $ids->toStringArray());
+        self::assertTrue($ids->contain(NodeAggregateId::fromString('123')));
+
+        $ids = NodeAggregateIds::fromArray(['abc', '123']);
+        self::assertSame(['abc', '123'], $ids->toStringArray());
+        self::assertTrue($ids->contain(NodeAggregateId::fromString('123')));
+        self::assertTrue($ids->contain(NodeAggregateId::fromString('abc')));
+
+        $ids = NodeAggregateIds::fromArray(['123', 'abc']);
+        self::assertSame(['123', 'abc'], $ids->toStringArray());
+        self::assertTrue($ids->contain(NodeAggregateId::fromString('123')));
+    }
+
+    /**
+     * @test
+     */
+    public function jsonRepresentation()
+    {
+        // FIXME, why do we encode the collection as object and not as list?
+        $ids = NodeAggregateIds::fromArray(['abc', 'def']);
+        self::assertSame('{"abc":"abc","def":"def"}', $ids->toJson());
+    }
+}

--- a/Neos.Neos/Classes/Domain/Service/NodeDuplication/NodeAggregateIdMapping.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeDuplication/NodeAggregateIdMapping.php
@@ -28,17 +28,17 @@ final class NodeAggregateIdMapping implements \JsonSerializable
      *
      * e.g. {main => my-main-node}
      *
-     * @var array<string,NodeAggregateId>
+     * @var array<string|int,NodeAggregateId>
      */
     private array $nodeAggregateIds = [];
 
     /**
-     * @param array<string,NodeAggregateId> $nodeAggregateIds
+     * @param array<string|int,NodeAggregateId> $nodeAggregateIds
      */
     private function __construct(array $nodeAggregateIds)
     {
         foreach ($nodeAggregateIds as $oldNodeAggregateId => $newNodeAggregateId) {
-            $oldNodeAggregateId = NodeAggregateId::fromString($oldNodeAggregateId);
+            $oldNodeAggregateId = NodeAggregateId::fromString((string)$oldNodeAggregateId);
             if (!$newNodeAggregateId instanceof NodeAggregateId) {
                 throw new \InvalidArgumentException(
                     'NodeAggregateIdMapping objects can only be composed of NodeAggregateId.',
@@ -82,7 +82,7 @@ final class NodeAggregateIdMapping implements \JsonSerializable
     }
 
     /**
-     * @return array<string,NodeAggregateId>
+     * @return array<string|int,NodeAggregateId>
      */
     public function jsonSerialize(): array
     {

--- a/Neos.Neos/Tests/Unit/Domain/Service/NodeDuplication/NodeAggregateIdMappingTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/NodeDuplication/NodeAggregateIdMappingTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Neos\Tests\Unit\Domain\Service\NodeDuplication;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\Neos\Domain\Service\NodeDuplication\NodeAggregateIdMapping;
+use PHPUnit\Framework\TestCase;
+
+class NodeAggregateIdMappingTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function constructWithNumericIds()
+    {
+        $ids = NodeAggregateIdMapping::fromArray(['123' => '456']);
+        self::assertNull($ids->getNewNodeAggregateId(NodeAggregateId::fromString('456')));
+        self::assertSame('456', $ids->getNewNodeAggregateId(NodeAggregateId::fromString('123'))?->value);
+
+        $ids = NodeAggregateIdMapping::createEmpty()->withNewNodeAggregateId(
+            NodeAggregateId::fromString('123'),
+            NodeAggregateId::fromString('456')
+        );
+        self::assertSame('456', $ids->getNewNodeAggregateId(NodeAggregateId::fromString('123'))?->value);
+    }
+}


### PR DESCRIPTION
Currently by not restricting numeric values like `"132"` in the NodeAggregateId validation we allow it. Yet the behaviour is utterly broken due to us being tricked by phps "feature" which converts numeric strings to integers when using it as array index. We often put node ids into a hashmap but get integers back and then fail recreating a node aggregate id and other funky cases. I hope i found all cases...

Type error: Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId::fromString(): Argument #1 ($value) must be of type string, int given, called in Packages/Neos/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php on line 290

A classic one thanks due to phps type casting for numeric array keys :)

$array['123'] will be stored as int `123` and not accessible via `"123"`

Additionally the SubtreeTags - pained by a similar bug - are now restricted to be never fully numeric. See discussion in Slack: https://neos-project.slack.com/archives/C04PYL8H3/p1767965980113829

At some point phpstan might be able to detect all cases for once and for all: https://phpstan.org/blog/why-array-string-keys-are-not-type-safe

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
