### PR TITLE
BUGFIX: Use Node instead of Document in linkTypes reference

### DIFF
--- a/Neos.Neos/Documentation/References/PropertyEditorReference.rst
+++ b/Neos.Neos/Documentation/References/PropertyEditorReference.rst
@@ -417,12 +417,12 @@ Link Type Options Reference:
 ``position`` (string|integer)
 	Defines order of this link type. E.g. ``"before <id of link type>"``.
 
-Document (configuration ``linkTypes.Document``):
+Node (configuration ``linkTypes.Node``):
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The `Document` Link Type handles internal links. The editor offers you a document tree from which you can select documents from within your site. It also offers a search and a node type filter similar to the main document tree in the left side bar of the Neos UI.
+The `Node` Link Type handles internal links. The editor offers you a document tree from which you can select documents from within your site. It also offers a search and a node type filter similar to the main document tree in the left side bar of the Neos UI.
 
-The `Document` Link Type can be configured as follows:
+The `Node` Link Type can be configured as follows:
 
 Link Type Options Reference:
 


### PR DESCRIPTION
The key needs to be `Node`, as in the example in that section. Just the headline and copy were wrong.

**Review instructions**

Hope this covers all places that would need to be adjusted.

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
