### PR TITLE
TASK: Improve pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,10 @@
 
 - [ ] Code follows the PSR-2 coding style
 - [ ] Tests have been created, run and adjusted as needed
-- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
+- [ ] The PR is created against the correct branch:
+  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
+  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
+  - If it's a breaking feature it should typically go into the next major version
 - [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
 - [ ] Reviewer - The first section explains the change briefly for change-logs
 - [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

While working on my first feature I noticed that the various contribution guidelines sometimes contradict each other or are not perfectly clear.

This PR is part of trying to improve this for the forking/branching-model. However I am not sure if I've got the facts right in the first place 😅 - @Sebobo ?

Furthermore I do think it would be useful to consolidate all of that information into one single source of truth instead of having it repeated across multiple pages.
Apart from the pr-template these are some of the pages which are being referenced across various docs:
- https://discuss.neos.io/t/creating-a-pull-request/506 (referenced by [this discuss post](https://discuss.neos.io/t/code-contribution-guideline/503), which istelf is being referenced by [the contribution guidelines in this repo](https://github.com/neos/neos-development-collection/blob/9.0/CONTRIBUTING.md)
- https://docs.neos.io/guide/contributing-to-neos/neos-core#contribution-workflow

In my opinion it would probably make the most sense, if all necessary information was part of the `CONTRIBUTING.md`-file. The neos docs site could also be shortened and just point to the markdown file. I would also remove the links to these discuss posts and just make sure that all information is part of the markdown file and up to date.
The CONTRIBUTING.md file is typically the documentation I would be looking for when contributing to open source and standard practice. Though having a couple of lines directly inside the neos docs to point newcomers to this resource would still definitely make sense.

What do you think?