### PR TITLE
BUGFIX: Resolve proptype errors in Workspace.Ui

### DIFF
--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Create.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Create.fusion
@@ -91,7 +91,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.Create) < prototype(Neos.Fusion:Comp
                 field.name="visibility"
                 field.value="shared"
               >
-                {private.i18n.id('workspaces.workspace.visibility.shared')}
+                {private.i18n.id('workspaces.workspace.visibility.shared').translate()}
               </Neos.Fusion.Form:Radio>
               <p>
                 {private.i18n.id('workspaces.workspace.visibility.shared.help')}
@@ -101,7 +101,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.Create) < prototype(Neos.Fusion:Comp
                 field.name="visibility"
                 field.value="private"
               >
-                {private.i18n.id('workspaces.workspace.visibility.private')}
+                {private.i18n.id('workspaces.workspace.visibility.private').translate()}
               </Neos.Fusion.Form:Radio>
               <p>
                 {private.i18n.id('workspaces.workspace.visibility.private.help')}
@@ -119,7 +119,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.Create) < prototype(Neos.Fusion:Comp
             {private.i18n.id('cancel')}
           </button>
           <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">
-            {private.i18n.id('workspaces.createWorkspace')}
+            {private.i18n.id('workspaces.createWorkspace').translate()}
           </Neos.Fusion.Form:Button>
         </footer>
       </Neos.Fusion.Form:Form>

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Edit.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Edit.fusion
@@ -122,14 +122,14 @@ prototype(Neos.Workspace.Ui:Component.Modal.Edit) < prototype(Neos.Fusion:Compon
               field.name="visibility"
             >
               <Neos.Fusion.Form:Radio field.value="shared">
-                {private.i18n.id('workspaces.workspace.visibility.shared')}
+                {private.i18n.id('workspaces.workspace.visibility.shared').translate()}
               </Neos.Fusion.Form:Radio>
               <p>
                 {private.i18n.id('workspaces.workspace.visibility.shared.help')}
               </p>
               <br/>
               <Neos.Fusion.Form:Radio field.value="private">
-                {private.i18n.id('workspaces.workspace.visibility.private')}
+                {private.i18n.id('workspaces.workspace.visibility.private').translate()}
               </Neos.Fusion.Form:Radio>
               <p>
                 {private.i18n.id('workspaces.workspace.visibility.private.help')}
@@ -147,7 +147,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.Edit) < prototype(Neos.Fusion:Compon
             {private.i18n.id('cancel')}
           </button>
           <Neos.Fusion.Form:Button attributes.class="neos-button neos-button-primary">
-            {private.i18n.id('applyChanges')}
+            {private.i18n.id('applyChanges').translate()}
           </Neos.Fusion.Form:Button>
         </footer>
       </Neos.Fusion.Form:Form>


### PR DESCRIPTION
TranslationParameterToken are not valid as FormElement content and throw Exceptions when the PropTypes package is installed.

Resolves: #5757