### PR TITLE
BUGFIX: Failed subscription does not contain full stack-trace logged in database

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
@@ -28,34 +28,34 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
     public function subscriptionErrorLogging()
     {
         $exception = new \RuntimeException('This projection is kaputt.', code: 1031);
+        $traceAsString = str_replace(FLOW_PATH_ROOT, '/', $exception->getTraceAsString());
 
         $subscriptionError = SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception);
 
         self::assertEquals('This projection is kaputt.', $subscriptionError->errorMessage);
-        self::assertStringStartsWith(<<<MSG
+        self::assertSame(<<<MSG
             Class: RuntimeException
             File: /Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
-            Line: 31
+            Line: {$exception->getLine()}
             Code: 1031
             
-            #0 /Packages/Libraries/phpunit/phpunit/src/Framework/TestCase.php(1617): Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription\ProjectionErrorTest->subscriptionErrorLogging()
-            #1
+            {$traceAsString}
             MSG,
             str_replace(FLOW_PATH_ROOT, '/', $subscriptionError->errorTrace)
         );
 
         $exception = new \RuntimeException('This projection is kaputt.', previous: new \InvalidArgumentException('Infrastructure is kaputt (previous).', code: 1048));
+        $previousTraceAsString = str_replace(FLOW_PATH_ROOT, '/', $exception->getPrevious()->getTraceAsString());
         $subscriptionError = SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception);
         self::assertStringContainsString(<<<MSG
             
             Previous: Infrastructure is kaputt (previous).
             Class: InvalidArgumentException
             File: /Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
-            Line: 48
+            Line: {$exception->getPrevious()->getLine()}
             Code: 1048
             
-            #0 /Packages/Libraries/phpunit/phpunit/src/Framework/TestCase.php(1617): Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription\ProjectionErrorTest->subscriptionErrorLogging()
-            #1
+            {$previousTraceAsString}
             MSG,
             str_replace(FLOW_PATH_ROOT, '/', $subscriptionError->errorTrace)
         );

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
@@ -35,11 +35,12 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
         self::assertEquals('This projection is kaputt.', $subscriptionError->errorMessage);
         self::assertSame(<<<MSG
             Class: RuntimeException
+            Message: This projection is kaputt.
+            Code: 1031
             File: /Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
             Line: {$exception->getLine()}
-            Code: 1031
             
-            {$traceAsString}
+            Trace: {$traceAsString}
             MSG,
             str_replace(FLOW_PATH_ROOT, '/', $subscriptionError->errorTrace)
         );
@@ -49,13 +50,13 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
         $subscriptionError = SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception);
         self::assertStringContainsString(<<<MSG
             
-            Previous: Infrastructure is kaputt (previous).
             Class: InvalidArgumentException
+            Message: Infrastructure is kaputt (previous).
+            Code: 1048
             File: /Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
             Line: {$exception->getPrevious()->getLine()}
-            Code: 1048
             
-            {$previousTraceAsString}
+            Trace: {$previousTraceAsString}
             MSG,
             str_replace(FLOW_PATH_ROOT, '/', $subscriptionError->errorTrace)
         );

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
@@ -25,6 +25,43 @@ use Neos\EventStore\Model\EventEnvelope;
 final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
 {
     /** @test */
+    public function subscriptionErrorLogging()
+    {
+        $exception = new \RuntimeException('This projection is kaputt.', code: 1031);
+
+        $subscriptionError = SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception);
+
+        self::assertEquals('This projection is kaputt.', $subscriptionError->errorMessage);
+        self::assertStringStartsWith(<<<MSG
+            Class: RuntimeException
+            File: /Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+            Line: 31
+            Code: 1031
+            
+            #0 /Packages/Libraries/phpunit/phpunit/src/Framework/TestCase.php(1617): Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription\ProjectionErrorTest->subscriptionErrorLogging()
+            #1
+            MSG,
+            str_replace(FLOW_PATH_ROOT, '/', $subscriptionError->errorTrace)
+        );
+
+        $exception = new \RuntimeException('This projection is kaputt.', previous: new \InvalidArgumentException('Infrastructure is kaputt (previous).', code: 1048));
+        $subscriptionError = SubscriptionError::fromPreviousStatusAndException(SubscriptionStatus::ACTIVE, $exception);
+        self::assertStringContainsString(<<<MSG
+            
+            Previous: Infrastructure is kaputt (previous).
+            Class: InvalidArgumentException
+            File: /Packages/Neos/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+            Line: 48
+            Code: 1048
+            
+            #0 /Packages/Libraries/phpunit/phpunit/src/Framework/TestCase.php(1617): Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription\ProjectionErrorTest->subscriptionErrorLogging()
+            #1
+            MSG,
+            str_replace(FLOW_PATH_ROOT, '/', $subscriptionError->errorTrace)
+        );
+    }
+
+    /** @test */
     public function projectionWithErrorCanBeReactivated()
     {
         $this->eventStore->setup();

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
@@ -18,33 +18,33 @@ final class SubscriptionError
 
     public static function fromPreviousStatusAndException(SubscriptionStatus $previousStatus, \Throwable $error): self
     {
-        $class = get_class(...);
+        $messageLines = [];
+        $level = 0;
+        $exception = $error;
+        do {
+            $level++;
+            if ($level >= 8) {
+                $messageLines[] = '...Recursion';
+                break;
+            }
+
+            $exceptionFqn = $exception::class;
+
+            $messageLines[] = <<<MESSAGE
+                Class: {$exceptionFqn}
+                Message: {$exception->getMessage()}
+                Code: {$exception->getCode()}
+                File: {$exception->getFile()}
+                Line: {$exception->getLine()}
+
+                Trace: {$exception->getTraceAsString()}
+                MESSAGE;
+        } while ($exception = $exception->getPrevious());
+
         return new self(
             $error->getMessage(),
             $previousStatus,
-            <<<TEXT
-            Class: {$class($error)}
-            File: {$error->getFile()}
-            Line: {$error->getLine()}
-            Code: {$error->getCode()}
-            
-            
-            TEXT
-            . $error->getTraceAsString()
-            . ($error->getPrevious() ? (
-                <<<TEXT
-                
-                
-                Previous: {$error->getPrevious()->getMessage()}
-                Class: {$class($error->getPrevious())}
-                File: {$error->getPrevious()->getFile()}
-                Line: {$error->getPrevious()->getLine()}
-                Code: {$error->getPrevious()->getCode()}
-                
-                
-                TEXT
-                . $error->getPrevious()->getTraceAsString()
-            ) : '')
+            join("\n\n", $messageLines)
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
@@ -43,7 +43,7 @@ final class SubscriptionError
                 
                 
                 TEXT
-                . $error->getTraceAsString()
+                . $error->getPrevious()->getTraceAsString()
             ) : '')
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
@@ -44,7 +44,7 @@ final class SubscriptionError
         return new self(
             $error->getMessage(),
             $previousStatus,
-            join("\n\n", $messageLines)
+            implode(PHP_EOL . PHP_EOL, $messageLines)
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionError.php
@@ -18,6 +18,33 @@ final class SubscriptionError
 
     public static function fromPreviousStatusAndException(SubscriptionStatus $previousStatus, \Throwable $error): self
     {
-        return new self($error->getMessage(), $previousStatus, $error->getTraceAsString());
+        $class = get_class(...);
+        return new self(
+            $error->getMessage(),
+            $previousStatus,
+            <<<TEXT
+            Class: {$class($error)}
+            File: {$error->getFile()}
+            Line: {$error->getLine()}
+            Code: {$error->getCode()}
+            
+            
+            TEXT
+            . $error->getTraceAsString()
+            . ($error->getPrevious() ? (
+                <<<TEXT
+                
+                
+                Previous: {$error->getPrevious()->getMessage()}
+                Class: {$class($error->getPrevious())}
+                File: {$error->getPrevious()->getFile()}
+                Line: {$error->getPrevious()->getLine()}
+                Code: {$error->getPrevious()->getCode()}
+                
+                
+                TEXT
+                . $error->getTraceAsString()
+            ) : '')
+        );
     }
 }


### PR DESCRIPTION
`$error->getTraceAsString()` does not include the important line and file where the error actually happened now but only information of the lines and files before

Also the previous error if any was not logged.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
