### PR TITLE
TASK: Remove `@adapters=` and other obsolete tags in CR behaviour tests

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/AllNodesAreConnectedToARootNodePerSubgraph.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/AllNodesAreConnectedToARootNodePerSubgraph.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Run projection integrity violation detection regarding root connection
 
   As a user of the CR I want to be able to check whether there are nodes that are not connected to a root node.

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/HierarchyIntegrityIsProvided.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Run integrity violation detection regarding hierarchy relations and nodes
 
   As a user of the CR I want to know whether there are nodes or hierarchy relations with invalid hashes or parents / children

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/NodesHaveAtMostOneParentPerSubgraph.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Run integrity violation detection regarding parent relations
 
   As a user of the CR I want to know whether there are nodes that have multiple parents per subgraph

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Run integrity violation detection regarding reference relations
 
   As a user of the CR I want to know whether there are disconnected reference relations

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Run integrity violation detection regarding sibling sorting
 
   As a user of the CR I want to know whether there are siblings with ambiguous sorting

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SubtreeTagsAreInherited.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Run integrity violation detection regarding subtree tag inheritance
 
   As a user of the CR I want to know whether there are nodes with subtree tags that are not inherited from its ancestors

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/TetheredNodesAreNamed.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Run projection integrity violation detection regarding naming of tethered nodes
 
   As a user of the CR I want to be able to detect whether there are unnamed tethered events

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Sibling positions are properly resolved
 
   In the general DBAL adapter, hierarchy relations are sorted by an integer field. It defaults to a distance of 128,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/01-CreateRootNodeAggregateWithNode_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create a root node aggregate
 
   As a user of the CR I want to create a new root node aggregate with an initial node.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/02-CreateRootNodeAggregateWithNode_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create a root node aggregate
 
   As a user of the CR I want to create a new root node aggregate with an initial node.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Create a root node aggregate with tethered children
 
   As a user of the CR I want to create a new root node aggregate with an initial node and tethered children.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Create a root node aggregate with tethered children
 
   As a user of the CR I want to create a new root node aggregate with an initial node and tethered children.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/05-CreateRootNodeAggregateWithNode_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create a root node aggregate
 
   As a user of the CR I want to create a new root node aggregate with an initial node.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/01-CreateNodeAggregateWithNode_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node aggregate with node
 
   As a user of the CR I want to create a new externally referencable node aggregate of a specific type with an initial node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/02-CreateNodeAggregateWithNode_ConstraintChecks_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node aggregate with node
 
   As a user of the CR I want to create a new externally referencable node aggregate of a specific type with an initial node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node aggregate with node
 
   As a user of the CR I want to create a new externally referencable node aggregate of a specific type with an initial node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node aggregate with node
 
   As a user of the CR I want to create a new externally referencable node aggregate of a specific type with a node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create a node aggregate with complex default values
 
   As a user of the CR I want default properties of complex types to be un/serialized

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/06-CreateNodeAggregateWithNode_NodeTypeConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node aggregate with node
 
   As a user of the CR I want to define NodeType constraints which will restrict the allowed child nodes

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/01-CreateNodeVariant_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node variant
 
   As a user of the CR I want to create a copy of a node within an aggregate to another dimension space point.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node specialization
 
   As a user of the CR I want to create a copy of a node within an aggregate to a more specialized dimension space point.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node generalization
 
   As a user of the CR I want to create a copy of a node within an aggregate to a more general dimension space point.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node peer variant
 
   As a user of the CR I want to create a copy of a node within an aggregate to a peer dimension space point, i.e. one that is neither a generalization nor a specialization.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/01-SetNodeProperties_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Set node properties: Constraint checks
 
   As a user of the CR I want to modify node properties.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/02-SetNodeProperties.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Set properties
 
   As a user of the CR I want to modify node properties.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/04-NodeModification/03-SetNodeProperties_PropertyScopes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Set node properties with different scopes
 
   As a user of the CR I want to modify node properties with different scopes.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Constraint checks on SetNodeReferences
 
   As a user of the CR I expect invalid SetNodeReferences commands to be blocked

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/02-SetNodeReferences_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Node References without Dimensions
 
   As a user of the CR I want to be able to create, overwrite, reorder and delete reference between nodes

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/03-SetNodeReferences_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Node References with Dimensions
 
   As a user of the CR I want to be able to create, overwrite, reorder and delete reference between nodes

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/04-SetNodeReferences_PropertyScopes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Set node properties with different scopes
 
   As a user of the CR I want to modify node references with different scopes.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/05-NodeVariation_After_NodeReferencing.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Node References with Dimensions
 
   As a user of the CR I want to be able to create, overwrite, reorder and delete reference between nodes

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/01-DisableNodeAggregate_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Constraint checks on node aggregate disabling
 
   As a user of the CR I want to disable a node aggregate and expect its descendants to also be disabled.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Disable a node aggregate
 
   As a user of the CR I want to disable a node aggregate and expect its descendants to also be disabled.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Disable a node aggregate
 
   As a user of the CR I want to disable a node aggregate and expect its descendants to also be disabled.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/04-EnableNodeAggregate_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Enable a node aggregate
 
   As a user of the CR I want to enable a disabled node and expect its descendants that have been directly disabled by this node to become enabled as well.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Enable a node aggregate
 
   As a user of the CR I want to enable a node aggregate and expect its descendants to also be enabled unless otherwise disabled.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Enable a node aggregate
 
   As a user of the CR I want to disable a node aggregate and expect its descendants to also be disabled.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Creation of nodes underneath disabled nodes
 
   If we create new nodes underneath of disabled nodes, they must be marked as disabled as well;

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Creation of nodes underneath disabled nodes
 
   If we create new nodes underneath of disabled nodes, they must be marked as disabled as well;

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Variation of hidden nodes
 
   If we create variants of nodes hidden in the respective dimension space point(s),

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/Rebase_Legacy_DisableAndEnableNodeAggregate.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/Rebase_Legacy_DisableAndEnableNodeAggregate.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Rebase disable a node aggregate
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/01-RemoveNodeAggregate_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Remove NodeAggregate
 
   As a user of the CR I want to be able to remove a NodeAggregate or parts of it.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Remove NodeAggregate
 
   As a user of the CR I want to be able to remove a NodeAggregate or parts of it.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Remove NodeAggregate
 
   As a user of the CR I want to be able to remove a NodeAggregate or parts of it.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Recreate a node variant
 
   As a user of the CR I want to be able to recreate a variant after I deleted and published it

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node specialization
 
   As a user of the CR I want to create a node at the proper place after deletion

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Create node specialization
 
   As a user of the CR I want to create a copy of a node within an aggregate to a more specialized dimension space point.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/01-MoveNodes_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move node to a new parent / within the current parent before a sibling / to the end of the sibling list
 
   As a user of the CR I want to move a node to a new parent / within the current parent before a sibling / to the end of the sibling list,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move a node with content dimensions
 
   As a user of the CR I want to move a node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move a node with content dimensions
 
   As a user of the CR I want to move a node to a new parent

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move a node with content dimensions
 
   As a user of the CR, when I move a node to a new parent, where that parent or requested siblings have been scattered,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move a node aggregate into and out of a tagged parent
 
   As a user of the CR I want to move a node that

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/06-AdditionalConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Additional constraint checks after move node capabilities are introduced
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move a node without content dimensions
 
   As a user of the CR I want to move a node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/08-SubtreeTaggingAfterNodeMove.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Tag and untag nodes after moving their children in or out
 
   As a user of the CR I want to

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/01-ChangeNodeAggregateName_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/01-ChangeNodeAggregateName_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change node name
 
   As a user of the CR I want to change the name of a hierarchical relation between two nodes (e.g. in taxonomies)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change node aggregate name
 
   As a user of the CR I want to change the name of a node aggregate

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change node aggregate type - basic error cases
 
   As a user of the CR I want to change the type of a node aggregate.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/02-ChangeNodeAggregateType_DeleteStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/02-ChangeNodeAggregateType_DeleteStrategy.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change node aggregate type - behavior of DELETE strategy
 
   As a user of the CR I want to change the type of a node aggregate.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change node aggregate type - behavior of HAPPYPATH strategy
 
   As a user of the CR I want to change the type of a node aggregate.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/01-ForkContentStream_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: ForkContentStream Without Dimensions
 
   We have only one node underneath the root node: /foo.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: On forking a content stream, hidden nodes should be correctly copied as well.
 
   Because we store hidden node information in an extra DB table, this needs to be copied correctly on ForkContentStream

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: ForkContentStream Without Dimensions
 
   We have only one node underneath the root node: /foo.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/NodeReferencesOnForkContentStream.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: On forking a content stream, node references should be copied as well.
 
   Because we store reference node information in an extra DB table, this needs to be copied correctly on ForkContentStream

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Add Dimension Specialization
 
   This is needed if "de" exists, and you want to create a "de_CH" specialization:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Add Dimension Specialization - constraint checks
 
   This is needed if "de" exists, and you want to create a "de_CH" specialization:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D2-UpdateRootNodeAggregateDimensions/UpdateRootNodeAggregateDimensions_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D2-UpdateRootNodeAggregateDimensions/UpdateRootNodeAggregateDimensions_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Update Root Node aggregate dimensions
 
   I want to update a root node aggregate's dimensions when the dimension config changes.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move dimension space point
 
   basically "renames" a dimension space point; needed if:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move dimension space point
 
   These are the constraint check tests to prevent damage to the content repository state

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint_ZeroDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint_ZeroDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Move dimension space point from / to the zero dimensional case
 
   basically "renames" a dimension space point; needed if:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/AddNewProperty_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Add New Property
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_Dimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change Property Value across dimensions; and test DimensionSpacePoints filter
 
   NOTE: ChangePropertyValue is tested exhaustively in ChangePropertyValues_NoDimensions.feature; here,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/ChangePropertyValue_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change Property
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_NodeName_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Filter - Node Name
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyNotEmpty_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Filter - Property not empty
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/Filter_PropertyValue_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Filter - Property Value
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_Dimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Adjust node types with a node migration
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/NodeTypeAdjustment_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Adjust node types with a node migration
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/PublishingOnSuccess_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/PublishingOnSuccess_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Publishing on Success
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove Nodes
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveProperty_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove Property
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameNodeAggregate_Dimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Rename Node Aggregate
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RenameProperty_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Rename Property
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/StripTagsOnProperty_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Strip Tags on Property
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Update root node aggregate dimensions
 
   Creates empty root node aggregate dimensions for each allowed dimension combination and removes them for all non-configured ones.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodePropertyConversion/NodePropertyConversion.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Node Property Conversion
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Disable a node aggregate
 
   As a user of the CR I want to disable a node aggregate and expect its descendants to also be disabled.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove NodeAggregate
 
   As a user of the CR I want to be able to remove a NodeAggregate completely.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodesFromAggregate.wip
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodesFromAggregate.wip
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove Nodes from Aggregate
 
   As a user of the CR I want to be able to remove a node.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -1,5 +1,4 @@
 @contentrepository @adapters=DoctrineDBAL
-  # TODO implement for Postgres
 Feature: Find and count nodes using the findAncestorNodes, countAncestorNodes and findAncestorNodeAggregateIds queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find and count nodes using the findAncestorNodes, countAncestorNodes and findAncestorNodeAggregateIds queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -1,5 +1,4 @@
 @contentrepository @adapters=DoctrineDBAL
-  # TODO implement for Postgres
 Feature: Find and count nodes using the findChildNodes and countChildNodes queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find and count nodes using the findChildNodes and countChildNodes queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
@@ -1,5 +1,4 @@
 @contentrepository @adapters=DoctrineDBAL
-  # TODO implement for Postgres
 Feature: Find nodes using the findClosestNode query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find nodes using the findClosestNode query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the countNodes query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -1,5 +1,4 @@
 @contentrepository @adapters=DoctrineDBAL
-  # TODO implement for Postgres
 Feature: Find and count nodes using the findDescendantNodes and countDescendantNodes queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find and count nodes using the findDescendantNodes and countDescendantNodes queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the findNodeById query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the findNodeByPath query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the findNodeByPath query with node name as path argument
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the findNodeById query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the findParentNodes query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find root nodes by type
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL,Postgres
 Feature: Find nodes using the findSubtree query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find and count references and their target nodes using the findReferences, findBackReferences, countReferences and countBackReferences queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
@@ -1,5 +1,4 @@
 @contentrepository @adapters=DoctrineDBAL
-  # TODO implement for Postgres
 Feature: Find nodes using the retrieveNodePath query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find nodes using the retrieveNodePath query
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Find sibling nodes using the findPrecedingSiblingNodes and findSucceedingSiblingNodes queries
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -1,5 +1,4 @@
 @contentrepository @adapters=DoctrineDBAL
- # TODO implement for Postgres
 Feature: Behavior of Node timestamp properties "created", "originalCreated", "lastModified" and "originalLastModified"
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Behavior of Node timestamp properties "created", "originalCreated", "lastModified" and "originalLastModified"
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/AllNodesCoverTheirOrigin.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Run projection integrity violation detection to find nodes that do not cover their origin dimension space point
 
   As a user of the CR I want to be able to detect whether there are nodes that are disconnected from the subgraph they originate in

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/IntactContentGraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/IntactContentGraph.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Create an intact content graph and run integrity violation detection
 
   As a user of the CR I want to be able to get an empty integrity violation detection result on an intact content graph

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregateIdentifiersAreUniquePerSubgraph.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Create two nodes with the same node aggregate identifier in the same subgraph
 
   As a user of the CR I want to be able to check whether there are ambiguous node aggregates

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyClassifiedPerContentStream.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Run projection integrity violation detection regarding node aggregate classification consistency
 
   As a user of the CR I want to be able to detect whether there are node aggregates of ambiguous classification in a content stream

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/NodeAggregatesAreConsistentlyTypedPerContentStream.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Run projection integrity violation detection regarding node aggregate type consistency
 
   As a user of the CR I want to be able to detect whether there are node aggregates of ambiguous type in a content stream

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Run integrity violation detection regarding reference relations
 
   As a user of the CR I want to know whether there are disconnected reference relations

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DimensionMismatch.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Dimension mismatch
 
   Nodes must only cover specializations of their origin.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNode.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove disallowed Child Nodes and grandchild nodes
 
   As a user of the CR I want to be able to detect and remove disallowed child nodes according to the constraints

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/DisallowedChildNodesAndTetheredNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove disallowed Child Nodes and grandchild nodes
 
   As a user of the CR I want to be able to keep tethered child nodes although their type is not allowed below their parent

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/MissingTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/MissingTetheredNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Missing Tethered Nodes integrity violations
 
   As a user of the CR I want to be able to detect and fix tethered nodes that are missing

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/Properties.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Properties
 
   As a user of the CR I want to be able to detect and handle properties:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Tethered Nodes integrity violations
 
   As a user of the CR I want to be able to detect and fix tethered nodes that are missing, not allowed or otherwise incorrect

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Tethered Nodes Reordering Structure changes
 
   As a user of the CR I want to be able to detect wrongly ordered tethered nodes, and fix them.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/UnknownNodeType.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Unknown node types
 
   As a user of the CR I want to be able to detect and remove unknown node types

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Constraint checks on tag subtree
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Tag subtree with dimensions
 
   As a user of the CR I want to tag a node and expect its descendants to also be tagged.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Tag subtree without dimensions
 
   As a user of the CR I want to tag a node aggregate and expect its descendants to also be tagged.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/01-ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace discarding - complex chained functionality
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W10-IndividualNodeDiscarding/02-BasicFeatures.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Discard individual nodes (basics)
 
   Publishing an individual node works

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/01-ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change base workspace constraints
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W11-ChangeBaseWorkspace/02-BasicFeatures.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Change base workspace works :D what else
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/01-BasicFeatures.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Rebasing with no conflict
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Rebasing auto-created nodes works
 
   Tests a bugfix for auto-created nodes, which appeared in Neos UI.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/03-RebasingWithConflictingChanges.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace rebasing - conflicting changes
 
   This is an END TO END test; testing all layers of the related functionality step by step together

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/04-WorkspaceMaintenanceService.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/04-WorkspaceMaintenanceService.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace rebasing - via workspace maintenance service
 
   These are the test cases for the workspace maintenance service to properly do its job

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W7-WorkspacePublication/02-PublishWorkspace.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace based content publishing
 
   This is an END TO END test; testing all layers of the related functionality step by step together

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/01-ConstraintChecks.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace publication - complex chained functionality
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Individual node publication
 
   Publishing an individual node works

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Publishing individual nodes (basics)
 
   Publishing an individual node works

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Publishing hide/show scenario of nodes
 
   Node structure is as follows:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Publishing moved nodes without dimensions
 
   As a user of the CR I want to move a node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/06-PublishNodeTypeChangeWithTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/06-PublishNodeTypeChangeWithTetheredNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Partial publish after node type change tagging tethered children
 
   Publishing a node type change (Document→Shortcut) that tags tethered children

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W9-WorkspaceDiscarding/02-DiscardWorkspace.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace discarding - basic functionality
 
   This is an END TO END test; testing all layers of the related functionality step by step together

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Single Node operations on multiple workspaces/content streams; e.g. copy on write!
 
   Background:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/PruneContentStreams.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: If content streams are not in use anymore by the workspace, they can be properly pruned - this is
   tested here.
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodeAggregateWithDimensions.wip
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodeAggregateWithDimensions.wip
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove NodeAggregate
 
   As a user of the CR I want to be able to remove a NodeAggregate completely.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodesFromAggregate.wip
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/RemoveNodesFromAggregate.wip
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Remove Nodes from Aggregate
 
   As a user of the CR I want to be able to remove a node.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/SingleNodeOperationsOnLiveWorkspace.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Single Node operations on live workspace
 
   As a user of the CR I want to execute operations on a node in live workspace.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/WorkspaceState.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/WorkspaceState.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Workspace status
   The workspace status signals if the workspace is UP_TO_DATE or OUTDATED
   All depending workspaces are considered OUTDATED if changes are made or published into a workspace

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/EventExportProcessor.feature
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/EventExportProcessor.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: As a user of the CR I want to export the event stream using the EventExportProcessor
 
   Background:

--- a/Neos.ContentRepository.Export/Tests/Behavior/Features/EventStoreImportProcessor.feature
+++ b/Neos.ContentRepository.Export/Tests/Behavior/Features/EventStoreImportProcessor.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: As a user of the CR I want to import events using the EventStoreImportProcessor
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Assets.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Assets.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Export of used Assets, Image Variants and Persistent Resources
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Basic.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Basic.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Simple migrations without content dimensions
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Errors.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Errors.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Exceptional cases during migrations
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Hidden.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Hidden.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Simple migrations without content dimensions for hidden state migration
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenWithoutTimeableNodeVisibility.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenWithoutTimeableNodeVisibility.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Simple migrations without content dimensions for hidden state migration without installed Neos.TimeableNodeVisibility
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/References.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/References.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Migrations that contain nodes with "reference" or "references properties
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/RootNodeTypeMapping.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/RootNodeTypeMapping.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Simple migrations without content dimensions but other root nodetype name
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Sites.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Sites.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Simple migrations without content dimensions
 
   Background:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Migrating nodes with content dimensions
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/02-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/01-NodeCreation/02-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/01-CreateNodeGeneralizationVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/01-CreateNodeGeneralizationVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node generalization variant
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node specialization variant
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/03-CreateNodeSpecializationVariant_InternalWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/03-CreateNodeSpecializationVariant_InternalWorkspace.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node peer variant with internal workspace between live and user workspace
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/02-NodeVariation/04-CreateNodePeerVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node peer variant
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/01-SetNodeProperties_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/01-SetNodeProperties_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/02-SetNodeProperties_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/03-NodeModification/02-SetNodeProperties_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/04-NodeRemoval/01-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/04-NodeRemoval/01-RemoveNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Remove node aggregate with node without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Move DimensionSpacePoints
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Build index for existing nodes without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/02-Indexing_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/02-Indexing_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Build index for existing nodes with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/01-PublishWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/01-PublishWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/02-PublishWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/02-PublishWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/03-PublishIndividualNodesFromWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/03-PublishIndividualNodesFromWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes partially without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/04-PublishIndividualNodesFromWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W01-WorkspacePublication/04-PublishIndividualNodesFromWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes partially with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/01-DiscardWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/01-DiscardWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard workspace without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/02-DiscardWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/02-DiscardWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard workspace with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/03-DiscardIndividualNodesFromWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/03-DiscardIndividualNodesFromWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard nodes partially without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/04-DiscardIndividualNodesFromWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/W02-WorkspaceDiscarding/04-DiscardIndividualNodesFromWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard nodes partially with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_ConstraintChecks_NoDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_ConstraintChecks_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Copy nodes constraint checks
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_ConstraintChecks_TetheredNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_ConstraintChecks_TetheredNodes.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Copy nodes constraint checks
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_NoDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_NoDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Copy nodes (without dimensions)
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeDisabling.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeDisabling.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 Feature: Special invariant checks for neos node disabling
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Basic.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Basic routing functionality (match & resolve document nodes in one dimension)
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/NoopResolver.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/NoopResolver.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: NoopResolver does nothing (boilerplate testcase)
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/UriPathResolver.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DimensionResolution/UriPathResolver.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: UriPathResolver works as expected
 
   We model the following examples:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Dimensions.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Routing functionality with multiple content dimensions
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Routing behavior of removed, disabled and re-enabled nodes
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_ProjectionTests.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Low level tests covering the inner behavior of the routing projection
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MissingPathSegments.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Routing functionality if path segments are missing like during tethered node creation
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/MultiSiteLinking.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Linking between multiple websites
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeAggregateTypeChangeEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeAggregateTypeChangeEdgeCases.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Test cases for node aggregate type change edge cases
 
   Scenario: Create a (non-document) node with uri path segment, change the node aggregate's type to be a document and expect it to now have a uri path segment

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeCreationEdgeCases.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Test cases for node creation edge cases
 
   Scenario: Delete the succeeding sibling node in a virtual specialization and then create the node

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Test cases for node variation edge cases
 
   Scenario: Create peer variant of node to dimension space point with specializations

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/PartialPublish.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Test cases for partial publish to live and uri path generation
 
   Scenario: Create Document in another workspace and partially publish to live

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/RouteCache.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Route cache invalidation
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Shortcuts.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Routing behavior of shortcut nodes
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/SoftRemovedNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/SoftRemovedNodes.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Routing behavior of soft removed nodes
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Tests for site node child documents. These are special in that they have the first non-dimension uri path segment.
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/UnknownNodeTypes.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Basic routing functionality (match & resolve nodes with unknown types)
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCache.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ContentCache.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Tests for Fusion ContentCache
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Tests for the "Neos.ContentRepository" Flow Query methods.
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery_Advanced.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/FlowQuery_Advanced.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Tests for Flow Query context operation
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/Menu.feature
@@ -1,4 +1,4 @@
-@flowEntities @contentrepository
+@flowEntities
 Feature: Tests for the "Neos.Neos:Menu" and related Fusion prototypes
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/01-NodeCreation/01-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node without dimensions
   TODO Remove this test, obsolete because of 02-CreateNodeAggregateWithNode_WithDimensions

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/01-NodeCreation/02-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/01-NodeCreation/02-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -1,5 +1,4 @@
-# @contentrepository @adapters=DoctrineDBAL
-@flowEntities
+# @flowEntities
 Feature: Create node aggregate with node with dimensions
 
   Background:

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/01-CreateNodeGeneralizationVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/01-CreateNodeGeneralizationVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node generalization variant
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node specialization variant
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/03-CreateNodeSpecializationVariant_InternalWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/03-CreateNodeSpecializationVariant_InternalWorkspace.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node peer variant with internal workspace between live and user workspace
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/02-NodeVariation/04-CreateNodePeerVariant.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node peer variant
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/03-NodeModification/01-SetNodeProperties_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/03-NodeModification/01-SetNodeProperties_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node without dimensions
   TODO remove this test, obsolete because of 02-SetNodeProperties_WithDimensions

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/03-NodeModification/02-SetNodeProperties_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/03-NodeModification/02-SetNodeProperties_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Create node aggregate with node with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/04-NodeReferencing/01-SetNodeReferences_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/04-NodeReferencing/01-SetNodeReferences_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Node referencing without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/04-NodeReferencing/02-SetNodeReferences_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/04-NodeReferencing/02-SetNodeReferences_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Node referencing with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/05-NodeDisabling/01-DisableNode_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/05-NodeDisabling/01-DisableNode_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Disable node without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/05-NodeDisabling/02-DisableNodes_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/05-NodeDisabling/02-DisableNodes_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Disable node with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/06-NodeRemoval/01-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/06-NodeRemoval/01-RemoveNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Remove node aggregate with node without dimensions
   Todo obsolete via 02-RemoveNodeAggregate_WithDimensions

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/06-NodeRemoval/02-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/06-NodeRemoval/02-RemoveNodeAggregate_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Hard remove node aggregate with node
   Nodes in non-live workspace must be soft removed to be properly publishable via the neos ui

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/07-NodeMove/01-MoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/07-NodeMove/01-MoveNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Move node aggregate without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/07-NodeMove/02-MoveNodeAggregate_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/07-NodeMove/02-MoveNodeAggregate_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Move node aggregate with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/08-NodeRenaming/01-ChangeNodeAggregateName_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/08-NodeRenaming/01-ChangeNodeAggregateName_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Change node aggregate name without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/08-NodeRenaming/02-ChangeNodeAggregateName_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/08-NodeRenaming/02-ChangeNodeAggregateName_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Change node aggregate name with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/09-NodeTypeChange/01-ChangeNodeAggregateType_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/09-NodeTypeChange/01-ChangeNodeAggregateType_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Change node aggregate type without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/09-NodeTypeChange/02-ChangeNodeAggregateType_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/09-NodeTypeChange/02-ChangeNodeAggregateType_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Change node aggregate type with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/01-SoftRemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/01-SoftRemoveNodeAggregate_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Soft remove node aggregate with node without dimensions
   TODO obsolete because of 02-SoftRemoveNodeAggregate_WithDimensions.feature

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/02-SoftRemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/NodeSoftRemoval/02-SoftRemoveNodeAggregate_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Soft remove node aggregate with node
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/01-PublishWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/01-PublishWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/02-PublishWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/02-PublishWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/03-PublishIndividualNodesFromWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/03-PublishIndividualNodesFromWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes partially without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/04-PublishIndividualNodesFromWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/04-PublishIndividualNodesFromWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Publish nodes partially with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/05-PublishNodeTypeChangeWithTetheredNodes_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/05-PublishNodeTypeChangeWithTetheredNodes_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Partial publish after node type change tagging tethered nodes (without dimensions)
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/01-DiscardWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/01-DiscardWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard workspace without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/02-DiscardWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/02-DiscardWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard workspace with dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/03-DiscardIndividualNodesFromWorkspace_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/03-DiscardIndividualNodesFromWorkspace_WithoutDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard nodes partially without dimensions
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/04-DiscardIndividualNodesFromWorkspace_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W02-WorkspaceDiscarding/04-DiscardIndividualNodesFromWorkspace_WithDimensions.feature
@@ -1,4 +1,3 @@
-@contentrepository @adapters=DoctrineDBAL
 @flowEntities
 Feature: Discard nodes partially with dimensions
 

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
@@ -1,4 +1,3 @@
-@contentrepository
 Feature: Simple handling of nodes with exceeded enableAfter and disableAfter datetime properties
 
   Background:


### PR DESCRIPTION
So this does not clutter the pr #5751 
We currently do not evaluate any of these tags and they are just chilling there.
We could keep the `@contentrepository` tag but some test dont implement them and they work without and dont do anything.

For history:

With 94f72b1e2385640a1da56250590b0e8eb56c8b69 we used multiple content graphs at once during testing - for the same content repository - that was possible at that time where the content graph was not a first level projection citizen.

Later with https://github.com/neos/neos-development-collection/pull/4455 this was removed but the `@adapters` tags were kept.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
