### PR TITLE
BUGFIX: Always ensure tethered descendant node ids don't exist during command handling

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
@@ -16,6 +16,12 @@ Feature: Create a root node aggregate
     'Neos.ContentRepository.Testing:OtherRoot':
       superTypes:
         'Neos.ContentRepository:Root': true
+    'Neos.ContentRepository.Testing:RootWithTetheredChildNode':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+      childNodes:
+        child-node:
+          type: 'Neos.ContentRepository.Testing:NonRoot'
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -75,3 +81,11 @@ Feature: Create a root node aggregate
       | nodeAggregateId | "nody-mc-nodeface"                       |
       | nodeTypeName    | "Neos.ContentRepository.Testing:NonRoot" |
     Then the last command should have thrown an exception of type "NodeTypeIsNotOfTypeRoot"
+
+  Scenario: Try to create a root node aggregate with tethered children and specify a tethered descendant id which is already occupied
+    When the command CreateRootNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                                | Value                                                      |
+      | nodeAggregateId                    | "other-rootford"                                           |
+      | nodeTypeName                       | "Neos.ContentRepository.Testing:RootWithTetheredChildNode" |
+      | tetheredDescendantNodeAggregateIds | {"child-node": "lady-eleonode-rootford"}                   |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyExists"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -27,6 +27,10 @@ Feature: Create node aggregate with node
             iDoNotExist: 'whatever'
     'Neos.ContentRepository.Testing:AbstractNode':
       abstract: true
+    'Neos.ContentRepository.Testing:WithTetheredChildNode':
+      childNodes:
+        child-node:
+          type: 'Neos.ContentRepository.Testing:Node'
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -183,3 +187,12 @@ Feature: Create node aggregate with node
       | nodeTypeName          | "Neos.ContentRepository.Testing:NodeWithInvalidDefaultValue" |
       | parentNodeAggregateId | "lady-eleonode-rootford"                                     |
     Then the last command should have thrown an exception of type "InvalidArgumentException"
+
+  Scenario: Try to create a root node aggregate with tethered children and specify a tethered descendant id which is already occupied
+    When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                                | Value                                                  |
+      | nodeAggregateId                    | "nody-mc-nodeface"                                     |
+      | parentNodeAggregateId              | "lady-eleonode-rootford"                               |
+      | nodeTypeName                       | "Neos.ContentRepository.Testing:WithTetheredChildNode" |
+      | tetheredDescendantNodeAggregateIds | {"child-node": "lady-eleonode-rootford"}               |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyExists"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
@@ -205,3 +205,25 @@ Feature: Change node aggregate type - basic error cases
       | newNodeTypeName | "Neos.ContentRepository.Testing:GrandParentNodeType" |
       | strategy        | "happypath"                                          |
     Then the last command should have thrown an exception of type "NodeAggregateIsUntethered"
+
+  Scenario: Try to change a node to a type with a descendant tethered node declaration and specify a tethered descendant id which is already occupied
+    When the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId   | parentNodeAggregateId  | nodeTypeName                          |
+      | oddnode-tetherton | lady-eleonode-rootford | Neos.ContentRepository.Testing:Simple |
+
+    And the command ChangeNodeAggregateType is executed with payload and exceptions are caught:
+      | Key                                | Value                                                |
+      | nodeAggregateId                    | "sir-david-nodenborough"                             |
+      | newNodeTypeName                    | "Neos.ContentRepository.Testing:GrandParentNodeType" |
+      | strategy                           | "happypath"                                          |
+      | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "oddnode-tetherton"}             |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyExists"
+
+    # "nodewyn-tetherton" is already occupied by its current tethered node
+    And the command ChangeNodeAggregateType is executed with payload and exceptions are caught:
+      | Key                                | Value                                                                                      |
+      | nodeAggregateId                    | "sir-david-nodenborough"                                                                   |
+      | newNodeTypeName                    | "Neos.ContentRepository.Testing:GrandParentNodeType"                                       |
+      | strategy                           | "happypath"                                                                                |
+      | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "nodimer-tetherton", "child-of-type-b/tethered": "nodewyn-tetherton"} |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyExists"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -229,11 +229,11 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | targetOrigin    | {"language":"gsw"} |
 
     When the command ChangeNodeAggregateType is executed with payload:
-      | Key                                | Value                                                                                      |
-      | nodeAggregateId                    | "nody-mc-nodeface"                                                                         |
-      | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB"                                                 |
-      | strategy                           | "happypath"                                                                                |
-      | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "nodimer-tetherton", "child-of-type-b/tethered": "nodewyn-tetherton"} |
+      | Key                                | Value                                                                                       |
+      | nodeAggregateId                    | "nody-mc-nodeface"                                                                          |
+      | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeB"                                                  |
+      | strategy                           | "happypath"                                                                                 |
+      | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "nodimer-tetherton", "child-of-type-b/tethered": "nodimer-tether-son"} |
 
     Then I expect exactly 15 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateTypeWasChanged" with payload:
@@ -284,7 +284,7 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | Key                           | Expected                                                            |
       | workspaceName                 | "live"                                                              |
       | contentStreamId               | "cs-identifier"                                                     |
-      | nodeAggregateId               | "nodewyn-tetherton"                                                 |
+      | nodeAggregateId               | "nodimer-tether-son"                                                |
       | nodeTypeName                  | "Neos.ContentRepository.Testing:Tethered"                           |
       | originDimensionSpacePoint     | {"language":"gsw"}                                                  |
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId":null}] |
@@ -296,7 +296,7 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | Key                       | Expected                                                           |
       | workspaceName             | "live"                                                             |
       | contentStreamId           | "cs-identifier"                                                    |
-      | nodeAggregateId           | "nodewyn-tetherton"                                                |
+      | nodeAggregateId           | "nodimer-tether-son"                                               |
       | sourceOrigin              | {"language":"gsw"}                                                 |
       | generalizationOrigin      | {"language":"de"}                                                  |
       | variantSucceedingSiblings | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}] |
@@ -319,16 +319,28 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | child-of-type-b | cs-identifier;nodimer-tetherton;{"language":"de"} |
 
     And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"language":"de"}
+    And I expect this node to be classified as "tethered"
+    And I expect this node to be of type "Neos.ContentRepository.Testing:ChildOfNodeTypeA"
+    And I expect this node to be named "child-of-type-a"
     And I expect this node to have the following properties:
       | Key               | Value                |
       | commonDefaultText | "commonDefaultTextA" |
       | defaultTextA      | "defaultTextA"       |
 
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"language":"de"}
+    And I expect this node to be classified as "tethered"
+    And I expect this node to be of type "Neos.ContentRepository.Testing:ChildOfNodeTypeB"
+    And I expect this node to be named "child-of-type-b"
     And I expect this node to have the following properties:
       | Key               | Value                |
       | commonDefaultText | "commonDefaultTextB" |
       | defaultTextB      | "defaultTextB"       |
+
+    And I expect node aggregate identifier "nodimer-tether-son" to lead to node cs-identifier;nodimer-tether-son;{"language":"de"}
+    And I expect this node to be classified as "tethered"
+    And I expect this node to be of type "Neos.ContentRepository.Testing:Tethered"
+    And I expect this node to be named "tethered"
+    And I expect this node to have no properties
 
     When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"gsw"}

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -192,9 +192,7 @@ trait NodeCreation
         // so that when rebasing the command, it stays fully deterministic.
         $command = $command->withTetheredDescendantNodeAggregateIds($descendantNodeAggregateIds);
 
-        foreach (
-            $descendantNodeAggregateIds->getNodeAggregateIds() as $descendantNodeAggregateId
-        ) {
+        foreach ($descendantNodeAggregateIds->getNodeAggregateIds() as $descendantNodeAggregateId) {
             $this->requireProjectedNodeAggregateToNotExist(
                 $contentGraph,
                 $descendantNodeAggregateId

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -192,6 +192,13 @@ trait NodeTypeChange
         // so that when rebasing the command, it stays fully deterministic.
         $command = $command->withTetheredDescendantNodeAggregateIds($descendantNodeAggregateIds);
 
+        foreach ($descendantNodeAggregateIds->getNodeAggregateIds() as $descendantNodeAggregateId) {
+            $this->requireProjectedNodeAggregateToNotExist(
+                $contentGraph,
+                $descendantNodeAggregateId
+            );
+        }
+
         /**************
          * Creating the events
          **************/

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
@@ -100,6 +100,13 @@ trait RootNodeHandling
         // so that when rebasing the command, it stays fully deterministic.
         $command = $command->withTetheredDescendantNodeAggregateIds($descendantNodeAggregateIds);
 
+        foreach ($descendantNodeAggregateIds->getNodeAggregateIds() as $descendantNodeAggregateId) {
+            $this->requireProjectedNodeAggregateToNotExist(
+                $contentGraph,
+                $descendantNodeAggregateId
+            );
+        }
+
         $events = [
             $this->createRootWithNode(
                 $command,


### PR DESCRIPTION
## Adjust test to not attempt to create illegal state

Following integrity violations are detected:

- Node aggregate nodewyn-tetherton is ambiguous in content stream cs-identifier and dimension space point {"language":"gsw"},
- Node aggregate nodewyn-tetherton in content stream cs-identifier is of ambiguous type ("Neos.ContentRepository.Testing:ChildOfNodeTypeA","Neos.ContentRepository.Testing:Tethered")

see https://github.com/neos/neos-development-collection/issues/5795

## Test and implement that `tetheredDescendantNodeAggregateIds` are not occupied


- `CreateRootNodeAggregateWithNode` was already implemented but not tested
- `CreateRootNodeAggregateWithNode` and `ChangeNodeAggregateType` allowed to create illegal state in the projections