### PR TITLE
WIP: BUGFIX: Speed up `findChildNodes` in a large content repository

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -70,12 +70,12 @@ class DoctrineDbalContentGraphSchemaBuilder
         ]);
 
         return $table
+            ->setPrimaryKey(['parentnodeanchor', 'childnodeanchor', 'contentstreamid', 'dimensionspacepointhash'])
             ->addIndex(['childnodeanchor'])
             ->addIndex(['contentstreamid'])
             ->addIndex(['parentnodeanchor'])
-            ->addIndex(['childnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'position'])
-            ->addIndex(['parentnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'position'])
-            ->addIndex(['contentstreamid', 'dimensionspacepointhash']);
+            ->addIndex(['contentstreamid', 'dimensionspacepointhash'])
+            ->addIndex(['position']);
     }
 
     private function createDimensionSpacePointsTable(AbstractPlatform $platform): Table


### PR DESCRIPTION
see https://discuss.neos.io/t/discussion-editing-and-storing-thousands-of-blog-posts-news-entries-in-nodes-in-neos-9-0/7154 for the full discussion


a query always uses both the 'parentnodeanchor' and 'childnodeanchor' column thus we group them into a single (unique) index (we can simply use them as primary key)

the position is now an own index otherwise `EXPLAIN SELECT` shows that the default ordering `h.position ASC` is not done via index

this is merely the index adjustment. The queries must be adjusted as well to leverage subselects wich brings the full performance gain with the new indexes

Ironically we _had_ the primary key like this already but reverted that change https://github.com/neos/neos-development-collection/pull/5009 because of slow replay performance. That will need to be reevaluated. See https://github.com/neos/neos-development-collection/issues/5011#issuecomment-3765710524

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
