### PR TITLE
BUGFIX: Relax descendant node type checks to allow matching tethered children on node type change

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -93,6 +93,10 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       childNodes:
         child-of-type-b:
           type: 'Neos.ContentRepository.Testing:ChildOfNodeTypeB'
+      constraints:
+        nodeTypes:
+          '*': false
+          'Neos.ContentRepository.Testing:ChildOfNodeTypeA': true
       properties:
         defaultTextB:
           type: string
@@ -100,6 +104,20 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
         commonDefaultText:
           type: string
           defaultValue: 'commonDefaultTextB'
+    'Neos.ContentRepository.Testing:NodeTypeB2':
+      childNodes:
+        child-of-type-b:
+          type: 'Neos.ContentRepository.Testing:ChildOfNodeTypeB'
+      constraints:
+        nodeTypes:
+          '*': false
+      properties:
+        defaultTextB2:
+          type: string
+          defaultValue: 'defaultTextB2'
+        commonDefaultText:
+          type: string
+          defaultValue: 'commonDefaultTextB2'
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -192,7 +210,6 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | newNodeTypeName | "Neos.ContentRepository.Testing:GrandParentNodeTypeC" |
       | strategy        | "happypath"                                           |
     Then the last command should have thrown an exception of type "NodeConstraintException"
-
 
   Scenario: Change node type with tethered children
     When the following CreateNodeAggregateWithNode commands are executed:
@@ -430,3 +447,83 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
 
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"language":"gsw"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeCCollection"
+
+  Scenario: Change node type to another type with the same tethered children
+    When the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId  | originDimensionSpacePoint | parentNodeAggregateId  | nodeTypeName                             | initialPropertyValues | tetheredDescendantNodeAggregateIds        |
+      | nody-mc-nodeface | {"language":"de"}         | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeTypeB | {}                    | { "child-of-type-b": "nodewyn-tetherton"} |
+
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value              |
+      | nodeAggregateId | "nody-mc-nodeface" |
+      | sourceOrigin    | {"language":"de"}  |
+      | targetOrigin    | {"language":"gsw"} |
+
+    When the command ChangeNodeAggregateType is executed with payload:
+      | Key             | Value                                       |
+      | nodeAggregateId | "nody-mc-nodeface"                          |
+      | newNodeTypeName | "Neos.ContentRepository.Testing:NodeTypeB2" |
+      | strategy        | "happypath"                                 |
+
+    Then I expect exactly 11 events to be published on stream "ContentStream:cs-identifier"
+    And event at index 8 is of type "NodeAggregateTypeWasChanged" with payload:
+      | Key             | Expected                                    |
+      | workspaceName   | "live"                                      |
+      | contentStreamId | "cs-identifier"                             |
+      | nodeAggregateId | "nody-mc-nodeface"                          |
+      | newNodeTypeName | "Neos.ContentRepository.Testing:NodeTypeB2" |
+    And event at index 9 is of type "NodePropertiesWereSet" with payload:
+      | Key                          | Expected                                                    |
+      | workspaceName                | "live"                                                      |
+      | contentStreamId              | "cs-identifier"                                             |
+      | nodeAggregateId              | "nody-mc-nodeface"                                          |
+      | originDimensionSpacePoint    | {"language":"gsw"}                                          |
+      | affectedDimensionSpacePoints | [{"language":"gsw"}]                                        |
+      | propertyValues               | {"defaultTextB2":{"value":"defaultTextB2","type":"string"}} |
+      | propertiesToUnset            | ["defaultTextB"]                                            |
+    And event at index 10 is of type "NodePropertiesWereSet" with payload:
+      | Key                          | Expected                                                    |
+      | workspaceName                | "live"                                                      |
+      | contentStreamId              | "cs-identifier"                                             |
+      | nodeAggregateId              | "nody-mc-nodeface"                                          |
+      | originDimensionSpacePoint    | {"language":"de"}                                           |
+      | affectedDimensionSpacePoints | [{"language":"de"}]                                         |
+      | propertyValues               | {"defaultTextB2":{"value":"defaultTextB2","type":"string"}} |
+      | propertiesToUnset            | ["defaultTextB"]                                            |
+
+    # the type has changed
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB2"
+    And I expect this node to have the following properties:
+      | Key               | Value                |
+      # Not modified because it was already present
+      | commonDefaultText | "commonDefaultTextB" |
+      | defaultTextB2     | "defaultTextB2"      |
+      # defaultTextB missing because it does not exist in NodeTypeB2
+
+    And I expect this node to have the following child nodes:
+      | Name            | NodeDiscriminator                                 |
+      # the tethered child of the old node type has not been changed because it its type is identical
+      | child-of-type-b | cs-identifier;nodewyn-tetherton;{"language":"de"} |
+
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"language":"de"}
+    And I expect this node to have the following properties:
+      | Key               | Value                |
+      | commonDefaultText | "commonDefaultTextB" |
+      | defaultTextB      | "defaultTextB"       |
+
+    When I am in workspace "live" and dimension space point {"language":"gsw"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"gsw"}
+    And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB2"
+
+    And I expect this node to have the following child nodes:
+      | Name            | NodeDiscriminator                                  |
+      # the tethered child of the old node type has not been changed because it its type is identical
+      | child-of-type-b | cs-identifier;nodewyn-tetherton;{"language":"gsw"} |
+
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"language":"gsw"}
+    And I expect this node to have the following properties:
+      | Key               | Value                |
+      | commonDefaultText | "commonDefaultTextB" |
+      | defaultTextB      | "defaultTextB"       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -71,6 +71,12 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
           type: string
           defaultValue: 'commonDefaultTextA'
     'Neos.ContentRepository.Testing:ChildOfNodeTypeB':
+      childNodes:
+        tethered:
+          type: 'Neos.ContentRepository.Testing:Tethered'
+      constraints:
+        nodeTypes:
+          '*': false
       properties:
         defaultTextB:
           type: string
@@ -223,13 +229,13 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | targetOrigin    | {"language":"gsw"} |
 
     When the command ChangeNodeAggregateType is executed with payload:
-      | Key                                | Value                                      |
-      | nodeAggregateId                    | "nody-mc-nodeface"                         |
-      | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB" |
-      | strategy                           | "happypath"                                |
-      | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "nodimer-tetherton"}  |
+      | Key                                | Value                                                                                      |
+      | nodeAggregateId                    | "nody-mc-nodeface"                                                                         |
+      | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB"                                                 |
+      | strategy                           | "happypath"                                                                                |
+      | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "nodimer-tetherton", "child-of-type-b/tethered": "nodewyn-tetherton"} |
 
-    Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
+    Then I expect exactly 15 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateTypeWasChanged" with payload:
       | Key             | Expected                                   |
       | workspaceName   | "live"                                     |
@@ -271,6 +277,26 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceName             | "live"                                                             |
       | contentStreamId           | "cs-identifier"                                                    |
       | nodeAggregateId           | "nodimer-tetherton"                                                |
+      | sourceOrigin              | {"language":"gsw"}                                                 |
+      | generalizationOrigin      | {"language":"de"}                                                  |
+      | variantSucceedingSiblings | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}] |
+    And event at index 13 is of type "NodeAggregateWithNodeWasCreated" with payload:
+      | Key                           | Expected                                                            |
+      | workspaceName                 | "live"                                                              |
+      | contentStreamId               | "cs-identifier"                                                     |
+      | nodeAggregateId               | "nodewyn-tetherton"                                                 |
+      | nodeTypeName                  | "Neos.ContentRepository.Testing:Tethered"                           |
+      | originDimensionSpacePoint     | {"language":"gsw"}                                                  |
+      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId":null}] |
+      | parentNodeAggregateId         | "nodimer-tetherton"                                                 |
+      | nodeName                      | "tethered"                                                          |
+      | initialPropertyValues         | []                                                                  |
+      | nodeAggregateClassification   | "tethered"                                                          |
+    And event at index 14 is of type "NodeGeneralizationVariantWasCreated" with payload:
+      | Key                       | Expected                                                           |
+      | workspaceName             | "live"                                                             |
+      | contentStreamId           | "cs-identifier"                                                    |
+      | nodeAggregateId           | "nodewyn-tetherton"                                                |
       | sourceOrigin              | {"language":"gsw"}                                                 |
       | generalizationOrigin      | {"language":"de"}                                                  |
       | variantSucceedingSiblings | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}] |
@@ -450,8 +476,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
 
   Scenario: Change node type to another type with the same tethered children
     When the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId  | originDimensionSpacePoint | parentNodeAggregateId  | nodeTypeName                             | initialPropertyValues | tetheredDescendantNodeAggregateIds        |
-      | nody-mc-nodeface | {"language":"de"}         | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeTypeB | {}                    | { "child-of-type-b": "nodewyn-tetherton"} |
+      | nodeAggregateId  | originDimensionSpacePoint | parentNodeAggregateId  | nodeTypeName                             | initialPropertyValues | tetheredDescendantNodeAggregateIds                                                         |
+      | nody-mc-nodeface | {"language":"de"}         | lady-eleonode-rootford | Neos.ContentRepository.Testing:NodeTypeB | {}                    | { "child-of-type-b": "nodewyn-tetherton", "child-of-type-b/tethered": "nodimer-tetherton"} |
 
     When the command CreateNodeVariant is executed with payload:
       | Key             | Value              |
@@ -465,14 +491,14 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | newNodeTypeName | "Neos.ContentRepository.Testing:NodeTypeB2" |
       | strategy        | "happypath"                                 |
 
-    Then I expect exactly 11 events to be published on stream "ContentStream:cs-identifier"
-    And event at index 8 is of type "NodeAggregateTypeWasChanged" with payload:
+    Then I expect exactly 13 events to be published on stream "ContentStream:cs-identifier"
+    And event at index 10 is of type "NodeAggregateTypeWasChanged" with payload:
       | Key             | Expected                                    |
       | workspaceName   | "live"                                      |
       | contentStreamId | "cs-identifier"                             |
       | nodeAggregateId | "nody-mc-nodeface"                          |
       | newNodeTypeName | "Neos.ContentRepository.Testing:NodeTypeB2" |
-    And event at index 9 is of type "NodePropertiesWereSet" with payload:
+    And event at index 11 is of type "NodePropertiesWereSet" with payload:
       | Key                          | Expected                                                    |
       | workspaceName                | "live"                                                      |
       | contentStreamId              | "cs-identifier"                                             |
@@ -481,7 +507,7 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | affectedDimensionSpacePoints | [{"language":"gsw"}]                                        |
       | propertyValues               | {"defaultTextB2":{"value":"defaultTextB2","type":"string"}} |
       | propertiesToUnset            | ["defaultTextB"]                                            |
-    And event at index 10 is of type "NodePropertiesWereSet" with payload:
+    And event at index 12 is of type "NodePropertiesWereSet" with payload:
       | Key                          | Expected                                                    |
       | workspaceName                | "live"                                                      |
       | contentStreamId              | "cs-identifier"                                             |
@@ -513,6 +539,11 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | commonDefaultText | "commonDefaultTextB" |
       | defaultTextB      | "defaultTextB"       |
 
+    And I expect this node to have the following child nodes:
+      | Name     | NodeDiscriminator                                 |
+      # the tethered grandchild is not affected in any way
+      | tethered | cs-identifier;nodimer-tetherton;{"language":"de"} |
+
     When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"gsw"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:NodeTypeB2"
@@ -527,3 +558,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | Key               | Value                |
       | commonDefaultText | "commonDefaultTextB" |
       | defaultTextB      | "defaultTextB"       |
+
+    And I expect this node to have the following child nodes:
+      | Name     | NodeDiscriminator                                  |
+      # the tethered grandchild is not affected in any way
+      | tethered | cs-identifier;nodimer-tetherton;{"language":"gsw"} |

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -349,11 +349,21 @@ trait NodeTypeChange
                 } else {
                     $grandChildNodeTypeForConstraintChecks = $this->requireNodeType($grandchildNodeAggregate->nodeTypeName);
                 }
-                $this->requireNodeTypeConstraintsImposedByGrandparentToBeMet(
-                    $newNodeType, // the grandparent node type changes
-                    $childNodeAggregate->nodeName,
-                    $grandChildNodeTypeForConstraintChecks
-                );
+                if (
+                    $grandchildNodeAggregate->classification->isTethered()
+                    && $grandchildNodeAggregate->nodeName
+                    && $childNodeTypeForConstraintChecks->tetheredNodeTypeDefinitions->get($grandchildNodeAggregate->nodeName)?->nodeTypeName
+                        === $grandChildNodeTypeForConstraintChecks->name
+                ) {
+                    // this tethered grandchild node aggregate matches the tethered node declaration of the child's potentially new node type
+                    // and thus can stay the same and will simply be ignored
+                } else {
+                    $this->requireNodeTypeConstraintsImposedByGrandparentToBeMet(
+                        $newNodeType, // the grandparent node type changes
+                        $childNodeAggregate->nodeName,
+                        $grandChildNodeTypeForConstraintChecks
+                    );
+                }
             }
 
             foreach ($newNodeType->tetheredNodeTypeDefinitions as $tetheredNodeTypeDefinition) {

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -313,10 +313,20 @@ trait NodeTypeChange
             } else {
                 $childNodeTypeForConstraintChecks = $this->requireNodeType($childNodeAggregate->nodeTypeName);
             }
-            $this->requireNodeTypeConstraintsImposedByParentToBeMet(
-                $newNodeType,
-                $childNodeTypeForConstraintChecks
-            );
+            if (
+                $childNodeAggregate->classification->isTethered()
+                && $childNodeAggregate->nodeName
+                && $newNodeType->tetheredNodeTypeDefinitions->get($childNodeAggregate->nodeName)?->nodeTypeName
+                    === $childNodeAggregate->nodeTypeName
+            ) {
+                // this tethered child node aggregate matches the tethered node declaration of the new node type
+                // and thus can stay the same and will simply be ignored
+            } else {
+                $this->requireNodeTypeConstraintsImposedByParentToBeMet(
+                    $newNodeType,
+                    $childNodeTypeForConstraintChecks
+                );
+            }
 
             // we do not need to test for grandparents here, as we did not modify the grandparents.
             // Thus, if it was allowed before, it is allowed now.


### PR DESCRIPTION
Given I have Node Types A and B that both have the same tethered descendant named whatever of type C that would not be allowed as a child if it was not tethered

When I tried to change Node Type from A to B (e.g. via migration) this would fail because C is not allowed as child of B

I've added a check to match the tethering configuration; in this case the node of type C can stay as a tethered child even after the type change from A to B


**Upgrade instructions**

none

**Review instructions**

Check the tests or try this at home :)

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
