### PR TITLE
BUGFIX: Stabilize Workspace preview for broken assets

### DIFF
--- a/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
+++ b/Neos.Neos/Classes/Controller/Module/Management/WorkspacesController.php
@@ -11,6 +11,8 @@ namespace Neos\Neos\Controller\Module\Management;
  * source code.
  */
 
+use Doctrine\ORM\EntityNotFoundException;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Neos\Diff\Diff;
 use Neos\Diff\Renderer\Html\HtmlArrayRenderer;
 use Neos\Eel\FlowQuery\FlowQuery;
@@ -628,15 +630,15 @@ class WorkspacesController extends AbstractModuleController
                 $contentChanges[$propertyName] = [
                     'type' => 'image',
                     'propertyLabel' => $this->getPropertyLabel($propertyName, $changedNode),
-                    'original' => $originalPropertyValue,
-                    'changed' => $changedPropertyValue
+                    'original' => $this->loadAsset($originalPropertyValue),
+                    'changed' => $this->loadAsset($changedPropertyValue)
                 ];
             } elseif ($originalPropertyValue instanceof AssetInterface || $changedPropertyValue instanceof AssetInterface) {
                 $contentChanges[$propertyName] = [
                     'type' => 'asset',
                     'propertyLabel' => $this->getPropertyLabel($propertyName, $changedNode),
-                    'original' => $originalPropertyValue,
-                    'changed' => $changedPropertyValue
+                    'original' => $this->loadAsset($originalPropertyValue),
+                    'changed' => $this->loadAsset($changedPropertyValue)
                 ];
             } elseif ($originalPropertyValue instanceof \DateTime || $changedPropertyValue instanceof \DateTime) {
                 $changed = false;
@@ -656,6 +658,18 @@ class WorkspacesController extends AbstractModuleController
             }
         }
         return $contentChanges;
+    }
+
+    protected function loadAsset(AssetInterface|null $assetOrNull): AssetInterface|string|null
+    {
+        if ($assetOrNull instanceof DoctrineProxy) {
+            try {
+                $assetOrNull->__load();
+            } catch (EntityNotFoundException $e) {
+                return $e->getMessage();
+            }
+        }
+        return $assetOrNull;
     }
 
     /**

--- a/Neos.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
+++ b/Neos.Neos/Resources/Private/Partials/Module/Management/Workspaces/ContentChangeDiff.html
@@ -48,14 +48,11 @@
                         <table>
                             <tr>
                                 <td>
-                                    <f:if condition="{contentChanges.original}">
-                                        <m:image image="{contentChanges.original}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
-                                    </f:if>
+                                    <f:render section="renderImage" arguments="{image: contentChanges.original}" />"
                                 </td>
                                 <td>
-                                    <f:if condition="{contentChanges.changed}">
-                                        <m:image image="{contentChanges.changed}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
-                                    </f:if>
+                                    <f:render section="renderImage" arguments="{image: contentChanges.changed}" />"
+
                                 </td>
                             </tr>
                         </table>
@@ -65,12 +62,12 @@
                             <tr>
                                 <td>
                                     <f:if condition="{contentChanges.original}">
-                                        <del><a href="{f:uri.resource(resource: contentChanges.original.resource)}">{contentChanges.original.resource.filename}</a></del>
+                                        <f:render section="renderAssetLink" arguments="{asset: contentChanges.original, mode: 'del'}" />
                                     </f:if>
                                 </td>
                                 <td>
                                     <f:if condition="{contentChanges.changed}">
-                                        <ins><a href="{f:uri.resource(resource: contentChanges.changed.resource)}">{contentChanges.changed.resource.filename}</a></ins>
+                                        <f:render section="renderAssetLink" arguments="{asset: contentChanges.changed, mode: 'ins'}" />
                                     </f:if>
                               </td>
                           </tr>
@@ -93,3 +90,28 @@
         </f:for>
     </table>
 </div>
+
+<f:section name="renderImage">
+    <f:if condition="{image}">
+        <f:if condition="{image -> neos:getType()} == 'string'">
+            <f:then>
+                <span class="neos-label-important">{image}</span>
+            </f:then>
+            <f:else>
+                <m:image image="{image}" allowCropping="false" maximumWidth="500" maximumHeight="500" alt=""/>
+            </f:else>
+        </f:if>
+    </f:if>
+</f:section>
+<f:section name="renderAssetLink">
+    <f:if condition="{asset}">
+        <f:if condition="{asset -> neos:getType()} == 'string'">
+            <f:then>
+                <span class="neos-label-important">{asset}</span>
+            </f:then>
+            <f:else>
+                <{mode}><a href="{f:uri.resource(resource: asset.resource)}">{asset.resource.filename}</a></{mode}>
+            </f:else>
+        </f:if>
+    </f:if>
+</f:section>


### PR DESCRIPTION
Prevents missing assets from throwing an exception when trying to review workspace changes:

### Before

<img width="978" height="340" alt="image" src="https://github.com/user-attachments/assets/5d06b99a-ccbe-43df-b71f-9e05b1783dc6" />

### With fix

<img width="1842" height="1127" alt="image" src="https://github.com/user-attachments/assets/e33818ad-5d0e-4653-9c51-d753f44ec078" />

Fixes: #5754