### PR TITLE
BUGFIX: (8.3) Avoid orphans when publishing node move

### DIFF
--- a/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
@@ -486,7 +486,7 @@ class Workspace
             // At this point adjustShadowNodeDataForNodePublishing will not yield correct results as we cannot
             // find the _original_ state in the target workspace anymore and have a shadow node in memory already if
             // it was necessary. Therefore we will just delete any possibly existing shadow node in the source workspace.
-            $targetNodeData = $this->moveTargetNodeDataToNewPosition($targetNodeData, $sourceNode->getPath());
+            $targetNodeData = $targetNodeData->move($sourceNode->getPath(), $targetNodeData->getWorkspace());
             $sourceShadowNodeData = $this->nodeDataRepository->findOneByMovedTo($sourceNodeData);
             if ($sourceShadowNodeData !== null) {
                 $this->nodeDataRepository->remove($sourceShadowNodeData);
@@ -543,24 +543,6 @@ class Workspace
                 $nodeDataVariant->setPath($targetPath);
             }
         }
-    }
-
-    /**
-     * Moves an existing node in a target workspace to the place it should be in after publish,
-     * in order to move all children to the new position as well.
-     *
-     * @param NodeData $targetNodeData The (publish-) target node data to be moved
-     * @param string $destinationPath The destination path of the move
-     * @return NodeData Either the same object like $targetNodeData, or, if $targetNodeData was transformed into a shadow node, the new target node (see move())
-     */
-    protected function moveTargetNodeDataToNewPosition(NodeData $targetNodeData, $destinationPath)
-    {
-        if ($targetNodeData->getWorkspace()->getBaseWorkspace() === null) {
-            $targetNodeData->setPath($destinationPath);
-            return $targetNodeData;
-        }
-
-        return $targetNodeData->move($destinationPath, $targetNodeData->getWorkspace());
     }
 
     /**

--- a/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
+++ b/Neos.ContentRepository/Classes/Domain/Model/Workspace.php
@@ -428,6 +428,7 @@ class Workspace
         }
 
         $this->emitAfterNodePublishing($nodeToPublish, $targetWorkspace);
+        $this->nodeDataRepository->persistEntities();
     }
 
     /**

--- a/Neos.ContentRepository/Tests/Behavior/Features/Basic/MoveNode.feature
+++ b/Neos.ContentRepository/Tests/Behavior/Features/Basic/MoveNode.feature
@@ -487,3 +487,25 @@ Feature: Move node
       | live      |
     Then I should have one node
 
+  @fixtures
+  Scenario: Move a node and it's parent separately
+    Given I have the following nodes:
+      | Identifier                           | Path                                               | Node Type                           | Properties            | Workspace   |
+      | 0990ad05-cce6-4241-af8f-f0c77cbd9583 | /sites/content-repository/company/history          | Neos.ContentRepository.Testing:Page | {"title": "history"}  | live |
+    And I get a node by path "/sites/content-repository/company/history" with the following context:
+      | Workspace   |
+      | user-admin |
+    And I move the node into the node with path "/sites/content-repository/about"
+    When I get a node by path "/sites/content-repository/company" with the following context:
+      | Workspace  |
+      | user-admin |
+    And I move the node into the node with path "/sites/content-repository/about"
+    And I publish the workspace "user-admin"
+    When I get a node by path "/sites/content-repository/about/history" with the following context:
+      | Workspace |
+      | live      |
+    Then I should have one node
+    And I get a node by path "/sites/content-repository/about/company" with the following context:
+      | Workspace |
+      | live      |
+    Then I should have one node

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -30,7 +30,6 @@ use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\Workspace;
-use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\Fusion\Core\Cache\ContentCache;
 

--- a/Neos.Neos/Classes/Package.php
+++ b/Neos.Neos/Classes/Package.php
@@ -147,6 +147,5 @@ class Package extends BasePackage
         $dispatcher->connect(Workspace::class, 'baseWorkspaceChanged', RouteCacheFlusher::class, 'registerBaseWorkspaceChange');
 
         $dispatcher->connect(PersistenceManager::class, 'allObjectsPersisted', ContentRepositoryIntegrationService::class, 'updateEventsAfterPublish');
-        $dispatcher->connect(NodeDataRepository::class, 'repositoryObjectsPersisted', ContentRepositoryIntegrationService::class, 'updateEventsAfterPublish');
     }
 }


### PR DESCRIPTION
See issue for detailed explanation. In a nutshell: `NodeData::setPath` is dangerous as it mixes DB queries with memory state and can lead to unexpected results. Using only `NodeData::move` avoids the problem.

Fixes: #5763

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
