### PR TITLE
BUGFIX: MariaDB platform detection in Doctrine migrations

### DIFF
--- a/Neos.Neos/Migrations/Mysql/Version20150224171107.php
+++ b/Neos.Neos/Migrations/Mysql/Version20150224171107.php
@@ -1,7 +1,7 @@
 <?php
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
-use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
@@ -24,11 +24,11 @@ class Version20150224171107 extends AbstractMigration
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event DROP persistence_object_identifier, CHANGE parentevent parentevent INT UNSIGNED DEFAULT NULL, CHANGE uid uid INT UNSIGNED AUTO_INCREMENT NOT NULL");
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ADD CONSTRAINT FK_30AB3A75B684C08 FOREIGN KEY (parentevent) REFERENCES typo3_neos_eventlog_domain_model_event (uid)");
         $indexes = $this->sm->listTableIndexes('typo3_neos_eventlog_domain_model_event');
-        if (array_key_exists('uid', $indexes) && $this->connection->getDatabasePlatform() instanceof MariaDBPlatform) {
+        if (array_key_exists('uid', $indexes) && $this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
             $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event DROP INDEX uid, ADD INDEX olduid (uid)");
         }
         $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event ADD PRIMARY KEY (uid)");
-        if (array_key_exists('uid', $indexes) && $this->connection->getDatabasePlatform() instanceof MariaDBPlatform) {
+        if (array_key_exists('uid', $indexes) && $this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
             $this->addSql("ALTER TABLE typo3_neos_eventlog_domain_model_event DROP INDEX olduid");
         }
     }

--- a/Neos.Neos/Migrations/Mysql/Version20150309215317.php
+++ b/Neos.Neos/Migrations/Mysql/Version20150309215317.php
@@ -1,7 +1,7 @@
 <?php
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
-use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
@@ -38,7 +38,7 @@ class Version20150309215317 extends AbstractMigration
             $this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT typo3_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
         }
         $indexes = $this->sm->listTableIndexes('typo3_neos_eventlog_domain_model_event');
-        if (array_key_exists('uid', $indexes) && $this->connection->getDatabasePlatform() instanceof MariaDBPlatform) {
+        if (array_key_exists('uid', $indexes) && $this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
             $this->addSql("DROP INDEX uid ON typo3_neos_eventlog_domain_model_event");
         }
     }


### PR DESCRIPTION
## Summary

Fixes MariaDB platform detection issues in Doctrine migrations that cause "Incorrect index name 'uid'" errors when running migrations on empty databases.

**Root Cause:** 
- `MariaDb1027Platform` (used by current MariaDB versions) is not an instance of `MariaDBPlatform`
- It inherits from `MySqlPlatform` instead
- This causes conditional logic for handling existing 'uid' indexes to be skipped
- Results in SQL errors when trying to add PRIMARY KEY on 'uid' column

**Solution:**
- Change platform detection from `MariaDBPlatform` to `MySqlPlatform`
- This correctly identifies both MySQL and MariaDB platforms since MariaDB platforms inherit from `MySqlPlatform`
- Ensures proper index cleanup before adding PRIMARY KEY constraints

## Files Changed

- `Neos.Neos/Migrations/Mysql/Version20150224171107.php`
- `Neos.Neos/Migrations/Mysql/Version20150309215317.php`

## Test Plan

- [x] Verified fix works on MariaDB 10.11.10 (MariaDb1027Platform)
- [x] Confirmed `MariaDb1027Platform instanceof MySqlPlatform` returns `true`
- [x] Tested migration runs successfully on empty database
- [x] Verified existing index cleanup logic now executes correctly

## Technical Details

The issue occurs because:
1. Initial migration creates `uid` column with `AUTO_INCREMENT UNIQUE` 
2. This implicitly creates an index named 'uid'
3. Later migration tries to add `PRIMARY KEY (uid)` 
4. Without proper index cleanup, this causes name conflict
5. Platform detection was failing, so cleanup was skipped

The fix ensures the cleanup logic runs on all MySQL-compatible platforms.