### PR TITLE
BUGFIX: Log `fusionPath` when absorbing exceptions during Fusion rendering

### DIFF
--- a/Neos.Fusion/Classes/Core/ExceptionHandlers/AbsorbingHandler.php
+++ b/Neos.Fusion/Classes/Core/ExceptionHandlers/AbsorbingHandler.php
@@ -43,7 +43,7 @@ class AbsorbingHandler extends AbstractRenderingExceptionHandler
     protected function handle($fusionPath, \Exception $exception, $referenceCode)
     {
         $this->systemLogger->debug('Absorbed Exception: ' . $exception->getMessage(), ['fusionPath' => $fusionPath, 'referenceCode' => $referenceCode, 'FLOW_LOG_ENVIRONMENT' => ['packageKey' => 'Neos.Fusion', 'className' => self::class, 'methodName' => 'handle']]);
-        $this->throwableStorage->logThrowable($exception);
+        $this->throwableStorage->logThrowable($exception, ['fusionPath' => $fusionPath, 'referenceCode' => $referenceCode]);
         return '';
     }
 


### PR DESCRIPTION
The `AbsorbingHandler` is active by default and will log the current `fusionPath` and `referenceCode` to the System Log. But it is not logged with the exception itself and there is no way to correlate the two (apart from the timestamp).

This fix adds `fusionPath` and `referenceCode` to the `additionalData` array, making them appear in the exception log, too.