### PR TITLE
BUGFIX: Partial Publishing node type changes did not work if child nodes were removed (because constraints did not match anymore)

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/06-PublishNodeTypeChangeWithTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/06-PublishNodeTypeChangeWithTetheredNodes.feature
@@ -1,0 +1,91 @@
+@contentrepository @adapters=DoctrineDBAL
+Feature: Partial publish after node type change tagging tethered children
+
+  Publishing a node type change (Document→Shortcut) that tags tethered children
+  should also correctly handle grandchild nodes that were inside those tethered children.
+
+  See https://github.com/neos/neos-development-collection/pull/5767
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Content':
+      properties:
+        text:
+          type: string
+
+    'Neos.ContentRepository.Testing:ContentCollection':
+      constraints:
+        nodeTypes:
+          'Neos.ContentRepository.Testing:Content': true
+
+    'Neos.ContentRepository.Testing:Document':
+      childNodes:
+        main:
+          type: 'Neos.ContentRepository.Testing:ContentCollection'
+
+    'Neos.ContentRepository.Testing:Shortcut': []
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+  Scenario: Publish node type change from Document to Shortcut that tags tethered child containing a grandchild
+    # Step 1: Create a Document page with a tethered "main" child in the user workspace
+    Given I am in workspace "user-test"
+    And I am in dimension space point {}
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds |
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document | {"main": "main-collection-id"}     |
+
+    # Step 2: Create a Content node inside the tethered "main" collection
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId  | nodeTypeName                           | parentNodeAggregateId | nodeName |
+      | nody-mc-nodeface | Neos.ContentRepository.Testing:Content | main-collection-id    | text1    |
+
+    # Step 3: Change the page's node type to Shortcut (which has no tethered children → tags "main" and cascades to text node)
+    And the command ChangeNodeAggregateType is executed with payload:
+      | Key             | Value                                     |
+      | workspaceName   | "user-test"                               |
+      | nodeAggregateId | "sir-david-nodenborough"                  |
+      | newNodeTypeName | "Neos.ContentRepository.Testing:Shortcut" |
+      | strategy        | "mark_with_tag:removed"                   |
+
+    # Step 4: Partial publish with only the page node ID (simulates what the Neos UI does after resolveNodeIdsToPublishOrDiscard excludes the removed text node)
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                          |
+      | workspaceName                   | "user-test"                    |
+      | nodesToPublish                  | ["sir-david-nodenborough"]     |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
+
+    # Step 5: Assert the publish succeeded — page exists in live as Shortcut, tethered child is tagged (not removed)
+    # nody-mc-nodeface was only created in user-test and was not in nodesToPublish, so it does not exist in live
+    Then I am in workspace "live" and dimension space point {}
+    When VisibilityConstraints are set to "empty"
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to be of type "Neos.ContentRepository.Testing:Shortcut"
+    And I expect the node with aggregate identifier "main-collection-id" to be explicitly tagged "removed"
+
+    # User workspace remaining — nody-mc-nodeface still exists (was not published) and inherits the "removed" tag
+    And I am in workspace "user-test" and dimension space point {}
+    When VisibilityConstraints are set to "empty"
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-remaining;sir-david-nodenborough;{}
+    And I expect this node to be of type "Neos.ContentRepository.Testing:Shortcut"
+    And I expect the node with aggregate identifier "main-collection-id" to be explicitly tagged "removed"
+    And I expect the node with aggregate identifier "nody-mc-nodeface" to inherit the tag "removed"

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
@@ -33,7 +33,7 @@ trait NodeTypeChangeInternals
      * NOTE: when changing this method, also check {@see NodeTypeChange::requireConstraintsImposedByHappyPathStrategyAreMet}
      * which traverses children/grandchildren similarly for validation purposes.
      *
-     * @param \Closure(NodeAggregate, DimensionSpacePointSet): EventInterface $handleNode
+     * @param \Closure(NodeAggregate, DimensionSpacePointSet): EventInterface $handleNodeFn
      * @return array<EventInterface>
      */
     private function handleDisallowedNodesWhenChangingNodeType(

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
@@ -15,9 +15,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
  */
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
-use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
@@ -32,16 +30,18 @@ trait NodeTypeChangeInternals
     use ConstraintChecks;
 
     /**
-     * NOTE: when changing this method, {@see NodeTypeChange::requireConstraintsImposedByHappyPathStrategyAreMet}
-     * needs to be modified as well (as they are structurally the same)
+     * NOTE: when changing this method, also check {@see NodeTypeChange::requireConstraintsImposedByHappyPathStrategyAreMet}
+     * which traverses children/grandchildren similarly for validation purposes.
      *
+     * @param \Closure(NodeAggregate, DimensionSpacePointSet): EventInterface $handleNode
      * @return array<EventInterface>
      */
-    private function deleteDisallowedNodesWhenChangingNodeType(
+    private function handleDisallowedNodesWhenChangingNodeType(
         ContentGraphInterface $contentGraph,
         NodeAggregate $nodeAggregate,
         NodeType $newNodeType,
         NodeAggregateIds &$alreadyRemovedNodeAggregateIds,
+        \Closure $handleNodeFn,
     ): array {
         $events = [];
         // if we have children, we need to check whether they are still allowed
@@ -59,22 +59,18 @@ trait NodeTypeChangeInternals
                     $newNodeType,
                     $this->requireNodeType($childNodeAggregate->nodeTypeName)
                 )
-                // descendants might be disallowed by both parent and grandparent after NodeTypeChange, but must be deleted only once
+                // descendants might be disallowed by both parent and grandparent after NodeTypeChange, but must be handled only once
                 && !$alreadyRemovedNodeAggregateIds->contain($childNodeAggregate->nodeAggregateId)
             ) {
                 // this aggregate (or parts thereof) are DISALLOWED according to constraints.
-                // We now need to find out which edges we need to remove,
-                $dimensionSpacePointsToBeRemoved = $this->findDimensionSpacePointsConnectingParentAndChildAggregate(
+                // We now need to find out which edges we need to handle,
+                $dimensionSpacePoints = $this->findDimensionSpacePointsConnectingParentAndChildAggregate(
                     $contentGraph,
                     $nodeAggregate,
                     $childNodeAggregate
                 );
-                // AND REMOVE THEM
-                $events[] = $this->removeNodeInDimensionSpacePointSet(
-                    $contentGraph,
-                    $childNodeAggregate,
-                    $dimensionSpacePointsToBeRemoved,
-                );
+                // AND HANDLE THEM (e.g. remove or tag)
+                $events[] = $handleNodeFn($childNodeAggregate, $dimensionSpacePoints);
                 $alreadyRemovedNodeAggregateIds = $alreadyRemovedNodeAggregateIds->merge(
                     NodeAggregateIds::create($childNodeAggregate->nodeAggregateId)
                 );
@@ -96,22 +92,18 @@ trait NodeTypeChangeInternals
                         $childNodeAggregate->nodeName,
                         $this->requireNodeType($grandchildNodeAggregate->nodeTypeName)
                     )
-                    // descendants might be disallowed by both parent and grandparent after NodeTypeChange, but must be deleted only once
+                    // descendants might be disallowed by both parent and grandparent after NodeTypeChange, but must be handled only once
                     && !$alreadyRemovedNodeAggregateIds->contain($grandchildNodeAggregate->nodeAggregateId)
                 ) {
                     // this aggregate (or parts thereof) are DISALLOWED according to constraints.
-                    // We now need to find out which edges we need to remove,
-                    $dimensionSpacePointsToBeRemoved = $this->findDimensionSpacePointsConnectingParentAndChildAggregate(
+                    // We now need to find out which edges we need to handle,
+                    $dimensionSpacePoints = $this->findDimensionSpacePointsConnectingParentAndChildAggregate(
                         $contentGraph,
                         $childNodeAggregate,
                         $grandchildNodeAggregate
                     );
-                    // AND REMOVE THEM
-                    $events[] = $this->removeNodeInDimensionSpacePointSet(
-                        $contentGraph,
-                        $grandchildNodeAggregate,
-                        $dimensionSpacePointsToBeRemoved,
-                    );
+                    // AND HANDLE THEM (e.g. remove or tag)
+                    $events[] = $handleNodeFn($grandchildNodeAggregate, $dimensionSpacePoints);
                     $alreadyRemovedNodeAggregateIds = $alreadyRemovedNodeAggregateIds->merge(
                         NodeAggregateIds::create($grandchildNodeAggregate->nodeAggregateId)
                     );
@@ -123,13 +115,15 @@ trait NodeTypeChangeInternals
     }
 
     /**
+     * @param \Closure(NodeAggregate, DimensionSpacePointSet): EventInterface $handleNodeFn
      * @return array<EventInterface>
      */
-    private function deleteObsoleteTetheredNodesWhenChangingNodeType(
+    private function handleObsoleteTetheredNodesWhenChangingNodeType(
         ContentGraphInterface $contentGraph,
         NodeAggregate $nodeAggregate,
         NodeType $newNodeType,
         NodeAggregateIds &$alreadyRemovedNodeAggregateIds,
+        \Closure $handleNodeFn,
     ): array {
         $events = [];
         // find disallowed tethered nodes
@@ -143,18 +137,14 @@ trait NodeTypeChangeInternals
                 && !$alreadyRemovedNodeAggregateIds->contain($tetheredNodeAggregate->nodeAggregateId)
             ) {
                 // this aggregate (or parts thereof) are DISALLOWED according to constraints.
-                // We now need to find out which edges we need to remove,
-                $dimensionSpacePointsToBeRemoved = $this->findDimensionSpacePointsConnectingParentAndChildAggregate(
+                // We now need to find out which edges we need to handle,
+                $dimensionSpacePoints = $this->findDimensionSpacePointsConnectingParentAndChildAggregate(
                     $contentGraph,
                     $nodeAggregate,
                     $tetheredNodeAggregate
                 );
-                // AND REMOVE THEM
-                $events[] = $this->removeNodeInDimensionSpacePointSet(
-                    $contentGraph,
-                    $tetheredNodeAggregate,
-                    $dimensionSpacePointsToBeRemoved,
-                );
+                // AND HANDLE THEM (e.g. remove or tag)
+                $events[] = $handleNodeFn($tetheredNodeAggregate, $dimensionSpacePoints);
                 $alreadyRemovedNodeAggregateIds = $alreadyRemovedNodeAggregateIds->merge(
                     NodeAggregateIds::create($tetheredNodeAggregate->nodeAggregateId)
                 );
@@ -206,18 +196,5 @@ trait NodeTypeChangeInternals
         }
 
         return new DimensionSpacePointSet($points);
-    }
-
-    private function removeNodeInDimensionSpacePointSet(
-        ContentGraphInterface $contentGraph,
-        NodeAggregate $nodeAggregate,
-        DimensionSpacePointSet $coveredDimensionSpacePointsToBeRemoved,
-    ): NodeAggregateWasRemoved {
-        return new NodeAggregateWasRemoved(
-            $contentGraph->getWorkspaceName(),
-            $contentGraph->getContentStreamId(),
-            $nodeAggregate->nodeAggregateId,
-            $coveredDimensionSpacePointsToBeRemoved,
-        );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyV
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
 use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
+use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Event\NodeAggregateTypeWasChanged;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeGeneralizationVariantWasCreated;
@@ -288,7 +289,7 @@ trait TetheredNodeInternals
         NodeTypeName $newNodeTypeName,
         NodeAggregateIdsByNodePaths $nodeAggregateIdsByNodePaths,
         NodePath $currentNodePath,
-        NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $conflictResolutionStrategy,
+        NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy $conflictResolutionStrategy,
         NodeAggregateIds $alreadyRemovedNodeAggregateIds,
     ): Events {
         $events = [];
@@ -331,7 +332,7 @@ trait TetheredNodeInternals
         }
 
         // remove or tag disallowed nodes
-        if ($conflictResolutionStrategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::delete())) {
+        if ($conflictResolutionStrategy === NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE) {
             $handleNode = fn(NodeAggregate $nodeAggregateToDelete, DimensionSpacePointSet $points) => new NodeAggregateWasRemoved(
                 $contentGraph->getWorkspaceName(),
                 $contentGraph->getContentStreamId(),
@@ -341,7 +342,7 @@ trait TetheredNodeInternals
 
             array_push($events, ...$this->handleDisallowedNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $tetheredNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
             array_push($events, ...$this->handleObsoleteTetheredNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $tetheredNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
-        } elseif ($conflictResolutionStrategy->subtreeTag !== null) { // NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::markWithTag
+        } elseif ($conflictResolutionStrategy instanceof NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy) {
             $handleNode = fn(NodeAggregate $nodeAggregateToTag, DimensionSpacePointSet $points) => new SubtreeWasTagged(
                 $contentGraph->getWorkspaceName(),
                 $contentGraph->getContentStreamId(),

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -25,11 +25,13 @@ use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNode
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
+use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Event\NodeAggregateTypeWasChanged;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeGeneralizationVariantWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodePeerVariantWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeSpecializationVariantWasCreated;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\NodeType\TetheredNodeTypeDefinition;
@@ -328,20 +330,27 @@ trait TetheredNodeInternals
             }
         }
 
-        // remove disallowed nodes
-        if ($conflictResolutionStrategy === NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE) {
-            array_push($events, ...$this->deleteDisallowedNodesWhenChangingNodeType(
-                $contentGraph,
-                $nodeAggregate,
-                $tetheredNodeType,
-                $alreadyRemovedNodeAggregateIds
-            ));
-            array_push($events, ...$this->deleteObsoleteTetheredNodesWhenChangingNodeType(
-                $contentGraph,
-                $nodeAggregate,
-                $tetheredNodeType,
-                $alreadyRemovedNodeAggregateIds
-            ));
+        // remove or tag disallowed nodes
+        if ($conflictResolutionStrategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::delete())) {
+            $handleNode = fn(NodeAggregate $nodeAggregateToDelete, DimensionSpacePointSet $points) => new NodeAggregateWasRemoved(
+                $contentGraph->getWorkspaceName(),
+                $contentGraph->getContentStreamId(),
+                $nodeAggregateToDelete->nodeAggregateId,
+                $points,
+            );
+
+            array_push($events, ...$this->handleDisallowedNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $tetheredNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
+            array_push($events, ...$this->handleObsoleteTetheredNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $tetheredNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
+        } elseif ($conflictResolutionStrategy->subtreeTag !== null) { // NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::markWithTag
+            $handleNode = fn(NodeAggregate $nodeAggregateToTag, DimensionSpacePointSet $points) => new SubtreeWasTagged(
+                $contentGraph->getWorkspaceName(),
+                $contentGraph->getContentStreamId(),
+                $nodeAggregateToTag->nodeAggregateId,
+                $points,
+                $conflictResolutionStrategy->subtreeTag,
+            );
+            array_push($events, ...$this->handleDisallowedNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $tetheredNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
+            array_push($events, ...$this->handleObsoleteTetheredNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $tetheredNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
         }
 
         # Handle descendant nodes

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Command/ChangeNodeAggregateType.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Command/ChangeNodeAggregateType.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\NodeTypeChange\Command;
 use Neos\ContentRepository\Core\CommandHandler\CommandInterface;
 use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterface;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Dto\NodeAggregateIdsByNodePaths;
+use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -36,14 +37,14 @@ final readonly class ChangeNodeAggregateType implements
      * @param WorkspaceName $workspaceName The workspace in which the operation is to be performed
      * @param NodeAggregateId $nodeAggregateId The unique identifier of the node aggregate to change
      * @param NodeTypeName $newNodeTypeName Name of the new node type
-     * @param NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $strategy Strategy for conflicts on affected child nodes ({@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy})
+     * @param NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy $strategy Strategy for conflicts on affected child nodes ({@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy})
      * @param NodeAggregateIdsByNodePaths $tetheredDescendantNodeAggregateIds Predefined aggregate ids of any tethered child nodes for the new node type per path. For any tethered node that has no matching entry in this set, the node aggregate id is generated randomly. Since tethered nodes may have tethered child nodes themselves, this works for multiple levels ({@see self::withTetheredDescendantNodeAggregateIds()})
      */
     private function __construct(
         public WorkspaceName $workspaceName,
         public NodeAggregateId $nodeAggregateId,
         public NodeTypeName $newNodeTypeName,
-        public NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $strategy,
+        public NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy $strategy,
         public NodeAggregateIdsByNodePaths $tetheredDescendantNodeAggregateIds,
     ) {
     }
@@ -52,9 +53,9 @@ final readonly class ChangeNodeAggregateType implements
      * @param WorkspaceName $workspaceName The workspace in which the operation is to be performed
      * @param NodeAggregateId $nodeAggregateId The unique identifier of the node aggregate to change
      * @param NodeTypeName $newNodeTypeName Name of the new node type
-     * @param NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $strategy Strategy for conflicts on affected child nodes ({@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy})
+     * @param NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy $strategy Strategy for conflicts on affected child nodes ({@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy})
      */
-    public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, NodeTypeName $newNodeTypeName, NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $strategy): self
+    public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, NodeTypeName $newNodeTypeName, NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy $strategy): self
     {
         return new self($workspaceName, $nodeAggregateId, $newNodeTypeName, $strategy, NodeAggregateIdsByNodePaths::createEmpty());
     }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Command/ChangeNodeAggregateType.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Command/ChangeNodeAggregateType.php
@@ -65,7 +65,7 @@ final readonly class ChangeNodeAggregateType implements
             WorkspaceName::fromString($array['workspaceName']),
             NodeAggregateId::fromString($array['nodeAggregateId']),
             NodeTypeName::fromString($array['newNodeTypeName']),
-            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::from($array['strategy']),
+            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::fromString($array['strategy']),
             isset($array['tetheredDescendantNodeAggregateIds'])
                 ? NodeAggregateIdsByNodePaths::fromArray($array['tetheredDescendantNodeAggregateIds'])
                 : NodeAggregateIdsByNodePaths::createEmpty()

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto;
+
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
+
+/**
+ * Strategy for {@see ChangeNodeAggregateType} that hides newly disallowed child nodes
+ * by tagging them with a SubtreeTag ("soft delete"), instead of removing them outright.
+ *
+ * This is safe for workspace rebase: the node aggregates remain in the graph, so event
+ * references to them are still resolvable. Use this strategy instead of
+ * {@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE}
+ * when users have workspace events that reference nodes inside a tethered child that is
+ * about to be removed by the type change.
+ *
+ * Serialization format: `"mark_with_tag:[tagName]"`, e.g. `"mark_with_tag:disabled"`
+ *
+ * @api DTO of {@see ChangeNodeAggregateType} command
+ */
+final readonly class NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy implements \JsonSerializable
+{
+    /** @internal used by {@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::fromString()} */
+    public const string SERIALIZATION_PREFIX = 'mark_with_tag:';
+
+    public function __construct(public readonly SubtreeTag $subtreeTag)
+    {
+    }
+
+    /**
+     * Reconstruct from a serialized string of the form `"mark_with_tag:[tagName]"`.
+     *
+     * @throws \InvalidArgumentException for malformed values
+     */
+    public static function fromString(string $value): self
+    {
+        if (!str_starts_with($value, self::SERIALIZATION_PREFIX)) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid mark-with-tag strategy value "%s". Expected format: "mark_with_tag:[tagName]".', $value),
+            );
+        }
+        $tagName = substr($value, strlen(self::SERIALIZATION_PREFIX));
+        if ($tagName === '') {
+            throw new \InvalidArgumentException(
+                'Invalid mark-with-tag strategy value: tag name must not be empty. Expected format: "mark_with_tag:[tagName]".',
+            );
+        }
+        return new self(SubtreeTag::fromString($tagName));
+    }
+
+    public function jsonSerialize(): string
+    {
+        return self::SERIALIZATION_PREFIX . $this->subtreeTag->value;
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy.php
@@ -33,7 +33,7 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 final readonly class NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy implements \JsonSerializable
 {
     /** @internal used by {@see NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::fromString()} */
-    public const string SERIALIZATION_PREFIX = 'mark_with_tag:';
+    public const SERIALIZATION_PREFIX = 'mark_with_tag:';
 
     public function __construct(public readonly SubtreeTag $subtreeTag)
     {

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
@@ -14,138 +14,59 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto;
 
-use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
-
 /**
  * The strategy how to handle node type constraint conflicts with already present child nodes
  * when changing a node aggregate's type.
  *
  * - delete will delete all newly disallowed child nodes
+ * - markWithTag will hide disallowed child nodes via a SubtreeTag (soft delete), safe for workspace rebase
  *
- * Serialization format:
- * - All strategies except `markWithTag` serialize to a fixed string, e.g. `"delete"`.
- * - The `markWithTag` strategy serializes to "mark_with_tag:[tagname]
+ * @see NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy for the mark-with-tag strategy
  *
  * @api DTO of {@see ChangeNodeAggregateType} command
  */
-final class NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy implements \JsonSerializable
+enum NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy: string implements \JsonSerializable
 {
-    private const STRATEGY_DELETE = 'delete';
-    private const STRATEGY_MARK_WITH_TAG = 'mark_with_tag';
-    private const STRATEGY_HAPPY_PATH = 'happypath';
-    private const STRATEGY_PROMISED_CASCADE = 'promisedCascade';
-
-    private const VALID_VALUES = [
-        self::STRATEGY_DELETE,
-        self::STRATEGY_MARK_WITH_TAG,
-        self::STRATEGY_HAPPY_PATH,
-        self::STRATEGY_PROMISED_CASCADE,
-    ];
-
-    /** @var array<string, self> */
-    private static array $instances = [];
-
-    private function __construct(
-        private readonly string $value,
-        public readonly SubtreeTag|null $subtreeTag
-    ) {
-    }
-
-    private static function instance(string $value): self
-    {
-        return self::$instances[$value] ??= new self($value, null);
-    }
-
     /**
      * This strategy means "we remove all children / grandchildren nodes which do not match the constraint"
      */
-    public static function delete(): self
-    {
-        return self::instance(self::STRATEGY_DELETE);
-    }
-
-    /**
-     * This strategy means "we mark children with a special SubtreeTag"
-     */
-    public static function markWithTag(SubtreeTag $tag): self
-    {
-        return new self(self::STRATEGY_MARK_WITH_TAG, $tag);
-    }
+    case STRATEGY_DELETE = 'delete';
 
     /**
      * This strategy means "we only change the NodeAggregateType if all constraints of parents
      * AND children and grandchildren are still respected."
      */
-    public static function happyPath(): self
-    {
-        return self::instance(self::STRATEGY_HAPPY_PATH);
-    }
+    case STRATEGY_HAPPY_PATH = 'happypath';
 
     /**
      * This strategy extends happypath by expecting that identically typed children will also be changed, affecting validation.
      * Required e.g. for global type change transformations
      */
-    public static function promisedCascade(): self
-    {
-        return self::instance(self::STRATEGY_PROMISED_CASCADE);
-    }
+    case STRATEGY_PROMISED_CASCADE = 'promisedCascade';
 
     /**
-     * Reconstruct from a serialized string.
+     * Reconstruct from a serialized string. Acts as the single deserialization entry point for all strategies,
+     * including the mark-with-tag strategy which produces a {@see NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy}.
      *
      * Accepts:
      *   - `"delete"`, `"happypath"`, `"promisedCascade"` — plain strategy strings
-     *   - `"mark_with_tag"` — legacy form, tag will be null
-     *   - `"mark_with_tag:[tagName]"` — full form with SubtreeTag
+     *   - `"mark_with_tag:[tagName]"` — produces a NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy
      *
      * @throws \InvalidArgumentException for unknown or malformed values
      */
-    public static function fromString(string $value): self
+    public static function fromString(string $value): self|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy
     {
-        if (str_starts_with($value, self::STRATEGY_MARK_WITH_TAG . ':')) {
-            $tagName = substr($value, strlen(self::STRATEGY_MARK_WITH_TAG) + 1);
-            if ($tagName === '') {
-                throw new \InvalidArgumentException(
-                    'Invalid strategy value: tag name must not be empty in "mark_with_tag:[tagName]".'
-                );
-            }
-            return self::markWithTag(SubtreeTag::fromString($tagName));
+        if (str_starts_with($value, NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy::SERIALIZATION_PREFIX)) {
+            return NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy::fromString($value);
         }
-
-        if (!in_array($value, self::VALID_VALUES, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Invalid strategy value "%s". Valid values are: %s, or "mark_with_tag:[tagName]".',
-                    $value,
-                    implode(', ', self::VALID_VALUES)
-                )
-            );
-        }
-
-        return self::instance($value);
+        return self::from($value);
     }
 
     /**
-     * Serialize to a plain string for JSON encoding.
-     *
-     * - All strategies except `markWithTag` serialize to their string value (e.g. `"delete"`),
-     *   preserving full backwards-compatibility.
-     * - `markWithTag` with a tag serializes to `"mark_with_tag:[tagName]"`.
-     * - `markWithTag` without a tag (legacy) serializes to the bare `"mark_with_tag"` string.
-     *
-     * Deserialization counterpart: {@see fromString()}.
+     * @return string
      */
     public function jsonSerialize(): string
     {
-        if ($this->value === self::STRATEGY_MARK_WITH_TAG && $this->subtreeTag !== null) {
-            return self::STRATEGY_MARK_WITH_TAG . ':' . $this->subtreeTag->value;
-        }
-
         return $this->value;
-    }
-
-    public function equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $other): bool
-    {
-        return $this->jsonSerialize() === $other->jsonSerialize();
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
@@ -46,10 +46,9 @@ final class NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy imp
     private static array $instances = [];
 
     private function __construct(
-        private readonly string         $value,
+        private readonly string $value,
         public readonly SubtreeTag|null $subtreeTag
-    )
-    {
+    ) {
     }
 
     private static function instance(string $value): self

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
@@ -14,38 +14,139 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto;
 
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
+
 /**
  * The strategy how to handle node type constraint conflicts with already present child nodes
  * when changing a node aggregate's type.
  *
  * - delete will delete all newly disallowed child nodes
  *
+ * Serialization format:
+ * - All strategies except `markWithTag` serialize to a fixed string, e.g. `"delete"`.
+ * - The `markWithTag` strategy serializes to "mark_with_tag:[tagname]
+ *
  * @api DTO of {@see ChangeNodeAggregateType} command
  */
-enum NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy: string implements \JsonSerializable
+final class NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy implements \JsonSerializable
 {
+    private const string STRATEGY_DELETE = 'delete';
+    private const string STRATEGY_MARK_WITH_TAG = 'mark_with_tag';
+    private const string STRATEGY_HAPPY_PATH = 'happypath';
+    private const string STRATEGY_PROMISED_CASCADE = 'promisedCascade';
+
+    private const array VALID_VALUES = [
+        self::STRATEGY_DELETE,
+        self::STRATEGY_MARK_WITH_TAG,
+        self::STRATEGY_HAPPY_PATH,
+        self::STRATEGY_PROMISED_CASCADE,
+    ];
+
+    /** @var array<string, self> */
+    private static array $instances = [];
+
+    private function __construct(
+        private readonly string         $value,
+        public readonly SubtreeTag|null $subtreeTag
+    )
+    {
+    }
+
+    private static function instance(string $value): self
+    {
+        return self::$instances[$value] ??= new self($value, null);
+    }
+
     /**
      * This strategy means "we remove all children / grandchildren nodes which do not match the constraint"
      */
-    case STRATEGY_DELETE = 'delete';
+    public static function delete(): self
+    {
+        return self::instance(self::STRATEGY_DELETE);
+    }
+
+    /**
+     * This strategy means "we mark children with a special SubtreeTag"
+     */
+    public static function markWithTag(SubtreeTag $tag): self
+    {
+        return new self(self::STRATEGY_MARK_WITH_TAG, $tag);
+    }
 
     /**
      * This strategy means "we only change the NodeAggregateType if all constraints of parents
      * AND children and grandchildren are still respected."
      */
-    case STRATEGY_HAPPY_PATH = 'happypath';
+    public static function happyPath(): self
+    {
+        return self::instance(self::STRATEGY_HAPPY_PATH);
+    }
 
     /**
      * This strategy extends happypath by expecting that identically typed children will also be changed, affecting validation.
      * Required e.g. for global type change transformations
      */
-    case STRATEGY_PROMISED_CASCADE = 'promisedCascade';
+    public static function promisedCascade(): self
+    {
+        return self::instance(self::STRATEGY_PROMISED_CASCADE);
+    }
 
     /**
-     * @return string
+     * Reconstruct from a serialized string.
+     *
+     * Accepts:
+     *   - `"delete"`, `"happypath"`, `"promisedCascade"` — plain strategy strings
+     *   - `"mark_with_tag"` — legacy form, tag will be null
+     *   - `"mark_with_tag:[tagName]"` — full form with SubtreeTag
+     *
+     * @throws \InvalidArgumentException for unknown or malformed values
+     */
+    public static function fromString(string $value): self
+    {
+        if (str_starts_with($value, self::STRATEGY_MARK_WITH_TAG . ':')) {
+            $tagName = substr($value, strlen(self::STRATEGY_MARK_WITH_TAG) + 1);
+            if ($tagName === '') {
+                throw new \InvalidArgumentException(
+                    'Invalid strategy value: tag name must not be empty in "mark_with_tag:[tagName]".'
+                );
+            }
+            return self::markWithTag(SubtreeTag::fromString($tagName));
+        }
+
+        if (!in_array($value, self::VALID_VALUES, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid strategy value "%s". Valid values are: %s, or "mark_with_tag:[tagName]".',
+                    $value,
+                    implode(', ', self::VALID_VALUES)
+                )
+            );
+        }
+
+        return self::instance($value);
+    }
+
+    /**
+     * Serialize to a plain string for JSON encoding.
+     *
+     * - All strategies except `markWithTag` serialize to their string value (e.g. `"delete"`),
+     *   preserving full backwards-compatibility.
+     * - `markWithTag` with a tag serializes to `"mark_with_tag:[tagName]"`.
+     * - `markWithTag` without a tag (legacy) serializes to the bare `"mark_with_tag"` string.
+     *
+     * Deserialization counterpart: {@see fromString()}.
      */
     public function jsonSerialize(): string
     {
+        if ($this->value === self::STRATEGY_MARK_WITH_TAG && $this->subtreeTag !== null) {
+            return self::STRATEGY_MARK_WITH_TAG . ':' . $this->subtreeTag->value;
+        }
+
         return $this->value;
+    }
+
+    public function equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $other): bool
+    {
+        return $this->jsonSerialize() === $other->jsonSerialize();
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/Dto/NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy.php
@@ -30,12 +30,12 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
  */
 final class NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy implements \JsonSerializable
 {
-    private const string STRATEGY_DELETE = 'delete';
-    private const string STRATEGY_MARK_WITH_TAG = 'mark_with_tag';
-    private const string STRATEGY_HAPPY_PATH = 'happypath';
-    private const string STRATEGY_PROMISED_CASCADE = 'promisedCascade';
+    private const STRATEGY_DELETE = 'delete';
+    private const STRATEGY_MARK_WITH_TAG = 'mark_with_tag';
+    private const STRATEGY_HAPPY_PATH = 'happypath';
+    private const STRATEGY_PROMISED_CASCADE = 'promisedCascade';
 
-    private const array VALID_VALUES = [
+    private const VALID_VALUES = [
         self::STRATEGY_DELETE,
         self::STRATEGY_MARK_WITH_TAG,
         self::STRATEGY_HAPPY_PATH,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -30,6 +30,7 @@ use Neos\ContentRepository\Core\Feature\NodeCreation\Dto\NodeAggregateIdsByNodeP
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;
+use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Event\NodeAggregateTypeWasChanged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
@@ -113,7 +114,7 @@ trait NodeTypeChange
         NodeTypeName $newNodeTypeName,
         NodeAggregateIdsByNodePaths $nodeAggregateIdsByNodePaths,
         NodePath $currentNodePath,
-        NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy $conflictResolutionStrategy,
+        NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy|NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy $conflictResolutionStrategy,
         NodeAggregateIds $alreadyRemovedNodeAggregates,
     ): Events;
 
@@ -162,21 +163,23 @@ trait NodeTypeChange
             );
         }
 
-        if ($command->strategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::happyPath())) {
-            $this->requireConstraintsImposedByHappyPathStrategyAreMet(
-                $contentGraph,
-                $nodeAggregate,
-                $newNodeType,
-                null,
-            );
-        } elseif ($command->strategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::promisedCascade())) {
-            $this->requireConstraintsImposedByHappyPathStrategyAreMet(
-                $contentGraph,
-                $nodeAggregate,
-                $newNodeType,
-                $nodeAggregate->nodeTypeName,
-            );
-        }
+        match ($command->strategy) {
+            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_HAPPY_PATH
+                => $this->requireConstraintsImposedByHappyPathStrategyAreMet(
+                    $contentGraph,
+                    $nodeAggregate,
+                    $newNodeType,
+                    null,
+                ),
+            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_PROMISED_CASCADE
+                => $this->requireConstraintsImposedByHappyPathStrategyAreMet(
+                    $contentGraph,
+                    $nodeAggregate,
+                    $newNodeType,
+                    $nodeAggregate->nodeTypeName,
+                ),
+            default => null,
+        };
 
         /**************
          * Preparation - make the command fully deterministic in case of rebase
@@ -232,7 +235,7 @@ trait NodeTypeChange
 
         // remove or tag disallowed nodes
         $alreadyRemovedNodeAggregateIds = NodeAggregateIds::createEmpty();
-        if ($command->strategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::delete())) {
+        if ($command->strategy === NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE) {
             $handleNode = fn(NodeAggregate $nodeAggregateToDelete, DimensionSpacePointSet $points) => new NodeAggregateWasRemoved(
                 $contentGraph->getWorkspaceName(),
                 $contentGraph->getContentStreamId(),
@@ -242,7 +245,7 @@ trait NodeTypeChange
 
             array_push($events, ...$this->handleDisallowedNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $newNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
             array_push($events, ...$this->handleObsoleteTetheredNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $newNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
-        } elseif ($command->strategy->subtreeTag !== null) { // NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::markWithTag
+        } elseif ($command->strategy instanceof NodeAggregateTypeChangeChildConstraintConflictResolutionMarkWithTagStrategy) {
             $handleNode = fn(NodeAggregate $aggregateToTag, DimensionSpacePointSet $points) => new SubtreeWasTagged(
                 $contentGraph->getWorkspaceName(),
                 $contentGraph->getContentStreamId(),

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -15,11 +15,13 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Feature\NodeTypeChange;
 
 use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
+use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
 use Neos\ContentRepository\Core\Feature\RebaseableCommand;
 use Neos\ContentRepository\Core\Feature\Common\NodeTypeChangeInternals;
 use Neos\ContentRepository\Core\Feature\Common\TetheredNodeInternals;
@@ -30,6 +32,7 @@ use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWer
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Dto\NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Event\NodeAggregateTypeWasChanged;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -159,19 +162,21 @@ trait NodeTypeChange
             );
         }
 
-        match ($command->strategy) {
-            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_HAPPY_PATH,
-            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_PROMISED_CASCADE,
-                => $this->requireConstraintsImposedByHappyPathStrategyAreMet(
-                    $contentGraph,
-                    $nodeAggregate,
-                    $newNodeType,
-                    $command->strategy === NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_PROMISED_CASCADE
-                        ? $nodeAggregate->nodeTypeName
-                        : null,
-                ),
-            NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE => null
-        };
+        if ($command->strategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::happyPath())) {
+            $this->requireConstraintsImposedByHappyPathStrategyAreMet(
+                $contentGraph,
+                $nodeAggregate,
+                $newNodeType,
+                null,
+            );
+        } elseif ($command->strategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::promisedCascade())) {
+            $this->requireConstraintsImposedByHappyPathStrategyAreMet(
+                $contentGraph,
+                $nodeAggregate,
+                $newNodeType,
+                $nodeAggregate->nodeTypeName,
+            );
+        }
 
         /**************
          * Preparation - make the command fully deterministic in case of rebase
@@ -225,21 +230,28 @@ trait NodeTypeChange
             }
         }
 
-        // remove disallowed nodes
+        // remove or tag disallowed nodes
         $alreadyRemovedNodeAggregateIds = NodeAggregateIds::createEmpty();
-        if ($command->strategy === NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE) {
-            array_push($events, ...$this->deleteDisallowedNodesWhenChangingNodeType(
-                $contentGraph,
-                $nodeAggregate,
-                $newNodeType,
-                $alreadyRemovedNodeAggregateIds,
-            ));
-            array_push($events, ...$this->deleteObsoleteTetheredNodesWhenChangingNodeType(
-                $contentGraph,
-                $nodeAggregate,
-                $newNodeType,
-                $alreadyRemovedNodeAggregateIds
-            ));
+        if ($command->strategy->equals(NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::delete())) {
+            $handleNode = fn(NodeAggregate $nodeAggregateToDelete, DimensionSpacePointSet $points) => new NodeAggregateWasRemoved(
+                $contentGraph->getWorkspaceName(),
+                $contentGraph->getContentStreamId(),
+                $nodeAggregateToDelete->nodeAggregateId,
+                $points,
+            );
+
+            array_push($events, ...$this->handleDisallowedNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $newNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
+            array_push($events, ...$this->handleObsoleteTetheredNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $newNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
+        } elseif ($command->strategy->subtreeTag !== null) { // NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::markWithTag
+            $handleNode = fn(NodeAggregate $aggregateToTag, DimensionSpacePointSet $points) => new SubtreeWasTagged(
+                $contentGraph->getWorkspaceName(),
+                $contentGraph->getContentStreamId(),
+                $aggregateToTag->nodeAggregateId,
+                $points,
+                $command->strategy->subtreeTag,
+            );
+            array_push($events, ...$this->handleDisallowedNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $newNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
+            array_push($events, ...$this->handleObsoleteTetheredNodesWhenChangingNodeType($contentGraph, $nodeAggregate, $newNodeType, $alreadyRemovedNodeAggregateIds, $handleNode));
         }
 
         // handle (missing) tethered node aggregates
@@ -286,8 +298,8 @@ trait NodeTypeChange
     }
 
     /**
-     * NOTE: when changing this method, {@see NodeTypeChange::deleteDisallowedNodesWhenChangingNodeType}
-     * needs to be modified as well (as they are structurally the same)
+     * NOTE: when changing this method, also check {@see NodeTypeChangeInternals::handleDisallowedNodesWhenChangingNodeType}
+     * which applies the same traversal pattern to produce events.
      * @throws NodeConstraintException|NodeTypeNotFound
      */
     private function requireConstraintsImposedByHappyPathStrategyAreMet(

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
@@ -35,10 +35,10 @@ class ChangeNodeTypeTransformationFactory implements TransformationFactoryInterf
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         // by default, we won't delete anything.
         $nodeAggregateTypeChangeChildConstraintConflictResolutionStrategy
-            = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::promisedCascade();
+            = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_PROMISED_CASCADE;
         if (isset($settings['forceDeleteNonMatchingChildren']) && $settings['forceDeleteNonMatchingChildren']) {
             $nodeAggregateTypeChangeChildConstraintConflictResolutionStrategy
-                = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::delete();
+                = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE;
         }
 
         return new class (

--- a/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
+++ b/Neos.ContentRepository.NodeMigration/src/Transformation/ChangeNodeTypeTransformationFactory.php
@@ -35,10 +35,10 @@ class ChangeNodeTypeTransformationFactory implements TransformationFactoryInterf
     ): GlobalTransformationInterface|NodeAggregateBasedTransformationInterface|NodeBasedTransformationInterface {
         // by default, we won't delete anything.
         $nodeAggregateTypeChangeChildConstraintConflictResolutionStrategy
-            = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_PROMISED_CASCADE;
+            = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::promisedCascade();
         if (isset($settings['forceDeleteNonMatchingChildren']) && $settings['forceDeleteNonMatchingChildren']) {
             $nodeAggregateTypeChangeChildConstraintConflictResolutionStrategy
-                = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::STRATEGY_DELETE;
+                = NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy::delete();
         }
 
         return new class (

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -110,12 +110,13 @@ trait CRTestSuiteRuntimeVariables
     }
 
     /**
-     * @When /^VisibilityConstraints are set to "(withoutRestrictions|default)"$/
+     * @When /^VisibilityConstraints are set to "(withoutRestrictions|empty|default)"$/
      */
     public function visibilityConstraintsAreSetTo(string $restrictionType): void
     {
         $this->currentVisibilityConstraints = match ($restrictionType) {
             'withoutRestrictions' => VisibilityConstraints::withoutRestrictions(),
+            'empty' => VisibilityConstraints::createEmpty(),
             'default' => VisibilityConstraints::default(),
             default => throw new \InvalidArgumentException('Visibility constraint "' . $restrictionType . '" not supported.'),
         };

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/05-PublishNodeTypeChangeWithTetheredNodes_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/05-PublishNodeTypeChangeWithTetheredNodes_WithoutDimensions.feature
@@ -1,0 +1,94 @@
+@contentrepository @adapters=DoctrineDBAL
+@flowEntities
+Feature: Partial publish after node type change tagging tethered nodes (without dimensions)
+
+  Publishing a document whose node type was changed to one with fewer tethered children
+  (using the mark_with_tag:removed strategy) must succeed even when a grandchild node
+  that lived inside the now-removed tethered child still exists in the workspace.
+
+  See https://github.com/neos/neos-development-collection/pull/5767
+
+  Background:
+    Given using no content dimensions
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository:Root': {}
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    'Neos.Neos:Document': {}
+    'Neos.Neos:Content': {}
+    'Neos.Neos:ContentCollection': {}
+    'Neos.ContentRepository.Testing:DocumentWithMain':
+      superTypes:
+        'Neos.Neos:Document': true
+      childNodes:
+        main:
+          type: 'Neos.Neos:ContentCollection'
+    'Neos.ContentRepository.Testing:Content':
+      superTypes:
+        'Neos.Neos:Content': true
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:Shortcut':
+      superTypes:
+        'Neos.Neos:Document': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And I am in dimension space point {}
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value             |
+      | nodeAggregateId | "root"            |
+      | nodeTypeName    | "Neos.Neos:Sites" |
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value            |
+      | nodeAggregateId       | "site"           |
+      | nodeTypeName          | "Neos.Neos:Site" |
+      | parentNodeAggregateId | "root"           |
+      | nodeName              | "site"           |
+
+  Scenario: publishChangesInDocument succeeds after node type change that tags tethered children
+    # Step 1: Set up a user workspace
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+    And I am in workspace "user-test"
+
+    # Step 2: Create a DocumentWithMain page with a tethered "main" ContentCollection child, and a content node into it
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId        | nodeTypeName                                    | parentNodeAggregateId | nodeName | tetheredDescendantNodeAggregateIds |
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:DocumentWithMain | site                  | document | {"main": "main-collection-id"}     |
+      | nody-mc-nodeface       | Neos.ContentRepository.Testing:Content          | main-collection-id    | text1    |                                    |
+
+    # Step 3: Change the page's node type to Shortcut (tags "main" and cascades to content node)
+    And the command ChangeNodeAggregateType is executed with payload:
+      | Key             | Value                                     |
+      | workspaceName   | "user-test"                               |
+      | nodeAggregateId | "sir-david-nodenborough"                  |
+      | newNodeTypeName | "Neos.ContentRepository.Testing:Shortcut" |
+      | strategy        | "mark_with_tag:removed"                   |
+
+    # Step 5: Publish changes in document via WorkspacePublishingService — must not throw PartialWorkspaceRebaseFailed
+    # The count covers: sir-david (type changed), main-collection (tagged), nody-mc-nodeface (tagged+created)
+    When I publish the 3 changes in document "sir-david-nodenborough" from workspace "user-test" to "live"
+
+    # Step 6: Assert page is Shortcut in live and tethered child is tagged (not hard-deleted)
+    # nody-mc-nodeface was not in the published set so it does not exist in live
+    Then I am in workspace "live" and dimension space point {}
+    When VisibilityConstraints are set to "empty"
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to be of type "Neos.ContentRepository.Testing:Shortcut"
+    And I expect the node with aggregate identifier "main-collection-id" to be explicitly tagged "removed"


### PR DESCRIPTION
### Problem

Publishing a workspace could fail with `PartialWorkspaceRebaseFailed` after a `ChangeNodeAggregateType` command was executed using the `delete` strategy:

```
ServerSideError: Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\PartialWorkspaceRebaseFailed
Publication failed, events cannot be reordered as filtered:
"Node aggregate "62671e14-…" does currently not exist."
```

## Reproduction steps:

1. Create a page — and ensure this auto-creates a tethered child node (e.g. a content collection)
2. Insert content into the tethered child node (e.g. Text)
3. Change the page's node type to one that no longer declares the tethered node (e.g. a Shortcut). This then applies `strategy: delete`
4. Publish all changes via "Publish All" **in the Content Module** -> this triggers a Partial Publish in all cases.

The original command order on the user workspace is:

- Create Page (also creates tethered ContentCollection)
- Create Text
- ChangeNodeAggregateType (Page -> Shortcut)
  - auto-emits a "NodeAggregateWasRemoved"

**this removes the tethered node + Text node physically from the user workspace**

The `delete` strategy emitted `NodeAggregateWasRemoved` events, physically removing the tethered node and its children. **Because of this physical removal, the tethered child node's ID cannot be detected during partial publishing**, and thus the content creation (from step 2) is sorted not as "to-be-publishedCommands", but "remainingCommands".

Thus, the order used during partial publish will be:

- **to be published**
  - Create Page (also creates tethered ContentCollection)
  - ChangeNodeAggregateType (Page -> Shortcut)
    - auto-emits a "NodeAggregateWasRemoved"
- **remainingCommands**
  - Create Text <-- WRONG (no existing parent, as it has been removed in a previous step)

There exist multiple variations of the above bug, all caused by the same mechanism described above.

### Solution

A new **`markWithTag`** strategy is introduced for `ChangeNodeAggregateType`. Instead of emitting `NodeAggregateWasRemoved`, it emits `SubtreeWasTagged`, which hides the disallowed nodes via a `SubtreeTag` ("soft delete"). The node aggregates remain in the graph, so workspace rebase can still resolve event references — no ordering conflict occurs.

After publishing, soft removals are already physically removed.

**NOTE: This needs a corresponding change in Neos.Neos.Ui/Classes/Domain/Model/Changes/Property.php to use this Soft Removal**: https://github.com/neos/neos-ui/pull/4099

### Implementation Details

I needed to convert NodeAggregateTypeChangeChildConstraintConflictResolutionStrategy from an ENUM to a class, in order to store the additional tag-information for the new strategy.


**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
