### PR TITLE
WIP: Feature: Fast forward content streams during rebase (Made non breaking)

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\ContentStream;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\ContentStreamForking;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeMove;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeRemoval;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeVariation;
@@ -80,6 +81,7 @@ use Neos\EventStore\Model\EventEnvelope;
 final class DoctrineDbalContentGraphProjection implements ContentGraphProjectionInterface
 {
     use ContentStream;
+    use ContentStreamForking;
     use NodeMove;
     use NodeRemoval;
     use NodeVariation;
@@ -215,6 +217,27 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenContentStreamWasForked(ContentStreamWasForked $event): void
     {
+        if ($event->fastForwardFromContentStreamId) {
+            $fastForwardFromContentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->fastForwardFromContentStreamId);
+            $sourceContentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->sourceContentStreamId);
+
+            // todo cleanup dangling old node records like in remove content stream!
+            $this->fastForwardHierarchyRelations($fastForwardFromContentStreamDbId, $sourceContentStreamDbId);
+
+            // todo this is mean and removes the old content stream!!!
+            $this->dbal->update($this->tableNames->contentStream(), [
+                'id' => $event->newContentStreamId->value,
+                'sourceContentStreamId' => $event->sourceContentStreamId->value, // todo this line needs further testing as we fast forward a content stream where its base stream was removed during its rebase
+                'sourceContentStreamVersion' => $event->versionOfSourceContentStream->value,
+                'closed' => 0
+            ], [
+                'dbId' => $fastForwardFromContentStreamDbId->value
+            ]);
+            // todo hack :O
+            $this->contentStreamDbIdFinder->clearRuntimeCacheEntry($event->fastForwardFromContentStreamId);
+            return;
+        }
+
         $this->createContentStream($event->newContentStreamId, $event->sourceContentStreamId, $event->versionOfSourceContentStream);
 
         $newContentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->newContentStreamId);
@@ -258,7 +281,12 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
 
     private function whenContentStreamWasRemoved(ContentStreamWasRemoved $event): void
     {
-        $contentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->contentStreamId);
+        try {
+            $contentStreamDbId = $this->contentStreamDbIdFinder->getContentStreamDbId($event->contentStreamId);
+        } catch (\RuntimeException) {
+            // not found, todo hacky
+            return;
+        }
 
         // Drop hierarchy relations
         $deleteHierarchyRelationStatement = <<<SQL

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStreamForking.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStreamForking.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamDbId;
+
+/**
+ * @internal
+ */
+trait ContentStreamForking
+{
+    private function fastForwardHierarchyRelations(ContentStreamDbId $fastForwardContentStreamDbId, ContentStreamDbId $sourceContentStreamDbId): void
+    {
+        $removeStaleExclusiveEdges = <<<SQL
+        DELETE
+        FROM
+          {$this->tableNames->hierarchyRelation()}
+        WHERE
+          (dimensionspacepointhash, parentnodeanchor, childnodeanchor, contentstreamdbid)
+          IN (
+            SELECT
+              dimensionspacepointhash, parentnodeanchor, childnodeanchor, contentstreamdbid
+            FROM
+              {$this->tableNames->hierarchyRelation()} h_source
+            WHERE
+              h_source.contentstreamdbid = :fastForwardContentStreamDbId
+              AND NOT EXISTS (
+                SELECT
+                  h_target.*
+                FROM
+                  {$this->tableNames->hierarchyRelation()} h_target
+                WHERE
+                  h_target.contentstreamdbid = :sourceContentStreamDbId
+                  AND h_target.dimensionspacepointhash = h_source.dimensionspacepointhash
+                  AND h_target.parentnodeanchor = h_source.parentnodeanchor
+                  AND h_target.childnodeanchor = h_source.childnodeanchor
+              )
+          );
+        SQL;
+
+        $copyNewExclusiveEdges = <<<SQL
+        INSERT INTO {$this->tableNames->hierarchyRelation()} (position, dimensionspacepointhash, parentnodeanchor, childnodeanchor, contentstreamdbid, subtreetags)
+        SELECT
+              position, dimensionspacepointhash, parentnodeanchor, childnodeanchor, :fastForwardContentStreamDbId AS contentstreamdbid, subtreetags
+            FROM
+              {$this->tableNames->hierarchyRelation()} h_target
+            WHERE
+              h_target.contentstreamdbid = :sourceContentStreamDbId
+              AND NOT EXISTS (
+                SELECT
+                  h_source.*
+                FROM
+                  {$this->tableNames->hierarchyRelation()} h_source
+                WHERE
+                  h_source.contentstreamdbid = :fastForwardContentStreamDbId
+                  AND h_source.dimensionspacepointhash = h_target.dimensionspacepointhash
+                  AND h_source.parentnodeanchor = h_target.parentnodeanchor
+                  AND h_source.childnodeanchor = h_target.childnodeanchor
+              );
+        SQL;
+
+        try {
+            $this->dbal->executeStatement($removeStaleExclusiveEdges, [
+                'fastForwardContentStreamDbId' => $fastForwardContentStreamDbId->value,
+                'sourceContentStreamDbId' => $sourceContentStreamDbId->value,
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Todo: %s', $e->getMessage()), 1716489211, $e);
+        }
+        try {
+            $this->dbal->executeStatement($copyNewExclusiveEdges, [
+                'fastForwardContentStreamDbId' => $fastForwardContentStreamDbId->value,
+                'sourceContentStreamDbId' => $sourceContentStreamDbId->value,
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Todo: %s', $e->getMessage()), 1716489211, $e);
+        }
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentStreamDbIdFinder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentStreamDbIdFinder.php
@@ -59,6 +59,11 @@ final class ContentStreamDbIdFinder
         return $this->contentStreamIdRuntimeCache[$contentStreamId->value] ?? null;
     }
 
+    public function clearRuntimeCacheEntry(ContentStreamId $contentStreamId): void
+    {
+        unset($this->contentStreamIdRuntimeCache[$contentStreamId->value]);
+    }
+
     private function fillRuntimeCacheFromDatabase(): void
     {
         $allContentStreamIdsStatement = <<<SQL

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -76,9 +76,10 @@ Feature: Rebasing with no conflict
 
     Then I expect exactly 1 events to be published on stream with prefix "ContentStream:user-cs-rebased"
     And event at index 0 is of type "ContentStreamWasForked" with payload:
-      | Key                   | Expected          |
-      | newContentStreamId    | "user-cs-rebased" |
-      | sourceContentStreamId | "cs-identifier"   |
+      | Key                            | Expected             |
+      | newContentStreamId             | "user-cs-rebased"    |
+      | sourceContentStreamId          | "cs-identifier"      |
+      | fastForwardFromContentStreamId | "user-cs-identifier" |
 
     Then I expect exactly 3 events to be published on stream with prefix "ContentStream:user-cs-identifier"
     And event at index 2 is of type "ContentStreamWasRemoved" with payload:
@@ -122,9 +123,10 @@ Feature: Rebasing with no conflict
 
     Then I expect exactly 1 events to be published on stream with prefix "ContentStream:user-cs-rebased"
     And event at index 0 is of type "ContentStreamWasForked" with payload:
-      | Key                   | Expected          |
-      | newContentStreamId    | "user-cs-rebased" |
-      | sourceContentStreamId | "cs-identifier"   |
+      | Key                            | Expected             |
+      | newContentStreamId             | "user-cs-rebased"    |
+      | sourceContentStreamId          | "cs-identifier"      |
+      | fastForwardFromContentStreamId | "user-cs-identifier" |
 
     Then I expect exactly 3 events to be published on stream with prefix "ContentStream:user-cs-identifier"
     And event at index 2 is of type "ContentStreamWasRemoved" with payload:
@@ -171,9 +173,10 @@ Feature: Rebasing with no conflict
 
     Then I expect exactly 4 events to be published on stream with prefix "ContentStream:user-cs-rebased"
     And event at index 0 is of type "ContentStreamWasForked" with payload:
-      | Key                   | Expected          |
-      | newContentStreamId    | "user-cs-rebased" |
-      | sourceContentStreamId | "cs-identifier"   |
+      | Key                            | Expected          |
+      | newContentStreamId             | "user-cs-rebased" |
+      | sourceContentStreamId          | "cs-identifier"   |
+      | fastForwardFromContentStreamId | null              |
 
     Then I expect exactly 4 events to be published on stream with prefix "ContentStream:user-cs-identifier"
     And event at index 3 is of type "ContentStreamWasRemoved" with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -58,12 +58,33 @@ Feature: Rebasing with no conflict
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
 
-    # only if the force flag is used we enforce a fork:
+  Scenario: Rebase via force creates new content stream even if there are no changes
+    # force flag used
     When the command RebaseWorkspace is executed with payload:
       | Key                         | Value                 |
       | workspaceName               | "user-test"           |
       | rebasedContentStreamId      | "user-cs-rebased"     |
       | rebaseErrorHandlingStrategy | "force"               |
+
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user-test"
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                     | Expected             |
+      | workspaceName           | "user-test"          |
+      | newContentStreamId      | "user-cs-rebased"    |
+      | previousContentStreamId | "user-cs-identifier" |
+      | skippedEvents           | []                   |
+
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:user-cs-rebased"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "user-cs-rebased" |
+      | sourceContentStreamId | "cs-identifier"   |
+
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:user-cs-identifier"
+    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected             |
+      | contentStreamId | "user-cs-identifier" |
+
     Then I expect the content stream "user-cs-identifier" to not exist
 
     Then I expect exactly 2 events to be published on stream with prefix "Workspace:user-test"
@@ -90,6 +111,26 @@ Feature: Rebasing with no conflict
       | Key                         | Value                 |
       | workspaceName               | "user-test"           |
       | rebasedContentStreamId      | "user-cs-rebased"     |
+
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user-test"
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                     | Expected             |
+      | workspaceName           | "user-test"          |
+      | newContentStreamId      | "user-cs-rebased"    |
+      | previousContentStreamId | "user-cs-identifier" |
+      | skippedEvents           | []                   |
+
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:user-cs-rebased"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "user-cs-rebased" |
+      | sourceContentStreamId | "cs-identifier"   |
+
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:user-cs-identifier"
+    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected             |
+      | contentStreamId | "user-cs-identifier" |
+
     Then I expect the content stream "user-cs-identifier" to not exist
     Then workspaces live,user-test have status UP_TO_DATE
 
@@ -119,6 +160,26 @@ Feature: Rebasing with no conflict
       | Key                         | Value                 |
       | workspaceName               | "user-test"           |
       | rebasedContentStreamId      | "user-cs-rebased"     |
+
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user-test"
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                     | Expected             |
+      | workspaceName           | "user-test"          |
+      | newContentStreamId      | "user-cs-rebased"    |
+      | previousContentStreamId | "user-cs-identifier" |
+      | skippedEvents           | []                   |
+
+    Then I expect exactly 4 events to be published on stream with prefix "ContentStream:user-cs-rebased"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "user-cs-rebased" |
+      | sourceContentStreamId | "cs-identifier"   |
+
+    Then I expect exactly 4 events to be published on stream with prefix "ContentStream:user-cs-identifier"
+    And event at index 3 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected             |
+      | contentStreamId | "user-cs-identifier" |
+
     Then I expect the content stream "user-cs-identifier" to not exist
 
     Then workspaces live,user-test have status UP_TO_DATE

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamForking/Event/ContentStreamWasForked.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamForking/Event/ContentStreamWasForked.php
@@ -31,6 +31,7 @@ final readonly class ContentStreamWasForked implements EventInterface, EmbedsCon
         public ContentStreamId $newContentStreamId,
         public ContentStreamId $sourceContentStreamId,
         public Version $versionOfSourceContentStream,
+        public ?ContentStreamId $fastForwardFromContentStreamId,
     ) {
     }
 
@@ -45,6 +46,7 @@ final readonly class ContentStreamWasForked implements EventInterface, EmbedsCon
             ContentStreamId::fromString($values['newContentStreamId']),
             ContentStreamId::fromString($values['sourceContentStreamId']),
             Version::fromInteger($values['versionOfSourceContentStream']),
+            isset($values['fastForwardFromContentStreamId']) ? ContentStreamId::fromString($values['fastForwardFromContentStreamId']) : null,
         );
     }
 
@@ -54,6 +56,7 @@ final readonly class ContentStreamWasForked implements EventInterface, EmbedsCon
             'newContentStreamId' => $this->newContentStreamId,
             'sourceContentStreamId' => $this->sourceContentStreamId,
             'versionOfSourceContentStream' => $this->versionOfSourceContentStream->value,
+            'fastForwardFromContentStreamId' => $this->fastForwardFromContentStreamId?->value
         ];
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -90,6 +90,7 @@ trait ContentStreamHandling
                         $newContentStreamId,
                         $sourceContentStreamId,
                         $sourceContentStreamVersion,
+                        fastForwardFromContentStreamId: null
                     ),
                     metadata: ['debug_reason' => $debugReason]
                 )

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -29,6 +29,7 @@ use Neos\ContentRepository\Core\Feature\Common\WorkspaceConstraintChecks;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasClosed;
 use Neos\ContentRepository\Core\Feature\ContentStreamClosing\Event\ContentStreamWasReopened;
 use Neos\ContentRepository\Core\Feature\ContentStreamCreation\Event\ContentStreamWasCreated;
+use Neos\ContentRepository\Core\Feature\ContentStreamForking\Event\ContentStreamWasForked;
 use Neos\ContentRepository\Core\Feature\ContentStreamRemoval\Event\ContentStreamWasRemoved;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
@@ -284,11 +285,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         Version $baseWorkspaceContentStreamVersion,
         ContentStreamId $newContentStreamId
     ): \Generator {
-        yield $this->forkContentStream(
-            $newContentStreamId,
-            $baseWorkspace->currentContentStreamId,
-            $baseWorkspaceContentStreamVersion,
-            sprintf('Rebase empty workspace %s and fork base %s', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value)
+        yield new EventsToPublish(
+            ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName(),
+            Events::with(
+                DecoratedEvent::create(
+                    event: new ContentStreamWasForked(
+                        $newContentStreamId,
+                        $baseWorkspace->currentContentStreamId,
+                        $baseWorkspaceContentStreamVersion,
+                        fastForwardFromContentStreamId: $workspace->currentContentStreamId
+                    ),
+                    metadata: ['debug_reason' => sprintf('Rebase empty workspace %s and fast-forward to base %s', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value)]
+                )
+            ),
+            // NO_STREAM to ensure the "fork" happens as the first event of the new content stream
+            ExpectedVersion::NO_STREAM()
         );
 
         yield new EventsToPublish(
@@ -304,6 +315,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             ExpectedVersion::ANY()
         );
 
+        // todo technically obsolete as we already fast-forward to a new cs stream
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
     }
 
@@ -356,6 +368,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         if (!$workspace->hasPublishableChanges()) {
             // if we have no changes in the workspace we can fork from the base directly
+            // todo we close here but the fast-forward must reopen it
             yield $this->closeContentStream(
                 $workspace->currentContentStreamId,
                 $workspaceContentStreamVersion


### PR DESCRIPTION
depends on https://github.com/neos/neos-development-collection/pull/5735
fundament later for https://github.com/neos/neos-development-collection/pull/5771

as elaborated here https://github.com/neos/neos-development-collection/issues/5264#issuecomment-4182943154
there is a dilemma to be solved. As we didn't put the fast forward event into the Neos betas at that time, half a year  before the release we now have to find a way to implement fast forwarding non breaking with the events we have.
My primary goal was to keep the `WorkspaceWasRebased` event as is meaning that we require the previous content stream id and a new content stream id. That is achieved internally by just moving the internal pointer from old to new. But moving a content stream like this now looks very weird on the events as one event affects now the outcome of two streams which is not the intention.

Maybe the outcome is that we do still want new events and be a little breaking for 9.2, i could for example for catchup hooks and simple projections imagine an marker interface like `WorkspaceNewContentInterface` which can simply implemented by the `WorkspaceWasRebased` event as well as a `WorkspaceWasForwarded` event to denote that any data build up sofar must be reevaluated.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
