### PR TITLE
TASK: Adjust to use correct `neos/behat` subcontext in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,8 +270,10 @@ jobs:
           mkdir -p ${{ github.workspace }}/Data/DebugDatabaseDumps
           touch ${{ github.workspace }}/Data/DebugDatabaseDumps/keep
 
+          export FLOW_CONTEXT=Testing/Behat
+
           ./flow package:list --loading-order
-          FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate --quiet
+          ./flow doctrine:migrate --quiet
           cd Packages/Neos
 
           # composer test:behavioral


### PR DESCRIPTION
Requires https://github.com/neos/neos-development-collection/pull/5284

With https://github.com/neos/behat/pull/42 the `FLOW_CONTEXT` is respected

as we specify FLOW_CONTEXT: Testing behat now fails as the context must either not be defined or set to Testing/Behat or Testing/Behat/*

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
