### PR TITLE
WIP: BUGFIX: Cleanup back references in node removal

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
@@ -47,6 +47,32 @@ trait NodeRemoval
             $this->removeRelationRecursivelyFromDatabaseIncludingNonReferencedNodes($outgoingRelation);
         }
 
+        // TODO Write tests that we only remove in the correct dimension with copy on write before or without
+        // TODO Only remove back references if no other hierarchy uses that node row (no copy on write happened)
+        //  -> Or trigger copy on write as if we still keep the back reference because that node row is shared the back references can silently become valid again and the projection integrity violator complains
+        $deleteBackReferencesStatement = <<<SQL
+            DELETE
+                r
+            FROM
+                {$this->tableNames->node()} n
+                LEFT JOIN {$this->tableNames->referenceRelation()} r ON r.destinationnodeaggregateid = n.nodeaggregateid
+                LEFT JOIN {$this->tableNames->hierarchyRelation()} h
+                    ON h.contentstreamid = :contentStreamId
+                    AND h.dimensionspacepointhash = :dimensionSpacePointHash
+                    AND h.childnodeanchor = r.nodeanchorpoint
+            WHERE
+                n.relationanchorpoint = :anchorPointForNode
+        SQL;
+        try {
+            $this->dbal->executeStatement($deleteBackReferencesStatement, [
+                'anchorPointForNode' => $ingoingRelation->childNodeAnchor->value,
+                'contentStreamId' => $ingoingRelation->contentStreamId->value,
+                'dimensionSpacePointHash' => $ingoingRelation->dimensionSpacePoint->hash,
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to remove backreferences from database: %s', $e->getMessage()), 1777050925, $e);
+        }
+
         // remove node itself if it does not have any incoming hierarchy relations anymore
         // also remove outbound reference relations
         $deleteRelationsStatement = <<<SQL

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -11,8 +11,10 @@ Feature: Remove NodeAggregate
     """yaml
     'Neos.ContentRepository.Testing:Document':
       properties:
-        references:
-          type: references
+        text:
+          type: string
+      references:
+        references: {}
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -28,26 +30,32 @@ Feature: Remove NodeAggregate
       | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName |
-      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document |
-      | nodingers-cat          | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | pet      |
-      | nodingers-kitten       | Neos.ContentRepository.Testing:Document | nodingers-cat          | kitten   |
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document      |
+      | nody-mc-nodeface       | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | child         |
+      | younger-mc-nodeface    | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | younger-child |
+      | nodingers-cat          | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | pet           |
+      | nodingers-kitten       | Neos.ContentRepository.Testing:Document | nodingers-cat          | kitten        |
     And the command SetNodeReferences is executed with payload:
       | Key                   | Value                                  |
       | sourceNodeAggregateId | "nodingers-cat"                        |
       | references            | [{"referenceName": "references", "references": [{"target": "sir-david-nodenborough"}]}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value                                                                          |
+      | sourceNodeAggregateId | "nody-mc-nodeface"                                                             |
+      | references            | [{"referenceName": "references", "references": [{"target": "nodingers-cat"}]}] |
 
   Scenario: Remove a node aggregate
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    Then I expect exactly 7 events to be published on stream with prefix "ContentStream:cs-identifier"
-    And event at index 6 is of type "NodeAggregateWasRemoved" with payload:
+    Then I expect exactly 10 events to be published on stream with prefix "ContentStream:cs-identifier"
+    And event at index 9 is of type "NodeAggregateWasRemoved" with payload:
       | Key                                  | Expected        |
       | contentStreamId                      | "cs-identifier" |
       | nodeAggregateId                      | "nodingers-cat" |
       | affectedCoveredDimensionSpacePoints  | [[]]            |
-    Then I expect the graph projection to consist of exactly 2 nodes
+    Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
@@ -63,6 +71,9 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect the node aggregate "nodingers-cat" to not exist
     And I expect the node aggregate "nodingers-kitten" to not exist
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have no references
 
   Scenario: Disable a node aggregate, remove it, recreate it and expect it to be enabled
     When the command DisableNodeAggregate is executed with payload:
@@ -82,7 +93,7 @@ Feature: Remove NodeAggregate
 
     Then I expect the node aggregate "nodingers-cat" to exist
     And I expect this node aggregate to disable dimension space points []
-    And I expect the graph projection to consist of exactly 3 nodes
+    And I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
     And I expect a node identified by cs-identifier;nodingers-cat;{} to exist in the content graph
@@ -101,7 +112,7 @@ Feature: Remove NodeAggregate
     And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{}
     And I expect the node aggregate "nodingers-kitten" to not exist
 
-  Scenario: Remove a node aggregate, recreate it and expect it to have no references
+  Scenario: Remove a node aggregate, recreate it and expect it to have no references (or backreferences)
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
@@ -118,13 +129,120 @@ Feature: Remove NodeAggregate
     And I expect this node to not be referenced
     And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{}
     And I expect this node to have no references
+    And I expect this node to not be referenced
     And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
 
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have no references
+
+  Scenario: Remove a node aggregate in root workspace and expect to be still existing with references and backreferences in another workspace
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user"               |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    When the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value           |
+      | workspaceName                | "live"          |
+      | nodeAggregateId              | "nodingers-cat" |
+      | nodeVariantSelectionStrategy | "allVariants"   |
+
+    When I am in workspace "live"
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+
+    When I am in workspace "user"
+    And I expect node aggregate identifier "nodingers-cat" to lead to node user-cs-identifier;nodingers-cat;{}
+    And I expect this node to have the following references:
+      | Name       | Node                                | Properties |
+      | references | user-cs-identifier;sir-david-nodenborough;{} | null       |
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following references:
+      | Name       | Node                                | Properties |
+      | references | user-cs-identifier;nodingers-cat;{} | null       |
+
+    # recreate the node in live
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                     |
+      | workspaceName         | "live"                                    |
+      | nodeAggregateId       | "nodingers-cat"                           |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                  |
+      | nodeName              | "pet"                                     |
+
+    When I am in workspace "live"
+
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to have no references
+    And I expect this node to not be referenced
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have no references
+
+  Scenario: Remove a node aggregate in root workspace and expect to be still existing with references and backreferences in another workspace with other modifications
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user"               |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    # triggers dependent on implementation a copy on write we are not allowed to cleanup backreferences to this node
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                   |
+      | workspaceName             | "user"                  |
+      | nodeAggregateId           | "nodingers-cat"         |
+      | originDimensionSpacePoint | {}                      |
+      | propertyValues            | {"text": "User change"} |
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                   |
+      | workspaceName             | "user"                  |
+      | nodeAggregateId           | "nody-mc-nodeface"         |
+      | originDimensionSpacePoint | {}                      |
+      | propertyValues            | {"text": "User change"} |
+
+    When the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value           |
+      | workspaceName                | "live"          |
+      | nodeAggregateId              | "nodingers-cat" |
+      | nodeVariantSelectionStrategy | "allVariants"   |
+
+    When I am in workspace "live"
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+
+    When I am in workspace "user"
+    And I expect node aggregate identifier "nodingers-cat" to lead to node user-cs-identifier;nodingers-cat;{}
+    And I expect this node to have the following properties:
+      | Key  | Value         |
+      | text | "User change" |
+    And I expect this node to have the following references:
+      | Name       | Node                                | Properties |
+      | references | user-cs-identifier;sir-david-nodenborough;{} | null       |
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following references:
+      | Name       | Node                                | Properties |
+      | references | user-cs-identifier;nodingers-cat;{} | null       |
+
+    # recreate the node in live
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                     |
+      | workspaceName         | "live"                                    |
+      | nodeAggregateId       | "nodingers-cat"                           |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                  |
+      | nodeName              | "pet"                                     |
+
+    When I am in workspace "live"
+
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to have no references
+    And I expect this node to not be referenced
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have no references
+
   Scenario: Remove a node aggregate with descendants and expect all of them to be gone
-    When the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName |
-      | nody-mc-nodeface | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | child |
-      | younger-mc-nodeface | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | younger-child |
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "sir-david-nodenborough" |


### PR DESCRIPTION
Adds a failing tests that back-references are not cleaned up.

This is relevant as
- there is a growing amount of back references rows which are stale
- the graph integrity is compromised when recreating a node which existed beforehand as backreference target as the reference will suddenly be queried again
- the projection integrity violation rightfully complains (refs https://github.com/neos/neos-development-collection/issues/5795):

> Destination node aggregate sir-david-nodenborough does not cover any dimension space points the source nodingers-cat does in content stream cs-identifier

A simple cleanup query in the NodeRemoval like

```
 -- target reference relations (incoming)
LEFT JOIN {$this->tableNames->referenceRelation()} rt ON rt.destinationnodeaggregateid = n.nodeaggregateid
```

would fail as all back references independent of workspace and dimension would be removed. Even the cleanup by taking content stream and dsp into account does not work as the dilemma of invalid backreferences would still persist in case the removed node was not a copy on write but shared.

Im was not part of the discussions in the past but @nezaniel said that the decision was to even keep it this way? cc @bwaidelich @skurfuerst? Are there any resources where i could read up on that or what is your stand on this?

These might be the solutions:
- Ignore the problem, no one recreates nodes with the same id? Tell the projection integrity violation to not raise an error because there is none
- Figure out to cleanup the back references which is costly as copy on write might be necessary
- Build a more capable actual reference graph

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
