### PR TITLE
FEATURE: ContentGraph content stream id auto increment (new `ContentStreamDbId`)

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
 use Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
 use Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap\Helpers\TestingNodeAggregateId;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
@@ -118,7 +119,9 @@ trait ProjectionIntegrityViolationDetectionTrait
         unset($record['subtreetags']);
 
         $newParentHierarchyRelation = $this->findHierarchyRelationByIds(
-            ContentStreamId::fromString($dataset['contentStreamId']),
+            $this->getContentStreamDbId(
+                ContentStreamId::fromString($dataset['contentStreamId'])
+            ),
             DimensionSpacePoint::fromArray($dataset['dimensionSpacePoint']),
             NodeAggregateId::fromString($dataset['newParentNodeAggregateId'])
         );
@@ -162,14 +165,18 @@ trait ProjectionIntegrityViolationDetectionTrait
     {
         $dataset = $this->transformPayloadTableToDataset($payloadTable);
 
+        $contentStreamDbId = $this->getContentStreamDbId(
+            ContentStreamId::fromString($dataset['contentStreamId'])
+        );
+
         $relationAnchorPoint = $this->dbal->executeQuery(
             'SELECT n.relationanchorpoint FROM ' . $this->tableNames()->node() . ' n
                 JOIN ' . $this->tableNames()->hierarchyRelation() . ' h ON h.childnodeanchor = n.relationanchorpoint
-                WHERE h.contentstreamid = :contentStreamId
+                WHERE h.contentstreamdbid = :contentStreamDbId
                 AND n.nodeaggregateId = :nodeAggregateId
                 AND n.origindimensionspacepointhash = :originDimensionSpacePointHash',
             [
-                'contentStreamId' => $dataset['contentStreamId'],
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'nodeAggregateId' => $dataset['nodeAggregateId'],
                 'originDimensionSpacePointHash' => OriginDimensionSpacePoint::fromArray($dataset['originDimensionSpacePoint'])->hash,
             ]
@@ -195,8 +202,13 @@ trait ProjectionIntegrityViolationDetectionTrait
     {
         $dataset = $this->transformPayloadTableToDataset($payloadTable);
         $dimensionSpacePoint = DimensionSpacePoint::fromArray($dataset['dimensionSpacePoint']);
+
+        $contentStreamDbId = $this->getContentStreamDbId(
+            ContentStreamId::fromString($dataset['contentStreamId'])
+        );
+
         $record = [
-            'contentstreamid' => $dataset['contentStreamId'],
+            'contentstreamdbid' => $contentStreamDbId->value,
             'dimensionspacepointhash' => $dimensionSpacePoint->hash,
             'childnodeanchor' => $this->findRelationAnchorPointByDataset($dataset)
         ];
@@ -251,7 +263,9 @@ trait ProjectionIntegrityViolationDetectionTrait
         return [
             'name' => $dataset['referenceName'],
             'nodeanchorpoint' => $this->findHierarchyRelationByIds(
-                ContentStreamId::fromString($dataset['contentStreamId']),
+                $this->getContentStreamDbId(
+                    ContentStreamId::fromString($dataset['contentStreamId'])
+                ),
                 DimensionSpacePoint::fromArray($dataset['dimensionSpacePoint']),
                 NodeAggregateId::fromString($dataset['sourceNodeAggregateId'])
             )['childnodeanchor'],
@@ -264,11 +278,14 @@ trait ProjectionIntegrityViolationDetectionTrait
         $dimensionSpacePoint = DimensionSpacePoint::fromArray($dataset['dimensionSpacePoint']);
         $parentNodeAggregateId = TestingNodeAggregateId::fromString($dataset['parentNodeAggregateId']);
         $childAggregateId = TestingNodeAggregateId::fromString($dataset['childNodeAggregateId']);
+        $contentStreamDbId = $this->getContentStreamDbId(
+            ContentStreamId::fromString($dataset['contentStreamId'])
+        );
 
         $parentHierarchyRelation = $parentNodeAggregateId->isNonExistent()
             ? null
             : $this->findHierarchyRelationByIds(
-                ContentStreamId::fromString($dataset['contentStreamId']),
+                $contentStreamDbId,
                 $dimensionSpacePoint,
                 NodeAggregateId::fromString($dataset['parentNodeAggregateId'])
             );
@@ -276,13 +293,13 @@ trait ProjectionIntegrityViolationDetectionTrait
         $childHierarchyRelation = $childAggregateId->isNonExistent()
             ? null
             : $this->findHierarchyRelationByIds(
-                ContentStreamId::fromString($dataset['contentStreamId']),
+                $contentStreamDbId,
                 $dimensionSpacePoint,
                 NodeAggregateId::fromString($dataset['childNodeAggregateId'])
             );
 
         return [
-            'contentstreamid' => $dataset['contentStreamId'],
+            'contentstreamdbid' => $contentStreamDbId->value,
             'dimensionspacepointhash' => $dimensionSpacePoint->hash,
             'parentnodeanchor' => $parentHierarchyRelation !== null ? $parentHierarchyRelation['childnodeanchor'] : 9999999,
             'childnodeanchor' => $childHierarchyRelation !== null ? $childHierarchyRelation['childnodeanchor'] : 8888888,
@@ -296,14 +313,16 @@ trait ProjectionIntegrityViolationDetectionTrait
         $dimensionSpacePoint = DimensionSpacePoint::fromArray($dataset['originDimensionSpacePoint'] ?? $dataset['dimensionSpacePoint']);
 
         return $this->findHierarchyRelationByIds(
-            ContentStreamId::fromString($dataset['contentStreamId']),
+            $this->getContentStreamDbId(
+                ContentStreamId::fromString($dataset['contentStreamId'])
+            ),
             $dimensionSpacePoint,
             NodeAggregateId::fromString($dataset['nodeAggregateId'] ?? $dataset['childNodeAggregateId'])
         )['childnodeanchor'];
     }
 
     private function findHierarchyRelationByIds(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint,
         NodeAggregateId $nodeAggregateId
     ): array {
@@ -312,17 +331,17 @@ trait ProjectionIntegrityViolationDetectionTrait
                 FROM ' . $this->tableNames()->node() . ' n
                 INNER JOIN ' . $this->tableNames()->hierarchyRelation() . ' h
                 ON n.relationanchorpoint = h.childnodeanchor
-                WHERE n.nodeaggregateid = :nodeAggregateId
-                AND h.contentstreamid = :contentStreamId
+                WHERE h.contentstreamdbid = :contentStreamDbId
+                AND n.nodeaggregateid = :nodeAggregateId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash',
             [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
                 'nodeAggregateId' => $nodeAggregateId->value
             ]
         )->fetchAssociative();
         if ($nodeRecord === false) {
-            throw new \InvalidArgumentException(sprintf('Failed to find hierarchy relation for content stream "%s", dimension space point "%s" and node aggregate id "%s"', $contentStreamId->value, $dimensionSpacePoint->hash, $nodeAggregateId->value), 1708617712);
+            throw new \InvalidArgumentException(sprintf('Failed to find hierarchy relation for content stream "%s", dimension space point "%s" and node aggregate id "%s"', $contentStreamDbId->value, $dimensionSpacePoint->hash, $nodeAggregateId->value), 1708617712);
         }
 
         return $nodeRecord;
@@ -336,6 +355,18 @@ trait ProjectionIntegrityViolationDetectionTrait
         }
 
         return $result;
+    }
+
+    private function getContentStreamDbId(ContentStreamId $contentStreamId): ContentStreamDbId
+    {
+        return ContentStreamDbId::fromInt(
+            $this->dbal->executeQuery(
+                'SELECT dbId FROM ' . $this->tableNames()->contentStream() . ' WHERE id = :contentStreamId',
+                [
+                    'contentStreamId' => $contentStreamId->value,
+                ]
+            )->fetchOne()
+        );
     }
 
     /**

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -17,6 +17,7 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentGraph;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
@@ -49,11 +50,13 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
     {
         $currentContentStreamIdStatement = <<<SQL
             SELECT
-                currentContentStreamId
+                ws.currentContentStreamId,
+                cs.dbId AS contentStreamDbId
             FROM
-                {$this->tableNames->workspace()}
+                {$this->tableNames->workspace()} ws
+                JOIN {$this->tableNames->contentStream()} cs ON cs.id = ws.currentContentStreamId
             WHERE
-                name = :workspaceName
+                ws.name = :workspaceName
             LIMIT 1
         SQL;
         try {
@@ -67,7 +70,8 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);
         }
         $currentContentStreamId = ContentStreamId::fromString($row['currentContentStreamId']);
-        return new ContentGraph($this->dbal, $this->nodeFactory, $this->contentRepositoryId, $this->nodeTypeManager, $this->tableNames, $workspaceName, $currentContentStreamId);
+        $contentStreamDbId = ContentStreamDbId::fromInt((int)$row['contentStreamDbId']);
+        return new ContentGraph($this->dbal, $this->nodeFactory, $this->contentRepositoryId, $this->nodeTypeManager, $this->tableNames, $workspaceName, $currentContentStreamId, $contentStreamDbId);
     }
 
     public function findWorkspaceByName(WorkspaceName $workspaceName): ?Workspace

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -215,6 +215,11 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenContentStreamWasForked(ContentStreamWasForked $event): void
     {
+        $this->createContentStream($event->newContentStreamId, $event->sourceContentStreamId, $event->versionOfSourceContentStream);
+
+        $newContentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->newContentStreamId);
+        $sourceContentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->sourceContentStreamId);
+
         //
         // 1) Copy HIERARCHY RELATIONS (this is the MAIN OPERATION here)
         //
@@ -225,7 +230,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               position,
               dimensionspacepointhash,
               subtreetags,
-              contentstreamid
+              contentstreamdbid
             )
             SELECT
               h.parentnodeanchor,
@@ -233,14 +238,15 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               h.position,
               h.dimensionspacepointhash,
               h.subtreetags,
-              "{$event->newContentStreamId->value}" AS contentstreamid
+              :newContentStreamDbId AS contentstreamdbid
             FROM
                 {$this->tableNames->hierarchyRelation()} h
-                WHERE h.contentstreamid = :sourceContentStreamId
+                WHERE h.contentstreamdbid = :sourceContentStreamDbId
         SQL;
         try {
             $this->dbal->executeStatement($insertRelationStatement, [
-                'sourceContentStreamId' => $event->sourceContentStreamId->value
+                'newContentStreamDbId' => $newContentStreamDbId->value,
+                'sourceContentStreamDbId' => $sourceContentStreamDbId->value
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to insert hierarchy relation: %s', $e->getMessage()), 1716489211, $e);
@@ -248,19 +254,19 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
         // NOTE: as reference edges are attached to Relation Anchor Points (and they are lazily copy-on-written),
         // we do not need to copy reference edges here (but we need to do it during copy on write).
-
-        $this->createContentStream($event->newContentStreamId, $event->sourceContentStreamId, $event->versionOfSourceContentStream);
     }
 
     private function whenContentStreamWasRemoved(ContentStreamWasRemoved $event): void
     {
+        $contentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->contentStreamId);
+
         // Drop hierarchy relations
         $deleteHierarchyRelationStatement = <<<SQL
-            DELETE FROM {$this->tableNames->hierarchyRelation()} WHERE contentstreamid = :contentStreamId
+            DELETE FROM {$this->tableNames->hierarchyRelation()} WHERE contentstreamdbid = :contentStreamDbId
         SQL;
         try {
             $this->dbal->executeStatement($deleteHierarchyRelationStatement, [
-                'contentStreamId' => $event->contentStreamId->value
+                'contentStreamDbId' => $contentStreamDbId->value
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to delete hierarchy relations: %s', $e->getMessage()), 1716489265, $e);
@@ -314,23 +320,23 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               position,
               subtreetags,
               dimensionspacepointhash,
-              contentstreamid
+              contentstreamdbid
             )
             SELECT
               h.parentnodeanchor,
               h.childnodeanchor,
               h.position,
               h.subtreetags,
-             :newDimensionSpacePointHash AS dimensionspacepointhash,
-              h.contentstreamid
+              :newDimensionSpacePointHash AS dimensionspacepointhash,
+              h.contentstreamdbid
             FROM
                 {$this->tableNames->hierarchyRelation()} h
-                WHERE h.contentstreamid = :contentStreamId
+                WHERE h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :sourceDimensionSpacePointHash
         SQL;
         try {
             $this->dbal->executeStatement($insertHierarchyRelationsStatement, [
-                'contentStreamId' => $this->getContentStreamDbId($event)->value,
+                'contentStreamDbId' => $this->getContentStreamDbId($event)->value,
                 'sourceDimensionSpacePointHash' => $event->source->hash,
                 'newDimensionSpacePointHash' => $event->target->hash,
             ]);
@@ -352,7 +358,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             FROM {$this->tableNames->node()} n
             INNER JOIN {$this->tableNames->hierarchyRelation()} h
                 ON h.childnodeanchor = n.relationanchorpoint
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
                 -- find only nodes which have their ORIGIN at the source DimensionSpacePoint,
                 -- as we need to rewrite these origins (using copy on write)
@@ -362,7 +368,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         try {
             $relationAnchorPoints = $this->dbal->fetchFirstColumn($selectRelationsStatement, [
                 'dimensionSpacePointHash' => $event->source->hash,
-                'contentStreamId' => $this->getContentStreamDbId($event)->value
+                'contentStreamDbId' => $this->getContentStreamDbId($event)->value
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to load relation anchor points: %s', $e->getMessage()), 1716489628, $e);
@@ -385,13 +391,13 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 h.dimensionspacepointhash = :newDimensionSpacePointHash
             WHERE
               h.dimensionspacepointhash = :originalDimensionSpacePointHash
-              AND h.contentstreamid = :contentStreamId
+              AND h.contentstreamdbid = :contentStreamDbId
         SQL;
         try {
             $this->dbal->executeStatement($updateHierarchyRelationsStatement, [
                 'originalDimensionSpacePointHash' => $event->source->hash,
                 'newDimensionSpacePointHash' => $event->target->hash,
-                'contentStreamId' => $this->getContentStreamDbId($event)->value,
+                'contentStreamDbId' => $this->getContentStreamDbId($event)->value,
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to update hierarchy relations: %s', $e->getMessage()), 1716489951, $e);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -7,6 +7,7 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\ContentStream;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeMove;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeRemoval;
@@ -16,6 +17,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\Workspace;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRecord;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentStreamDbIdFinder;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\DimensionSpacePointsRepository;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ProjectionContentGraph;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
@@ -69,7 +71,6 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Dbal\DbalSchemaDiff;
 use Neos\EventStore\Model\EventEnvelope;
 
@@ -93,6 +94,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         private readonly ProjectionContentGraph $projectionContentGraph,
         private readonly ContentGraphTableNames $tableNames,
         private readonly DimensionSpacePointsRepository $dimensionSpacePointsRepository,
+        private readonly ContentStreamDbIdFinder $contentStreamDbIdFinder,
         private readonly ContentGraphReadModelInterface $contentGraphReadModel
     ) {
     }
@@ -328,7 +330,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         SQL;
         try {
             $this->dbal->executeStatement($insertHierarchyRelationsStatement, [
-                'contentStreamId' => $event->contentStreamId->value,
+                'contentStreamId' => $this->getContentStreamDbId($event)->value,
                 'sourceDimensionSpacePointHash' => $event->source->hash,
                 'newDimensionSpacePointHash' => $event->target->hash,
             ]);
@@ -360,14 +362,14 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         try {
             $relationAnchorPoints = $this->dbal->fetchFirstColumn($selectRelationsStatement, [
                 'dimensionSpacePointHash' => $event->source->hash,
-                'contentStreamId' => $event->contentStreamId->value
+                'contentStreamId' => $this->getContentStreamDbId($event)->value
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to load relation anchor points: %s', $e->getMessage()), 1716489628, $e);
         }
         foreach ($relationAnchorPoints as $relationAnchorPoint) {
             $this->updateNodeRecordWithCopyOnWrite(
-                $event->contentStreamId,
+                $this->getContentStreamDbId($event),
                 NodeRelationAnchorPoint::fromInteger($relationAnchorPoint),
                 function (NodeRecord $nodeRecord) use ($event) {
                     $nodeRecord->originDimensionSpacePoint = $event->target->coordinates;
@@ -389,7 +391,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             $this->dbal->executeStatement($updateHierarchyRelationsStatement, [
                 'originalDimensionSpacePointHash' => $event->source->hash,
                 'newDimensionSpacePointHash' => $event->target->hash,
-                'contentStreamId' => $event->contentStreamId->value,
+                'contentStreamId' => $this->getContentStreamDbId($event)->value,
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to update hierarchy relations: %s', $e->getMessage()), 1716489951, $e);
@@ -401,11 +403,11 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         foreach (
             $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream(
                 $event->nodeAggregateId,
-                $event->contentStreamId,
+                $this->getContentStreamDbId($event),
             ) as $anchorPoint
         ) {
             $this->updateNodeRecordWithCopyOnWrite(
-                $event->contentStreamId,
+                $this->getContentStreamDbId($event),
                 $anchorPoint,
                 function (NodeRecord $node) use ($event, $eventEnvelope) {
                     $node->nodeName = $event->newNodeName;
@@ -420,10 +422,10 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenNodeAggregateTypeWasChanged(NodeAggregateTypeWasChanged $event, EventEnvelope $eventEnvelope): void
     {
-        $anchorPoints = $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream($event->nodeAggregateId, $event->contentStreamId);
+        $anchorPoints = $this->projectionContentGraph->getAnchorPointsForNodeAggregateInContentStream($event->nodeAggregateId, $this->getContentStreamDbId($event));
         foreach ($anchorPoints as $anchorPoint) {
             $this->updateNodeRecordWithCopyOnWrite(
-                $event->contentStreamId,
+                $this->getContentStreamDbId($event),
                 $anchorPoint,
                 function (NodeRecord $node) use ($event, $eventEnvelope) {
                     $node->nodeTypeName = $event->newNodeTypeName;
@@ -438,18 +440,18 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenNodeAggregateWasMoved(NodeAggregateWasMoved $event): void
     {
-        $this->moveNodeAggregate($event->contentStreamId, $event->nodeAggregateId, $event->newParentNodeAggregateId, $event->succeedingSiblingsForCoverage);
+        $this->moveNodeAggregate($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->newParentNodeAggregateId, $event->succeedingSiblingsForCoverage);
     }
 
     private function whenNodeAggregateWasRemoved(NodeAggregateWasRemoved $event): void
     {
-        $this->removeNodeAggregate($event->contentStreamId, $event->nodeAggregateId, $event->affectedCoveredDimensionSpacePoints);
+        $this->removeNodeAggregate($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->affectedCoveredDimensionSpacePoints);
     }
 
     private function whenNodeAggregateWithNodeWasCreated(NodeAggregateWithNodeWasCreated $event, EventEnvelope $eventEnvelope): void
     {
         $this->createNodeWithHierarchy(
-            $event->contentStreamId,
+            $this->getContentStreamDbId($event),
             $event->nodeAggregateId,
             $event->nodeTypeName,
             $event->parentNodeAggregateId,
@@ -465,12 +467,12 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenNodeGeneralizationVariantWasCreated(NodeGeneralizationVariantWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->createNodeGeneralizationVariant($event->contentStreamId, $event->nodeAggregateId, $event->sourceOrigin, $event->generalizationOrigin, $event->variantSucceedingSiblings, $eventEnvelope);
+        $this->createNodeGeneralizationVariant($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->sourceOrigin, $event->generalizationOrigin, $event->variantSucceedingSiblings, $eventEnvelope);
     }
 
     private function whenNodePeerVariantWasCreated(NodePeerVariantWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->createNodePeerVariant($event->contentStreamId, $event->nodeAggregateId, $event->sourceOrigin, $event->peerOrigin, $event->peerSucceedingSiblings, $eventEnvelope);
+        $this->createNodePeerVariant($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->sourceOrigin, $event->peerOrigin, $event->peerSucceedingSiblings, $eventEnvelope);
     }
 
     private function whenNodePropertiesWereSet(NodePropertiesWereSet $event, EventEnvelope $eventEnvelope): void
@@ -479,7 +481,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
                 $event->getNodeAggregateId(),
                 $event->getOriginDimensionSpacePoint(),
-                $event->getContentStreamId()
+                $this->getContentStreamDbId($event)
             );
         if (is_null($anchorPoint)) {
             throw new \InvalidArgumentException(
@@ -490,7 +492,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             );
         }
         $this->updateNodeRecordWithCopyOnWrite(
-            $event->getContentStreamId(),
+            $this->getContentStreamDbId($event),
             $anchorPoint,
             function (NodeRecord $node) use ($event, $eventEnvelope) {
                 $node->properties = $node->properties
@@ -511,7 +513,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
                     $event->nodeAggregateId,
                     $originDimensionSpacePoint,
-                    $event->contentStreamId
+                    $this->getContentStreamDbId($event)
                 );
 
             if (is_null($nodeAnchorPoint)) {
@@ -525,7 +527,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             }
 
             $this->updateNodeRecordWithCopyOnWrite(
-                $event->contentStreamId,
+                $this->getContentStreamDbId($event),
                 $nodeAnchorPoint,
                 function (NodeRecord $node) use ($eventEnvelope) {
                     $node->timestamps = $node->timestamps->with(
@@ -539,7 +541,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 ->getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
                     $event->nodeAggregateId,
                     $originDimensionSpacePoint,
-                    $event->contentStreamId
+                    $this->getContentStreamDbId($event)
                 );
 
 
@@ -600,7 +602,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenNodeSpecializationVariantWasCreated(NodeSpecializationVariantWasCreated $event, EventEnvelope $eventEnvelope): void
     {
-        $this->createNodeSpecializationVariant($event->contentStreamId, $event->nodeAggregateId, $event->sourceOrigin, $event->specializationOrigin, $event->specializationSiblings, $eventEnvelope);
+        $this->createNodeSpecializationVariant($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->sourceOrigin, $event->specializationOrigin, $event->specializationSiblings, $eventEnvelope);
     }
 
     private function whenRootNodeAggregateDimensionsWereUpdated(RootNodeAggregateDimensionsWereUpdated $event): void
@@ -610,7 +612,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $event->nodeAggregateId,
                 /** the origin DSP of the root node is always the empty dimension ({@see whenRootNodeAggregateWithNodeWasCreated}) */
                 OriginDimensionSpacePoint::createWithoutDimensions(),
-                $event->contentStreamId
+                $this->getContentStreamDbId($event)
             );
         if ($rootNodeAnchorPoint === null) {
             // should never happen.
@@ -619,7 +621,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
         $ingoingRelations = $this->projectionContentGraph->findIngoingHierarchyRelationsForNode(
             $rootNodeAnchorPoint,
-            $event->contentStreamId
+            $this->getContentStreamDbId($event)
         );
 
         $currentlyCoveredDimensionSpacePoints = [];
@@ -631,7 +633,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
         // add hierarchy edges for newly added dimensions
         $this->connectHierarchy(
-            $event->contentStreamId,
+            $this->getContentStreamDbId($event),
             NodeRelationAnchorPoint::forRootEdge(),
             $rootNodeAnchorPoint,
             $newlyCoveredDimensionSpacePoints,
@@ -656,7 +658,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         );
 
         $this->connectHierarchy(
-            $event->contentStreamId,
+            $this->getContentStreamDbId($event),
             NodeRelationAnchorPoint::forRootEdge(),
             $node->relationAnchorPoint,
             $event->coveredDimensionSpacePoints,
@@ -671,12 +673,12 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenSubtreeWasTagged(SubtreeWasTagged $event): void
     {
-        $this->addSubtreeTag($event->contentStreamId, $event->nodeAggregateId, $event->affectedDimensionSpacePoints, $event->tag);
+        $this->addSubtreeTag($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->affectedDimensionSpacePoints, $event->tag);
     }
 
     private function whenSubtreeWasUntagged(SubtreeWasUntagged $event): void
     {
-        $this->removeSubtreeTag($event->contentStreamId, $event->nodeAggregateId, $event->affectedDimensionSpacePoints, $event->tag);
+        $this->removeSubtreeTag($this->getContentStreamDbId($event), $event->nodeAggregateId, $event->affectedDimensionSpacePoints, $event->tag);
     }
 
     private function whenWorkspaceBaseWorkspaceWasChanged(WorkspaceBaseWorkspaceWasChanged $event): void
@@ -720,6 +722,11 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     /** --------------------------------- */
 
+    public function getContentStreamDbId(EmbedsContentStreamId $event): ContentStreamDbId
+    {
+        return $this->contentStreamDbIdFinder->getContentStreamDbId($event->getContentStreamId());
+    }
+
     /**
      * @return array<string>
      */
@@ -749,12 +756,12 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
      * @template T
      */
     private function updateNodeRecordWithCopyOnWrite(
-        ContentStreamId $contentStreamIdWhereWriteOccurs,
+        ContentStreamDbId $contentStreamDbIdWhereWriteOccurs,
         NodeRelationAnchorPoint $anchorPoint,
         callable $operations
     ): mixed {
-        $contentStreamIds = $this->projectionContentGraph->getAllContentStreamIdsAnchorPointIsContainedIn($anchorPoint);
-        if (count($contentStreamIds) > 1) {
+        $contentStreamDbIds = $this->projectionContentGraph->getAllContentStreamDbIdsAnchorPointIsContainedIn($anchorPoint);
+        if (count($contentStreamDbIds) > 1) {
             // Copy on Write needed!
             // Copy on Write is a purely "Content Stream" related concept;
             // thus we do not care about different DimensionSpacePoints here (but we copy all edges)
@@ -778,13 +785,13 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                     h.parentnodeanchor = IF(h.parentnodeanchor = :originalNodeAnchor, :newNodeAnchor, h.parentnodeanchor)
                 WHERE
                   :originalNodeAnchor IN (h.childnodeanchor, h.parentnodeanchor)
-                  AND h.contentstreamid = :contentStreamId
+                  AND h.contentstreamdbid = :contentStreamDbId
             SQL;
             try {
                 $this->dbal->executeStatement($updateHierarchyRelationStatement, [
                     'newNodeAnchor' => $copiedNode->relationAnchorPoint->value,
                     'originalNodeAnchor' => $anchorPoint->value,
-                    'contentStreamId' => $contentStreamIdWhereWriteOccurs->value,
+                    'contentStreamDbId' => $contentStreamDbIdWhereWriteOccurs->value,
                 ]);
             } catch (DBALException $e) {
                 throw new \RuntimeException(sprintf('Failed to update hierarchy relation: %s', $e->getMessage()), 1716486444, $e);
@@ -851,7 +858,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     }
 
     private function createNodeWithHierarchy(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeAggregateId $nodeAggregateId,
         NodeTypeName $nodeTypeName,
         NodeAggregateId $parentNodeAggregateId,
@@ -889,7 +896,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
             foreach ($missingParentRelations as $dimensionSpacePoint) {
                 $parentNode = $this->projectionContentGraph->findNodeInAggregate(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $parentNodeAggregateId,
                     $dimensionSpacePoint
                 );
@@ -897,7 +904,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $succeedingSiblingNodeAggregateId = $coverageSucceedingSiblings->getSucceedingSiblingIdForDimensionSpacePoint($dimensionSpacePoint);
                 $succeedingSibling = $succeedingSiblingNodeAggregateId
                     ? $this->projectionContentGraph->findNodeInAggregate(
-                        $contentStreamId,
+                        $contentStreamDbId,
                         $succeedingSiblingNodeAggregateId,
                         $dimensionSpacePoint
                     )
@@ -905,7 +912,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
                 if ($parentNode) {
                     $this->connectHierarchy(
-                        $contentStreamId,
+                        $contentStreamDbId,
                         $parentNode->relationAnchorPoint,
                         $node->relationAnchorPoint,
                         new DimensionSpacePointSet([$dimensionSpacePoint]),
@@ -919,7 +926,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     }
 
     private function connectHierarchy(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeRelationAnchorPoint $parentNodeAnchorPoint,
         NodeRelationAnchorPoint $childNodeAnchorPoint,
         DimensionSpacePointSet $dimensionSpacePointSet,
@@ -930,17 +937,17 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $parentNodeAnchorPoint,
                 null,
                 $succeedingSiblingNodeAnchorPoint,
-                $contentStreamId,
+                $contentStreamDbId,
                 $dimensionSpacePoint
             );
 
-            $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamId, $parentNodeAnchorPoint, $dimensionSpacePoint);
+            $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamDbId, $parentNodeAnchorPoint, $dimensionSpacePoint);
             $inheritedSubtreeTags = NodeTags::create(SubtreeTags::createEmpty(), $parentSubtreeTags->all());
 
             $hierarchyRelation = new HierarchyRelation(
                 $parentNodeAnchorPoint,
                 $childNodeAnchorPoint,
-                $contentStreamId,
+                $contentStreamDbId,
                 $dimensionSpacePoint,
                 $dimensionSpacePoint->hash,
                 $position,
@@ -955,14 +962,14 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         ?NodeRelationAnchorPoint $parentAnchorPoint,
         ?NodeRelationAnchorPoint $childAnchorPoint,
         ?NodeRelationAnchorPoint $succeedingSiblingAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint
     ): int {
         $position = $this->projectionContentGraph->determineHierarchyRelationPosition(
             $parentAnchorPoint,
             $childAnchorPoint,
             $succeedingSiblingAnchorPoint,
-            $contentStreamId,
+            $contentStreamDbId,
             $dimensionSpacePoint
         );
 
@@ -971,7 +978,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $parentAnchorPoint,
                 $childAnchorPoint,
                 $succeedingSiblingAnchorPoint,
-                $contentStreamId,
+                $contentStreamDbId,
                 $dimensionSpacePoint
             );
         }
@@ -983,7 +990,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         ?NodeRelationAnchorPoint $parentAnchorPoint,
         ?NodeRelationAnchorPoint $childAnchorPoint,
         ?NodeRelationAnchorPoint $succeedingSiblingAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint
     ): int {
         if (!$childAnchorPoint && !$parentAnchorPoint) {
@@ -998,12 +1005,12 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         $hierarchyRelations = $parentAnchorPoint
             ? $this->projectionContentGraph->getOutgoingHierarchyRelationsForNodeAndSubgraph(
                 $parentAnchorPoint,
-                $contentStreamId,
+                $contentStreamDbId,
                 $dimensionSpacePoint
             )
             : $this->projectionContentGraph->getIngoingHierarchyRelationsForNodeAndSubgraph(
                 $childAnchorPoint,
-                $contentStreamId,
+                $contentStreamDbId,
                 $dimensionSpacePoint
             );
 
@@ -1029,25 +1036,25 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function copyHierarchyRelationToDimensionSpacePoint(
         HierarchyRelation $sourceHierarchyRelation,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint,
         NodeRelationAnchorPoint $newParent,
         NodeRelationAnchorPoint $newChild,
         ?NodeRelationAnchorPoint $newSucceedingSibling = null,
     ): HierarchyRelation {
-        $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamId, $newParent, $dimensionSpacePoint);
+        $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamDbId, $newParent, $dimensionSpacePoint);
         $inheritedSubtreeTags = NodeTags::create($sourceHierarchyRelation->subtreeTags->withoutInherited()->all(), $parentSubtreeTags->withoutInherited()->all());
         $copy = new HierarchyRelation(
             $newParent,
             $newChild,
-            $contentStreamId,
+            $contentStreamDbId,
             $dimensionSpacePoint,
             $dimensionSpacePoint->hash,
             $this->getRelationPosition(
                 $newParent,
                 $newChild,
                 $newSucceedingSibling,
-                $contentStreamId,
+                $contentStreamDbId,
                 $dimensionSpacePoint
             ),
             $inheritedSubtreeTags,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjectionFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjectionFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentGraph\DoctrineDbalAdapter;
 
 use Doctrine\DBAL\Connection;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentStreamDbIdFinder;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\DimensionSpacePointsRepository;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ProjectionContentGraph;
@@ -31,6 +32,7 @@ final class DoctrineDbalContentGraphProjectionFactory implements ContentGraphPro
         );
 
         $dimensionSpacePointsRepository = new DimensionSpacePointsRepository($this->dbal, $tableNames);
+        $contentStreamDbIdRepository = new ContentStreamDbIdFinder($this->dbal, $tableNames);
 
         $nodeFactory = new NodeFactory(
             $projectionFactoryDependencies->contentRepositoryId,
@@ -54,6 +56,7 @@ final class DoctrineDbalContentGraphProjectionFactory implements ContentGraphPro
             ),
             $tableNames,
             $dimensionSpacePointsRepository,
+            $contentStreamDbIdRepository,
             $contentGraphReadModel
         );
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -62,7 +62,7 @@ class DoctrineDbalContentGraphSchemaBuilder
     {
         $table = self::createTable($this->tableNames->hierarchyRelation(), [
             (new Column('position', self::type(Types::INTEGER)))->setNotnull(true),
-            DbalSchemaFactory::columnForContentStreamId('contentstreamid', $platform)->setNotnull(true),
+            (new Column('contentstreamdbid', self::type(Types::INTEGER)))->setNotnull(true),
             DbalSchemaFactory::columnForDimensionSpacePointHash('dimensionspacepointhash', $platform)->setNotnull(true),
             DbalSchemaFactory::columnForNodeAnchorPoint('parentnodeanchor', $platform),
             DbalSchemaFactory::columnForNodeAnchorPoint('childnodeanchor', $platform),
@@ -71,11 +71,11 @@ class DoctrineDbalContentGraphSchemaBuilder
 
         return $table
             ->addIndex(['childnodeanchor'])
-            ->addIndex(['contentstreamid'])
+            ->addIndex(['contentstreamdbid'])
             ->addIndex(['parentnodeanchor'])
-            ->addIndex(['childnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'position'])
-            ->addIndex(['parentnodeanchor', 'contentstreamid', 'dimensionspacepointhash', 'position'])
-            ->addIndex(['contentstreamid', 'dimensionspacepointhash']);
+            ->addIndex(['childnodeanchor', 'contentstreamdbid', 'dimensionspacepointhash', 'position'])
+            ->addIndex(['parentnodeanchor', 'contentstreamdbid', 'dimensionspacepointhash', 'position'])
+            ->addIndex(['contentstreamdbid', 'dimensionspacepointhash']);
     }
 
     private function createDimensionSpacePointsTable(AbstractPlatform $platform): Table
@@ -120,6 +120,7 @@ class DoctrineDbalContentGraphSchemaBuilder
     private function createContentStreamTable(AbstractPlatform $platform): Table
     {
         $contentStreamTable = self::createTable($this->tableNames->contentStream(), [
+            (new Column('dbId', Type::getType(Types::INTEGER)))->setAutoincrement(true)->setNotnull(true),
             DbalSchemaFactory::columnForContentStreamId('id', $platform)->setNotnull(true),
             (new Column('version', Type::getType(Types::INTEGER)))->setNotnull(true),
             DbalSchemaFactory::columnForContentStreamId('sourceContentStreamId', $platform)->setNotnull(false),
@@ -128,7 +129,9 @@ class DoctrineDbalContentGraphSchemaBuilder
             (new Column('hasChanges', Type::getType(Types::BOOLEAN)))->setNotnull(true),
         ]);
 
-        return $contentStreamTable->setPrimaryKey(['id']);
+        return $contentStreamTable
+            ->addUniqueIndex(['id'])
+            ->setPrimaryKey(['dbId']);
     }
 
     /**

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ContentStreamDbId.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ContentStreamDbId.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+
+/**
+ * @internal adapter specific id for content streams.
+ * Auto-incrementing int to optimise schema vs unconstrained cr content-stream-ids.
+ * Each {@see ContentStreamDbId} points to exactly one {@see ContentStreamId}.
+ */
+final readonly class ContentStreamDbId
+{
+    private function __construct(
+        public int $value
+    ) {
+    }
+
+    public static function fromInt(int $value): self
+    {
+        return new self($value);
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeMove.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeMove.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRecord;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
@@ -11,7 +12,6 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSibling;
 use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
  * The NodeMove projection feature trait
@@ -22,34 +22,34 @@ trait NodeMove
 {
     use SubtreeTagging;
 
-    private function moveNodeAggregate(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, ?NodeAggregateId $newParentNodeAggregateId, InterdimensionalSiblings $succeedingSiblingsForCoverage): void
+    private function moveNodeAggregate(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, ?NodeAggregateId $newParentNodeAggregateId, InterdimensionalSiblings $succeedingSiblingsForCoverage): void
     {
         foreach ($succeedingSiblingsForCoverage as $succeedingSiblingForCoverage) {
             $nodeToBeMoved = $this->projectionContentGraph->findNodeInAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $nodeAggregateId,
                 $succeedingSiblingForCoverage->dimensionSpacePoint
             );
 
             if (is_null($nodeToBeMoved)) {
-                throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because it does not exist', $nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamId->value), 1716471638);
+                throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because it does not exist', $nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamDbId->value), 1716471638);
             }
 
             if ($newParentNodeAggregateId) {
                 $this->moveNodeBeneathParent(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $nodeToBeMoved,
                     $newParentNodeAggregateId,
                     $succeedingSiblingForCoverage
                 );
                 $this->moveSubtreeTags(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $newParentNodeAggregateId,
                     $succeedingSiblingForCoverage->dimensionSpacePoint
                 );
             } else {
                 $this->moveNodeBeforeSucceedingSibling(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $nodeToBeMoved,
                     $succeedingSiblingForCoverage,
                 );
@@ -66,14 +66,14 @@ trait NodeMove
      * The move target is given as $succeedingSiblingNodeMoveTarget. This also specifies the new parent node.
      */
     private function moveNodeBeforeSucceedingSibling(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeRecord $nodeToBeMoved,
         InterdimensionalSibling $succeedingSiblingForCoverage,
     ): void {
         // find the single ingoing hierarchy relation which we want to move
         $ingoingHierarchyRelation = $this->findIngoingHierarchyRelationToBeMoved(
             $nodeToBeMoved,
-            $contentStreamId,
+            $contentStreamDbId,
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
 
@@ -81,12 +81,12 @@ trait NodeMove
         if ($succeedingSiblingForCoverage->nodeAggregateId) {
             // find the new succeeding sibling NodeRecord; We need this record because we'll use its RelationAnchorPoint later.
             $newSucceedingSibling = $this->projectionContentGraph->findNodeInAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $succeedingSiblingForCoverage->nodeAggregateId,
                 $succeedingSiblingForCoverage->dimensionSpacePoint
             );
             if ($newSucceedingSibling === null) {
-                throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because target succeeding sibling node "%s" is missing', $nodeToBeMoved->nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamId->value, $succeedingSiblingForCoverage->nodeAggregateId->value), 1716471881);
+                throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because target succeeding sibling node "%s" is missing', $nodeToBeMoved->nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamDbId->value, $succeedingSiblingForCoverage->nodeAggregateId->value), 1716471881);
             }
         }
 
@@ -95,7 +95,7 @@ trait NodeMove
             $ingoingHierarchyRelation->parentNodeAnchor,
             null,
             $newSucceedingSibling?->relationAnchorPoint,
-            $contentStreamId,
+            $contentStreamDbId,
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
 
@@ -116,7 +116,7 @@ trait NodeMove
      * We always move beneath the parent before the succeeding sibling if given (or to the end)
      */
     private function moveNodeBeneathParent(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeRecord $nodeToBeMoved,
         NodeAggregateId $parentNodeAggregateId,
         InterdimensionalSibling $succeedingSiblingForCoverage,
@@ -124,30 +124,30 @@ trait NodeMove
         // find the single ingoing hierarchy relation which we want to move
         $ingoingHierarchyRelation = $this->findIngoingHierarchyRelationToBeMoved(
             $nodeToBeMoved,
-            $contentStreamId,
+            $contentStreamDbId,
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
 
         // find the new parent NodeRecord; We need this record because we'll use its RelationAnchorPoints later.
         $newParent = $this->projectionContentGraph->findNodeInAggregate(
-            $contentStreamId,
+            $contentStreamDbId,
             $parentNodeAggregateId,
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
         if ($newParent === null) {
-            throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because target parent node is missing', $nodeToBeMoved->nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamId->value), 1716471955);
+            throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because target parent node is missing', $nodeToBeMoved->nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamDbId->value), 1716471955);
         }
 
         $newSucceedingSibling = null;
         if ($succeedingSiblingForCoverage->nodeAggregateId) {
             // find the new succeeding sibling NodeRecord; We need this record because we'll use its RelationAnchorPoint later.
             $newSucceedingSibling = $this->projectionContentGraph->findNodeInAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $succeedingSiblingForCoverage->nodeAggregateId,
                 $succeedingSiblingForCoverage->dimensionSpacePoint
             );
             if ($newSucceedingSibling === null) {
-                throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because target succeeding sibling node is missing', $nodeToBeMoved->nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamId->value), 1716471995);
+                throw new \RuntimeException(sprintf('Failed to move node "%s" in sub graph %s@%s because target succeeding sibling node is missing', $nodeToBeMoved->nodeAggregateId->value, $succeedingSiblingForCoverage->dimensionSpacePoint->toJson(), $contentStreamDbId->value), 1716471995);
             }
         }
 
@@ -156,7 +156,7 @@ trait NodeMove
             $newParent->relationAnchorPoint,
             null,
             $newSucceedingSibling?->relationAnchorPoint,
-            $contentStreamId,
+            $contentStreamDbId,
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
 
@@ -171,27 +171,22 @@ trait NodeMove
 
     /**
      * Helper for the move methods.
-     *
-     * @param NodeRecord $nodeToBeMoved
-     * @param ContentStreamId $contentStreamId
-     * @param DimensionSpacePoint $coveredDimensionSpacePointWhereMoveShouldHappen
-     * @return HierarchyRelation
      */
     private function findIngoingHierarchyRelationToBeMoved(
         NodeRecord $nodeToBeMoved,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $coveredDimensionSpacePointWhereMoveShouldHappen
     ): HierarchyRelation {
         $restrictToSet = DimensionSpacePointSet::fromArray([$coveredDimensionSpacePointWhereMoveShouldHappen]);
         $ingoingHierarchyRelations = $this->projectionContentGraph->findIngoingHierarchyRelationsForNode(
             $nodeToBeMoved->relationAnchorPoint,
-            $contentStreamId,
+            $contentStreamDbId,
             $restrictToSet,
         );
         if (count($ingoingHierarchyRelations) !== 1) {
             // there should always be exactly one incoming relation in the given DimensionSpacePoint; everything
             // else would be a totally wrong behavior of findIngoingHierarchyRelationsForNode().
-            throw new \RuntimeException(sprintf('Failed move node "%s" in sub graph %s@%s because ingoing source hierarchy relation is missing', $nodeToBeMoved->nodeAggregateId->value, $restrictToSet->toJson(), $contentStreamId->value), 1716472138);
+            throw new \RuntimeException(sprintf('Failed move node "%s" in sub graph %s@%s because ingoing source hierarchy relation is missing', $nodeToBeMoved->nodeAggregateId->value, $restrictToSet->toJson(), $contentStreamDbId->value), 1716472138);
         }
         return reset($ingoingHierarchyRelations);
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
 use Doctrine\DBAL\Exception as DBALException;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
  * The NodeRemoval projection feature trait
@@ -17,12 +17,12 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  */
 trait NodeRemoval
 {
-    private function removeNodeAggregate(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedCoveredDimensionSpacePoints): void
+    private function removeNodeAggregate(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedCoveredDimensionSpacePoints): void
     {
         // the focus here is to be correct; that's why the method is not overly performant (for now at least). We might
         // lateron find tricks to improve performance
         $ingoingRelations = $this->projectionContentGraph->findIngoingHierarchyRelationsForNodeAggregate(
-            $contentStreamId,
+            $contentStreamDbId,
             $nodeAggregateId,
             $affectedCoveredDimensionSpacePoints
         );
@@ -40,7 +40,7 @@ trait NodeRemoval
         foreach (
             $this->projectionContentGraph->findOutgoingHierarchyRelationsForNode(
                 $ingoingRelation->childNodeAnchor,
-                $ingoingRelation->contentStreamId,
+                $ingoingRelation->contentStreamDbId,
                 new DimensionSpacePointSet([$ingoingRelation->dimensionSpacePoint])
             ) as $outgoingRelation
         ) {
@@ -59,7 +59,7 @@ trait NodeRemoval
             WHERE
                 n.relationanchorpoint = :anchorPointForNode
                 -- the following line means "left join leads to NO MATCHING hierarchyrelation"
-                AND h.contentstreamid IS NULL
+                AND h.contentstreamdbid IS NULL
         SQL;
         try {
             $this->dbal->executeStatement($deleteRelationsStatement, [

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeVariation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeVariation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
@@ -11,7 +12,6 @@ use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\EventStore\Model\EventEnvelope;
 
 /**
@@ -21,16 +21,16 @@ use Neos\EventStore\Model\EventEnvelope;
  */
 trait NodeVariation
 {
-    private function createNodeSpecializationVariant(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $sourceOrigin, OriginDimensionSpacePoint $specializationOrigin, InterdimensionalSiblings $specializationSiblings, EventEnvelope $eventEnvelope): void
+    private function createNodeSpecializationVariant(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $sourceOrigin, OriginDimensionSpacePoint $specializationOrigin, InterdimensionalSiblings $specializationSiblings, EventEnvelope $eventEnvelope): void
     {
         // Do the actual specialization
         $sourceNode = $this->projectionContentGraph->findNodeInAggregate(
-            $contentStreamId,
+            $contentStreamDbId,
             $nodeAggregateId,
             $sourceOrigin->toDimensionSpacePoint()
         );
         if (is_null($sourceNode)) {
-            throw new \RuntimeException(sprintf('Failed to create node specialization variant for node "%s" in sub graph %s@%s because the source node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498651);
+            throw new \RuntimeException(sprintf('Failed to create node specialization variant for node "%s" in sub graph %s@%s because the source node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498651);
         }
 
         $specializedNode = $this->copyNodeToDimensionSpacePoint(
@@ -42,7 +42,7 @@ trait NodeVariation
         $uncoveredDimensionSpacePoints = $specializationSiblings->toDimensionSpacePointSet()->points;
         foreach (
             $this->projectionContentGraph->findIngoingHierarchyRelationsForNodeAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $sourceNode->nodeAggregateId,
                 $specializationSiblings->toDimensionSpacePointSet()
             ) as $hierarchyRelation
@@ -56,29 +56,29 @@ trait NodeVariation
         }
         if (!empty($uncoveredDimensionSpacePoints)) {
             $sourceParent = $this->projectionContentGraph->findParentNode(
-                $contentStreamId,
+                $contentStreamDbId,
                 $nodeAggregateId,
                 $sourceOrigin,
             );
             if (is_null($sourceParent)) {
-                throw new \RuntimeException(sprintf('Failed to create node specialization variant for node "%s" in sub graph %s@%s because the source parent node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498695);
+                throw new \RuntimeException(sprintf('Failed to create node specialization variant for node "%s" in sub graph %s@%s because the source parent node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498695);
             }
             foreach ($uncoveredDimensionSpacePoints as $uncoveredDimensionSpacePoint) {
                 $parentNode = $this->projectionContentGraph->findNodeInAggregate(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $sourceParent->nodeAggregateId,
                     $uncoveredDimensionSpacePoint
                 );
                 if (is_null($parentNode)) {
-                    throw new \RuntimeException(sprintf('Failed to create node specialization variant for node "%s" in sub graph %s@%s because the target parent node "%s" is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value, $sourceParent->nodeAggregateId->value), 1716498734);
+                    throw new \RuntimeException(sprintf('Failed to create node specialization variant for node "%s" in sub graph %s@%s because the target parent node "%s" is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value, $sourceParent->nodeAggregateId->value), 1716498734);
                 }
-                $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamId, $parentNode->relationAnchorPoint, $uncoveredDimensionSpacePoint);
+                $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamDbId, $parentNode->relationAnchorPoint, $uncoveredDimensionSpacePoint);
 
                 $specializationSucceedingSiblingNodeAggregateId = $specializationSiblings
                     ->getSucceedingSiblingIdForDimensionSpacePoint($uncoveredDimensionSpacePoint);
                 $specializationSucceedingSiblingNode = $specializationSucceedingSiblingNodeAggregateId
                     ? $this->projectionContentGraph->findNodeInAggregate(
-                        $contentStreamId,
+                        $contentStreamDbId,
                         $specializationSucceedingSiblingNodeAggregateId,
                         $uncoveredDimensionSpacePoint
                     )
@@ -87,14 +87,14 @@ trait NodeVariation
                 $hierarchyRelation = new HierarchyRelation(
                     $parentNode->relationAnchorPoint,
                     $specializedNode->relationAnchorPoint,
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $uncoveredDimensionSpacePoint,
                     $uncoveredDimensionSpacePoint->hash,
                     $this->projectionContentGraph->determineHierarchyRelationPosition(
                         $parentNode->relationAnchorPoint,
                         $specializedNode->relationAnchorPoint,
                         $specializationSucceedingSiblingNode?->relationAnchorPoint,
-                        $contentStreamId,
+                        $contentStreamDbId,
                         $uncoveredDimensionSpacePoint
                     ),
                     NodeTags::create(SubtreeTags::createEmpty(), $parentSubtreeTags->all()),
@@ -105,7 +105,7 @@ trait NodeVariation
 
         foreach (
             $this->projectionContentGraph->findOutgoingHierarchyRelationsForNodeAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $sourceNode->nodeAggregateId,
                 $specializationSiblings->toDimensionSpacePointSet()
             ) as $hierarchyRelation
@@ -125,24 +125,24 @@ trait NodeVariation
         );
     }
 
-    public function createNodeGeneralizationVariant(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $sourceOrigin, OriginDimensionSpacePoint $generalizationOrigin, InterdimensionalSiblings $variantSucceedingSiblings, EventEnvelope $eventEnvelope): void
+    public function createNodeGeneralizationVariant(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $sourceOrigin, OriginDimensionSpacePoint $generalizationOrigin, InterdimensionalSiblings $variantSucceedingSiblings, EventEnvelope $eventEnvelope): void
     {
         // do the generalization
         $sourceNode = $this->projectionContentGraph->findNodeInAggregate(
-            $contentStreamId,
+            $contentStreamDbId,
             $nodeAggregateId,
             $sourceOrigin->toDimensionSpacePoint()
         );
         if (is_null($sourceNode)) {
-            throw new \RuntimeException(sprintf('Failed to create node generalization variant for node "%s" in sub graph %s@%s because the source node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498802);
+            throw new \RuntimeException(sprintf('Failed to create node generalization variant for node "%s" in sub graph %s@%s because the source node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498802);
         }
         $sourceParentNode = $this->projectionContentGraph->findParentNode(
-            $contentStreamId,
+            $contentStreamDbId,
             $nodeAggregateId,
             $sourceOrigin
         );
         if (is_null($sourceParentNode)) {
-            throw new \RuntimeException(sprintf('Failed to create node generalization variant for node "%s" in sub graph %s@%s because the source parent node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498857);
+            throw new \RuntimeException(sprintf('Failed to create node generalization variant for node "%s" in sub graph %s@%s because the source parent node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498857);
         }
         $generalizedNode = $this->copyNodeToDimensionSpacePoint(
             $sourceNode,
@@ -153,7 +153,7 @@ trait NodeVariation
         $unassignedIngoingDimensionSpacePoints = $variantSucceedingSiblings->toDimensionSpacePointSet();
         foreach (
             $this->projectionContentGraph->findIngoingHierarchyRelationsForNodeAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $nodeAggregateId,
                 $variantSucceedingSiblings->toDimensionSpacePointSet()
             ) as $existingIngoingHierarchyRelation
@@ -172,7 +172,7 @@ trait NodeVariation
 
         foreach (
             $this->projectionContentGraph->findOutgoingHierarchyRelationsForNodeAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $nodeAggregateId,
                 $variantSucceedingSiblings->toDimensionSpacePointSet()
             ) as $existingOutgoingHierarchyRelation
@@ -188,18 +188,18 @@ trait NodeVariation
         if (count($unassignedIngoingDimensionSpacePoints) > 0) {
             $ingoingSourceHierarchyRelation = $this->projectionContentGraph->findIngoingHierarchyRelationsForNode(
                 $sourceNode->relationAnchorPoint,
-                $contentStreamId,
+                $contentStreamDbId,
                 new DimensionSpacePointSet([$sourceOrigin->toDimensionSpacePoint()])
             )[$sourceOrigin->hash] ?? null;
             if (is_null($ingoingSourceHierarchyRelation)) {
-                throw new \RuntimeException(sprintf('Failed to create node generalization variant for node "%s" in sub graph %s@%s because the ingoing hierarchy relation is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498940);
+                throw new \RuntimeException(sprintf('Failed to create node generalization variant for node "%s" in sub graph %s@%s because the ingoing hierarchy relation is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498940);
             }
             // the null case is caught by the NodeAggregate or its command handler
             foreach ($unassignedIngoingDimensionSpacePoints as $unassignedDimensionSpacePoint) {
                 // The parent node aggregate might be varied as well,
                 // so we need to find a parent node for each covered dimension space point
                 $generalizationParentNode = $this->projectionContentGraph->findNodeInAggregate(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $sourceParentNode->nodeAggregateId,
                     $unassignedDimensionSpacePoint
                 );
@@ -209,7 +209,7 @@ trait NodeVariation
                         $nodeAggregateId->value,
                         $sourceOrigin->toJson(),
                         $unassignedDimensionSpacePoint->toJson(),
-                        $contentStreamId->value,
+                        $contentStreamDbId->value,
                         $sourceParentNode->nodeAggregateId->value
                     ), 1716498961);
                 }
@@ -218,7 +218,7 @@ trait NodeVariation
                     ->getSucceedingSiblingIdForDimensionSpacePoint($unassignedDimensionSpacePoint);
                 $generalizationSucceedingSiblingNode = $generalizationSucceedingSiblingNodeAggregateId
                     ? $this->projectionContentGraph->findNodeInAggregate(
-                        $contentStreamId,
+                        $contentStreamDbId,
                         $generalizationSucceedingSiblingNodeAggregateId,
                         $unassignedDimensionSpacePoint
                     )
@@ -226,7 +226,7 @@ trait NodeVariation
 
                 $this->copyHierarchyRelationToDimensionSpacePoint(
                     $ingoingSourceHierarchyRelation,
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $unassignedDimensionSpacePoint,
                     $generalizationParentNode->relationAnchorPoint,
                     $generalizedNode->relationAnchorPoint,
@@ -242,16 +242,16 @@ trait NodeVariation
         );
     }
 
-    public function createNodePeerVariant(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $sourceOrigin, OriginDimensionSpacePoint $peerOrigin, InterdimensionalSiblings $peerSucceedingSiblings, EventEnvelope $eventEnvelope): void
+    public function createNodePeerVariant(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $sourceOrigin, OriginDimensionSpacePoint $peerOrigin, InterdimensionalSiblings $peerSucceedingSiblings, EventEnvelope $eventEnvelope): void
     {
         // Do the peer variant creation itself
         $sourceNode = $this->projectionContentGraph->findNodeInAggregate(
-            $contentStreamId,
+            $contentStreamDbId,
             $nodeAggregateId,
             $sourceOrigin->toDimensionSpacePoint()
         );
         if (is_null($sourceNode)) {
-            throw new \RuntimeException(sprintf('Failed to create node peer variant for node "%s" in sub graph %s@%s because the source node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498802);
+            throw new \RuntimeException(sprintf('Failed to create node peer variant for node "%s" in sub graph %s@%s because the source node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498802);
         }
         $peerNode = $this->copyNodeToDimensionSpacePoint(
             $sourceNode,
@@ -262,7 +262,7 @@ trait NodeVariation
         $unassignedIngoingDimensionSpacePoints = $peerSucceedingSiblings->toDimensionSpacePointSet();
         foreach (
             $this->projectionContentGraph->findIngoingHierarchyRelationsForNodeAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $nodeAggregateId,
                 $peerSucceedingSiblings->toDimensionSpacePointSet()
             ) as $existingIngoingHierarchyRelation
@@ -281,7 +281,7 @@ trait NodeVariation
 
         foreach (
             $this->projectionContentGraph->findOutgoingHierarchyRelationsForNodeAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $nodeAggregateId,
                 $peerSucceedingSiblings->toDimensionSpacePointSet()
             ) as $existingOutgoingHierarchyRelation
@@ -295,36 +295,36 @@ trait NodeVariation
         }
 
         $sourceParentNode = $this->projectionContentGraph->findParentNode(
-            $contentStreamId,
+            $contentStreamDbId,
             $nodeAggregateId,
             $sourceOrigin
         );
         if (is_null($sourceParentNode)) {
-            throw new \RuntimeException(sprintf('Failed to create node peer variant for node "%s" in sub graph %s@%s because the source parent node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value), 1716498881);
+            throw new \RuntimeException(sprintf('Failed to create node peer variant for node "%s" in sub graph %s@%s because the source parent node is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value), 1716498881);
         }
         foreach ($unassignedIngoingDimensionSpacePoints as $coveredDimensionSpacePoint) {
             // The parent node aggregate might be varied as well,
             // so we need to find a parent node for each covered dimension space point
             $peerParentNode = $this->projectionContentGraph->findNodeInAggregate(
-                $contentStreamId,
+                $contentStreamDbId,
                 $sourceParentNode->nodeAggregateId,
                 $coveredDimensionSpacePoint
             );
             if (is_null($peerParentNode)) {
-                throw new \RuntimeException(sprintf('Failed to create node peer variant for node "%s" in sub graph %s@%s because the target parent node "%s" is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamId->value, $sourceParentNode->nodeAggregateId->value), 1716499016);
+                throw new \RuntimeException(sprintf('Failed to create node peer variant for node "%s" in sub graph %s@%s because the target parent node "%s" is missing', $nodeAggregateId->value, $sourceOrigin->toJson(), $contentStreamDbId->value, $sourceParentNode->nodeAggregateId->value), 1716499016);
             }
             $peerSucceedingSiblingNodeAggregateId = $peerSucceedingSiblings
                 ->getSucceedingSiblingIdForDimensionSpacePoint($coveredDimensionSpacePoint);
             $peerSucceedingSiblingNode = $peerSucceedingSiblingNodeAggregateId
                 ? $this->projectionContentGraph->findNodeInAggregate(
-                    $contentStreamId,
+                    $contentStreamDbId,
                     $peerSucceedingSiblingNodeAggregateId,
                     $coveredDimensionSpacePoint
                 )
                 : null;
 
             $this->connectHierarchy(
-                $contentStreamId,
+                $contentStreamDbId,
                 $peerParentNode->relationAnchorPoint,
                 $peerNode->relationAnchorPoint,
                 new DimensionSpacePointSet([$coveredDimensionSpacePoint]),

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -14,7 +14,6 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
  * The subtree tagging projection feature trait
@@ -23,7 +22,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
  */
 trait SubtreeTagging
 {
-    private function addSubtreeTag(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
+    private function addSubtreeTag(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
     {
         $addTagToDescendantsStatement = <<<SQL
         UPDATE {$this->tableNames->hierarchyRelation()} h
@@ -34,7 +33,7 @@ trait SubtreeTagging
                     INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ch.parentnodeanchor
                     WHERE
                       n.nodeaggregateid = :nodeAggregateId
-                      AND ch.contentstreamid = :contentStreamId
+                      AND ch.contentstreamdbid = :contentStreamDbId
                       AND ch.dimensionspacepointhash in (:dimensionSpacePointHashes)
                       AND NOT JSON_CONTAINS_PATH(ch.subtreetags, 'one', :tagPath)
                     UNION ALL
@@ -44,7 +43,7 @@ trait SubtreeTagging
                     FROM
                       cte
                       JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.id
-                        AND dh.contentstreamid = :contentStreamId
+                        AND dh.contentstreamdbid = :contentStreamDbId
                         AND dh.dimensionspacepointhash = cte.dsp
                     WHERE
                       NOT JSON_CONTAINS_PATH(dh.subtreetags, 'one', :tagPath)
@@ -53,12 +52,12 @@ trait SubtreeTagging
             ) subquery ON h.dimensionspacepointhash = subquery.dsp
                 AND h.childnodeanchor = subquery.id
             SET h.subtreetags = JSON_INSERT(h.subtreetags, :tagPath, null)
-            WHERE h.contentstreamid = :contentStreamId
+            WHERE h.contentstreamdbid = :contentStreamDbId
         SQL;
 
         try {
             $this->dbal->executeStatement($addTagToDescendantsStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'dimensionSpacePointHashes' => $affectedDimensionSpacePoints->getPointHashes(),
                 'tagPath' => '$."' . $tag->value . '"',
@@ -66,7 +65,7 @@ trait SubtreeTagging
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('1: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479749, $e);
+            throw new \RuntimeException(sprintf('1: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamDbId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479749, $e);
         }
 
         $addTagToNodeStatement = <<<SQL
@@ -75,12 +74,12 @@ trait SubtreeTagging
             SET h.subtreetags = JSON_SET(h.subtreetags, :tagPath, true)
             WHERE
               n.nodeaggregateid = :nodeAggregateId
-              AND h.contentstreamid = :contentStreamId
+              AND h.contentstreamdbid = :contentStreamDbId
               AND h.dimensionspacepointhash in (:dimensionSpacePointHashes)
         SQL;
         try {
             $this->dbal->executeStatement($addTagToNodeStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'dimensionSpacePointHashes' => $affectedDimensionSpacePoints->getPointHashes(),
                 'tagPath' => '$."' . $tag->value . '"',
@@ -88,11 +87,11 @@ trait SubtreeTagging
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('2: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479840, $e);
+            throw new \RuntimeException(sprintf('2: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamDbId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479840, $e);
         }
     }
 
-    private function removeSubtreeTag(ContentStreamId $contentStreamId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
+    private function removeSubtreeTag(ContentStreamDbId $contentStreamDbId, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
     {
         $removeTagStatement = <<<SQL
             UPDATE {$this->tableNames->hierarchyRelation()} h
@@ -103,7 +102,7 @@ trait SubtreeTagging
                 INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
                 WHERE
                   n.nodeaggregateid = :nodeAggregateId
-                  AND ph.contentstreamid = :contentStreamId
+                  AND ph.contentstreamdbid = :contentStreamDbId
                   AND ph.dimensionspacepointhash in (:dimensionSpacePointHashes)
                 UNION ALL
                 SELECT
@@ -112,7 +111,7 @@ trait SubtreeTagging
                 FROM
                   cte
                   JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.id
-                    AND dh.contentstreamid = :contentStreamId
+                    AND dh.contentstreamdbid = :contentStreamDbId
                     AND dh.dimensionspacepointhash = cte.dsp
                 WHERE
                   JSON_EXTRACT(dh.subtreetags, :tagPath) != TRUE
@@ -131,15 +130,15 @@ trait SubtreeTagging
                   WHERE
                     ph.parentnodeanchor = gph.childnodeanchor
                     AND n.nodeaggregateid = :nodeAggregateId
-                    AND gph.contentstreamid = :contentStreamId
+                    AND gph.contentstreamdbid = :contentStreamDbId
                   LIMIT 1) as containsTagSubQuery
                 ), JSON_SET(subtreetags, :tagPath, null), JSON_REMOVE(subtreetags, :tagPath)
               )
-              WHERE contentstreamid = :contentStreamId
+              WHERE contentstreamdbid = :contentStreamDbId
         SQL;
         try {
             $this->dbal->executeStatement($removeTagStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'dimensionSpacePointHashes' => $affectedDimensionSpacePoints->getPointHashes(),
                 'tagPath' => '$."' . $tag->value . '"',
@@ -147,11 +146,11 @@ trait SubtreeTagging
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to remove subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716482293, $e);
+            throw new \RuntimeException(sprintf('Failed to remove subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamDbId->value, $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716482293, $e);
         }
     }
 
-    private function moveSubtreeTags(ContentStreamId $contentStreamId, NodeAggregateId $newParentNodeAggregateId, DimensionSpacePoint $coveredDimensionSpacePoint): void
+    private function moveSubtreeTags(ContentStreamDbId $contentStreamDbId, NodeAggregateId $newParentNodeAggregateId, DimensionSpacePoint $coveredDimensionSpacePoint): void
     {
         $moveSubtreeTagsStatement = <<<SQL
             UPDATE {$this->tableNames->hierarchyRelation()} h,
@@ -164,7 +163,7 @@ trait SubtreeTagging
                   INNER JOIN {$this->tableNames->node()} tn ON tn.relationanchorpoint = th.childnodeanchor
                 WHERE
                   tn.nodeaggregateid = :newParentNodeAggregateId
-                  AND th.contentstreamid = :contentStreamId
+                  AND th.contentstreamdbid = :contentStreamDbId
                   AND th.dimensionspacepointhash = :dimensionSpacePointHash
                 UNION
                 SELECT
@@ -181,7 +180,7 @@ trait SubtreeTagging
                 JOIN {$this->tableNames->hierarchyRelation()} dh
                     ON
                         dh.parentnodeanchor = cte.childnodeanchor
-                        AND dh.contentstreamid = :contentStreamId
+                        AND dh.contentstreamdbid = :contentStreamDbId
                         AND dh.dimensionspacepointhash = :dimensionSpacePointHash
               )
               SELECT * FROM cte
@@ -197,19 +196,19 @@ trait SubtreeTagging
             )
             WHERE
               h.childnodeanchor = r.childnodeanchor
-              AND h.contentstreamid = :contentStreamId
+              AND h.contentstreamdbid = :contentStreamDbId
               AND h.dimensionspacepointhash = :dimensionSpacePointHash
         SQL;
         try {
             // Mysql hack, too eager to optimize https://dev.mysql.com/doc/refman/8.4/en/derived-table-optimization.html
             $this->dbal->executeQuery('set optimizer_switch="derived_merge=off"');
             $this->dbal->executeStatement($moveSubtreeTagsStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'newParentNodeAggregateId' => $newParentNodeAggregateId->value,
                 'dimensionSpacePointHash' => $coveredDimensionSpacePoint->hash,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to move subtree tags for content stream %s, new parent node aggregate id %s and dimension space point %s: %s', $contentStreamId->value, $newParentNodeAggregateId->value, $coveredDimensionSpacePoint->toJson(), $e->getMessage()), 1716482574, $e);
+            throw new \RuntimeException(sprintf('Failed to move subtree tags for content stream %s, new parent node aggregate id %s and dimension space point %s: %s', $contentStreamDbId->value, $newParentNodeAggregateId->value, $coveredDimensionSpacePoint->toJson(), $e->getMessage()), 1716482574, $e);
         }
     }
 
@@ -231,10 +230,10 @@ trait SubtreeTagging
                 'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to fetch subtree tags for hierarchy parent anchor point "%s" in content subgraph "%s@%s": %s', $parentNodeAnchorPoint->value, $dimensionSpacePoint->toJson(), $contentStreamId->value, $e->getMessage()), 1716478760, $e);
+            throw new \RuntimeException(sprintf('Failed to fetch subtree tags for hierarchy parent anchor point "%s" in content subgraph "%s@%s": %s', $parentNodeAnchorPoint->value, $dimensionSpacePoint->toJson(), $contentStreamDbId->value, $e->getMessage()), 1716478760, $e);
         }
         if (!is_string($subtreeTagsJson)) {
-            throw new \RuntimeException(sprintf('Failed to fetch subtree tags for hierarchy parent anchor point "%s" in content subgraph "%s@%s"', $parentNodeAnchorPoint->value, $dimensionSpacePoint->toJson(), $contentStreamId->value), 1704199847);
+            throw new \RuntimeException(sprintf('Failed to fetch subtree tags for hierarchy parent anchor point "%s" in content subgraph "%s@%s"', $parentNodeAnchorPoint->value, $dimensionSpacePoint->toJson(), $contentStreamDbId->value), 1704199847);
         }
         return NodeFactory::extractNodeTagsFromJson($subtreeTagsJson);
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -6,6 +6,7 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception as DBALException;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
@@ -212,7 +213,7 @@ trait SubtreeTagging
         }
     }
 
-    private function subtreeTagsForHierarchyRelation(ContentStreamId $contentStreamId, NodeRelationAnchorPoint $parentNodeAnchorPoint, DimensionSpacePoint $dimensionSpacePoint): NodeTags
+    private function subtreeTagsForHierarchyRelation(ContentStreamDbId $contentStreamDbId, NodeRelationAnchorPoint $parentNodeAnchorPoint, DimensionSpacePoint $dimensionSpacePoint): NodeTags
     {
         if ($parentNodeAnchorPoint->equals(NodeRelationAnchorPoint::forRootEdge())) {
             return NodeTags::createEmpty();
@@ -222,11 +223,11 @@ trait SubtreeTagging
                     SELECT h.subtreetags FROM ' . $this->tableNames->hierarchyRelation() . ' h
                     WHERE
                       h.childnodeanchor = :parentNodeAnchorPoint
-                      AND h.contentstreamid = :contentStreamId
+                      AND h.contentstreamdbid = :contentStreamDbId
                       AND h.dimensionspacepointhash = :dimensionSpacePointHash
                 ', [
                 'parentNodeAnchorPoint' => $parentNodeAnchorPoint->value,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
             ]);
         } catch (DBALException $e) {

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
@@ -17,10 +17,9 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\DimensionSpacePointsRepository;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
  * The active record for reading and writing hierarchy relations from and to the database
@@ -32,7 +31,7 @@ final readonly class HierarchyRelation
     public function __construct(
         public NodeRelationAnchorPoint $parentNodeAnchor,
         public NodeRelationAnchorPoint $childNodeAnchor,
-        public ContentStreamId $contentStreamId,
+        public ContentStreamDbId $contentStreamDbId,
         public DimensionSpacePoint $dimensionSpacePoint,
         public string $dimensionSpacePointHash,
         public int $position,
@@ -54,7 +53,7 @@ final readonly class HierarchyRelation
             $databaseConnection->insert($tableNames->hierarchyRelation(), [
                 'parentnodeanchor' => $this->parentNodeAnchor->value,
                 'childnodeanchor' => $this->childNodeAnchor->value,
-                'contentstreamid' => $this->contentStreamId->value,
+                'contentstreamdbid' => $this->contentStreamDbId->value,
                 'dimensionspacepointhash' => $this->dimensionSpacePointHash,
                 'position' => $this->position,
                 'subtreetags' => $subtreeTagsJson,
@@ -131,13 +130,13 @@ final readonly class HierarchyRelation
 
     /**
      * @return array<string,mixed>
-     */
+     */ // todo rename? because ambiguous:
     public function getDatabaseId(): array
     {
         return [
             'parentnodeanchor' => $this->parentNodeAnchor->value,
             'childnodeanchor' => $this->childNodeAnchor->value,
-            'contentstreamid' => $this->contentStreamId->value,
+            'contentstreamdbid' => $this->contentStreamDbId->value,
             'dimensionspacepointhash' => $this->dimensionSpacePointHash
         ];
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -22,7 +22,6 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectorInterface;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Result;
 
@@ -94,14 +93,14 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
             SELECT
                 COUNT(*) as uniquenessCounter,
                 c.nodeaggregateid,
-                h.dimensionspacepointhash, h.contentstreamid FROM {$this->tableNames->hierarchyRelation()} h
+                h.dimensionspacepointhash, h.contentstreamdbid FROM {$this->tableNames->hierarchyRelation()} h
                 LEFT JOIN {$this->tableNames->node()} p ON h.parentnodeanchor = p.relationanchorpoint
                 LEFT JOIN {$this->tableNames->node()} c ON h.childnodeanchor = c.relationanchorpoint
             WHERE
                 h.parentnodeanchor != :rootNodeAnchor
             GROUP BY
                 p.nodeaggregateid, c.nodeaggregateid,
-                h.dimensionspacepointhash, h.contentstreamid
+                h.dimensionspacepointhash, h.contentstreamdbid
             HAVING uniquenessCounter > 1
         SQL;
         try {
@@ -128,14 +127,14 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
 
         $ambiguouslySortedHierarchyRelationStatement = <<<SQL
             SELECT
-                contentstreamid, dimensionspacepointhash, parentnodeanchor,
+                contentstreamdbid, dimensionspacepointhash, parentnodeanchor,
                 COUNT(position)
             FROM
                 {$this->tableNames->hierarchyRelation()}
             GROUP BY
                 position,
                 parentnodeanchor,
-                contentstreamid,
+                contentstreamdbid,
                 dimensionspacepointhash
             HAVING
                 COUNT(position) > 1
@@ -169,7 +168,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
 
             $result->addError(new Error(
                 'Siblings ' . implode(', ', array_map(static fn (array $record) => $record['nodeaggregateid'], $ambiguouslySortedNodeRecords))
-                . ' are ambiguously sorted in content stream ' . $hierarchyRelationRecord['contentstreamid']
+                . ' are ambiguously sorted in content stream ' . $hierarchyRelationRecord['contentstreamdbid']
                 . ' and dimension space point ' . $dimensionSpacePoints[$hierarchyRelationRecord['dimensionspacepointhash']]?->toJson(),
                 self::ERROR_CODE_SIBLINGS_ARE_AMBIGUOUSLY_SORTED
             ));
@@ -183,7 +182,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
         $result = new Result();
         $unnamedTetheredNodesStatement = <<<SQL
             SELECT
-                n.nodeaggregateid, h.contentstreamid
+                n.nodeaggregateid, h.contentstreamdbid
             FROM
                 {$this->tableNames->node()} n
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
@@ -191,7 +190,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 n.classification = :tethered
                 AND n.name IS NULL
             GROUP BY
-                n.nodeaggregateid, h.contentstreamid
+                n.nodeaggregateid, h.contentstreamdbid
         SQL;
         try {
             $unnamedTetheredNodeRecords = $this->dbal->fetchAllAssociative($unnamedTetheredNodesStatement, [
@@ -204,7 +203,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
         foreach ($unnamedTetheredNodeRecords as $unnamedTetheredNodeRecord) {
             $result->addError(new Error(
                 'Node aggregate ' . $unnamedTetheredNodeRecord['nodeaggregateid']
-                . ' is unnamed in content stream ' . $unnamedTetheredNodeRecord['contentstreamid'] . '.',
+                . ' is unnamed in content stream ' . $unnamedTetheredNodeRecord['contentstreamdbid'] . '.',
                 self::ERROR_CODE_TETHERED_NODE_IS_UNNAMED
             ));
         }
@@ -226,7 +225,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->hierarchyRelation()} h
                 INNER JOIN {$this->tableNames->hierarchyRelation()} ph
                     ON ph.childnodeanchor = h.parentnodeanchor
-                    AND ph.contentstreamid = h.contentstreamid
+                    AND ph.contentstreamdbid = h.contentstreamdbid
                     AND ph.dimensionspacepointhash = h.dimensionspacepointhash
             WHERE
                 EXISTS (
@@ -280,7 +279,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
 
         $referenceRelationRecordsWithInvalidTargetStatement = <<<SQL
             SELECT
-                sh.contentstreamid AS contentstreamId,
+                sh.contentstreamdbid,
                 s.nodeaggregateid AS sourceNodeAggregateId,
                 r.destinationnodeaggregateid AS destinationNodeAggregateId
             FROM
@@ -291,13 +290,13 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                     {$this->tableNames->node()} d
                     INNER JOIN {$this->tableNames->hierarchyRelation()} dh ON d.relationanchorpoint = dh.childnodeanchor
                 ) ON r.destinationnodeaggregateid = d.nodeaggregateid
-                  AND sh.contentstreamid = dh.contentstreamid
+                  AND sh.contentstreamdbid = dh.contentstreamdbid
                   AND sh.dimensionspacepointhash = dh.dimensionspacepointhash
                 WHERE
                     d.nodeaggregateid IS NULL
                 GROUP BY
                     s.nodeaggregateid,
-                    sh.contentstreamid,
+                    sh.contentstreamdbid,
                     r.destinationnodeaggregateid
         SQL;
         try {
@@ -310,7 +309,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
             $result->addError(new Error(
                 'Destination node aggregate ' . $record['destinationNodeAggregateId']
                 . ' does not cover any dimension space points the source ' . $record['sourceNodeAggregateId']
-                . ' does in content stream ' . $record['contentstreamId'],
+                . ' does in content stream ' . $record['contentstreamdbid'],
                 self::ERROR_CODE_REFERENCE_INTEGRITY_IS_COMPROMISED
             ));
         }
@@ -340,7 +339,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                     {$this->tableNames->hierarchyRelation()} h
                 WHERE
                     h.parentnodeanchor = :rootAnchorPoint
-                    AND h.contentstreamid = :contentStreamId
+                    AND h.contentstreamdbid = :contentStreamDbId
                     AND h.dimensionspacepointhash = :dimensionSpacePointHash
                 UNION
                  -- --------------------------------
@@ -353,24 +352,24 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                  INNER JOIN {$this->tableNames->hierarchyRelation()} h
                     on h.parentnodeanchor = p.childnodeanchor
                  WHERE
-                    h.contentstreamid = :contentStreamId
+                    h.contentstreamdbid = :contentStreamDbId
                     AND h.dimensionspacepointhash = :dimensionSpacePointHash
             )
             SELECT nodeaggregateid FROM {$this->tableNames->node()} n
             INNER JOIN {$this->tableNames->hierarchyRelation()} h
                 ON h.childnodeanchor = n.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
                 AND relationanchorpoint NOT IN (SELECT * FROM subgraph)
         SQL;
 
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             foreach ($this->findProjectedDimensionSpacePoints() as $dimensionSpacePoint) {
                 try {
                     $nodeAggregateIdsInCycles = $this->dbal->fetchFirstColumn($nodeAggregateIdsInCyclesStatement, [
                         'rootAnchorPoint' => NodeRelationAnchorPoint::forRootEdge()->value,
-                        'contentStreamId' => $contentStreamId->value,
+                        'contentStreamDbId' => $contentStreamDbId->value,
                         'dimensionSpacePointHash' => $dimensionSpacePoint->hash
                     ]);
                 } catch (DBALException $e) {
@@ -379,7 +378,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
 
                 if (!empty($nodeAggregateIdsInCycles)) {
                     $result->addError(new Error(
-                        'Subgraph defined by content stream ' . $contentStreamId->value
+                        'Subgraph defined by content stream ' . $contentStreamDbId->value
                         . ' and dimension space point ' . $dimensionSpacePoint->toJson()
                         . ' is cyclic for node aggregates '
                         . implode(',', $nodeAggregateIdsInCycles),
@@ -413,7 +412,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->node()} n
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
             GROUP BY
                 n.nodeaggregateid
@@ -421,11 +420,11 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 COUNT(DISTINCT(n.relationanchorpoint)) > 1
         SQL;
 
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             foreach ($this->findProjectedDimensionSpacePoints() as $dimensionSpacePoint) {
                 try {
                     $ambiguousNodeAggregateRecords = $this->dbal->fetchAllAssociative($ambiguousNodeAggregatesStatement, [
-                        'contentStreamId' => $contentStreamId->value,
+                        'contentStreamDbId' => $contentStreamDbId->value,
                         'dimensionSpacePointHash' => $dimensionSpacePoint->hash
                     ]);
                 } catch (DBALException $e) {
@@ -434,7 +433,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 foreach ($ambiguousNodeAggregateRecords as $ambiguousRecord) {
                     $result->addError(new Error(
                         'Node aggregate ' . $ambiguousRecord['nodeaggregateid']
-                        . ' is ambiguous in content stream ' . $contentStreamId->value
+                        . ' is ambiguous in content stream ' . $contentStreamDbId->value
                         . ' and dimension space point ' . $dimensionSpacePoint->toJson(),
                         self::ERROR_CODE_AMBIGUOUS_NODE_AGGREGATE_IN_SUBGRAPH
                     ));
@@ -455,7 +454,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->node()} c
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = c.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
             GROUP BY
                 c.relationanchorpoint
@@ -463,11 +462,11 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 COUNT(DISTINCT(h.parentnodeanchor)) > 1
         SQL;
 
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             foreach ($this->findProjectedDimensionSpacePoints() as $dimensionSpacePoint) {
                 try {
                     $nodeRecordsWithMultipleParents = $this->dbal->fetchAllAssociative($nodeRecordsWithMultipleParentsStatement, [
-                        'contentStreamId' => $contentStreamId->value,
+                        'contentStreamDbId' => $contentStreamDbId->value,
                         'dimensionSpacePointHash' => $dimensionSpacePoint->hash
                     ]);
                 } catch (DBALException $e) {
@@ -477,7 +476,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 foreach ($nodeRecordsWithMultipleParents as $record) {
                     $result->addError(new Error(
                         'Node aggregate ' . $record['nodeaggregateid']
-                        . ' has multiple parents in content stream ' . $contentStreamId->value
+                        . ' has multiple parents in content stream ' . $contentStreamDbId->value
                         . ' and dimension space point ' . $dimensionSpacePoint->toJson(),
                         self::ERROR_CODE_NODE_HAS_MULTIPLE_PARENTS
                     ));
@@ -498,18 +497,18 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->node()} n
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
                 AND n.nodeaggregateid = :nodeAggregateId
         SQL;
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             foreach (
                 $this->findProjectedNodeAggregateIdsInContentStream(
-                    $contentStreamId
+                    $contentStreamDbId
                 ) as $nodeAggregateId
             ) {
                 try {
                     $nodeTypeNames = $this->dbal->fetchFirstColumn($nodeAggregatesStatement, [
-                        'contentStreamId' => $contentStreamId->value,
+                        'contentStreamDbId' => $contentStreamDbId->value,
                         'nodeAggregateId' => $nodeAggregateId->value
                     ]);
                 } catch (DBALException $e) {
@@ -519,7 +518,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 if (count($nodeTypeNames) > 1) {
                     $result->addError(new Error(
                         'Node aggregate ' . $nodeAggregateId->value
-                        . ' in content stream ' . $contentStreamId->value
+                        . ' in content stream ' . $contentStreamDbId->value
                         . ' is of ambiguous type ("' . implode('","', $nodeTypeNames) . '")',
                         self::ERROR_CODE_NODE_AGGREGATE_IS_AMBIGUOUSLY_TYPED
                     ));
@@ -540,18 +539,18 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->node()} n
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
                 AND n.nodeaggregateid = :nodeAggregateId
         SQL;
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             foreach (
                 $this->findProjectedNodeAggregateIdsInContentStream(
-                    $contentStreamId
+                    $contentStreamDbId
                 ) as $nodeAggregateId
             ) {
                 try {
                     $classifications = $this->dbal->fetchFirstColumn($nodeAggregatesStatement, [
-                        'contentStreamId' => $contentStreamId->value,
+                        'contentStreamDbId' => $contentStreamDbId->value,
                         'nodeAggregateId' => $nodeAggregateId->value
                     ]);
                 } catch (DBALException $e) {
@@ -561,7 +560,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 if (count($classifications) > 1) {
                     $result->addError(new Error(
                         'Node aggregate ' . $nodeAggregateId->value
-                        . ' in content stream ' . $contentStreamId->value
+                        . ' in content stream ' . $contentStreamDbId->value
                         . ' is ambiguously classified ("' . implode('","', $classifications) . '")',
                         self::ERROR_CODE_NODE_AGGREGATE_IS_AMBIGUOUSLY_CLASSIFIED
                     ));
@@ -583,15 +582,15 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 INNER JOIN {$this->tableNames->node()} n ON c.childnodeanchor = n.relationanchorpoint
                 LEFT JOIN {$this->tableNames->hierarchyRelation()} p ON c.parentnodeanchor = p.childnodeanchor
             WHERE
-                c.contentstreamid = :contentStreamId
-                AND p.contentstreamid = :contentStreamId
+                c.contentstreamdbid = :contentStreamDbId
+                AND p.contentstreamdbid = :contentStreamDbId
                 AND c.dimensionspacepointhash = p.dimensionspacepointhash
                 AND p.childnodeanchor IS NULL
         SQL;
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             try {
                 $excessivelyCoveringNodeRecords = $this->dbal->fetchAllAssociative($excessivelyCoveringStatement, [
-                    'contentStreamId' => $contentStreamId->value
+                    'contentStreamDbId' => $contentStreamDbId->value
                 ]);
             } catch (DBALException $e) {
                 throw new \RuntimeException(sprintf('Failed to load excessively covering nodes: %s', $e->getMessage()), 1716494618, $e);
@@ -599,7 +598,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
             foreach ($excessivelyCoveringNodeRecords as $excessivelyCoveringNodeRecord) {
                 $result->addError(new Error(
                     'Node aggregate ' . $excessivelyCoveringNodeRecord['nodeaggregateid']
-                    . ' in content stream ' . $contentStreamId->value
+                    . ' in content stream ' . $contentStreamDbId->value
                     . ' covers dimension space point hash ' . $excessivelyCoveringNodeRecord['dimensionspacepointhash']
                     . ' but its parent does not.',
                     self::ERROR_CODE_CHILD_NODE_COVERAGE_IS_NO_SUBSET_OF_PARENT_NODE_COVERAGE
@@ -620,7 +619,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->node()} n
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
                 AND nodeaggregateid NOT IN (
                     -- this query finds all nodes whose origin *IS COVERED* by an incoming hierarchy relation.
                     SELECT
@@ -631,14 +630,14 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                             p.childnodeanchor = n.relationanchorpoint
                             AND p.dimensionspacepointhash = n.origindimensionspacepointhash
                         WHERE
-                            p.contentstreamid = :contentStreamId
+                            p.contentstreamdbid = :contentStreamDbId
                     )
                     AND classification != :rootClassification
         SQL;
-        foreach ($this->findProjectedContentStreamIds() as $contentStreamId) {
+        foreach ($this->findProjectedContentStreamDbIds() as $contentStreamDbId) {
             try {
                 $nodeRecordsWithMissingOriginCoverage = $this->dbal->fetchAllAssociative($nodesWithMissingOriginCoverageStatement, [
-                    'contentStreamId' => $contentStreamId->value,
+                    'contentStreamDbId' => $contentStreamDbId->value,
                     'rootClassification' => NodeAggregateClassification::CLASSIFICATION_ROOT->value
                 ]);
             } catch (DBALException $e) {
@@ -648,7 +647,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
             foreach ($nodeRecordsWithMissingOriginCoverage as $nodeRecord) {
                 $result->addError(new Error(
                     'Node aggregate ' . $nodeRecord['nodeaggregateid']
-                    . ' in content stream ' . $contentStreamId->value
+                    . ' in content stream ' . $contentStreamDbId->value
                     . ' does not cover its origin dimension space point hash ' . $nodeRecord['origindimensionspacepointhash']
                     . '.',
                     self::ERROR_CODE_NODE_DOES_NOT_COVER_ITS_ORIGIN
@@ -662,19 +661,19 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
     /**
      * Returns all content stream ids
      *
-     * @return iterable<ContentStreamId>
+     * @return iterable<ContentStreamDbId>
      */
-    private function findProjectedContentStreamIds(): iterable
+    private function findProjectedContentStreamDbIds(): iterable
     {
-        $contentStreamIdsStatement = <<<SQL
-            SELECT DISTINCT contentstreamid FROM {$this->tableNames->hierarchyRelation()}
+        $contentStreamDbIdsStatement = <<<SQL
+            SELECT DISTINCT contentstreamdbid FROM {$this->tableNames->hierarchyRelation()}
         SQL;
         try {
-            $contentStreamIds = $this->dbal->fetchFirstColumn($contentStreamIdsStatement);
+            $contentStreamDbIds = $this->dbal->fetchFirstColumn($contentStreamDbIdsStatement);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to load content stream ids: %s', $e->getMessage()), 1716494814, $e);
         }
-        return array_map(ContentStreamId::fromString(...), $contentStreamIds);
+        return array_map(fn (string $value) => ContentStreamDbId::fromInt((int)$value), $contentStreamDbIds);
     }
 
     /**
@@ -697,7 +696,7 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
      * @return array<NodeAggregateId>
      */
     protected function findProjectedNodeAggregateIdsInContentStream(
-        ContentStreamId $contentStreamId
+        ContentStreamDbId $contentStreamDbId
     ): array {
         $nodeAggregateIdsStatement = <<<SQL
             SELECT
@@ -706,11 +705,11 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 {$this->tableNames->node()} n
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
-                h.contentstreamid = :contentStreamId
+                h.contentstreamdbid = :contentStreamDbId
         SQL;
         try {
             $nodeAggregateIds = $this->dbal->fetchFirstColumn($nodeAggregateIdsStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to load node aggregate ids for content stream: %s', $e->getMessage()), 1716495988, $e);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
@@ -74,7 +75,8 @@ final class ContentGraph implements ContentGraphInterface
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly ContentGraphTableNames $tableNames,
         public readonly WorkspaceName $workspaceName,
-        public readonly ContentStreamId $contentStreamId
+        public readonly ContentStreamId $contentStreamId,
+        public readonly ContentStreamDbId $contentStreamDbId,
     ) {
         $this->nodeQueryBuilder = new NodeQueryBuilder($this->dbal, $this->tableNames);
     }
@@ -96,7 +98,7 @@ final class ContentGraph implements ContentGraphInterface
         return new ContentSubgraph(
             $this->contentRepositoryId,
             $this->workspaceName,
-            $this->contentStreamId,
+            $this->contentStreamDbId,
             $dimensionSpacePoint,
             $visibilityConstraints,
             $this->dbal,
@@ -135,7 +137,7 @@ final class ContentGraph implements ContentGraphInterface
     public function findRootNodeAggregates(
         FindRootNodeAggregatesFilter $filter,
     ): NodeAggregates {
-        $rootNodeAggregateQueryBuilder = $this->nodeQueryBuilder->buildFindRootNodeAggregatesQuery($this->contentStreamId, $filter);
+        $rootNodeAggregateQueryBuilder = $this->nodeQueryBuilder->buildFindRootNodeAggregatesQuery($this->contentStreamDbId, $filter);
         return $this->mapQueryBuilderToNodeAggregates($rootNodeAggregateQueryBuilder);
     }
 
@@ -146,7 +148,7 @@ final class ContentGraph implements ContentGraphInterface
         $queryBuilder
             ->andWhere('n.nodetypename = :nodeTypeName')
             ->setParameters([
-                'contentStreamId' => $this->contentStreamId->value,
+                'contentStreamDbId' => $this->contentStreamDbId->value,
                 'nodeTypeName' => $nodeTypeName->value,
             ]);
         return $this->mapQueryBuilderToNodeAggregates($queryBuilder);
@@ -160,7 +162,7 @@ final class ContentGraph implements ContentGraphInterface
             ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
                 'nodeAggregateId' => $nodeAggregateId->value,
-                'contentStreamId' => $this->contentStreamId->value
+                'contentStreamDbId' => $this->contentStreamDbId->value
             ]);
 
         return $this->nodeFactory->mapNodeRowsToNodeAggregate(
@@ -178,7 +180,7 @@ final class ContentGraph implements ContentGraphInterface
             ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
                 'nodeAggregateIds' => $nodeAggregateIds->toStringArray(),
-                'contentStreamId' => $this->contentStreamId->value
+                'contentStreamDbId' => $this->contentStreamDbId->value
             ], [
                 'nodeAggregateIds' => ArrayParameterType::STRING
             ]);
@@ -197,11 +199,11 @@ final class ContentGraph implements ContentGraphInterface
         $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
             ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
-            ->andWhere('ch.contentstreamid = :contentStreamId')
+            ->andWhere('ch.contentstreamdbid = :contentStreamDbId')
             ->andWhere('cn.nodeaggregateid = :nodeAggregateId')
             ->setParameters([
                 'nodeAggregateId' => $childNodeAggregateId->value,
-                'contentStreamId' => $this->contentStreamId->value
+                'contentStreamDbId' => $this->contentStreamDbId->value
             ]);
 
         return $this->mapQueryBuilderToNodeAggregates($queryBuilder);
@@ -213,20 +215,20 @@ final class ContentGraph implements ContentGraphInterface
             ->select('ch.parentnodeanchor')
             ->from($this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch')
             ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = ch.childnodeanchor')
-            ->where('ch.contentstreamid = :contentStreamId')
+            ->where('ch.contentstreamdbid = :contentStreamDbId')
             ->andWhere('c.nodeaggregateid = :entryNodeAggregateId');
 
         $queryBuilderRecursive = $this->createQueryBuilder()
             ->select('ph.parentnodeanchor')
             ->from('ancestry', 'ch')
             ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'ph.childnodeanchor = ch.parentnodeanchor')
-            ->where('ph.contentstreamid = :contentStreamId');
+            ->where('ph.contentstreamdbid = :contentStreamDbId');
 
         $queryBuilderCte = $this->createQueryBuilder()
             ->select('n.nodeAggregateId')
             ->from('ancestry', 'a')
             ->innerJoin('a', $this->nodeQueryBuilder->tableNames->node(), 'n', 'n.relationanchorpoint = a.parentnodeanchor')
-            ->setParameter('contentStreamId', $this->contentStreamId->value)
+            ->setParameter('contentStreamDbId', $this->contentStreamDbId->value)
             ->setParameter('entryNodeAggregateId', $entryNodeAggregateId->value);
 
         $nodeAggregateIdRows = $this->fetchCteResults(
@@ -242,7 +244,7 @@ final class ContentGraph implements ContentGraphInterface
     public function findChildNodeAggregates(
         NodeAggregateId $parentNodeAggregateId
     ): NodeAggregates {
-        $queryBuilder = $this->nodeQueryBuilder->buildChildNodeAggregateQuery($parentNodeAggregateId, $this->contentStreamId);
+        $queryBuilder = $this->nodeQueryBuilder->buildChildNodeAggregateQuery($parentNodeAggregateId, $this->contentStreamDbId);
         return $this->mapQueryBuilderToNodeAggregates($queryBuilder);
     }
 
@@ -253,20 +255,20 @@ final class ContentGraph implements ContentGraphInterface
             ->from($this->nodeQueryBuilder->tableNames->node(), 'pn')
             ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
-            ->where('ch.contentstreamid = :contentStreamId')
+            ->where('ch.contentstreamdbid = :contentStreamDbId')
             ->andWhere('ch.dimensionspacepointhash = :childOriginDimensionSpacePointHash')
             ->andWhere('cn.nodeaggregateid = :childNodeAggregateId')
             ->andWhere('cn.origindimensionspacepointhash = :childOriginDimensionSpacePointHash');
 
         $queryBuilder = $this->createQueryBuilder()
-            ->select('n.*, h.contentstreamid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->select('n.*, h.contentstreamdbid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
             ->innerJoin('h', $this->nodeQueryBuilder->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = h.dimensionspacepointhash')
             ->where('n.nodeaggregateid = (' . $subQueryBuilder->getSQL() . ')')
-            ->andWhere('h.contentstreamid = :contentStreamId')
+            ->andWhere('h.contentstreamdbid = :contentStreamDbId')
             ->setParameters([
-                'contentStreamId' => $this->contentStreamId->value,
+                'contentStreamDbId' => $this->contentStreamDbId->value,
                 'childNodeAggregateId' => $childNodeAggregateId->value,
                 'childOriginDimensionSpacePointHash' => $childOriginDimensionSpacePoint->hash,
             ]);
@@ -280,7 +282,7 @@ final class ContentGraph implements ContentGraphInterface
 
     public function findTetheredChildNodeAggregates(NodeAggregateId $parentNodeAggregateId): NodeAggregates
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildChildNodeAggregateQuery($parentNodeAggregateId, $this->contentStreamId)
+        $queryBuilder = $this->nodeQueryBuilder->buildChildNodeAggregateQuery($parentNodeAggregateId, $this->contentStreamDbId)
             ->andWhere('cn.classification = :tetheredClassification')
             ->setParameter('tetheredClassification', NodeAggregateClassification::CLASSIFICATION_TETHERED->value);
 
@@ -291,7 +293,7 @@ final class ContentGraph implements ContentGraphInterface
         NodeAggregateId $parentNodeAggregateId,
         NodeName $name
     ): ?NodeAggregate {
-        $queryBuilder = $this->nodeQueryBuilder->buildChildNodeAggregateQuery($parentNodeAggregateId, $this->contentStreamId)
+        $queryBuilder = $this->nodeQueryBuilder->buildChildNodeAggregateQuery($parentNodeAggregateId, $this->contentStreamDbId)
             ->andWhere('cn.name = :relationName')
             ->setParameter('relationName', $name->value);
 
@@ -308,14 +310,14 @@ final class ContentGraph implements ContentGraphInterface
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'ph.childnodeanchor = n.relationanchorpoint')
             ->where('n.nodeaggregateid = :parentNodeAggregateId')
             ->andWhere('n.origindimensionspacepointhash = :parentNodeOriginDimensionSpacePointHash')
-            ->andWhere('ph.contentstreamid = :contentStreamId')
-            ->andWhere('h.contentstreamid = :contentStreamId')
+            ->andWhere('ph.contentstreamdbid = :contentStreamDbId')
+            ->andWhere('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash IN (:dimensionSpacePointHashes)')
             ->andWhere('n.name = :nodeName')
             ->setParameters([
                 'parentNodeAggregateId' => $parentNodeAggregateId->value,
                 'parentNodeOriginDimensionSpacePointHash' => $parentNodeOriginDimensionSpacePoint->hash,
-                'contentStreamId' => $this->contentStreamId->value,
+                'contentStreamDbId' => $this->contentStreamDbId->value,
                 'dimensionSpacePointHashes' => $dimensionSpacePointsToCheck->getPointHashes(),
                 'nodeName' => $nodeName->value
             ], [
@@ -332,19 +334,19 @@ final class ContentGraph implements ContentGraphInterface
     public function findNodeAggregatesTaggedBy(SubtreeTag $subtreeTag): NodeAggregates
     {
         $queryBuilder =  $this->createQueryBuilder()
-            ->select('n.*, h.contentstreamid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->select('n.*, h.contentstreamdbid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             // select the subtree tags from tagged (t) h and then join h again to fetch all node rows in that aggregate
             ->from($this->tableNames->hierarchyRelation(), 'th')
             ->innerJoin('th', $this->tableNames->hierarchyRelation(), 'h', 'th.childnodeanchor = h.childnodeanchor')
             ->innerJoin('h', $this->tableNames->node(), 'n', 'h.childnodeanchor = n.relationanchorpoint')
             ->innerJoin('h', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = h.dimensionspacepointhash')
-            ->where('th.contentstreamid = :contentStreamId')
+            ->where('th.contentstreamdbid = :contentStreamDbId')
             ->andWhere('JSON_EXTRACT(th.subtreetags, :tagPath) LIKE "true"')
-            ->andWhere('h.contentstreamid = :contentStreamId')
+            ->andWhere('h.contentstreamdbid = :contentStreamDbId')
             ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
                 'tagPath' => '$."' . $subtreeTag->value . '"',
-                'contentStreamId' => $this->contentStreamId->value
+                'contentStreamDbId' => $this->contentStreamDbId->value
             ]);
 
         return $this->mapQueryBuilderToNodeAggregates($queryBuilder);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentStreamDbIdFinder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentStreamDbIdFinder.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentGraph.DoctrineDbalAdapter package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+
+/**
+ * A place to cache contentstreamid data, the db id for a content stream is autoincrement and unique there should never be an issue with having this in memory.
+ * Todo?
+ *
+ * @internal you should never need this in userland code
+ */
+final class ContentStreamDbIdFinder
+{
+    /**
+     * @var array<string, ContentStreamDbId>
+     */
+    private array $contentStreamIdRuntimeCache = [];
+
+    public function __construct(
+        private readonly Connection $dbal,
+        private readonly ContentGraphTableNames $tableNames,
+    ) {
+    }
+
+    public function getContentStreamDbId(ContentStreamId $contentStreamId): ContentStreamDbId
+    {
+        $contentStreamDbId = $this->getFromRuntimeCache($contentStreamId);
+        if ($contentStreamDbId === null) {
+            $this->fillRuntimeCacheFromDatabase();
+            $contentStreamDbId = $this->getFromRuntimeCache($contentStreamId);
+        }
+
+        if ($contentStreamDbId === null) {
+            throw new \RuntimeException(sprintf('A ContentStream with id "%s" was not found in the projection, cannot determine ContentStreamDbId.', $contentStreamId->value), 1769945094);
+        }
+
+        return $contentStreamDbId;
+    }
+
+    private function getFromRuntimeCache(ContentStreamId $contentStreamId): ?ContentStreamDbId
+    {
+        return $this->contentStreamIdRuntimeCache[$contentStreamId->value] ?? null;
+    }
+
+    private function fillRuntimeCacheFromDatabase(): void
+    {
+        $allContentStreamIdsStatement = <<<SQL
+            SELECT dbId, id FROM {$this->tableNames->contentStream()}
+        SQL;
+        try {
+            $allContentStreamIds = $this->dbal->fetchAllAssociative($allContentStreamIdsStatement);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to load content stream ids from database: %s', $e->getMessage()), 1769945050, $e);
+        }
+        foreach ($allContentStreamIds as $contentStreamIdRow) {
+            $this->contentStreamIdRuntimeCache[(string)$contentStreamIdRow['id']] = ContentStreamDbId::fromInt($contentStreamIdRow['dbId']);
+        }
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
@@ -58,7 +59,6 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
 /**
@@ -95,7 +95,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
     public function __construct(
         private readonly ContentRepositoryId $contentRepositoryId,
         private readonly WorkspaceName $workspaceName,
-        private readonly ContentStreamId $contentStreamId,
+        private readonly ContentStreamDbId $contentStreamDbId,
         private readonly DimensionSpacePoint $dimensionSpacePoint,
         private readonly VisibilityConstraints $visibilityConstraints,
         private readonly Connection $dbal,
@@ -169,7 +169,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findNodeById(NodeAggregateId $nodeAggregateId): ?Node
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamId, $this->dimensionSpacePoint)
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamDbId, $this->dimensionSpacePoint)
             ->andWhere('n.nodeaggregateid = :nodeAggregateId')
             ->setParameter('nodeAggregateId', $nodeAggregateId->value);
         $this->addSubtreeTagConstraints($queryBuilder);
@@ -178,7 +178,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findNodesByIds(NodeAggregateIds $nodeAggregateIds): Nodes
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamId, $this->dimensionSpacePoint)
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamDbId, $this->dimensionSpacePoint)
             ->andWhere('n.nodeaggregateid in (:nodeAggregateIds)')
             ->setParameter('nodeAggregateIds', $nodeAggregateIds->toStringArray(), ArrayParameterType::STRING);
         $this->addSubtreeTagConstraints($queryBuilder);
@@ -187,7 +187,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findRootNodeByType(NodeTypeName $nodeTypeName): ?Node
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamId, $this->dimensionSpacePoint)
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamDbId, $this->dimensionSpacePoint)
             ->andWhere('n.nodetypename = :nodeTypeName')->setParameter('nodeTypeName', $nodeTypeName->value)
             ->andWhere('n.classification = :nodeAggregateClassification')->setParameter('nodeAggregateClassification', NodeAggregateClassification::CLASSIFICATION_ROOT->value);
         $this->addSubtreeTagConstraints($queryBuilder);
@@ -196,7 +196,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findParentNode(NodeAggregateId $childNodeAggregateId): ?Node
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicParentNodeQuery($childNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicParentNodeQuery($childNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint);
         $this->addSubtreeTagConstraints($queryBuilder, 'ph');
         return $this->fetchNode($queryBuilder);
     }
@@ -228,7 +228,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
      */
     private function findChildNodeConnectedThroughEdgeName(NodeAggregateId $parentNodeAggregateId, NodeName $nodeName): ?Node
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicChildNodesQuery($parentNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint)
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicChildNodesQuery($parentNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint)
             ->andWhere('n.name = :edgeName')->setParameter('edgeName', $nodeName->value);
         $this->addSubtreeTagConstraints($queryBuilder);
         return $this->fetchNode($queryBuilder);
@@ -276,7 +276,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, 0 AS position')
             ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
-            ->where('h.contentstreamid = :contentStreamId')
+            ->where('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash')
             ->andWhere('n.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial);
@@ -286,7 +286,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->from('tree', 'p')
             ->innerJoin('p', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = p.relationanchorpoint')
             ->innerJoin('p', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = h.childnodeanchor')
-            ->where('h.contentstreamid = :contentStreamId')
+            ->where('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
         if ($filter->maximumLevels !== null) {
             $queryBuilderRecursive->andWhere('p.level < :maximumLevels')->setParameter('maximumLevels', $filter->maximumLevels);
@@ -301,7 +301,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->from('tree')
             ->orderBy('level')
             ->addOrderBy('position')
-            ->setParameter('contentStreamId', $this->contentStreamId->value)
+            ->setParameter('contentStreamDbId', $this->contentStreamDbId->value)
             ->setParameter('dimensionSpacePointHash', $this->dimensionSpacePoint->hash)
             ->setParameter('entryNodeAggregateId', $entryNodeAggregateId->value);
 
@@ -380,7 +380,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
             // we need to join with the hierarchy relation, because we need the node name.
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
-            ->andWhere('ph.contentstreamid = :contentStreamId')
+            ->andWhere('ph.contentstreamdbid = :contentStreamDbId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')
             ->andWhere('n.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
@@ -390,11 +390,11 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->from('ancestry', 'cn')
             ->innerJoin('cn', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = cn.parentnodeanchor')
             ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = pn.relationanchorpoint')
-            ->where('h.contentstreamid = :contentStreamId')
+            ->where('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
-        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint);
         $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
         $nodeRows = $this->fetchCteResults(
             $queryBuilderInitial,
@@ -437,7 +437,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function countNodes(): int
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamId, $this->dimensionSpacePoint, 'n', 'COUNT(*)');
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamDbId, $this->dimensionSpacePoint, 'n', 'COUNT(*)');
         try {
             $result = $this->executeQuery($queryBuilder)->fetchOne();
         } catch (DBALException $e) {
@@ -483,7 +483,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     private function buildChildNodesQuery(NodeAggregateId $parentNodeAggregateId, FindChildNodesFilter|CountChildNodesFilter $filter): QueryBuilder
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicChildNodesQuery($parentNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicChildNodesQuery($parentNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint);
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilder, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager));
         }
@@ -501,7 +501,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
     {
         $subselectParameters = [
             'nodeAggregateId' => $nodeAggregateId->value,
-            'contentStreamId' => $this->contentStreamId->value,
+            'contentStreamDbId' => $this->contentStreamDbId->value,
             'dimensionSpacePointHash' => $this->dimensionSpacePoint->hash,
         ];
         $subtreeTagConstraints = '';
@@ -521,12 +521,12 @@ final class ContentSubgraph implements ContentSubgraphInterface
                 SELECT relationanchorpoint FROM ' . $this->nodeQueryBuilder->tableNames->node() . ' sn
                 JOIN ' . $this->nodeQueryBuilder->tableNames->hierarchyRelation() . ' sh ON sn.relationanchorpoint = sh.childnodeanchor
                 WHERE sn.nodeaggregateid = :nodeAggregateId
-                AND sh.contentstreamid = :contentStreamId
+                AND sh.contentstreamdbid = :contentStreamDbId
                 AND sh.dimensionspacepointhash = :dimensionSpacePointHash '
                 . $subtreeTagConstraints . '
             )')->setParameters($subselectParameters)
             ->andWhere('dh.dimensionspacepointhash = :dimensionSpacePointHash')->setParameter('dimensionSpacePointHash', $this->dimensionSpacePoint->hash)
-            ->andWhere('dh.contentstreamid = :contentStreamId')->setParameter('contentStreamId', $this->contentStreamId->value);
+            ->andWhere('dh.contentstreamdbid = :contentStreamDbId')->setParameter('contentStreamDbId', $this->contentStreamDbId->value);
         $this->addSubtreeTagConstraints($queryBuilder, 'dh');
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilder, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), "dn");
@@ -565,7 +565,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
     {
         $subselectParameters = [
             'nodeAggregateId' => $nodeAggregateId->value,
-            'contentStreamId' => $this->contentStreamId->value,
+            'contentStreamDbId' => $this->contentStreamDbId->value,
             'dimensionSpacePointHash' => $this->dimensionSpacePoint->hash,
         ];
         $subtreeTagConstraints = '';
@@ -585,12 +585,12 @@ final class ContentSubgraph implements ContentSubgraphInterface
                 SELECT nodeaggregateid FROM ' . $this->nodeQueryBuilder->tableNames->node() . ' dn
                 JOIN ' . $this->nodeQueryBuilder->tableNames->hierarchyRelation() . ' dh ON dn.relationanchorpoint = dh.childnodeanchor
                 WHERE dn.nodeaggregateid = :nodeAggregateId
-                AND dh.contentstreamid = :contentStreamId
+                AND dh.contentstreamdbid = :contentStreamDbId
                 AND dh.dimensionspacepointhash = :dimensionSpacePointHash '
                 . $subtreeTagConstraints . '
             )')->setParameters($subselectParameters)
             ->andWhere('sh.dimensionspacepointhash = :dimensionSpacePointHash')->setParameter('dimensionSpacePointHash', $this->dimensionSpacePoint->hash)
-            ->andWhere('sh.contentstreamid = :contentStreamId')->setParameter('contentStreamId', $this->contentStreamId->value);
+            ->andWhere('sh.contentstreamdbid = :contentStreamDbId')->setParameter('contentStreamDbId', $this->contentStreamDbId->value);
         $this->addSubtreeTagConstraints($queryBuilder, 'sh');
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilder, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), "sn");
@@ -627,7 +627,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     private function buildSiblingsQuery(bool $preceding, NodeAggregateId $siblingNodeAggregateId, FindPrecedingSiblingNodesFilter|FindSucceedingSiblingNodesFilter $filter): QueryBuilder
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeSiblingsQuery($preceding, $siblingNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeSiblingsQuery($preceding, $siblingNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint);
 
         $this->addSubtreeTagConstraints($queryBuilder);
         if ($filter->nodeTypes !== null) {
@@ -657,9 +657,9 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
             ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = ch.childnodeanchor')
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
-            ->where('ch.contentstreamid = :contentStreamId')
+            ->where('ch.contentstreamdbid = :contentStreamDbId')
             ->andWhere('ch.dimensionspacepointhash = :dimensionSpacePointHash')
-            ->andWhere('ph.contentstreamid = :contentStreamId')
+            ->andWhere('ph.contentstreamdbid = :contentStreamDbId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')
             ->andWhere('c.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
@@ -670,11 +670,11 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->from('ancestry', 'ch')
             ->innerJoin('ch', $this->nodeQueryBuilder->tableNames->node(), 'pn', 'pn.relationanchorpoint = ch.parentnodeanchor')
             ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = pn.relationanchorpoint')
-            ->where('h.contentstreamid = :contentStreamId')
+            ->where('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
-        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint);
+        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint);
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
         }
@@ -694,9 +694,9 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->node(), 'p', 'p.relationanchorpoint = h.parentnodeanchor')
             ->innerJoin('n', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'ph', 'ph.childnodeanchor = p.relationanchorpoint')
-            ->where('h.contentstreamid = :contentStreamId')
+            ->where('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash')
-            ->andWhere('ph.contentstreamid = :contentStreamId')
+            ->andWhere('ph.contentstreamdbid = :contentStreamDbId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')
             ->andWhere('p.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial);
@@ -706,11 +706,11 @@ final class ContentSubgraph implements ContentSubgraphInterface
             ->from('tree', 'pn')
             ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('pn', $this->nodeQueryBuilder->tableNames->node(), 'cn', 'cn.relationanchorpoint = h.childnodeanchor')
-            ->where('h.contentstreamid = :contentStreamId')
+            ->where('h.contentstreamdbid = :contentStreamDbId')
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash');
         $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
-        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamId, $this->dimensionSpacePoint, 'tree', 'n');
+        $queryBuilderCte = $this->nodeQueryBuilder->buildBasicNodesCteQuery($entryNodeAggregateId, $this->contentStreamDbId, $this->dimensionSpacePoint, 'tree', 'n');
         if ($filter->nodeTypes !== null) {
             $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager));
         }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
 use Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphProjection;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRecord;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
@@ -26,7 +27,6 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 
 /**
  * The read only content graph for use by the {@see DoctrineDbalContentGraphProjection}. This is the class for low-level operations
@@ -51,14 +51,14 @@ class ProjectionContentGraph
      *     correct)
      */
     public function findParentNode(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeAggregateId $childNodeAggregateId,
         OriginDimensionSpacePoint $originDimensionSpacePoint,
         ?DimensionSpacePoint $coveredDimensionSpacePoint = null
     ): ?NodeRecord {
         $parentNodeStatement = <<<SQL
             SELECT
-                p.*, ph.contentstreamid, ph.subtreetags, dsp.dimensionspacepoint AS origindimensionspacepoint
+                p.*, ph.contentstreamdbid, ph.subtreetags, dsp.dimensionspacepoint AS origindimensionspacepoint
             FROM
                 {$this->tableNames->node()} p
                 INNER JOIN {$this->tableNames->hierarchyRelation()} ph ON ph.childnodeanchor = p.relationanchorpoint
@@ -68,27 +68,27 @@ class ProjectionContentGraph
             WHERE
                 c.nodeaggregateid = :childNodeAggregateId
                 AND c.origindimensionspacepointhash = :originDimensionSpacePointHash
-                AND ph.contentstreamid = :contentStreamId
-                AND ch.contentstreamid = :contentStreamId
+                AND ph.contentstreamdbid = :contentStreamDbId
+                AND ch.contentstreamdbid = :contentStreamDbId
                 AND ph.dimensionspacepointhash = :coveredDimensionSpacePointHash
                 AND ch.dimensionspacepointhash = :coveredDimensionSpacePointHash
         SQL;
         try {
             $nodeRow = $this->dbal->fetchAssociative($parentNodeStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'childNodeAggregateId' => $childNodeAggregateId->value,
                 'originDimensionSpacePointHash' => $originDimensionSpacePoint->hash,
                 'coveredDimensionSpacePointHash' => $coveredDimensionSpacePoint->hash ?? $originDimensionSpacePoint->hash
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load parent node for content stream %s, child node aggregate id %s, origin dimension space point %s from database: %s', $contentStreamId->value, $childNodeAggregateId->value, $originDimensionSpacePoint->toJson(), $e->getMessage()), 1716475976, $e);
+            throw new \RuntimeException(sprintf('Failed to load parent node for content stream %s, child node aggregate id %s, origin dimension space point %s from database: %s', $contentStreamDbId->value, $childNodeAggregateId->value, $originDimensionSpacePoint->toJson(), $e->getMessage()), 1716475976, $e);
         }
 
         return $nodeRow ? NodeRecord::fromDatabaseRow($nodeRow) : null;
     }
 
     public function findNodeInAggregate(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeAggregateId $nodeAggregateId,
         DimensionSpacePoint $coveredDimensionSpacePoint
     ): ?NodeRecord {
@@ -101,17 +101,17 @@ class ProjectionContentGraph
                 INNER JOIN {$this->tableNames->dimensionSpacePoints()} dsp ON n.origindimensionspacepointhash = dsp.hash
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
         SQL;
         try {
             $nodeRow = $this->dbal->fetchAssociative($nodeInAggregateStatement, [
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'dimensionSpacePointHash' => $coveredDimensionSpacePoint->hash
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load node for content stream %s, aggregate id %s and covered dimension space point %s from database: %s', $contentStreamId->value, $nodeAggregateId->value, $coveredDimensionSpacePoint->toJson(), $e->getMessage()), 1716474165, $e);
+            throw new \RuntimeException(sprintf('Failed to load node for content stream %s, aggregate id %s and covered dimension space point %s from database: %s', $contentStreamDbId->value, $nodeAggregateId->value, $coveredDimensionSpacePoint->toJson(), $e->getMessage()), 1716474165, $e);
         }
 
         return $nodeRow ? NodeRecord::fromDatabaseRow($nodeRow) : null;
@@ -120,7 +120,7 @@ class ProjectionContentGraph
     public function getAnchorPointForNodeAndOriginDimensionSpacePointAndContentStream(
         NodeAggregateId $nodeAggregateId,
         OriginDimensionSpacePoint $originDimensionSpacePoint,
-        ContentStreamId $contentStreamId
+        ContentStreamDbId $contentStreamDbId
     ): ?NodeRelationAnchorPoint {
         $relationAnchorPointsStatement = <<<SQL
             SELECT
@@ -131,20 +131,20 @@ class ProjectionContentGraph
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
                 AND n.origindimensionspacepointhash = :originDimensionSpacePointHash
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
         SQL;
         try {
             $relationAnchorPoints = $this->dbal->fetchFirstColumn($relationAnchorPointsStatement, [
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'originDimensionSpacePointHash' => $originDimensionSpacePoint->hash,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load node anchor points for content stream %s, node aggregate %s and origin dimension space point %s from database: %s', $contentStreamId->value, $nodeAggregateId->value, $originDimensionSpacePoint->toJson(), $e->getMessage()), 1716474224, $e);
+            throw new \RuntimeException(sprintf('Failed to load node anchor points for content stream %s, node aggregate %s and origin dimension space point %s from database: %s', $contentStreamDbId->value, $nodeAggregateId->value, $originDimensionSpacePoint->toJson(), $e->getMessage()), 1716474224, $e);
         }
 
         if (count($relationAnchorPoints) > 1) {
-            throw new \RuntimeException(sprintf('More than one node anchor point for content stream: %s, node aggregate id: %s and origin dimension space point: %s – this should not happen and might be a conceptual problem!', $contentStreamId->value, $nodeAggregateId->value, $originDimensionSpacePoint->toJson()), 1716474484);
+            throw new \RuntimeException(sprintf('More than one node anchor point for content stream: %s, node aggregate id: %s and origin dimension space point: %s – this should not happen and might be a conceptual problem!', $contentStreamDbId->value, $nodeAggregateId->value, $originDimensionSpacePoint->toJson()), 1716474484);
         }
         return $relationAnchorPoints === [] ? null : NodeRelationAnchorPoint::fromInteger($relationAnchorPoints[0]);
     }
@@ -154,7 +154,7 @@ class ProjectionContentGraph
      */
     public function getAnchorPointsForNodeAggregateInContentStream(
         NodeAggregateId $nodeAggregateId,
-        ContentStreamId $contentStreamId
+        ContentStreamDbId $contentStreamDbId
     ): iterable {
         $relationAnchorPointsStatement = <<<SQL
             SELECT
@@ -164,15 +164,15 @@ class ProjectionContentGraph
                 INNER JOIN {$this->tableNames->hierarchyRelation()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
         SQL;
         try {
             $relationAnchorPoints = $this->dbal->fetchFirstColumn($relationAnchorPointsStatement, [
                 'nodeAggregateId' => $nodeAggregateId->value,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load node anchor points for content stream %s and node aggregate id %s from database: %s', $contentStreamId->value, $nodeAggregateId->value, $e->getMessage()), 1716474706, $e);
+            throw new \RuntimeException(sprintf('Failed to load node anchor points for content stream %s and node aggregate id %s from database: %s', $contentStreamDbId->value, $nodeAggregateId->value, $e->getMessage()), 1716474706, $e);
         }
 
         return array_map(NodeRelationAnchorPoint::fromInteger(...), $relationAnchorPoints);
@@ -204,7 +204,7 @@ class ProjectionContentGraph
         ?NodeRelationAnchorPoint $parentAnchorPoint,
         ?NodeRelationAnchorPoint $childAnchorPoint,
         ?NodeRelationAnchorPoint $succeedingSiblingAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint
     ): int {
         if (!$parentAnchorPoint && !$childAnchorPoint) {
@@ -221,18 +221,18 @@ class ProjectionContentGraph
                     {$this->tableNames->hierarchyRelation()} h
                 WHERE
                     h.childnodeanchor = :succeedingSiblingAnchorPoint
-                    AND h.contentstreamid = :contentStreamId
+                    AND h.contentstreamdbid = :contentStreamDbId
                     AND h.dimensionspacepointhash = :dimensionSpacePointHash
             SQL;
             try {
                 /** @var array<string,mixed> $succeedingSiblingRelation */
                 $succeedingSiblingRelation = $this->dbal->fetchAssociative($succeedingSiblingRelationStatement, [
                     'succeedingSiblingAnchorPoint' => $succeedingSiblingAnchorPoint->value,
-                    'contentStreamId' => $contentStreamId->value,
+                    'contentStreamDbId' => $contentStreamDbId->value,
                     'dimensionSpacePointHash' => $dimensionSpacePoint->hash
                 ]);
             } catch (DBALException $e) {
-                throw new \RuntimeException(sprintf('Failed to load succeeding sibling relations for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamId->value, $succeedingSiblingAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716474854, $e);
+                throw new \RuntimeException(sprintf('Failed to load succeeding sibling relations for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamDbId->value, $succeedingSiblingAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716474854, $e);
             }
 
             if (!$succeedingSiblingRelation) {
@@ -252,19 +252,19 @@ class ProjectionContentGraph
                     {$this->tableNames->hierarchyRelation()} h
                 WHERE
                     h.parentnodeanchor = :anchorPoint
-                    AND h.contentstreamid = :contentStreamId
+                    AND h.contentstreamdbid = :contentStreamDbId
                     AND h.dimensionspacepointhash = :dimensionSpacePointHash
                     AND h.position < :position
             SQL;
             try {
                 $precedingSiblingData = $this->dbal->fetchAssociative($precedingSiblingStatement, [
                     'anchorPoint' => $parentAnchorPoint->value,
-                    'contentStreamId' => $contentStreamId->value,
+                    'contentStreamDbId' => $contentStreamDbId->value,
                     'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
                     'position' => $succeedingSiblingPosition
                 ]);
             } catch (DBALException $e) {
-                throw new \RuntimeException(sprintf('Failed to load preceding sibling relations for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamId->value, $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716474957, $e);
+                throw new \RuntimeException(sprintf('Failed to load preceding sibling relations for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamDbId->value, $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716474957, $e);
             }
             $precedingSiblingPosition = $precedingSiblingData ? ($precedingSiblingData['position'] ?? null) : null;
             if (!is_null($precedingSiblingPosition)) {
@@ -285,18 +285,18 @@ class ProjectionContentGraph
                         {$this->tableNames->hierarchyRelation()} h
                     WHERE
                         h.childnodeanchor = :childAnchorPoint
-                        AND h.contentstreamid = :contentStreamId
+                        AND h.contentstreamdbid = :contentStreamDbId
                         AND h.dimensionspacepointhash = :dimensionSpacePointHash
                 SQL;
                 try {
                     /** @var array<string,mixed> $childHierarchyRelationData */
                     $childHierarchyRelationData = $this->dbal->fetchAssociative($childHierarchyRelationStatement, [
                         'childAnchorPoint' => $childAnchorPoint->value,
-                        'contentStreamId' => $contentStreamId->value,
+                        'contentStreamDbId' => $contentStreamDbId->value,
                         'dimensionSpacePointHash' => $dimensionSpacePoint->hash
                     ]);
                 } catch (DBALException $e) {
-                    throw new \RuntimeException(sprintf('Failed to load child hierarchy relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamId->value, $childAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475001, $e);
+                    throw new \RuntimeException(sprintf('Failed to load child hierarchy relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamDbId->value, $childAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475001, $e);
                 }
                 $parentAnchorPoint = NodeRelationAnchorPoint::fromInteger(
                     $childHierarchyRelationData['parentnodeanchor']
@@ -309,17 +309,17 @@ class ProjectionContentGraph
                     {$this->tableNames->hierarchyRelation()} h
                 WHERE
                     h.parentnodeanchor = :parentAnchorPoint
-                    AND h.contentstreamid = :contentStreamId
+                    AND h.contentstreamdbid = :contentStreamDbId
                     AND h.dimensionspacepointhash = :dimensionSpacePointHash
             SQL;
             try {
                 $rightmostSucceedingSiblingRelationData = $this->dbal->fetchAssociative($rightmostSucceedingSiblingRelationStatement, [
                     'parentAnchorPoint' => $parentAnchorPoint->value,
-                    'contentStreamId' => $contentStreamId->value,
+                    'contentStreamDbId' => $contentStreamDbId->value,
                     'dimensionSpacePointHash' => $dimensionSpacePoint->hash
                 ]);
             } catch (DBALException $e) {
-                throw new \RuntimeException(sprintf('Failed to right most succeeding relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamId->value, $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475046, $e);
+                throw new \RuntimeException(sprintf('Failed to right most succeeding relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamDbId->value, $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475046, $e);
             }
 
             if ($rightmostSucceedingSiblingRelationData) {
@@ -338,7 +338,7 @@ class ProjectionContentGraph
      */
     public function getOutgoingHierarchyRelationsForNodeAndSubgraph(
         NodeRelationAnchorPoint $parentAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint
     ): array {
         $outgoingHierarchyRelationsStatement = <<<SQL
@@ -348,17 +348,17 @@ class ProjectionContentGraph
                 {$this->tableNames->hierarchyRelation()} h
             WHERE
                 h.parentnodeanchor = :parentAnchorPoint
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
         SQL;
         try {
             $rows = $this->dbal->fetchAllAssociative($outgoingHierarchyRelationsStatement, [
                 'parentAnchorPoint' => $parentAnchorPoint->value,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'dimensionSpacePointHash' => $dimensionSpacePoint->hash
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load outgoing hierarchy relations for content stream %s, parent anchor point %s and dimension space point %s from database: %s', $contentStreamId->value, $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475151, $e);
+            throw new \RuntimeException(sprintf('Failed to load outgoing hierarchy relations for content stream %s, parent anchor point %s and dimension space point %s from database: %s', $contentStreamDbId->value, $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475151, $e);
         }
         return array_map($this->mapRawDataToHierarchyRelation(...), $rows);
     }
@@ -368,7 +368,7 @@ class ProjectionContentGraph
      */
     public function getIngoingHierarchyRelationsForNodeAndSubgraph(
         NodeRelationAnchorPoint $childAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         DimensionSpacePoint $dimensionSpacePoint
     ): array {
         $ingoingHierarchyRelationsStatement = <<<SQL
@@ -378,17 +378,17 @@ class ProjectionContentGraph
                 {$this->tableNames->hierarchyRelation()} h
             WHERE
                 h.childnodeanchor = :childAnchorPoint
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash = :dimensionSpacePointHash
         SQL;
         try {
             $rows = $this->dbal->fetchAllAssociative($ingoingHierarchyRelationsStatement, [
                 'childAnchorPoint' => $childAnchorPoint->value,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'dimensionSpacePointHash' => $dimensionSpacePoint->hash
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, child anchor point %s and dimension space point %s from database: %s', $contentStreamId->value, $childAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475151, $e);
+            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, child anchor point %s and dimension space point %s from database: %s', $contentStreamDbId->value, $childAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475151, $e);
         }
         return array_map($this->mapRawDataToHierarchyRelation(...), $rows);
     }
@@ -398,7 +398,7 @@ class ProjectionContentGraph
      */
     public function findIngoingHierarchyRelationsForNode(
         NodeRelationAnchorPoint $childAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         ?DimensionSpacePointSet $restrictToSet = null
     ): array {
         $ingoingHierarchyRelationsStatement = <<<SQL
@@ -408,11 +408,11 @@ class ProjectionContentGraph
                 {$this->tableNames->hierarchyRelation()} h
             WHERE
                 h.childnodeanchor = :childAnchorPoint
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
         SQL;
         $parameters = [
             'childAnchorPoint' => $childAnchorPoint->value,
-            'contentStreamId' => $contentStreamId->value
+            'contentStreamDbId' => $contentStreamDbId->value
         ];
         $types = [];
 
@@ -424,7 +424,7 @@ class ProjectionContentGraph
         try {
             $rows = $this->dbal->fetchAllAssociative($ingoingHierarchyRelationsStatement, $parameters, $types);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, child anchor point %s and dimension space points %s from database: %s', $contentStreamId->value, $childAnchorPoint->value, $restrictToSet?->toJson() ?? '[any]', $e->getMessage()), 1716476299, $e);
+            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, child anchor point %s and dimension space points %s from database: %s', $contentStreamDbId->value, $childAnchorPoint->value, $restrictToSet?->toJson() ?? '[any]', $e->getMessage()), 1716476299, $e);
         }
         $relations = [];
         foreach ($rows as $row) {
@@ -438,7 +438,7 @@ class ProjectionContentGraph
      */
     public function findOutgoingHierarchyRelationsForNode(
         NodeRelationAnchorPoint $parentAnchorPoint,
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         ?DimensionSpacePointSet $restrictToSet = null
     ): array {
         $outgoingHierarchyRelationsStatement = <<<SQL
@@ -448,11 +448,11 @@ class ProjectionContentGraph
                 {$this->tableNames->hierarchyRelation()} h
             WHERE
                 h.parentnodeanchor = :parentAnchorPoint
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
         SQL;
         $parameters = [
             'parentAnchorPoint' => $parentAnchorPoint->value,
-            'contentStreamId' => $contentStreamId->value
+            'contentStreamDbId' => $contentStreamDbId->value
         ];
         $types = [];
 
@@ -464,7 +464,7 @@ class ProjectionContentGraph
         try {
             $rows = $this->dbal->fetchAllAssociative($outgoingHierarchyRelationsStatement, $parameters, $types);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load outgoing hierarchy relations for content stream %s, parent anchor point %s and dimension space points %s from database: %s', $contentStreamId->value, $parentAnchorPoint->value, $restrictToSet?->toJson() ?? '[any]', $e->getMessage()), 1716476573, $e);
+            throw new \RuntimeException(sprintf('Failed to load outgoing hierarchy relations for content stream %s, parent anchor point %s and dimension space points %s from database: %s', $contentStreamDbId->value, $parentAnchorPoint->value, $restrictToSet?->toJson() ?? '[any]', $e->getMessage()), 1716476573, $e);
         }
         $relations = [];
         foreach ($rows as $row) {
@@ -477,7 +477,7 @@ class ProjectionContentGraph
      * @return array<HierarchyRelation>
      */
     public function findOutgoingHierarchyRelationsForNodeAggregate(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeAggregateId $nodeAggregateId,
         DimensionSpacePointSet $dimensionSpacePointSet
     ): array {
@@ -489,19 +489,19 @@ class ProjectionContentGraph
                 INNER JOIN {$this->tableNames->node()} n ON h.parentnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
                 AND h.dimensionspacepointhash IN (:dimensionSpacePointHashes)
         SQL;
         try {
             $rows = $this->dbal->fetchAllAssociative($outgoingHierarchyRelationsStatement, [
                 'nodeAggregateId' => $nodeAggregateId->value,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'dimensionSpacePointHashes' => $dimensionSpacePointSet->getPointHashes()
             ], [
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING
             ]);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load outgoing hierarchy relations for content stream %s, node aggregate id %s and dimension space points %s from database: %s', $contentStreamId->value, $nodeAggregateId->value, $dimensionSpacePointSet->toJson(), $e->getMessage()), 1716476690, $e);
+            throw new \RuntimeException(sprintf('Failed to load outgoing hierarchy relations for content stream %s, node aggregate id %s and dimension space points %s from database: %s', $contentStreamDbId->value, $nodeAggregateId->value, $dimensionSpacePointSet->toJson(), $e->getMessage()), 1716476690, $e);
         }
         return array_map($this->mapRawDataToHierarchyRelation(...), $rows);
     }
@@ -510,7 +510,7 @@ class ProjectionContentGraph
      * @return array<HierarchyRelation>
      */
     public function findIngoingHierarchyRelationsForNodeAggregate(
-        ContentStreamId $contentStreamId,
+        ContentStreamDbId $contentStreamDbId,
         NodeAggregateId $nodeAggregateId,
         ?DimensionSpacePointSet $dimensionSpacePointSet = null
     ): array {
@@ -522,11 +522,11 @@ class ProjectionContentGraph
                 INNER JOIN {$this->tableNames->node()} n ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
-                AND h.contentstreamid = :contentStreamId
+                AND h.contentstreamdbid = :contentStreamDbId
         SQL;
         $parameters = [
             'nodeAggregateId' => $nodeAggregateId->value,
-            'contentStreamId' => $contentStreamId->value,
+            'contentStreamDbId' => $contentStreamDbId->value,
         ];
         $types = [];
         if ($dimensionSpacePointSet !== null) {
@@ -537,33 +537,33 @@ class ProjectionContentGraph
         try {
             $rows = $this->dbal->fetchAllAssociative($ingoingHierarchyRelationsStatement, $parameters, $types);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, node aggregate id %s and dimension space points %s from database: %s', $contentStreamId->value, $nodeAggregateId->value, $dimensionSpacePointSet?->toJson() ?? '[any]', $e->getMessage()), 1716476743, $e);
+            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, node aggregate id %s and dimension space points %s from database: %s', $contentStreamDbId->value, $nodeAggregateId->value, $dimensionSpacePointSet?->toJson() ?? '[any]', $e->getMessage()), 1716476743, $e);
         }
         return array_map($this->mapRawDataToHierarchyRelation(...), $rows);
     }
 
     /**
-     * @return array<ContentStreamId>
+     * @return array<ContentStreamDbId>
      */
-    public function getAllContentStreamIdsAnchorPointIsContainedIn(
+    public function getAllContentStreamDbIdsAnchorPointIsContainedIn(
         NodeRelationAnchorPoint $nodeRelationAnchorPoint
     ): array {
-        $contentStreamIdsStatement = <<<SQL
+        $contentStreamDbIdsStatement = <<<SQL
             SELECT
-                DISTINCT h.contentstreamid
+                DISTINCT h.contentstreamdbid
             FROM
                 {$this->tableNames->hierarchyRelation()} h
             WHERE
                 h.childnodeanchor = :nodeRelationAnchorPoint
         SQL;
         try {
-            $contentStreamIds = $this->dbal->fetchFirstColumn($contentStreamIdsStatement, [
+            $contentStreamDbIds = $this->dbal->fetchFirstColumn($contentStreamDbIdsStatement, [
                 'nodeRelationAnchorPoint' => $nodeRelationAnchorPoint->value,
             ]);
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to load content stream ids for relation anchor point %s from database: %s', $nodeRelationAnchorPoint->value, $e->getMessage()), 1716478504, $e);
         }
-        return array_map(ContentStreamId::fromString(...), $contentStreamIds);
+        return array_map(ContentStreamDbId::fromInt(...), $contentStreamDbIds);
     }
 
     /**
@@ -590,7 +590,7 @@ class ProjectionContentGraph
         return new HierarchyRelation(
             NodeRelationAnchorPoint::fromInteger((int)$rawData['parentnodeanchor']),
             NodeRelationAnchorPoint::fromInteger((int)$rawData['childnodeanchor']),
-            ContentStreamId::fromString($rawData['contentstreamid']),
+            ContentStreamDbId::fromInt((int)$rawData['contentstreamdbid']),
             DimensionSpacePoint::fromJsonString($dimensionSpacePointJson),
             $rawData['dimensionspacepointhash'],
             (int)$rawData['position'],

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -7,6 +7,7 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindRootNodeAggregatesFilter;
@@ -27,7 +28,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\Search
 use Neos\ContentRepository\Core\SharedModel\Id\UuidFactory;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Dbal\DbalSchemaFactory;
 
 /**
@@ -44,36 +44,36 @@ final readonly class NodeQueryBuilder
     public function buildBasicNodeAggregateQuery(): QueryBuilder
     {
         return $this->createQueryBuilder()
-            ->select('n.*, h.contentstreamid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->select('n.*, h.contentstreamdbid, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'n')
             ->innerJoin('n', $this->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
             ->innerJoin('h', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = h.dimensionspacepointhash')
-            ->where('h.contentstreamid = :contentStreamId');
+            ->where('h.contentstreamdbid = :contentStreamDbId');
     }
 
-    public function buildChildNodeAggregateQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamId $contentStreamId): QueryBuilder
+    public function buildChildNodeAggregateQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamDbId $contentStreamDbId): QueryBuilder
     {
         return $this->createQueryBuilder()
-            ->select('cn.*, ch.contentstreamid, ch.subtreetags, cdsp.dimensionspacepoint AS covereddimensionspacepoint')
+            ->select('cn.*, ch.contentstreamdbid, ch.subtreetags, cdsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'pn')
             ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'ch', 'ch.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('ch', $this->tableNames->dimensionSpacePoints(), 'cdsp', 'cdsp.hash = ch.dimensionspacepointhash')
             ->innerJoin('ch', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
             ->where('pn.nodeaggregateid = :parentNodeAggregateId')
-            ->andWhere('ch.contentstreamid = :contentStreamId')
+            ->andWhere('ch.contentstreamdbid = :contentStreamDbId')
             ->orderBy('ch.position')
             ->setParameters([
                 'parentNodeAggregateId' => $parentNodeAggregateId->value,
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
             ]);
     }
 
-    public function buildFindRootNodeAggregatesQuery(ContentStreamId $contentStreamId, FindRootNodeAggregatesFilter $filter): QueryBuilder
+    public function buildFindRootNodeAggregatesQuery(ContentStreamDbId $contentStreamDbId, FindRootNodeAggregatesFilter $filter): QueryBuilder
     {
         $queryBuilder = $this->buildBasicNodeAggregateQuery()
             ->andWhere('h.parentnodeanchor = :rootEdgeParentAnchorId')
             ->setParameters([
-                'contentStreamId' => $contentStreamId->value,
+                'contentStreamDbId' => $contentStreamDbId->value,
                 'rootEdgeParentAnchorId' => NodeRelationAnchorPoint::forRootEdge()->value,
             ]);
 
@@ -84,17 +84,17 @@ final readonly class NodeQueryBuilder
         return $queryBuilder;
     }
 
-    public function buildBasicNodeQuery(ContentStreamId $contentStreamId, DimensionSpacePoint $dimensionSpacePoint, string $nodeTableAlias = 'n', string $select = 'n.*, h.subtreetags'): QueryBuilder
+    public function buildBasicNodeQuery(ContentStreamDbId $contentStreamDbId, DimensionSpacePoint $dimensionSpacePoint, string $nodeTableAlias = 'n', string $select = 'n.*, h.subtreetags'): QueryBuilder
     {
         return $this->createQueryBuilder()
             ->select($select)
             ->from($this->tableNames->node(), $nodeTableAlias)
             ->innerJoin($nodeTableAlias, $this->tableNames->hierarchyRelation(), 'h', 'h.childnodeanchor = ' . $nodeTableAlias . '.relationanchorpoint')
-            ->where('h.contentstreamid = :contentStreamId')->setParameter('contentStreamId', $contentStreamId->value)
+            ->where('h.contentstreamdbid = :contentStreamDbId')->setParameter('contentStreamDbId', $contentStreamDbId->value)
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash')->setParameter('dimensionSpacePointHash', $dimensionSpacePoint->hash);
     }
 
-    public function buildBasicChildNodesQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamId $contentStreamId, DimensionSpacePoint $dimensionSpacePoint): QueryBuilder
+    public function buildBasicChildNodesQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamDbId $contentStreamDbId, DimensionSpacePoint $dimensionSpacePoint): QueryBuilder
     {
         return $this->createQueryBuilder()
             ->select('n.*, h.subtreetags')
@@ -102,11 +102,11 @@ final readonly class NodeQueryBuilder
             ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'h', 'h.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('pn', $this->tableNames->node(), 'n', 'h.childnodeanchor = n.relationanchorpoint')
             ->where('pn.nodeaggregateid = :parentNodeAggregateId')->setParameter('parentNodeAggregateId', $parentNodeAggregateId->value)
-            ->andWhere('h.contentstreamid = :contentStreamId')->setParameter('contentStreamId', $contentStreamId->value)
+            ->andWhere('h.contentstreamdbid = :contentStreamDbId')->setParameter('contentStreamDbId', $contentStreamDbId->value)
             ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash')->setParameter('dimensionSpacePointHash', $dimensionSpacePoint->hash);
     }
 
-    public function buildBasicParentNodeQuery(NodeAggregateId $childNodeAggregateId, ContentStreamId $contentStreamId, DimensionSpacePoint $dimensionSpacePoint): QueryBuilder
+    public function buildBasicParentNodeQuery(NodeAggregateId $childNodeAggregateId, ContentStreamDbId $contentStreamDbId, DimensionSpacePoint $dimensionSpacePoint): QueryBuilder
     {
         return $this->createQueryBuilder()
             ->select('pn.*, ch.subtreetags')
@@ -115,37 +115,37 @@ final readonly class NodeQueryBuilder
             ->innerJoin('pn', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = ph.childnodeanchor')
             ->innerJoin('pn', $this->tableNames->hierarchyRelation(), 'ch', 'ch.childnodeanchor = pn.relationanchorpoint')
             ->where('cn.nodeaggregateid = :childNodeAggregateId')->setParameter('childNodeAggregateId', $childNodeAggregateId->value)
-            ->andWhere('ph.contentstreamid = :contentStreamId')->setParameter('contentStreamId', $contentStreamId->value)
-            ->andWhere('ch.contentstreamid = :contentStreamId')
+            ->andWhere('ph.contentstreamdbid = :contentStreamDbId')->setParameter('contentStreamDbId', $contentStreamDbId->value)
+            ->andWhere('ch.contentstreamdbid = :contentStreamDbId')
             ->andWhere('ph.dimensionspacepointhash = :dimensionSpacePointHash')->setParameter('dimensionSpacePointHash', $dimensionSpacePoint->hash)
             ->andWhere('ch.dimensionspacepointhash = :dimensionSpacePointHash');
     }
 
-    public function buildBasicNodeSiblingsQuery(bool $preceding, NodeAggregateId $siblingNodeAggregateId, ContentStreamId $contentStreamId, DimensionSpacePoint $dimensionSpacePoint): QueryBuilder
+    public function buildBasicNodeSiblingsQuery(bool $preceding, NodeAggregateId $siblingNodeAggregateId, ContentStreamDbId $contentStreamDbId, DimensionSpacePoint $dimensionSpacePoint): QueryBuilder
     {
         $sharedSubQuery = $this->createQueryBuilder()
             ->from($this->tableNames->hierarchyRelation(), 'sh')
             ->innerJoin('sh', $this->tableNames->node(), 'sn', 'sn.relationanchorpoint = sh.childnodeanchor')
             ->where('sn.nodeaggregateid = :siblingNodeAggregateId')
-            ->andWhere('sh.contentstreamid = :contentStreamId')
+            ->andWhere('sh.contentstreamdbid = :contentStreamDbId')
             ->andWhere('sh.dimensionspacepointhash = :dimensionSpacePointHash');
 
         $parentNodeAnchorSubQuery = (clone $sharedSubQuery)->select('sh.parentnodeanchor');
         $siblingPositionSubQuery = (clone $sharedSubQuery)->select('sh.position');
 
-        return $this->buildBasicNodeQuery($contentStreamId, $dimensionSpacePoint)
+        return $this->buildBasicNodeQuery($contentStreamDbId, $dimensionSpacePoint)
             ->andWhere('h.parentnodeanchor = (' . $parentNodeAnchorSubQuery->getSQL() . ')')
             ->andWhere('n.nodeaggregateid != :siblingNodeAggregateId')->setParameter('siblingNodeAggregateId', $siblingNodeAggregateId->value)
             ->andWhere('h.position ' . ($preceding ? '<' : '>') . ' (' . $siblingPositionSubQuery->getSQL() . ')')
             ->orderBy('h.position', $preceding ? 'DESC' : 'ASC');
     }
 
-    public function buildBasicNodesCteQuery(NodeAggregateId $entryNodeAggregateId, ContentStreamId $contentStreamId, DimensionSpacePoint $dimensionSpacePoint, string $cteName = 'ancestry', string $cteAlias = 'pn'): QueryBuilder
+    public function buildBasicNodesCteQuery(NodeAggregateId $entryNodeAggregateId, ContentStreamDbId $contentStreamDbId, DimensionSpacePoint $dimensionSpacePoint, string $cteName = 'ancestry', string $cteAlias = 'pn'): QueryBuilder
     {
         return $this->createQueryBuilder()
             ->select('*')
             ->from($cteName, $cteAlias)
-            ->setParameter('contentStreamId', $contentStreamId->value)
+            ->setParameter('contentStreamDbId', $contentStreamDbId->value)
             ->setParameter('dimensionSpacePointHash', $dimensionSpacePoint->hash)
             ->setParameter('entryNodeAggregateId', $entryNodeAggregateId->value);
     }


### PR DESCRIPTION
Adjust hierarchy relation table to use auto-incrementing number as alias for ContentStreamId which is a uuid or rather any string.
Motivation was to reduce size and load on the hierarchy tables which are huge anyway.
Also during reading we do query the ContentStreamId for the requested workspace (see getContentGraph) now querying the internal ContentStreamDbId instead for all read operations is no overhead.

Update: Neos Sprint CH.

This change will be taken as base for https://github.com/neos/neos-development-collection/pull/5776 but itself is not to be merged.
