### PR TITLE
TASK: Greatly simplify pruning in CR maintainer

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/AbstractSubscriptionEngineTestCase.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/AbstractSubscriptionEngineTestCase.php
@@ -150,6 +150,10 @@ abstract class AbstractSubscriptionEngineTestCase extends TestCase // we don't u
 
     final protected function resetDatabase(Connection $connection, ContentRepositoryId $contentRepositoryId, bool $keepSchema): void
     {
+        // TODO use php api to reset when $keepSchema=true, but the subscriptions are not deleted from the database and just set to 0 and BOOTING
+        // $this->eventStore->reset();
+        // $this->subscriptionEngine->reset();
+
         $preDeleteStatement = match (true) {
             $connection->getDatabasePlatform() instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS = 0;',
             default => '',

--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
@@ -6,8 +6,6 @@ namespace Neos\ContentRepository\Core\Service;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
-use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
-use Neos\ContentRepository\Core\Feature\WorkspaceEventStreamName;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryStatus;
 use Neos\ContentRepository\Core\Subscription\Engine\Errors;
 use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngine;
@@ -17,11 +15,7 @@ use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatusCollection;
 use Neos\Error\Messages\Error;
 use Neos\EventStore\EventStoreInterface;
-use Neos\EventStore\Model\Event\EventType;
-use Neos\EventStore\Model\Event\EventTypes;
 use Neos\EventStore\Model\Event\SequenceNumber;
-use Neos\EventStore\Model\Event\StreamName;
-use Neos\EventStore\Model\EventStream\EventStreamFilter;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\EventStore\WithResetInterface;
 
@@ -202,13 +196,8 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
         if (!$this->eventStore instanceof WithResetInterface) {
             return new Error(sprintf('Reset is not supported of the event-store: "%s".', $this->eventStore::class));
         }
-        // prune all streams:
-        foreach ($this->findAllContentStreamStreamNames() as $contentStreamStreamName) {
-            $this->eventStore->deleteStream($contentStreamStreamName);
-        }
-        foreach ($this->findAllWorkspaceStreamNames() as $workspaceStreamName) {
-            $this->eventStore->deleteStream($workspaceStreamName);
-        }
+        $this->eventStore->reset();
+
         $resetResult = $this->subscriptionEngine->reset();
         if ($resetResult->errors !== null) {
             return self::createErrorForReason('Reset failed:', $resetResult->errors);
@@ -228,49 +217,5 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
             ...array_map(fn (string $line) => '    ' . $line, explode("\n", $errors->getClampedMessage()))
         ];
         return new Error(join("\n", $message));
-    }
-
-    /**
-     * @return list<StreamName>
-     */
-    private function findAllContentStreamStreamNames(): array
-    {
-        $events = $this->eventStore->load(
-            VirtualStreamName::forCategory(ContentStreamEventStreamName::EVENT_STREAM_NAME_PREFIX),
-            EventStreamFilter::create(
-                EventTypes::create(
-                    // we are only interested in the creation events to limit the amount of events to fetch
-                    EventType::fromString('ContentStreamWasCreated'),
-                    EventType::fromString('ContentStreamWasForked')
-                )
-            )
-        );
-        $allStreamNames = [];
-        foreach ($events as $eventEnvelope) {
-            $allStreamNames[] = $eventEnvelope->streamName;
-        }
-        return array_unique($allStreamNames, SORT_REGULAR);
-    }
-
-    /**
-     * @return list<StreamName>
-     */
-    private function findAllWorkspaceStreamNames(): array
-    {
-        $events = $this->eventStore->load(
-            VirtualStreamName::forCategory(WorkspaceEventStreamName::EVENT_STREAM_NAME_PREFIX),
-            EventStreamFilter::create(
-                EventTypes::create(
-                    // we are only interested in the creation events to limit the amount of events to fetch
-                    EventType::fromString('RootWorkspaceWasCreated'),
-                    EventType::fromString('WorkspaceWasCreated')
-                )
-            )
-        );
-        $allStreamNames = [];
-        foreach ($events as $eventEnvelope) {
-            $allStreamNames[] = $eventEnvelope->streamName;
-        }
-        return array_unique($allStreamNames, SORT_REGULAR);
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
@@ -213,21 +213,9 @@ trait CRBehavioralTestsSubjectProvider
             Assert::assertNull($result);
             self::$alreadySetUpContentRepositories[] = $contentRepository->id;
         }
-        // TODO We TRUNCATE here and do not want to use $contentRepositoryMaintainer->prune(); here as it would not reset the autoincrement sequence number making some assertions impossible
-        // TODO With https://github.com/neos/eventstore/pull/26 released we can use EventStore::prune() in the ContentRepositoryMaintainer::prune() and use that.
-        /** @var Connection $databaseConnection */
-        $databaseConnection = (new \ReflectionClass($eventStore))->getProperty('connection')->getValue($eventStore);
-        $eventTableName = sprintf('cr_%s_events', $contentRepositoryId->value);
-        if ($databaseConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName . ' RESTART IDENTITY');
-        } else {
-            $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName);
-        }
 
-        $result = $subscriptionEngine->reset();
-        Assert::assertNull($result->errors);
-        $result = $subscriptionEngine->boot();
-        Assert::assertNull($result->errors);
+        $result = $contentRepositoryMaintainer->prune();
+        Assert::assertNull($result);
 
         return $contentRepository;
     }


### PR DESCRIPTION
Requires https://github.com/neos/eventstore/pull/26
Fixes hack of https://github.com/neos/neos-development-collection/pull/5792 cleanly

Now as the `ContentRepositoryMaintainer` supports reset of the sequence number we can use it in CI



<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
