### PR TITLE
BUGFIX: Ignore orphaned reference relations in integrity violation

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -307,12 +307,30 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
         }
 
         foreach ($referenceRelationRecordsWithInvalidTarget as $record) {
-            $result->addError(new Error(
-                'Destination node aggregate ' . $record['destinationNodeAggregateId']
-                . ' does not cover any dimension space points the source ' . $record['sourceNodeAggregateId']
-                . ' does in content stream ' . $record['contentstreamId'],
-                self::ERROR_CODE_REFERENCE_INTEGRITY_IS_COMPROMISED
-            ));
+            $destinationNodeAggregateExistStatement = <<<SQL
+            SELECT 1 FROM {$this->tableNames->node()} AS n
+            WHERE n.nodeaggregateid = :destinationNodeAggregateId
+            LIMIT 1
+            SQL;
+            try {
+                $destinationNodeAggregateExist = $this->dbal->fetchOne($destinationNodeAggregateExistStatement, [
+                    'destinationNodeAggregateId' => $record['destinationNodeAggregateId'],
+                ]);
+            } catch (DBALException $e) {
+                throw new \RuntimeException(sprintf('Failed to check if node aggregate exists: %s', $e->getMessage()), 1777651107, $e);
+            }
+
+            // Neos 9.0 intentionally treats references rather like symlinks, which means that when removing the destination node the reference edge is not removed
+            // in a later stage this still can be implemented: https://github.com/neos/neos-development-collection/pull/5797
+            // but for now, we do not log an error but accept the state as is.
+            if ($destinationNodeAggregateExist !== false) {
+                $result->addError(new Error(
+                    'Destination node aggregate ' . $record['destinationNodeAggregateId']
+                    . ' does not cover any dimension space points the source ' . $record['sourceNodeAggregateId']
+                    . ' does in content stream ' . $record['contentstreamId'],
+                    self::ERROR_CODE_REFERENCE_INTEGRITY_IS_COMPROMISED
+                ));
+            }
         }
 
         return $result;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -308,13 +308,16 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
 
         foreach ($referenceRelationRecordsWithInvalidTarget as $record) {
             $destinationNodeAggregateExistStatement = <<<SQL
-            SELECT 1 FROM {$this->tableNames->node()} AS n
+            SELECT 1 FROM {$this->tableNames->hierarchyRelation()} AS h
+                INNER JOIN {$this->tableNames->node()} AS n ON n.relationanchorpoint = h.childnodeanchor
             WHERE n.nodeaggregateid = :destinationNodeAggregateId
+                AND h.contentstreamid = :contentStreamId
             LIMIT 1
             SQL;
             try {
                 $destinationNodeAggregateExist = $this->dbal->fetchOne($destinationNodeAggregateExistStatement, [
                     'destinationNodeAggregateId' => $record['destinationNodeAggregateId'],
+                    'contentStreamId' => $record['contentstreamId'],
                 ]);
             } catch (DBALException $e) {
                 throw new \RuntimeException(sprintf('Failed to check if node aggregate exists: %s', $e->getMessage()), 1777651107, $e);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -323,17 +323,17 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 throw new \RuntimeException(sprintf('Failed to check if node aggregate exists: %s', $e->getMessage()), 1777651107, $e);
             }
 
-            // Neos 9.0 intentionally treats references rather like symlinks, which means that when removing the destination node the reference edge is not removed
-            // in a later stage this still can be implemented: https://github.com/neos/neos-development-collection/pull/5797
-            // but for now, we do not log an error but accept the state as is.
-            if ($destinationNodeAggregateExist !== false) {
-                $result->addError(new Error(
-                    'Destination node aggregate ' . $record['destinationNodeAggregateId']
-                    . ' does not cover any dimension space points the source ' . $record['sourceNodeAggregateId']
-                    . ' does in content stream ' . $record['contentstreamId'],
-                    self::ERROR_CODE_REFERENCE_INTEGRITY_IS_COMPROMISED
-                ));
+            if ($destinationNodeAggregateExist === false) {
+                // Neos 9.0 intentionally treats references like symlinks, which means that when removing the destination node the reference edge is not removed.
+                // Thus, we do not yield an error. See https://github.com/neos/neos-development-collection/issues/5809
+                continue;
             }
+            $result->addError(new Error(
+                'Destination node aggregate ' . $record['destinationNodeAggregateId']
+                . ' does not cover any dimension space points the source ' . $record['sourceNodeAggregateId']
+                . ' does in content stream ' . $record['contentstreamId'],
+                self::ERROR_CODE_REFERENCE_INTEGRITY_IS_COMPROMISED
+            ));
         }
 
         return $result;

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -129,7 +129,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
 
-    # TODO After recreating the node the backreferences are magically reinstated (https://github.com/neos/neos-development-collection/pull/5797)
+    # Neos 9.0 intentionally treats references like symlinks, which means that when recreating the destination node the reference still exists.
+    # See https://github.com/neos/neos-development-collection/issues/5809
     # And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     # And I expect this node to have no references
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -36,6 +36,10 @@ Feature: Remove NodeAggregate
       | Key                   | Value                                  |
       | sourceNodeAggregateId | "nodingers-cat"                        |
       | references            | [{"referenceName": "references", "references": [{"target": "sir-david-nodenborough"}]}] |
+    And the command SetNodeReferences is executed with payload:
+      | Key                   | Value                                                                          |
+      | sourceNodeAggregateId | "nody-mc-nodeface"                                                             |
+      | references            | [{"referenceName": "references", "references": [{"target": "nodingers-cat"}]}] |
 
   Scenario: Remove a node aggregate
     When the command RemoveNodeAggregate is executed with payload:
@@ -62,8 +66,12 @@ Feature: Remove NodeAggregate
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no references
+    And I expect this node to not be referenced
     And I expect the node aggregate "nodingers-cat" to not exist
     And I expect the node aggregate "nodingers-kitten" to not exist
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have no references
 
   Scenario: Disable a node aggregate, remove it, recreate it and expect it to be enabled
     When the command DisableNodeAggregate is executed with payload:
@@ -120,6 +128,10 @@ Feature: Remove NodeAggregate
     And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{}
     And I expect this node to have no references
     And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+
+    # TODO After recreating the node the backreferences are magically reinstated (https://github.com/neos/neos-development-collection/pull/5797)
+    # And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    # And I expect this node to have no references
 
   Scenario: Remove a node aggregate with descendants and expect all of them to be gone
     When the command RemoveNodeAggregate is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -10,9 +10,8 @@ Feature: Remove NodeAggregate
     And using the following node types:
     """yaml
     'Neos.ContentRepository.Testing:Document':
-      properties:
-        references:
-          type: references
+      references:
+        references: {}
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -28,9 +27,11 @@ Feature: Remove NodeAggregate
       | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName |
-      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document |
-      | nodingers-cat          | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | pet      |
-      | nodingers-kitten       | Neos.ContentRepository.Testing:Document | nodingers-cat          | kitten   |
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document      |
+      | nody-mc-nodeface       | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | child         |
+      | younger-mc-nodeface    | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | younger-child |
+      | nodingers-cat          | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | pet           |
+      | nodingers-kitten       | Neos.ContentRepository.Testing:Document | nodingers-cat          | kitten        |
     And the command SetNodeReferences is executed with payload:
       | Key                   | Value                                  |
       | sourceNodeAggregateId | "nodingers-cat"                        |
@@ -41,13 +42,13 @@ Feature: Remove NodeAggregate
       | Key                          | Value           |
       | nodeAggregateId              | "nodingers-cat" |
       | nodeVariantSelectionStrategy | "allVariants"   |
-    Then I expect exactly 7 events to be published on stream with prefix "ContentStream:cs-identifier"
-    And event at index 6 is of type "NodeAggregateWasRemoved" with payload:
+    Then I expect exactly 10 events to be published on stream with prefix "ContentStream:cs-identifier"
+    And event at index 9 is of type "NodeAggregateWasRemoved" with payload:
       | Key                                  | Expected        |
       | contentStreamId                      | "cs-identifier" |
       | nodeAggregateId                      | "nodingers-cat" |
       | affectedCoveredDimensionSpacePoints  | [[]]            |
-    Then I expect the graph projection to consist of exactly 2 nodes
+    Then I expect the graph projection to consist of exactly 4 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
@@ -82,7 +83,7 @@ Feature: Remove NodeAggregate
 
     Then I expect the node aggregate "nodingers-cat" to exist
     And I expect this node aggregate to disable dimension space points []
-    And I expect the graph projection to consist of exactly 3 nodes
+    And I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
     And I expect a node identified by cs-identifier;nodingers-cat;{} to exist in the content graph
@@ -121,10 +122,6 @@ Feature: Remove NodeAggregate
     And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
 
   Scenario: Remove a node aggregate with descendants and expect all of them to be gone
-    When the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName |
-      | nody-mc-nodeface | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | child |
-      | younger-mc-nodeface | Neos.ContentRepository.Testing:Document | sir-david-nodenborough | younger-child |
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |
       | nodeAggregateId              | "sir-david-nodenborough" |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -133,6 +133,33 @@ Feature: Remove NodeAggregate
     # And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
     # And I expect this node to have no references
 
+  Scenario: Remove a node aggregate in root workspace and expect to be still existing with references and backreferences in another workspace
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user"               |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    When the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value           |
+      | workspaceName                | "live"          |
+      | nodeAggregateId              | "nodingers-cat" |
+      | nodeVariantSelectionStrategy | "allVariants"   |
+
+    When I am in workspace "live"
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+
+    When I am in workspace "user"
+    And I expect node aggregate identifier "nodingers-cat" to lead to node user-cs-identifier;nodingers-cat;{}
+    And I expect this node to have the following references:
+      | Name       | Node                                         | Properties |
+      | references | user-cs-identifier;sir-david-nodenborough;{} | null       |
+
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following references:
+      | Name       | Node                                | Properties |
+      | references | user-cs-identifier;nodingers-cat;{} | null       |
+
   Scenario: Remove a node aggregate with descendants and expect all of them to be gone
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value           |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ProjectionIntegrityViolationDetection/ReferenceIntegrityIsProvided.feature
@@ -42,8 +42,11 @@ Feature: Run integrity violation detection regarding reference relations
       | affectedSourceOriginDimensionSpacePoints | [{"language":"de"}]                                                |
       | references                               | [{"referenceName": "referenceProperty", "references": [{"target":"anthony-destinode", "properties":null}]}] |
     And I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 1 error
-    And I expect integrity violation detection result error number 1 to have code 1597919585
+    # Neos 9.0 intentionally treats references like symlinks, which means the state can be reproduced by deleting the destination node aggregate
+    # Thus, we do not expect and error. See https://github.com/neos/neos-development-collection/issues/5809
+    # Then I expect the integrity violation detection result to contain exactly 1 error
+    # And I expect integrity violation detection result error number 1 to have code 1597919585
+    Then I expect the integrity violation detection result to contain exactly 0 error
 
   Scenario: Reference a node aggregate not covering any of the DSPs the source does
     When the event NodeAggregateWithNodeWasCreated was published with payload:


### PR DESCRIPTION
solves: https://github.com/neos/neos-development-collection/issues/5795

As per #5809  orphaned reference edges are a design decision - at least for the released Neos 9.0 version(s). To prevent confusing users and also to allow us to run the projection integrity violation detection after each test scenario in ci, we silence the error in that specific case.

**Review commit by commit please if you dont think this change is harmless;)**
