### PR TITLE
BUGFIX: Variadic argument in SubtreeTags::with()

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
@@ -64,7 +64,7 @@ final readonly class SubtreeTags implements \IteratorAggregate, \Countable, \Jso
         if ($this->contain($subtreeTagToAdd)) {
             return $this;
         }
-        return new self(...[...$this->tags, $subtreeTagToAdd]);
+        return new self(...$this->tags, ...[$subtreeTagToAdd]);
     }
 
     public function without(SubtreeTag $subtreeTagToRemove): self

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/Dto/SubtreeTags.php
@@ -64,7 +64,7 @@ final readonly class SubtreeTags implements \IteratorAggregate, \Countable, \Jso
         if ($this->contain($subtreeTagToAdd)) {
             return $this;
         }
-        return new self(...$this->tags, ...[$subtreeTagToAdd]);
+        return new self(...[...array_values($this->tags), $subtreeTagToAdd]);
     }
 
     public function without(SubtreeTag $subtreeTagToRemove): self

--- a/Neos.ContentRepository.Core/Tests/Unit/Feature/SubtreeTagging/Dto/SubtreeTagsTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/Feature/SubtreeTagging/Dto/SubtreeTagsTest.php
@@ -27,6 +27,24 @@ class SubtreeTagsTest extends TestCase
     /**
      * @test
      */
+    public function withReturnsSameInstanceIfSpecifiedTagIsContained(): void
+    {
+        $tags = SubtreeTags::fromStrings('foo', 'bar');
+        self::assertSame($tags, $tags->with(SubtreeTag::fromString('foo')));
+    }
+
+    /**
+     * @test
+     */
+    public function withReturnsNewInstanceForAddedTag(): void
+    {
+        $tags = SubtreeTags::fromStrings('foo', 'bar');
+        self::assertSame(['foo', 'bar', 'baz'], $tags->with(SubtreeTag::fromString('baz'))->toStringArray());
+    }
+
+    /**
+     * @test
+     */
     public function withoutReturnsSameInstanceIfSpecifiedTagIsNotContained(): void
     {
         $tags = SubtreeTags::fromStrings('foo', 'bar');


### PR DESCRIPTION
This fixes https://github.com/neos/neos-development-collection/issues/5748 by unwrapping the existing subtreeTags and the subtreeTagsToAdd in a different manner.

Resolves `PHP Fatal error: Cannot use positional argument after argument unpacking` when using the FlowQuery ContextOperation with `{invisibleContentShown: false}`