### PR TITLE
Tweak `SoftRemovalGarbageCollector`

### DIFF
--- a/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovalGarbageCollector.php
+++ b/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovalGarbageCollector.php
@@ -79,6 +79,7 @@ final readonly class SoftRemovalGarbageCollector
         private ContentRepositoryRegistry $contentRepositoryRegistry,
         private ImpendingHardRemovalConflictRepository $impendingConflictRepository,
         private SecurityContext $securityContext,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -199,6 +200,7 @@ final readonly class SoftRemovalGarbageCollector
      */
     private function hardRemoveNodesInDimensionsThatImposeNoConflicts(SoftRemovedNodes $softRemovedNodes, ContentRepository $contentRepository, ?\DateInterval $gracePeriod): void
     {
+        $now = $this->clock->now();
         foreach ($softRemovedNodes as $softRemovedNode) {
             // the generalisations of the non-conflicting soft removed dimensions
             $generalizationsToRemoveWithAllSpecializations = $contentRepository->getVariationGraph()->reduceSetToRelativeRoots(
@@ -213,16 +215,13 @@ final readonly class SoftRemovalGarbageCollector
                         ->getIntersection($softRemovedNode->conflictingDimensionSpacePoints)
                         ->isEmpty()
                 ) {
-                    $contentRepositoryReflection = new \ReflectionClass($contentRepository);
-                    /** @var ClockInterface $clock */
-                    $clock = $contentRepositoryReflection->getProperty('clock')->getValue($contentRepository);
                     $trashItemFinder = $contentRepository->projectionState(TrashItemFinder::class);
                     $trashItem = $trashItemFinder->findItem(
                         WorkspaceName::forLive(),
                         $softRemovedNode->nodeAggregateId,
                         $generalization,
                     );
-                    if (!$gracePeriod || !$trashItem || !$trashItem->deleteTime || $trashItem->deleteTime->add($gracePeriod) < $clock->now()) {
+                    if (!$gracePeriod || !$trashItem || !$trashItem->deleteTime || $trashItem->deleteTime->add($gracePeriod) < $now) {
                         try {
                             $contentRepository->handle(RemoveNodeAggregate::create(
                                 WorkspaceName::forLive(),

--- a/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovalGarbageCollector.php
+++ b/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovalGarbageCollector.php
@@ -215,23 +215,26 @@ final readonly class SoftRemovalGarbageCollector
                         ->getIntersection($softRemovedNode->conflictingDimensionSpacePoints)
                         ->isEmpty()
                 ) {
-                    $trashItemFinder = $contentRepository->projectionState(TrashItemFinder::class);
-                    $trashItem = $trashItemFinder->findItem(
-                        WorkspaceName::forLive(),
-                        $softRemovedNode->nodeAggregateId,
-                        $generalization,
-                    );
-                    if (!$gracePeriod || !$trashItem || !$trashItem->deleteTime || $trashItem->deleteTime->add($gracePeriod) < $now) {
-                        try {
-                            $contentRepository->handle(RemoveNodeAggregate::create(
-                                WorkspaceName::forLive(),
-                                $softRemovedNode->nodeAggregateId,
-                                $generalization,
-                                NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
-                            ));
-                        } catch (NodeAggregateCurrentlyDoesNotExist | NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint) {
-                            // already removed by another command further up the graph
+                    if ($gracePeriod !== null) {
+                        $trashItemFinder = $contentRepository->projectionState(TrashItemFinder::class);
+                        $trashItem = $trashItemFinder->findItem(
+                            WorkspaceName::forLive(),
+                            $softRemovedNode->nodeAggregateId,
+                            $generalization,
+                        );
+                        if ($trashItem !== null && $trashItem->deleteTime->add($gracePeriod) >= $now) {
+                            continue;
                         }
+                    }
+                    try {
+                        $contentRepository->handle(RemoveNodeAggregate::create(
+                            WorkspaceName::forLive(),
+                            $softRemovedNode->nodeAggregateId,
+                            $generalization,
+                            NodeVariantSelectionStrategy::STRATEGY_ALL_SPECIALIZATIONS
+                        ));
+                    } catch (NodeAggregateCurrentlyDoesNotExist | NodeAggregateDoesCurrentlyNotCoverDimensionSpacePoint) {
+                        // already removed by another command further up the graph
                     }
                 }
             }

--- a/Neos.Neos/Configuration/Objects.yaml
+++ b/Neos.Neos/Configuration/Objects.yaml
@@ -28,11 +28,15 @@ Neos\Neos\Domain\Service\WorkspaceService:
     7:
       setting: "Neos.Neos.softRemoval.garbageCollectionGracePeriod"
 
+Neos\Neos\Domain\SubtreeTagging\SoftRemoval\SoftRemovalGarbageCollector:
+  arguments:
+    4:
+      object: 'Neos\ContentRepositoryRegistry\Factory\Clock\SystemClock'
+
 Neos\Neos\Domain\Service\WorkspacePublishingService:
   arguments:
     3:
       setting: "Neos.Neos.softRemoval.garbageCollectionGracePeriod"
-
 
 Neos\Fusion\Core\Cache\RuntimeContentCache:
   properties:

--- a/Neos.Neos/Configuration/Testing/Objects.yaml
+++ b/Neos.Neos/Configuration/Testing/Objects.yaml
@@ -1,2 +1,7 @@
 Neos\Neos\Domain\Service\FusionAutoIncludeHandler:
   className: Neos\Neos\Testing\TestingFusionAutoIncludeHandler
+
+Neos\Neos\Domain\SubtreeTagging\SoftRemoval\SoftRemovalGarbageCollector:
+  arguments:
+    4:
+      object: 'Neos\ContentRepository\TestSuite\Fakes\FakeClock'


### PR DESCRIPTION
- Attempt to get rid of reflection service hack in order to extract clock from content repository instance for test case
- Tweak grace period conditions to make them easier to parse and avoid unnecessary lookups if no grace period is configured