### PR TITLE
BUGFIX: Stabilise behavioural CR test for PostgreSQL graph

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -70,6 +70,13 @@ Feature: Recreate a node variant
       | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allSpecializations"     |
 
+    When I am in workspace "user-ws" and dimension space point {"language": "de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    When I am in workspace "user-ws" and dimension space point {"language": "gsw"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                    |
       | workspaceName   | "user-ws"                |

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
@@ -199,12 +200,16 @@ trait CRBehavioralTestsSubjectProvider
             Assert::assertNull($result);
             self::$alreadySetUpContentRepositories[] = $contentRepository->id;
         }
-        // todo we TRUNCATE here and do not want to use $contentRepositoryMaintainer->prune(); here as it would not reset the autoincrement sequence number making some assertions impossible
+        // We TRUNCATE here and do not want to use $contentRepositoryMaintainer->prune(); here as it would not reset the autoincrement sequence number making some assertions impossible
 
         /** @var Connection $databaseConnection */
         $databaseConnection = (new \ReflectionClass($eventStore))->getProperty('connection')->getValue($eventStore);
         $eventTableName = sprintf('cr_%s_events', $contentRepositoryId->value);
-        $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName);
+        if ($databaseConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName . ' RESTART IDENTITY');
+        } else {
+            $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName);
+        }
 
         $result = $subscriptionEngine->reset();
         Assert::assertNull($result->errors);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
@@ -200,8 +200,8 @@ trait CRBehavioralTestsSubjectProvider
             Assert::assertNull($result);
             self::$alreadySetUpContentRepositories[] = $contentRepository->id;
         }
-        // We TRUNCATE here and do not want to use $contentRepositoryMaintainer->prune(); here as it would not reset the autoincrement sequence number making some assertions impossible
-
+        // TODO We TRUNCATE here and do not want to use $contentRepositoryMaintainer->prune(); here as it would not reset the autoincrement sequence number making some assertions impossible
+        // TODO With https://github.com/neos/eventstore/pull/26 released we can use EventStore::prune() in the ContentRepositoryMaintainer::prune() and use that.
         /** @var Connection $databaseConnection */
         $databaseConnection = (new \ReflectionClass($eventStore))->getProperty('connection')->getValue($eventStore);
         $eventTableName = sprintf('cr_%s_events', $contentRepositoryId->value);

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -147,7 +147,17 @@ trait CRTestSuiteTrait
                 'publishable changes' => $workspace->hasPublishableChanges()
             ]);
         }
-        Assert::assertSame($payloadTable->getHash(), $actualComparableHash);
+
+        $expectedWorkspaces = $payloadTable->getHash();
+
+        // assertEqualsCanonicalizing removes keys by using sort recursively that's why we sort manually
+        // sort by unique index to make rows easier comparable when diffing
+        // TODO should core findWorkspaces() return workspaces in defined order? -> Possibly by insert order?
+        $sortRows = fn ($rowA, $rowB) => strcmp($rowA['name'], $rowB['name']);
+        usort($actualComparableHash, $sortRows);
+        usort($expectedWorkspaces, $sortRows);
+
+        Assert::assertSame($expectedWorkspaces, $actualComparableHash);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -671,7 +671,7 @@ trait GenericCommandExecutionAndEventPublication
             $key = $assertionTableRow['Key'];
             $actualValue = Arrays::getValueByPath($actualEventPayload, $key);
 
-            if ($key === 'affectedDimensionSpacePoints') {
+            if ($key === 'affectedDimensionSpacePoints' || $key === 'affectedCoveredDimensionSpacePoints') {
                 $expected = DimensionSpacePointSet::fromJsonString($assertionTableRow['Expected']);
                 $actual = DimensionSpacePointSet::fromArray($actualValue);
                 Assert::assertTrue($expected->equals($actual), 'Actual Dimension Space Point set "' . json_encode($actualValue) . '" does not match expected Dimension Space Point set "' . $assertionTableRow['Expected'] . '"');


### PR DESCRIPTION
Based on https://github.com/neos/neos-development-collection/pull/5791

Extracted from #5751 

- Fix assertion on DSP `affectedCoveredDimensionSpacePoints` in behavioural testsuite
- Fix sequence numbers for postgres test setup

the second fix, truncating the event table in the behaviour tests like that was a Provisorium already and touching this code begs the question if we can also find a better way - even only for the future, so lets discuss.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
