### PR TITLE
BUGFIX: Prevent unsigned integer underflow in DocumentUriPathProjection when duplicate SubtreeWasUntagged events reach live

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -529,7 +529,21 @@ trait GenericCommandExecutionAndEventPublication
         };
         $this->getContentRepositoryService($eventStoreAndSubscriptionEngine);
         $eventStoreAndSubscriptionEngine->eventStore->commit($streamName, Events::with($artificiallyConstructedEvent), ExpectedVersion::ANY());
-        $eventStoreAndSubscriptionEngine->subscriptionEngine->catchUpActive();
+        $this->lastCatchUpResult = $eventStoreAndSubscriptionEngine->subscriptionEngine->catchUpActive();
+    }
+
+    private ?\Neos\ContentRepository\Core\Subscription\Engine\ProcessedResult $lastCatchUpResult = null;
+
+    /**
+     * @Then catching up projections leads to no errors
+     */
+    public function catchingUpProjectionsLeadsToNoErrors(): void
+    {
+        Assert::assertNotNull($this->lastCatchUpResult, 'No catch-up result available. Did you publish an event before?');
+        Assert::assertFalse(
+            $this->lastCatchUpResult->hadErrors(),
+            'Catch-up had errors: ' . $this->lastCatchUpResult->errors?->getClampedMessage()
+        );
     }
 
     /**

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -453,6 +453,24 @@ final class DocumentUriPathProjection implements ProjectionInterface
                 continue;
             }
             $tagColumn = $event->tag->value;
+
+            if ($event->tag->equals(NeosSubtreeTag::disabled()) || $event->tag->equals(NeosSubtreeTag::removed())) {
+                $nodeTagLevel = $event->tag->equals(NeosSubtreeTag::disabled()) ? $node->getDisableLevel() : $node->getRemovedLevel();
+                $parentNode = $this->tryGetNode(fn () => $this->documentUriPathFinder->getParentNode($node));
+                $parentTagLevel = 0;
+                if ($parentNode !== null) {
+                    $parentTagLevel = $event->tag === NeosSubtreeTag::disabled() ? $parentNode->getDisableLevel() : $parentNode->getRemovedLevel();
+                }
+                if ($nodeTagLevel <= $parentTagLevel) {
+                    // Node was not explicitly tagged (its counter matches [or is below - should never happen] the parent's level).
+                    // Decrementing might cause an unsigned integer underflow. This can happen when
+                    // a duplicate SubtreeWasUntagged event reaches the live stream (e.g. due to
+                    // concurrent workspace publishes with stale projection state). See https://github.com/neos/neos-development-collection/issues/5778
+                    // for more details.
+                    continue;
+                }
+            }
+
             $this->updateNodeQuery('SET ' . $tagColumn . ' = ' . $tagColumn . ' - 1
                 WHERE dimensionSpacePointHash = :dimensionSpacePointHash
                     AND (

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -185,6 +185,51 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
     When I am on URL "/nody/nody-child"
     Then the matched node should be "nody-mc-nodeface-child" in dimension "{}"
 
+  Scenario: Duplicate SubtreeWasUntagged on live must not crash projection (issue #5778)
+    # Root cause identified in production:
+    #   SQLSTATE[22003]: Numeric value out of range: 1690
+    #   BIGINT UNSIGNED value is out of range in `disabled` - 1
+    #
+    # In production, a duplicate SubtreeWasUntagged event reached the live content stream
+    # The first untag set disabled from 1 to 0. The second untag tried 0 - 1 → unsigned underflow.
+    #
+    # We reproduce this by injecting a raw SubtreeWasUntagged event directly onto the live
+    # content stream, bypassing the command handler guard (SubtreeIsNotTagged).
+    # NOT SURE HOW THIS COULD BE TRIGGERED BY A USER -> WAS NOT ABLE TO REPRODUCE IT THROUGH THE UI, although the history showed
+    # that TWO UntagCommands for the same node were added a few seconds apart from each other.
+    # DETAILS: https://github.com/neos/neos-development-collection/issues/5778
+    When the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | coveredDimensionSpacePoint   | {}                 |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+    Then No node should match URL "/nody"
+
+    # First enable via normal command → disabled goes from 1 to 0
+    When the command EnableNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | coveredDimensionSpacePoint   | {}                 |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+    When I am on URL "/nody"
+    Then the matched node should be "nody-mc-nodeface" in dimension "{}"
+
+    # Inject a SECOND SubtreeWasUntagged event directly on live, bypassing the guard.
+    # This simulates the production scenario where a duplicate event reached live.
+    # Without the fix, this causes: disabled = 0 - 1 → UNSIGNED underflow crash.
+    And the event SubtreeWasUntagged was published with payload:
+      | Key                          | Value              |
+      | workspaceName                | "live"             |
+      | contentStreamId              | "cs-identifier"    |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | affectedDimensionSpacePoints | [{}]               |
+      | tag                          | "disabled"         |
+    Then catching up projections leads to no errors
+
+    # The projection must NOT crash and the node must still be accessible
+    When I am on URL "/nody"
+    Then the matched node should be "nody-mc-nodeface" in dimension "{}"
+
   Scenario: Disable leaf node and create sibling with same uri path segment
     When I am on URL "/david-nodenborough/earl-document/leaf"
     Then the matched node should be "leaf-mc-node" in dimension "{}"


### PR DESCRIPTION
Before decrementing the disabled/removed counter, check whether the node was actually explicitly tagged by comparing its counter with the parent node's counter. If the node's level is not greater than the parent's, the untag is a no-op — preventing 0 - 1 on the UNSIGNED column.

Resolves: #5778

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
