### PR TITLE
BUGFIX: Introduce `ProjectionIntegrityViolationDetectionRunnerFactoryInterface` to allow switching implementation via Objects.yaml

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/DoctrineDbalProjectionIntegrityViolatorTrait.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/DoctrineDbalProjectionIntegrityViolatorTrait.php
@@ -12,8 +12,6 @@
 
 declare(strict_types=1);
 
-namespace Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap;
-
 use Behat\Gherkin\Node\TableNode;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
@@ -24,26 +22,18 @@ use Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap\Help
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
-use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteRuntimeVariables;
-use Neos\Error\Messages\Error;
-use Neos\Error\Messages\Result;
-use PHPUnit\Framework\Assert;
 
 /**
- * Custom context trait for projection integrity violation detection specific to the Doctrine DBAL content graph adapter
- *
- * @todo move this class somewhere where its autoloaded
+ * @internal custom illegal mutations for the Doctrine DBAL content graph adapter to make the projection integrity violation fail
  */
-trait ProjectionIntegrityViolationDetectionTrait
+trait DoctrineDbalProjectionIntegrityViolatorTrait
 {
     use CRTestSuiteRuntimeVariables;
 
     private Connection $dbal;
-
-    protected Result $lastIntegrityViolationDetectionResult;
 
     /**
      * @template T of object
@@ -336,44 +326,5 @@ trait ProjectionIntegrityViolationDetectionTrait
         }
 
         return $result;
-    }
-
-    /**
-     * @When /^I run integrity violation detection$/
-     */
-    public function iRunIntegrityViolationDetection(): void
-    {
-        $projectionIntegrityViolationDetectionRunner = $this->getContentRepositoryService(
-            $this->getObject(ProjectionIntegrityViolationDetectionRunnerFactoryInterface::class)
-        );
-        $this->lastIntegrityViolationDetectionResult = $projectionIntegrityViolationDetectionRunner->run();
-    }
-
-    /**
-     * @Then /^I expect the integrity violation detection result to contain exactly (\d+) errors?$/
-     * @param int $expectedNumberOfErrors
-     */
-    public function iExpectTheIntegrityViolationDetectionResultToContainExactlyNErrors(int $expectedNumberOfErrors): void
-    {
-        Assert::assertCount(
-            $expectedNumberOfErrors,
-            $this->lastIntegrityViolationDetectionResult->getErrors(),
-            'Errors were: ' . implode(', ', array_map(fn (Error $e) => $e->render(), $this->lastIntegrityViolationDetectionResult->getErrors()))
-        );
-    }
-
-    /**
-     * @Then /^I expect integrity violation detection result error number (\d+) to have code (\d+)$/
-     * @param int $errorNumber
-     * @param int $expectedErrorCode
-     */
-    public function iExpectIntegrityViolationDetectionResultErrorNumberNToHaveCodeX(int $errorNumber, int $expectedErrorCode): void
-    {
-        /** @var Error $error */
-        $error = $this->lastIntegrityViolationDetectionResult->getErrors()[$errorNumber-1];
-        Assert::assertSame(
-            $expectedErrorCode,
-            $error->getCode()
-        );
     }
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -11,12 +11,9 @@ declare(strict_types=1);
  * source code.
  */
 
-require_once(__DIR__ . '/ProjectionIntegrityViolationDetectionTrait.php');
-
 use Behat\Behat\Context\Context as BehatContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Neos\Behat\FlowBootstrapTrait;
-use Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap\ProjectionIntegrityViolationDetectionTrait;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
@@ -33,7 +30,7 @@ use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 class FeatureContext implements BehatContext
 {
     use FlowBootstrapTrait;
-    use ProjectionIntegrityViolationDetectionTrait;
+    use DoctrineDbalProjectionIntegrityViolatorTrait;
     use CRTestSuiteTrait;
     use CRBehavioralTestsSubjectProvider;
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
@@ -19,12 +19,12 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
-use Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
 use Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap\Helpers\TestingNodeAggregateId;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteRuntimeVariables;
@@ -343,7 +343,9 @@ trait ProjectionIntegrityViolationDetectionTrait
      */
     public function iRunIntegrityViolationDetection(): void
     {
-        $projectionIntegrityViolationDetectionRunner = $this->getContentRepositoryService(new DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory($this->dbal));
+        $projectionIntegrityViolationDetectionRunner = $this->getContentRepositoryService(
+            $this->getObject(ProjectionIntegrityViolationDetectionRunnerFactoryInterface::class)
+        );
         $this->lastIntegrityViolationDetectionResult = $projectionIntegrityViolationDetectionRunner->run();
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory.php
@@ -7,14 +7,13 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 use Doctrine\DBAL\Connection;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ProjectionIntegrityViolationDetector;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryDependencies;
-use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunner;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface;
 
 /**
- * @implements ContentRepositoryServiceFactoryInterface<ProjectionIntegrityViolationDetectionRunner>
  * @internal
  */
-class DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory implements ContentRepositoryServiceFactoryInterface
+class DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory implements ProjectionIntegrityViolationDetectionRunnerFactoryInterface
 {
     public function __construct(
         private readonly Connection $dbal,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Bootstrap/FeatureContext.php
@@ -11,15 +11,10 @@ declare(strict_types=1);
  * source code.
  */
 
-// @todo remove this require statement
-require_once(__DIR__ . '/../../../../Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php');
-
 use Behat\Behat\Context\Context as BehatContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Doctrine\DBAL\Connection;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Behat\FlowBootstrapTrait;
-use Neos\ContentGraph\DoctrineDbalAdapter\Tests\Behavior\Features\Bootstrap\ProjectionIntegrityViolationDetectionTrait;
 use Neos\ContentRepository\BehavioralTests\ProjectionRaceConditionTester\Dto\TraceEntryType;
 use Neos\ContentRepository\BehavioralTests\ProjectionRaceConditionTester\RedisInterleavingLogger;
 use Neos\ContentRepository\Core\ContentRepository;
@@ -47,7 +42,6 @@ class FeatureContext implements BehatContext
     use FlowBootstrapTrait;
     use CRTestSuiteTrait;
     use CRBehavioralTestsSubjectProvider;
-    use ProjectionIntegrityViolationDetectionTrait;
     use StructureAdjustmentsTrait;
     use MigrationsTrait;
 
@@ -59,7 +53,6 @@ class FeatureContext implements BehatContext
     {
         self::bootstrapFlow();
 
-        $this->dbal = $this->getObject(Connection::class);
         $this->setUpInterleavingLogger();
         $this->contentRepositoryRegistry = $this->getObject(ContentRepositoryRegistry::class);
     }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ProjectionIntegrityViolationDetectionRunnerFactoryInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ProjectionIntegrityViolationDetectionRunnerFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph;
+
+use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
+
+/**
+ * @extends ContentRepositoryServiceFactoryInterface<ProjectionIntegrityViolationDetectionRunner>
+ * @internal only API for custom content repository integrations
+ */
+interface ProjectionIntegrityViolationDetectionRunnerFactoryInterface extends ContentRepositoryServiceFactoryInterface
+{
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ProjectionIntegrityViolationDetectorInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ProjectionIntegrityViolationDetectorInterface.php
@@ -19,7 +19,7 @@ use Neos\Error\Messages\Result;
 /**
  * interface because different impls.
  *
- * @internal
+ * @internal only API for custom content repository integrations
  */
 interface ProjectionIntegrityViolationDetectorInterface
 {

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -70,6 +70,8 @@ trait CRTestSuiteTrait
 
     use WorkspaceCreation;
 
+    use ProjectionIntegrityViolationDetectionTrait;
+
     /**
      * @BeforeScenario
      * @throws \Exception

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
+
+use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface;
+use Neos\Error\Messages\Error;
+use Neos\Error\Messages\Result;
+use PHPUnit\Framework\Assert;
+
+trait ProjectionIntegrityViolationDetectionTrait
+{
+    protected Result $lastIntegrityViolationDetectionResult;
+
+    /**
+     * @When /^I run integrity violation detection$/
+     */
+    public function iRunIntegrityViolationDetection(): void
+    {
+        $projectionIntegrityViolationDetectionRunner = $this->getContentRepositoryService(
+            $this->getObject(ProjectionIntegrityViolationDetectionRunnerFactoryInterface::class)
+        );
+        $this->lastIntegrityViolationDetectionResult = $projectionIntegrityViolationDetectionRunner->run();
+    }
+
+    /**
+     * @Then /^I expect the integrity violation detection result to contain exactly (\d+) errors?$/
+     * @param int $expectedNumberOfErrors
+     */
+    public function iExpectTheIntegrityViolationDetectionResultToContainExactlyNErrors(int $expectedNumberOfErrors): void
+    {
+        Assert::assertCount(
+            $expectedNumberOfErrors,
+            $this->lastIntegrityViolationDetectionResult->getErrors(),
+            'Errors were: ' . implode(', ', array_map(fn (Error $e) => $e->render(), $this->lastIntegrityViolationDetectionResult->getErrors()))
+        );
+    }
+
+    /**
+     * @Then /^I expect integrity violation detection result error number (\d+) to have code (\d+)$/
+     * @param int $errorNumber
+     * @param int $expectedErrorCode
+     */
+    public function iExpectIntegrityViolationDetectionResultErrorNumberNToHaveCodeX(int $errorNumber, int $expectedErrorCode): void
+    {
+        /** @var Error $error */
+        $error = $this->lastIntegrityViolationDetectionResult->getErrors()[$errorNumber - 1];
+        Assert::assertSame(
+            $expectedErrorCode,
+            $error->getCode()
+        );
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentGraphIntegrityCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentGraphIntegrityCommandController.php
@@ -11,8 +11,7 @@ namespace Neos\ContentRepositoryRegistry\Command;
  * source code.
  */
 
-use Doctrine\DBAL\Connection;
-use Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Error\Messages\Result;
@@ -25,7 +24,7 @@ final class ContentGraphIntegrityCommandController extends CommandController
     private const OUTPUT_MODE_LOG = 'log';
 
     #[Flow\Inject()]
-    protected Connection $dbal;
+    protected ProjectionIntegrityViolationDetectionRunnerFactoryInterface $projectionIntegrityViolationDetectionRunnerFactory;
 
     #[Flow\Inject()]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
@@ -34,7 +33,7 @@ final class ContentGraphIntegrityCommandController extends CommandController
     {
         $detectionRunner = $this->contentRepositoryRegistry->buildService(
             ContentRepositoryId::fromString($contentRepository),
-            new DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory($this->dbal)
+            $this->projectionIntegrityViolationDetectionRunnerFactory
         );
 
         $outputMode = $this->resolveOutputMode($outputMode);

--- a/Neos.ContentRepositoryRegistry/Configuration/Objects.yaml
+++ b/Neos.ContentRepositoryRegistry/Configuration/Objects.yaml
@@ -9,6 +9,16 @@ Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphProjectionFactory:
     2:
       object: 'Doctrine\DBAL\Connection'
 
+# This adds a soft-dependency to the neos/contentgraph-doctrinedbaladapter package
+Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface:
+  scope: singleton
+  factoryObjectName: 'Neos\ContentRepositoryRegistry\Infrastructure\GenericObjectFactory'
+  arguments:
+    1:
+      value: 'Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalProjectionIntegrityViolationDetectionRunnerFactory'
+    2:
+      object: 'Doctrine\DBAL\Connection'
+
 'Neos.ContentRepositoryRegistry:Logger':
   className: Psr\Log\LoggerInterface
   scope: singleton


### PR DESCRIPTION
Non breaking and clean way to allow custom graphs to be implemented. Leverages the Framework to determine the implementation rather than adding the concept to the `ContentRepository` object itself which would be partly breaking custom implementations.

The need came up with #5751

And extract shared `ProjectionIntegrityViolationDetectionTrait` from DBAL specific implementation

- removes all autoloading hacks
- allows custom content graph implementations to be tested without DBAL adapter and autoloading issues
- objects.yaml determines which  ProjectionIntegrityViolationDetection to use

