### PR TITLE
FEATURE: Add backend document node link to workspace breadcrumb

### DIFF
--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewDocumentTableRow.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewDocumentTableRow.fusion
@@ -13,6 +13,15 @@ prototype(Neos.Workspace.Ui:Component.ReviewDocumentTableRow) < prototype(Neos.F
   @private {
     i18n = ${I18n.id('').source('Main').package('Neos.Workspace.Ui')}
 
+    openNodeInBackendAction = Neos.Fusion:ActionUri {
+      request = ${request.mainRequest}
+      package = 'Neos.Neos.Ui'
+      controller = 'Backend'
+      action = 'index'
+      arguments {
+        node = ${document.document.documentNodeAddress}
+      }
+    }
     openNodeInPreviewAction = Neos.Fusion:ActionUri {
       request = ${request.mainRequest}
       package = 'Neos.Neos'
@@ -75,7 +84,16 @@ prototype(Neos.Workspace.Ui:Component.ReviewDocumentTableRow) < prototype(Neos.F
               <i @if.nodeIsHidden={document.documentChanges.isHidden} class="icon-red fa-solid fa-circle-xmark"></i>
             </span>
             <span>
-              {crumb}
+              <a
+                href={private.openNodeInBackendAction}
+                target="_blank"
+                @if.isLast={iterator.isLast}
+                @if.notRemoved={!document.documentChanges.isRemoved}>
+                {crumb}
+              </a>
+              <span @if.shouldRenderAsSpan={!iterator.isLast || document.documentChanges.isRemoved}>
+                {crumb}
+              </span>
             </span>
           </span>
         </Neos.Fusion:Loop>


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

This PR introduces a small quality of life improvement to the workspace review process.
The final document node of a changes breadcrumb is now a link to the document inside the neos backend, allowing editors to quickly jump back to the document and make changes.

resolved: #5737

<img width="765" height="326" alt="546057539-864e2b33-8365-4cb6-aac7-11f6e1ba0da1" src="https://github.com/user-attachments/assets/569935fa-c148-42bb-bc08-0304fb6239ec" />


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
