### PR TITLE
BUGFIX: Add missing content type header to create-image-variant endpoint

### DIFF
--- a/Neos.Neos/Classes/Controller/Backend/ContentController.php
+++ b/Neos.Neos/Classes/Controller/Backend/ContentController.php
@@ -181,6 +181,7 @@ class ContentController extends ActionController
      */
     public function createImageVariantAction(ImageVariant $asset)
     {
+        $this->response->setContentType('application/json');
         if ($this->persistenceManager->isNewObject($asset)) {
             $this->assetRepository->add($asset);
         }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

### Upgrade instructions

Currently, the enpoint `/neos/content/create-image-variant` does not set a `Content-Type` header and therefore uses the default `text/html` content type. This can lead to issues, if any of the used middlewares require a correct content type to be set. One example could be that you have a middleware that will add an attribute to all `<script>`-Tags if the returned content type is `text/html`. When using the php [DOMDocument](https://www.php.net/manual/en/class.domdocument.php) or sth. similar to parse and update the content, this will result in the response being wrapped by a `<p>`-Tag and therefore returns an error.

### Review instructions

To test this behaviour:

- Add a new middleware.
- Add sth. like the following to this middleware:
  ```php
  use GuzzleHttp\Psr7\Utils;
  
  // ...
  
  public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
  {
      $response = $next->handle($request);
      
      if (str_contains($response->getHeaderLine('Content-Type'), 'text/html')) {
          $content = $response->getBody()->getContents();
          
          // This is one case, that could result in an issue with the current state.
          $dom = new \DOMDocument();
          libxml_use_internal_errors(true);
          $dom->loadHTML($content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
          libxml_use_internal_errors(false);
          
          $scripts = $dom->getElementsByTagName('script');
          foreach ($scripts as $script) {
              $script->setAttribute('x-custom-attribute', 'some-value');
          }

          $newContent = $dom->saveHtml();
          
          $response = $response->withBody(Utils::streamFor($newContent));
      }
      
      return $response;
  }
  ```

### Checklist

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
