### PR TITLE
BUGFIX: SoftRemoval: Avoid uneccessary queries which become costly with many workspaces

### DIFF
--- a/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovalGarbageCollector.php
+++ b/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovalGarbageCollector.php
@@ -96,6 +96,10 @@ final readonly class SoftRemovalGarbageCollector
 
             $softRemovedNodes = $this->findNodeAggregatesInWorkspaceByExplicitRemovedTag($liveContentGraph);
 
+            if ($softRemovedNodes->isEmpty()) {
+                return;
+            }
+
             $softRemovedNodes = $this->withVisibleInDependingWorkspacesConflicts($softRemovedNodes, $contentRepository);
 
             $softRemovedNodes = $this->withImpendingHardRemovalConflicts($softRemovedNodes, $contentRepository);


### PR DESCRIPTION
In `withVisibleInDependingWorkspacesConflicts` we invoke for every workspace `$contentGraph->findNodeAggregatesByIds()` This is intended and the fastest way with the current API, but its relatively useless when `$softRemovedNodes` are empty as there will be no objections to be found.

Found during benching with 1000 workspaces and publications.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
