### PR TITLE
Fix logic error in enable/disable date handling

### DIFF
--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -12,6 +12,7 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\OrCriteria;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueGreaterThanOrEqual;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueLessThanOrEqual;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
@@ -107,7 +108,7 @@ class TimeableNodeVisibilityService
                 FindDescendantNodesFilter::create(
                     nodeTypes: NodeTypeCriteria::createWithAllowedNodeTypeNames(NodeTypeNames::fromStringArray(['Neos.TimeableNodeVisibility:Timeable'])),
                     propertyValue: OrCriteria::create(
-                        PropertyValueLessThanOrEqual::create(PropertyName::fromString('enableAfterDateTime'), $now->format(\DateTime::RFC3339)),
+                        PropertyValueGreaterThanOrEqual::create(PropertyName::fromString('enableAfterDateTime'), $now->format(\DateTime::RFC3339)),
                         PropertyValueLessThanOrEqual::create(PropertyName::fromString('disableAfterDateTime'), $now->format(\DateTime::RFC3339)),
                     )
 
@@ -128,27 +129,27 @@ class TimeableNodeVisibilityService
 
     private function needsEnabling(Node $node, \DateTimeImmutable $now): bool
     {
-        return $node->hasProperty('enableAfterDateTime')
-            && $node->getProperty('enableAfterDateTime') != null
+        return (
+            $node->hasProperty('enableAfterDateTime')
+            && $node->getProperty('enableAfterDateTime') !== null
             && $node->getProperty('enableAfterDateTime') < $now
-            && (
-                !$node->hasProperty('disableAfterDateTime')
-                || $node->getProperty('disableAfterDateTime') == null
-                || $node->getProperty('disableAfterDateTime') > $now
-                || $node->getProperty('disableAfterDateTime') < $node->getProperty('enableAfterDateTime')
+            ) || (
+                $node->hasProperty('disableAfterDateTime')
+                && $node->getProperty('disableAfterDateTime') !== null
+                && $node->getProperty('disableAfterDateTime') > $now
             );
     }
 
     private function needsDisabling(Node $node, \DateTimeImmutable $now): bool
     {
-        return $node->hasProperty('disableAfterDateTime')
-            && $node->getProperty('disableAfterDateTime') != null
-            && $node->getProperty('disableAfterDateTime') < $now
-            && (
-                !$node->hasProperty('enableAfterDateTime')
-                || $node->getProperty('enableAfterDateTime') == null
-                || $node->getProperty('enableAfterDateTime') > $now
-                || $node->getProperty('enableAfterDateTime') <= $node->getProperty('disableAfterDateTime')
+        return (
+                $node->hasProperty('disableAfterDateTime')
+                && $node->getProperty('disableAfterDateTime') !== null
+                && $node->getProperty('disableAfterDateTime') < $now
+            ) || (
+                $node->hasProperty('enableAfterDateTime')
+                && $node->getProperty('enableAfterDateTime') !== null
+                && $node->getProperty('enableAfterDateTime') > $now
             );
     }
 


### PR DESCRIPTION
**Problem**

The previous implementation of needsDisabling() and needsEnabling() had a logical flaw due to nested conditions and short-circuiting.

Both methods required one date property to exist before evaluating the other:

needsDisabling() only evaluated enableAfterDateTime if disableAfterDateTime was set
needsEnabling() only evaluated disableAfterDateTime if enableAfterDateTime was set

This caused valid scenarios to be ignored. For example:

If disableAfterDateTime was not set, enableAfterDateTime was never checked in needsDisabling()
Similarly, missing enableAfterDateTime prevented evaluation of disableAfterDateTime in needsEnabling()

As a result, nodes could end up in the wrong state because relevant conditions were skipped.

**Solution**

The logic was refactored to decouple both properties and evaluate them independently.

Each date (enableAfterDateTime, disableAfterDateTime) is now checked on its own
No property is a prerequisite for evaluating the other
The logic now correctly reflects that both dates can independently influence the node state

This removes the unintended short-circuiting and ensures all relevant conditions are considered.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
