### PR TITLE
TASK: Run projection integrity violation detection after every scenario to assert integrity

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough.feature
@@ -171,9 +171,6 @@ Feature: Add Dimension Specialization
     And I expect this node to be exactly explicitly tagged "disabled"
     And I expect this node to exactly inherit the tags ""
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Add shine through while other workspace contains publishable changes
     When the command CreateWorkspace is executed with payload:
       | Key                | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
@@ -97,9 +97,6 @@ Feature: Move dimension space point
     And I expect node aggregate identifier "only-specialization-nodenborough" to lead to node migration-cs;only-specialization-nodenborough;{"language": "gsw"}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"language": "de"}
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Success Case - Generalizations can be renamed if the specialization structure is unchanged
     Given I change the content dimensions in content repository "default" to:
       | Identifier | Values             | Generalizations         |
@@ -153,9 +150,6 @@ Feature: Move dimension space point
     And I expect node aggregate identifier "only-specialization-nodenborough" to lead to node migration-cs;only-specialization-nodenborough;{"language": "ch"}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"language": "de_DE"}
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Success Case - disabled nodes stay disabled
 
     When the command DisableNodeAggregate is executed with payload:
@@ -202,9 +196,6 @@ Feature: Move dimension space point
     And I expect this node to exactly inherit the tags ""
     When I am in dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
 
   Scenario: Success Case - other migrations do not block this with changes on this workspace
 
@@ -256,9 +247,6 @@ Feature: Move dimension space point
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{"language": "de"}
     And I expect this node to be of type "Neos.ContentRepository.Testing:OtherDocument"
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Success Case - after eliminating all fallbacks via variation, a generalization can be moved while changing the specialization structure
     # Eliminate all fallbacks by varying the nodes
     When the command CreateNodeVariant is executed with payload:
@@ -309,9 +297,6 @@ Feature: Move dimension space point
 
     When I am in dimension space point {"language": "de"}
     Then I expect the subgraph projection to consist of exactly 0 nodes
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
 
     When the command PublishWorkspace is executed with payload:
       | Key           | Value                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint_ZeroDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint_ZeroDimensions.feature
@@ -78,9 +78,6 @@ Feature: Move dimension space point from / to the zero dimensional case
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{"example": "source"}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{"example": "source"}
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Move dimension space point from one- to zero-dimensional
     Given using the following content dimensions:
       | Identifier | Values       | Generalizations |
@@ -148,6 +145,3 @@ Feature: Move dimension space point from / to the zero dimensional case
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node migration-cs;lady-eleonode-rootford;{}
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node migration-cs;nody-mc-nodeface;{}
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/RemoveNodes_Dimensions.feature
@@ -84,10 +84,6 @@ Feature: Remove Nodes
     When I am in workspace "migration-workspace" and dimension space point {"language": "en"}
     Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "en"} to exist in the content graph
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
-
   Scenario: Remove nodes in a given dimension space point removes the node without shine-throughs with strategy "allSpecializations"
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
     """yaml
@@ -129,10 +125,6 @@ Feature: Remove Nodes
 
     When I am in workspace "migration-workspace" and dimension space point {"language": "en"}
     Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "en"} to exist in the content graph
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
 
   Scenario: allVariants is not supported in RemoveNode, as this would violate the filter configuration potentially
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs" and exceptions are caught:
@@ -200,10 +192,6 @@ Feature: Remove Nodes
     When I am in workspace "migration-workspace" and dimension space point {"language": "en"}
     Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "en"} to exist in the content graph
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
-
   Scenario: Remove nodes in a shine-through dimension space point (gsw)
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
     """yaml
@@ -240,10 +228,6 @@ Feature: Remove Nodes
 
     When I am in workspace "migration-workspace" and dimension space point {"language": "en"}
     Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "en"} to exist in the content graph
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
 
   Scenario: Remove nodes in a shine-through dimension space point (DE,gsw)
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
@@ -287,9 +271,6 @@ Feature: Remove Nodes
     When I am in workspace "migration-workspace" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Remove nodes in a shine-through dimension space point (DE,gsw) - variant 2
     When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", without publishing on success:
     """yaml
@@ -324,6 +305,3 @@ Feature: Remove Nodes
 
     When I am in workspace "migration-workspace" and dimension space point {"language": "en"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
@@ -57,9 +57,6 @@ Feature: Update root node aggregate dimensions
 
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node migration-cs;lady-eleonode-rootford;{}
 
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors
-
   Scenario: Success Case - other migrations do not block this with changes on this workspace
     When the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                     |
@@ -147,6 +144,3 @@ Feature: Update root node aggregate dimensions
     And I expect this node aggregate to cover dimension space points [{"language":"mul"},{"language":"de"},{"language":"ch"}]
 
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to no node
-
-    When I run integrity violation detection
-    Then I expect the integrity violation detection result to contain exactly 0 errors

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
@@ -46,6 +46,10 @@ trait ProjectionIntegrityViolationDetectionTrait
                 throw new \RuntimeException(sprintf('Integrity violation result "%s" was not asserted', $this->lastIntegrityViolationDetectionResult->getFirstError()), 1777650586);
             }
         } else {
+            if ($this->currentContentRepository === null) {
+                // CR Has not been used.
+                return;
+            }
             $this->iRunIntegrityViolationDetection();
             $this->iExpectTheIntegrityViolationDetectionResultToContainExactlyNErrors(0);
         }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectionIntegrityViolationDetectionTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ProjectionIntegrityViolationDetectionRunnerFactoryInterface;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Result;
@@ -11,7 +13,12 @@ use PHPUnit\Framework\Assert;
 
 trait ProjectionIntegrityViolationDetectionTrait
 {
-    protected Result $lastIntegrityViolationDetectionResult;
+    protected ?Result $lastIntegrityViolationDetectionResult = null;
+
+    /**
+     * Prevents feature authors from running the detection but never asserting
+     */
+    protected bool $lastIntegrityViolationDetectionResultWasAsserted = false;
 
     /**
      * @When /^I run integrity violation detection$/
@@ -24,12 +31,33 @@ trait ProjectionIntegrityViolationDetectionTrait
         $this->lastIntegrityViolationDetectionResult = $projectionIntegrityViolationDetectionRunner->run();
     }
 
+    #[BeforeScenario]
+    public function setupIntegrityViolationDetection(): void
+    {
+        $this->lastIntegrityViolationDetectionResult = null;
+        $this->lastIntegrityViolationDetectionResultWasAsserted = false;
+    }
+
+    #[AfterScenario]
+    public function afterScenarioEnsureIntegrityViolationDetectionWasRun(): void
+    {
+        if ($this->lastIntegrityViolationDetectionResult !== null) {
+            if ($this->lastIntegrityViolationDetectionResultWasAsserted === false) {
+                throw new \RuntimeException(sprintf('Integrity violation result "%s" was not asserted', $this->lastIntegrityViolationDetectionResult->getFirstError()), 1777650586);
+            }
+        } else {
+            $this->iRunIntegrityViolationDetection();
+            $this->iExpectTheIntegrityViolationDetectionResultToContainExactlyNErrors(0);
+        }
+    }
+
     /**
      * @Then /^I expect the integrity violation detection result to contain exactly (\d+) errors?$/
      * @param int $expectedNumberOfErrors
      */
     public function iExpectTheIntegrityViolationDetectionResultToContainExactlyNErrors(int $expectedNumberOfErrors): void
     {
+        $this->lastIntegrityViolationDetectionResultWasAsserted = true;
         Assert::assertCount(
             $expectedNumberOfErrors,
             $this->lastIntegrityViolationDetectionResult->getErrors(),
@@ -44,6 +72,7 @@ trait ProjectionIntegrityViolationDetectionTrait
      */
     public function iExpectIntegrityViolationDetectionResultErrorNumberNToHaveCodeX(int $errorNumber, int $expectedErrorCode): void
     {
+        $this->lastIntegrityViolationDetectionResultWasAsserted = true;
         /** @var Error $error */
         $error = $this->lastIntegrityViolationDetectionResult->getErrors()[$errorNumber - 1];
         Assert::assertSame(


### PR DESCRIPTION
solves: https://github.com/neos/neos-development-collection/issues/5795

requires https://github.com/neos/neos-development-collection/pull/5807
requires https://github.com/neos/neos-development-collection/pull/5798
requires https://github.com/neos/neos-development-collection/pull/5820

Now we run  the `ProjectionIntegrityViolationDetection` after every scenario to assert integrity

This is done via Behat Hooks to avoid specifying the line every time which is verbose and can be forgotten.

Before the integrity was only checked after dimension adjustments though as outlined in #5795 two regular tests lead to a faulty integrity.

Also this change becomes relevant with new adapters on rise postgresql #5751 and for big m*sql graph refactoring like #5776 so that we are sure integrity is always provided.