### PR TITLE
BUGFIX: Update version and release to 8.4 in conf.py

### DIFF
--- a/Neos.Neos/Documentation/conf.py
+++ b/Neos.Neos/Documentation/conf.py
@@ -27,9 +27,9 @@ copyright = '2006 and onwards by the authors'
 author = 'Neos Team and Contributors'
 
 # The short X.Y version.
-version = '8.3'
+version = '8.4'
 # The full version, including alpha/beta/rc tags.
-release = '8.3.x'
+release = '8.4.x'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
The documenttation for 8.4 claimed to be 8.3 on https://neos.readthedocs.io/en/8.4/.

**Checklist**

- [ ] ~~Code follows the PSR-2 coding style~~
- [ ] ~~Tests have been created, run and adjusted as needed~~
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~~
