### PR TITLE
BUGFIX: Find reference nodes by their aggregate id

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -172,6 +172,14 @@ class NodesController extends ActionController
                     // include the starting node if it matches
                     $nodes = $nodes->prepend($entryNode);
                 }
+                $nodeAggregateIdOrNull = NodeAggregateId::tryFromString($searchTerm->term);
+                if ($nodeAggregateIdOrNull !== null) {
+                    $nodeByAggregateId = $subgraph->findNodeById($nodeAggregateIdOrNull);
+                    if ($nodeByAggregateId !== null) {
+                        // include node by aggregate id if it matches the search term
+                        $nodes = $nodes->prepend($nodeByAggregateId);
+                    }
+                }
             }
         } else {
             if ($searchTerm->term !== '') {


### PR DESCRIPTION
Adjusts the `nodes` service endpoint to include a node if its id equals the specified search term

Fixes: #5756
Related: https://github.com/neos/neos-ui/pull/4093