### PR TITLE
TASK: Simplify and cleanup behaviour test to avoid path assertions

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
@@ -141,7 +141,6 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
-    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/03-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithoutDimensions.feature
@@ -140,7 +140,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-node" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator              |
@@ -150,7 +151,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodimus-prime" and node path "child-node/grandchild-node" to lead to node cs-identifier;nodimus-prime;{}
+    And I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{}
+    And I expect this node to have path "child-node/grandchild-node"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
@@ -181,7 +181,6 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "de"}
-    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -212,7 +211,6 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "de"}
-    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -244,7 +242,6 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "en"}
-    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -276,7 +273,6 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "en"}
-    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/01-RootNodeCreation/04-CreateRootNodeAggregateWithNodeAndTetheredChildren_WithDimensions.feature
@@ -180,7 +180,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-node" to lead to node cs-identifier;nody-mc-nodeface;{"language": "de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "de"}
+    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -190,7 +191,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodimus-prime" and node path "child-node/grandchild-node" to lead to node cs-identifier;nodimus-prime;{"language": "de"}
+    And I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"language": "de"}
+    And I expect this node to have path "child-node/grandchild-node"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"language": "de"}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -209,7 +211,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-node" to lead to node cs-identifier;nody-mc-nodeface;{"language": "de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "de"}
+    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -219,7 +222,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodimus-prime" and node path "child-node/grandchild-node" to lead to node cs-identifier;nodimus-prime;{"language": "de"}
+    And I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"language": "de"}
+    And I expect this node to have path "child-node/grandchild-node"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"language": "de"}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -239,7 +243,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-node" to lead to node cs-identifier;nody-mc-nodeface;{"language": "en"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "en"}
+    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -249,7 +254,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodimus-prime" and node path "child-node/grandchild-node" to lead to node cs-identifier;nodimus-prime;{"language": "en"}
+    And I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"language": "en"}
+    And I expect this node to have path "child-node/grandchild-node"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"language": "en"}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -269,7 +275,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-node" to lead to node cs-identifier;nody-mc-nodeface;{"language": "en"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language": "en"}
+    And I expect this node to have path "child-node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator                              |
@@ -279,7 +286,8 @@ Feature: Create a root node aggregate with tethered children
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodimus-prime" and node path "child-node/grandchild-node" to lead to node cs-identifier;nodimus-prime;{"language": "en"}
+    And I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"language": "en"}
+    And I expect this node to have path "child-node/grandchild-node"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"language": "en"}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -159,7 +159,6 @@ Feature: Create node aggregate with node
     And I expect this node to have no succeeding siblings
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name       | NodeDiscriminator                 |
@@ -177,7 +176,6 @@ Feature: Create node aggregate with node
     And I expect this node to have no succeeding siblings
 
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -236,7 +234,6 @@ Feature: Create node aggregate with node
 
     And I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -408,7 +405,6 @@ Feature: Create node aggregate with node
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name       | NodeDiscriminator                 |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/03-CreateNodeAggregateWithNode_WithoutDimensions.feature
@@ -158,7 +158,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "node" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name       | NodeDiscriminator                 |
@@ -168,13 +169,15 @@ Feature: Create node aggregate with node
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "node/child-node" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "node/child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
 
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -232,7 +235,8 @@ Feature: Create node aggregate with node
       | nodeAggregateClassification   | "regular"                                                               |
 
     And I am in workspace "live" and dimension space point {}
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -403,7 +407,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "node" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name       | NodeDiscriminator                 |
@@ -413,7 +418,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "node/child-node" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "node/child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have the following child nodes:
       | Name            | NodeDiscriminator              |
@@ -423,7 +429,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodimus-prime" and node path "node/child-node/grandchild-node" to lead to node cs-identifier;nodimus-prime;{}
+    And I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{}
+    And I expect this node to have path "node/child-node/grandchild-node"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -259,12 +259,12 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-eldest" and node path "node/eldest-child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" and node path "node/elder-child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "node/child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" and node path "node/younger-child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface-the-youngest" and node path "node/youngest-child-node" to lead to no node
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-eldest" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-youngest" to lead to no node
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 
 
     When I am in dimension space point {"language":"de"}
@@ -319,9 +319,9 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-eldest" and node path "node/eldest-child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" and node path "node/younger-child-node" to lead to no node
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-eldest" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" to lead to no node
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 
 
     When I am in dimension space point {"language":"gsw"}
@@ -412,7 +412,7 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to no node
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 
 
     When I am in dimension space point {"language":"en"}
@@ -433,9 +433,9 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" and node path "node/elder-child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "node/child-node" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" and node path "node/younger-child-node" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" to lead to no node
 
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"en"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -252,7 +252,6 @@ Feature: Create node aggregate with node
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -276,7 +275,6 @@ Feature: Create node aggregate with node
       | node | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "node"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                             |
       | elder-child-node    | cs-identifier;nody-mc-nodeface-the-elder;{"language":"de"}    |
@@ -337,7 +335,6 @@ Feature: Create node aggregate with node
       | node | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "node"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                             |
       | eldest-child-node   | cs-identifier;nody-mc-nodeface-the-eldest;{"language":"gsw"}  |
@@ -435,7 +432,6 @@ Feature: Create node aggregate with node
       | esquire | cs-identifier;sir-nodeward-nodington-iii;{"language":"en"} |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -450,7 +446,6 @@ Feature: Create node aggregate with node
     And I expect node aggregate identifier "nody-mc-nodeface-the-younger" to lead to no node
 
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"en"}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/04-CreateNodeAggregateWithNode_WithDimensions.feature
@@ -251,7 +251,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "node" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -274,7 +275,8 @@ Feature: Create node aggregate with node
       | Name | NodeDiscriminator                                       |
       | node | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "node" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "node"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                             |
       | elder-child-node    | cs-identifier;nody-mc-nodeface-the-elder;{"language":"de"}    |
@@ -285,7 +287,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" and node path "node/elder-child-node" to lead to node cs-identifier;nody-mc-nodeface-the-elder;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" to lead to node cs-identifier;nody-mc-nodeface-the-elder;{"language":"de"}
+    And I expect this node to have path "node/elder-child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -296,7 +299,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "node/child-node" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to have path "node/child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -308,7 +312,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-youngest" and node path "node/youngest-child-node" to lead to node cs-identifier;nody-mc-nodeface-the-youngest;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface-the-youngest" to lead to node cs-identifier;nody-mc-nodeface-the-youngest;{"language":"de"}
+    And I expect this node to have path "node/youngest-child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -331,7 +336,8 @@ Feature: Create node aggregate with node
       | Name | NodeDiscriminator                                       |
       | node | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "node" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "node"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                             |
       | eldest-child-node   | cs-identifier;nody-mc-nodeface-the-eldest;{"language":"gsw"}  |
@@ -344,7 +350,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-eldest" and node path "node/eldest-child-node" to lead to node cs-identifier;nody-mc-nodeface-the-eldest;{"language":"gsw"}
+    And I expect node aggregate identifier "nody-mc-nodeface-the-eldest" to lead to node cs-identifier;nody-mc-nodeface-the-eldest;{"language":"gsw"}
+    And I expect this node to have path "node/eldest-child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -357,7 +364,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" and node path "node/elder-child-node" to lead to node cs-identifier;nody-mc-nodeface-the-elder;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface-the-elder" to lead to node cs-identifier;nody-mc-nodeface-the-elder;{"language":"de"}
+    And I expect this node to have path "node/elder-child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -371,7 +379,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "node/child-node" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to have path "node/child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -385,7 +394,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" and node path "node/younger-child-node" to lead to node cs-identifier;nody-mc-nodeface-the-younger;{"language":"gsw"}
+    And I expect node aggregate identifier "nody-mc-nodeface-the-younger" to lead to node cs-identifier;nody-mc-nodeface-the-younger;{"language":"gsw"}
+    And I expect this node to have path "node/younger-child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -399,7 +409,8 @@ Feature: Create node aggregate with node
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nody-mc-nodeface-the-youngest" and node path "node/youngest-child-node" to lead to node cs-identifier;nody-mc-nodeface-the-youngest;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface-the-youngest" to lead to node cs-identifier;nody-mc-nodeface-the-youngest;{"language":"de"}
+    And I expect this node to have path "node/youngest-child-node"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:
@@ -423,7 +434,8 @@ Feature: Create node aggregate with node
       | node    | cs-identifier;sir-david-nodenborough;{"language":"mul"}    |
       | esquire | cs-identifier;sir-nodeward-nodington-iii;{"language":"en"} |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "node" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "node"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no preceding siblings
@@ -437,7 +449,8 @@ Feature: Create node aggregate with node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface-the-younger" to lead to no node
 
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"en"}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"en"}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following preceding siblings:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -159,7 +159,8 @@ Feature: Create node specialization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -167,7 +168,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -176,7 +178,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
@@ -189,13 +192,17 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"spec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -204,7 +211,8 @@ Feature: Create node specialization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -223,7 +231,8 @@ Feature: Create node specialization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -231,7 +240,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -240,7 +250,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
@@ -253,13 +264,17 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"spec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -268,7 +283,8 @@ Feature: Create node specialization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -375,7 +391,8 @@ Feature: Create node specialization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -383,7 +400,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -392,7 +410,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
@@ -405,13 +424,17 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"spec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -420,7 +443,8 @@ Feature: Create node specialization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -439,7 +463,8 @@ Feature: Create node specialization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"leafSpec"}   |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -447,7 +472,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"leafSpec"}   |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -456,7 +482,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"leafSpec"}   |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"leafSpec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"leafSpec"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"leafSpec"}    |
@@ -469,13 +496,17 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"leafSpec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"leafSpec"}
+    And I expect this node to have path "document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                      |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"leafSpec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"leafSpec"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"leafSpec"}
+    And I expect this node to have path "document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"leafSpec"} |
@@ -484,7 +515,8 @@ Feature: Create node specialization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/02-CreateNodeSpecializationVariant.feature
@@ -160,7 +160,6 @@ Feature: Create node specialization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -169,7 +168,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -179,7 +177,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
@@ -202,7 +199,6 @@ Feature: Create node specialization
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
     And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -212,7 +208,6 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -232,7 +227,6 @@ Feature: Create node specialization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -241,7 +235,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -251,7 +244,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
@@ -274,7 +266,6 @@ Feature: Create node specialization
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
     And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -284,7 +275,6 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -392,7 +382,6 @@ Feature: Create node specialization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -401,7 +390,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -411,7 +399,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
@@ -434,7 +421,6 @@ Feature: Create node specialization
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
     And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -444,7 +430,6 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -464,7 +449,6 @@ Feature: Create node specialization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -473,7 +457,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -483,7 +466,6 @@ Feature: Create node specialization
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"leafSpec"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"leafSpec"}    |
@@ -506,7 +488,6 @@ Feature: Create node specialization
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
     And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"leafSpec"} |
@@ -516,7 +497,6 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -277,20 +277,20 @@ Feature: Create node generalization
       | cs-identifier;elder-mc-nodeface;{"example":"general"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example":"rootGeneral"}
     Then I expect the subgraph projection to consist of exactly 1 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to no node
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to no node
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to no node
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to no node
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to no node
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example":"specB"}
     Then I expect the subgraph projection to consist of exactly 8 nodes
@@ -355,7 +355,7 @@ Feature: Create node generalization
       | cs-identifier;elder-mc-nodeface;{"example":"general"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
   Scenario: Create generalization of a node to dimension space point with specializations that are partially occupied
     Given the command CreateNodeVariant is executed with payload:
@@ -477,7 +477,7 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
@@ -499,8 +499,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "specB"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
@@ -516,7 +516,7 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                   |
@@ -538,8 +538,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}     |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
   Scenario: Create generalization of a node to dimension space point with specializations that are partially covered
     Given the command CreateNodeVariant is executed with payload:
@@ -661,7 +661,7 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
@@ -683,8 +683,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "specB"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
@@ -700,7 +700,7 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                   |
@@ -722,8 +722,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}     |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
   Scenario: Create generalization of a node to a dimension space point that is already covered by a more general generalization
     Given the command CreateNodeVariant is executed with payload:
@@ -837,8 +837,8 @@ Feature: Create node generalization
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                        |
       | document | cs-identifier;nody-mc-nodeface;{"example":"rootGeneral"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to no node
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"rootGeneral"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                         |
@@ -850,9 +850,9 @@ Feature: Create node generalization
       | Name     | NodeDiscriminator                                         |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"rootGeneral"} |
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"rootGeneral"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
@@ -868,7 +868,7 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
@@ -890,8 +890,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "specB"}
     Then I expect the subgraph projection to consist of exactly 6 nodes
@@ -907,7 +907,7 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
@@ -929,5 +929,5 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -163,7 +163,8 @@ Feature: Create node generalization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -171,7 +172,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
@@ -180,7 +182,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-document   | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -193,10 +196,14 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-document"
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}    |
@@ -205,7 +212,8 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
@@ -224,7 +232,8 @@ Feature: Create node generalization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"general"}     |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                        |
@@ -232,7 +241,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
@@ -241,7 +251,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -253,14 +264,17 @@ Feature: Create node generalization
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                     |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"general"} |
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -269,7 +283,8 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                        |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
@@ -302,7 +317,8 @@ Feature: Create node generalization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"general"}     |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                        |
@@ -310,7 +326,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
@@ -319,7 +336,8 @@ Feature: Create node generalization
       | cs-identifier;nody-mc-nodeface;{"example":"general"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -331,14 +349,17 @@ Feature: Create node generalization
       | NodeDiscriminator                                        |
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                     |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"general"} |
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -347,7 +368,8 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                        |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
@@ -471,14 +493,16 @@ Feature: Create node generalization
       | eldest-document  | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -488,12 +512,15 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                     |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"general"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -510,14 +537,16 @@ Feature: Create node generalization
       | eldest-document  | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
       | document         | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                   |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"specB"} |
@@ -527,12 +556,15 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"specB"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"specB"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                   |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"specB"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"specB"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"specB"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}     |
@@ -655,14 +687,16 @@ Feature: Create node generalization
       | eldest-document  | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -672,12 +706,15 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                     |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"general"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -694,14 +731,16 @@ Feature: Create node generalization
       | eldest-document  | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
       | document         | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                   |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"specB"} |
@@ -711,12 +750,15 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"specB"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"specB"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                   |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"specB"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"specB"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"specB"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}     |
@@ -839,17 +881,20 @@ Feature: Create node generalization
       | document | cs-identifier;nody-mc-nodeface;{"example":"rootGeneral"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"rootGeneral"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"rootGeneral"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                         |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"rootGeneral"} |
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"rootGeneral"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"rootGeneral"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                         |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"rootGeneral"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"rootGeneral"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"rootGeneral"}
+    And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
@@ -862,14 +907,16 @@ Feature: Create node generalization
       | eldest-document  | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -879,12 +926,15 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                     |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"general"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -901,14 +951,16 @@ Feature: Create node generalization
       | eldest-document  | cs-identifier;eldest-mc-nodeface;{"example":"general"}  |
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -918,12 +970,15 @@ Feature: Create node generalization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                     |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"general"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/03-CreateNodeGeneralizationVariant.feature
@@ -164,7 +164,6 @@ Feature: Create node generalization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -173,7 +172,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
@@ -183,7 +181,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-document   | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -203,7 +200,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
     And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}    |
@@ -213,7 +209,6 @@ Feature: Create node generalization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
@@ -233,7 +228,6 @@ Feature: Create node generalization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                        |
@@ -242,7 +236,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
@@ -252,7 +245,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -274,7 +266,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -284,7 +275,6 @@ Feature: Create node generalization
       | NodeDiscriminator                                        |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
@@ -318,7 +308,6 @@ Feature: Create node generalization
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                        |
@@ -327,7 +316,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;eldest-mc-nodeface;{"example":"general"} |
@@ -337,7 +325,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -359,7 +346,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -369,7 +355,6 @@ Feature: Create node generalization
       | NodeDiscriminator                                        |
       | cs-identifier;youngest-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
@@ -494,7 +479,6 @@ Feature: Create node generalization
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -502,7 +486,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -520,7 +503,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -538,7 +520,6 @@ Feature: Create node generalization
       | document         | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -546,7 +527,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                   |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"specB"} |
@@ -564,7 +544,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"specB"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}     |
@@ -688,7 +667,6 @@ Feature: Create node generalization
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -696,7 +674,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -714,7 +691,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -732,7 +708,6 @@ Feature: Create node generalization
       | document         | cs-identifier;nody-mc-nodeface;{"example":"specB"}      |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -740,7 +715,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"specB"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                   |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"specB"} |
@@ -758,7 +732,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"specB"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"specB"}     |
@@ -882,7 +855,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"rootGeneral"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                         |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"rootGeneral"} |
@@ -908,7 +880,6 @@ Feature: Create node generalization
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -916,7 +887,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -934,7 +904,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |
@@ -952,7 +921,6 @@ Feature: Create node generalization
       | document         | cs-identifier;nody-mc-nodeface;{"example":"general"}    |
       | younger-document | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -960,7 +928,6 @@ Feature: Create node generalization
       | cs-identifier;younger-mc-nodeface;{"example":"general"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                     |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"general"} |
@@ -978,7 +945,6 @@ Feature: Create node generalization
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"general"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"general"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;nody-mc-nodeface;{"example":"general"}   |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -171,14 +171,12 @@ Feature: Create node peer variant
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-document   | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -197,7 +195,6 @@ Feature: Create node peer variant
     And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}  |
@@ -215,7 +212,6 @@ Feature: Create node peer variant
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
@@ -224,7 +220,6 @@ Feature: Create node peer variant
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
@@ -234,7 +229,6 @@ Feature: Create node peer variant
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -256,7 +250,6 @@ Feature: Create node peer variant
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
@@ -266,7 +259,6 @@ Feature: Create node peer variant
       | NodeDiscriminator                                     |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"} |
@@ -287,7 +279,6 @@ Feature: Create node peer variant
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
@@ -296,7 +287,6 @@ Feature: Create node peer variant
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
@@ -306,7 +296,6 @@ Feature: Create node peer variant
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -328,7 +317,6 @@ Feature: Create node peer variant
     And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
     And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
@@ -338,7 +326,6 @@ Feature: Create node peer variant
       | NodeDiscriminator                                     |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"} |
@@ -461,14 +448,12 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                 |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -495,14 +480,12 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"}   |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                      |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peerSpec"} |
@@ -634,14 +617,12 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                 |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -668,14 +649,12 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"}   |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                      |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peerSpec"} |
@@ -784,13 +763,11 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | elder-document  | cs-identifier;elder-mc-nodeface;{"example":"peer"}  |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                  |
       | cs-identifier;elder-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following child nodes:
       | Name                 | NodeDiscriminator                                        |
       | elder-child-document | cs-identifier;elder-child-mc-nodeface;{"example":"peer"} |
@@ -805,13 +782,11 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | elder-document  | cs-identifier;elder-mc-nodeface;{"example":"peer"}  |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                  |
       | cs-identifier;elder-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following child nodes:
       | Name                 | NodeDiscriminator                                        |
       | elder-child-document | cs-identifier;elder-child-mc-nodeface;{"example":"peer"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -169,7 +169,7 @@ Feature: Create node peer variant
       | elder-document    | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to no node
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -190,7 +190,7 @@ Feature: Create node peer variant
     And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
@@ -261,7 +261,7 @@ Feature: Create node peer variant
       | cs-identifier;elder-mc-nodeface;{"example":"peer"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"}  |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example":"peerSpec"}
     Then I expect the subgraph projection to consist of exactly 8 nodes
@@ -326,7 +326,7 @@ Feature: Create node peer variant
       | cs-identifier;elder-mc-nodeface;{"example":"peer"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"}  |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
   Scenario: Create peer variant of node to dimension space point with specializations that are partially occupied
     Given the command CreateNodeVariant is executed with payload:
@@ -445,7 +445,7 @@ Feature: Create node peer variant
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                 |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
@@ -459,9 +459,9 @@ Feature: Create node peer variant
       | Name     | NodeDiscriminator                                  |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peer"} |
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "peerSpec"}
     Then I expect the subgraph projection to consist of exactly 5 nodes
@@ -475,7 +475,7 @@ Feature: Create node peer variant
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                      |
@@ -489,9 +489,9 @@ Feature: Create node peer variant
       | Name     | NodeDiscriminator                                      |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peerSpec"} |
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peerSpec"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
   Scenario: Create peer variant of node to dimension space point that is already covered
     Given the command CreateNodeVariant is executed with payload:
@@ -606,7 +606,7 @@ Feature: Create node peer variant
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
     And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                 |
@@ -624,9 +624,9 @@ Feature: Create node peer variant
       | Name     | NodeDiscriminator                                  |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peer"} |
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "peerSpec"}
     Then I expect the subgraph projection to consist of exactly 5 nodes
@@ -640,7 +640,7 @@ Feature: Create node peer variant
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to no node
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                      |
@@ -654,9 +654,9 @@ Feature: Create node peer variant
       | Name     | NodeDiscriminator                                      |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peerSpec"} |
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peerSpec"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
 
   Scenario: Create a peer node variant to a dimension space point with specializations and where the parent node aggregate is already specialized in
     # We need a new node for this
@@ -775,7 +775,7 @@ Feature: Create node peer variant
       | Name                 | NodeDiscriminator                                        |
       | elder-child-document | cs-identifier;elder-child-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-child-mc-nodeface" and node path "elder-document/elder-child-document" to lead to node cs-identifier;elder-child-mc-nodeface;{"example":"peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to no node
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to no node
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/03-NodeVariation/04-CreateNodePeerVariant.feature
@@ -170,13 +170,15 @@ Feature: Create node peer variant
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-document   | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -187,11 +189,15 @@ Feature: Create node peer variant
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-document"
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}  |
@@ -208,7 +214,8 @@ Feature: Create node peer variant
       | document          | cs-identifier;nody-mc-nodeface;{"example":"peer"}     |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
@@ -216,7 +223,8 @@ Feature: Create node peer variant
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
@@ -225,7 +233,8 @@ Feature: Create node peer variant
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -237,14 +246,17 @@ Feature: Create node peer variant
       | NodeDiscriminator                                     |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                  |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peer"} |
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
@@ -253,7 +265,8 @@ Feature: Create node peer variant
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"} |
@@ -273,7 +286,8 @@ Feature: Create node peer variant
       | document          | cs-identifier;nody-mc-nodeface;{"example":"peer"}     |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
@@ -281,7 +295,8 @@ Feature: Create node peer variant
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
@@ -290,7 +305,8 @@ Feature: Create node peer variant
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}     |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -302,14 +318,17 @@ Feature: Create node peer variant
       | NodeDiscriminator                                     |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                  |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peer"} |
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                   |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
@@ -318,7 +337,8 @@ Feature: Create node peer variant
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;youngest-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                    |
       | cs-identifier;younger-mc-nodeface;{"example":"peer"} |
@@ -440,13 +460,15 @@ Feature: Create node peer variant
       | Name            | NodeDiscriminator                                   |
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                 |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -454,11 +476,13 @@ Feature: Create node peer variant
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                  |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peer"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
@@ -470,13 +494,15 @@ Feature: Create node peer variant
       | Name            | NodeDiscriminator                                     |
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"}   |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                      |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peerSpec"} |
@@ -484,11 +510,13 @@ Feature: Create node peer variant
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peerSpec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peerSpec"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                      |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peerSpec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peerSpec"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peerSpec"}
+    And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
@@ -605,13 +633,15 @@ Feature: Create node peer variant
       | Name            | NodeDiscriminator                                   |
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peer"}   |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                 |
       | cs-identifier;nody-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                  |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peer"} |
@@ -619,11 +649,13 @@ Feature: Create node peer variant
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                  |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peer"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peer"}
+    And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
@@ -635,13 +667,15 @@ Feature: Create node peer variant
       | Name            | NodeDiscriminator                                     |
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"}   |
       | document        | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"peerSpec"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peerSpec"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                      |
       | tethered-document | cs-identifier;nodewyn-tetherton;{"example":"peerSpec"} |
@@ -649,11 +683,13 @@ Feature: Create node peer variant
       | NodeDiscriminator                                   |
       | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-document" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peerSpec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"peerSpec"}
+    And I expect this node to have path "document/tethered-document"
     And I expect this node to have the following child nodes:
       | Name     | NodeDiscriminator                                      |
       | tethered | cs-identifier;nodimer-tetherton;{"example":"peerSpec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-document/tethered" to lead to node cs-identifier;nodimer-tetherton;{"example":"peerSpec"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"peerSpec"}
+    And I expect this node to have path "document/tethered-document/tethered"
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "invariable-mc-nodeface" to lead to no node
@@ -747,16 +783,19 @@ Feature: Create node peer variant
       | Name            | NodeDiscriminator                                   |
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | elder-document  | cs-identifier;elder-mc-nodeface;{"example":"peer"}  |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                  |
       | cs-identifier;elder-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following child nodes:
       | Name                 | NodeDiscriminator                                        |
       | elder-child-document | cs-identifier;elder-child-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-child-mc-nodeface" and node path "elder-document/elder-child-document" to lead to node cs-identifier;elder-child-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "elder-child-mc-nodeface" to lead to node cs-identifier;elder-child-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "elder-document/elder-child-document"
 
     When I am in workspace "live" and dimension space point {"example": "peerSpec"}
     Then I expect the subgraph projection to consist of exactly 4 nodes
@@ -765,16 +804,19 @@ Feature: Create node peer variant
       | Name            | NodeDiscriminator                                   |
       | eldest-document | cs-identifier;eldest-mc-nodeface;{"example":"peer"} |
       | elder-document  | cs-identifier;elder-mc-nodeface;{"example":"peer"}  |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                  |
       | cs-identifier;elder-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following child nodes:
       | Name                 | NodeDiscriminator                                        |
       | elder-child-document | cs-identifier;elder-child-mc-nodeface;{"example":"peer"} |
-    And I expect node aggregate identifier "elder-child-mc-nodeface" and node path "elder-document/elder-child-document" to lead to node cs-identifier;elder-child-mc-nodeface;{"example":"peer"}
+    And I expect node aggregate identifier "elder-child-mc-nodeface" to lead to node cs-identifier;elder-child-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "elder-document/elder-child-document"
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -126,10 +126,10 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                        |
       | cs-identifier;succeeding-nodenborough;{} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;preceding-nodenborough;{} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -77,7 +77,8 @@ Feature: Disable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -87,7 +88,8 @@ Feature: Disable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -98,14 +100,16 @@ Feature: Disable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
       | cs-identifier;preceding-nodenborough;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
 
     When VisibilityConstraints are set to "default"
@@ -119,7 +123,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -127,7 +132,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -78,7 +78,6 @@ Feature: Disable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -89,7 +88,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -101,7 +99,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -124,7 +121,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -133,7 +129,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -89,7 +89,8 @@ Feature: Disable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -99,7 +100,8 @@ Feature: Disable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -110,14 +112,16 @@ Feature: Disable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     When VisibilityConstraints are set to "default"
@@ -131,7 +135,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -139,7 +144,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -162,7 +168,8 @@ Feature: Disable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -172,7 +179,8 @@ Feature: Disable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -183,14 +191,16 @@ Feature: Disable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     # Tests for the virtual specialization
@@ -206,7 +216,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -214,7 +225,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -235,7 +247,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -243,7 +256,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -267,7 +281,8 @@ Feature: Disable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -277,7 +292,8 @@ Feature: Disable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -288,14 +304,16 @@ Feature: Disable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
   Scenario: Disable node aggregate with strategy allVariants
@@ -340,7 +358,8 @@ Feature: Disable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -350,7 +369,8 @@ Feature: Disable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -361,14 +381,16 @@ Feature: Disable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     When VisibilityConstraints are set to "default"
@@ -382,7 +404,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -390,7 +413,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -410,7 +434,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -418,7 +443,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -439,7 +465,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -447,7 +474,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -468,7 +496,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -476,7 +505,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -497,7 +527,8 @@ Feature: Disable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -505,7 +536,8 @@ Feature: Disable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -90,7 +90,6 @@ Feature: Disable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -101,7 +100,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -113,7 +111,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -136,7 +133,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -145,7 +141,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -169,7 +164,6 @@ Feature: Disable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -180,7 +174,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -192,7 +185,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -217,7 +209,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -226,7 +217,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -248,7 +238,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -257,7 +246,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -282,7 +270,6 @@ Feature: Disable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -293,7 +280,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -305,7 +291,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -359,7 +344,6 @@ Feature: Disable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -370,7 +354,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -382,7 +365,6 @@ Feature: Disable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -405,7 +387,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -414,7 +395,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -435,7 +415,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -444,7 +423,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -466,7 +444,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -475,7 +452,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -497,7 +473,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -506,7 +481,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -528,7 +502,6 @@ Feature: Disable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -537,7 +510,6 @@ Feature: Disable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -138,13 +138,13 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
@@ -213,14 +213,14 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
@@ -242,14 +242,14 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
@@ -389,13 +389,13 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
@@ -417,14 +417,14 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
@@ -446,14 +446,14 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
@@ -475,14 +475,14 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
@@ -504,11 +504,11 @@ Feature: Disable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -186,7 +186,7 @@ Feature: Enable a node aggregate
       | cs-identifier;sir-david-nodenborough;{} |
       | cs-identifier;preceding-nodenborough;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
 
   Scenario: Enable a previously disabled node with explicitly disabled parent node with arbitrary strategy since dimensions are not involved
     Given the command DisableNodeAggregate is executed with payload:
@@ -229,5 +229,5 @@ Feature: Enable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -82,7 +82,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -92,7 +93,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -103,14 +105,16 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
       | cs-identifier;preceding-nodenborough;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
 
   Scenario: Enable a previously disabled node with explicitly disabled child nodes with arbitrary strategy since dimensions are not involved
@@ -158,7 +162,8 @@ Feature: Enable a node aggregate
       | 1     | succeeding-nodenborough |
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no child nodes
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -168,7 +173,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -179,7 +185,8 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -83,7 +83,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -94,7 +93,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -106,7 +104,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -163,7 +160,6 @@ Feature: Enable a node aggregate
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no child nodes
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -174,7 +170,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -186,7 +181,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -189,7 +189,7 @@ Feature: Enable a node aggregate
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
@@ -211,15 +211,15 @@ Feature: Enable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
@@ -270,7 +270,7 @@ Feature: Enable a node aggregate
     And I expect this node to have no succeeding siblings
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
@@ -321,7 +321,7 @@ Feature: Enable a node aggregate
     And I expect this node to have no succeeding siblings
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
@@ -343,15 +343,15 @@ Feature: Enable a node aggregate
       | NodeDiscriminator                                        |
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
   Scenario: Enable node aggregate with strategy allVariants
     When I am in dimension space point {"language":"de"}
@@ -484,7 +484,7 @@ Feature: Enable a node aggregate
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
@@ -534,7 +534,7 @@ Feature: Enable a node aggregate
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
@@ -585,7 +585,7 @@ Feature: Enable a node aggregate
     And I expect this node to have no succeeding siblings
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
@@ -636,7 +636,7 @@ Feature: Enable a node aggregate
     And I expect this node to have no succeeding siblings
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
@@ -686,7 +686,7 @@ Feature: Enable a node aggregate
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
   Scenario: Enable node aggregate with hidden ancestors
     When I am in dimension space point {"language":"de"}
@@ -717,24 +717,24 @@ Feature: Enable a node aggregate
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
     And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
     And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
     And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
     And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -107,7 +107,6 @@ Feature: Enable a node aggregate
       | 2     | the-great-nodini        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -118,7 +117,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -134,7 +132,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -163,7 +160,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -174,7 +170,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -189,7 +184,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -214,7 +208,6 @@ Feature: Enable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -223,7 +216,6 @@ Feature: Enable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -249,7 +241,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -260,7 +251,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -275,7 +265,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -304,7 +293,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -315,7 +303,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"ltz"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -330,7 +317,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -356,7 +342,6 @@ Feature: Enable a node aggregate
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -365,7 +350,6 @@ Feature: Enable a node aggregate
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -423,7 +407,6 @@ Feature: Enable a node aggregate
       | 2     | the-great-nodini        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -434,7 +417,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -450,7 +432,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -479,7 +460,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -490,7 +470,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -505,7 +484,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -533,7 +511,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -544,7 +521,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -559,7 +535,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -587,7 +562,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -598,7 +572,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -613,7 +586,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -642,7 +614,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -653,7 +624,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"ltz"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -668,7 +638,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -697,7 +666,6 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -708,7 +676,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -723,7 +690,6 @@ Feature: Enable a node aggregate
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
     And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -750,7 +716,6 @@ Feature: Enable a node aggregate
     When I am in dimension space point {"language":"de"}
     And VisibilityConstraints are set to "withoutRestrictions"
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
       | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -106,7 +106,8 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 2     | the-great-nodini        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -116,7 +117,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -131,16 +133,19 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect this node to have path "document/court-magician"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     When VisibilityConstraints are set to "default"
@@ -157,7 +162,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -167,7 +173,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -181,13 +188,15 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -204,7 +213,8 @@ Feature: Enable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -212,7 +222,8 @@ Feature: Enable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -237,7 +248,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -247,7 +259,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -261,14 +274,16 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -288,7 +303,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -298,7 +314,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"ltz"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -312,14 +329,16 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"ltz"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -336,7 +355,8 @@ Feature: Enable a node aggregate
       | 0     | lady-eleonode-rootford  |
       | 1     | preceding-nodenborough  |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -344,7 +364,8 @@ Feature: Enable a node aggregate
       | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
     And I expect this node to have no references
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -401,7 +422,8 @@ Feature: Enable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 2     | the-great-nodini        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -411,7 +433,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -426,16 +449,19 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect this node to have path "document/court-magician"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     When VisibilityConstraints are set to "default"
@@ -452,7 +478,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -462,7 +489,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -476,13 +504,15 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -502,7 +532,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -512,7 +543,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -526,13 +558,15 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -552,7 +586,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -562,7 +597,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -576,14 +612,16 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -603,7 +641,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -613,7 +652,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"ltz"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -627,14 +667,16 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"ltz"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -654,7 +696,8 @@ Feature: Enable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "preceding-nodenborough" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "preceding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -664,7 +707,8 @@ Feature: Enable a node aggregate
     And I expect this node to have the following references:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
@@ -678,13 +722,15 @@ Feature: Enable a node aggregate
     And I expect this node to be referenced by:
       | Name       | Node                                                    | Properties |
       | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "succeeding-nodenborough" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
+    And I expect this node to have path "succeeding-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
       | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
@@ -703,7 +749,8 @@ Feature: Enable a node aggregate
     # Tests for the given variant
     When I am in dimension space point {"language":"de"}
     And VisibilityConstraints are set to "withoutRestrictions"
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name           | NodeDiscriminator                                 |
       | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
@@ -713,7 +760,8 @@ Feature: Enable a node aggregate
       | 0     | sir-david-nodenborough |
       | 1     | nody-mc-nodeface       |
       | 1     | the-great-nodini       |
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect this node to have path "document/court-magician"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
 
     When VisibilityConstraints are set to "default"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -38,7 +38,7 @@ Feature: Creation of nodes underneath disabled nodes
       | nodingers-cat   | Neos.ContentRepository.Testing:Document | the-great-nodini      | pet-document |
     Then I expect the node aggregate "nodingers-cat" to exist
     And I expect this node aggregate to disable dimension space points []
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -44,5 +44,6 @@ Feature: Creation of nodes underneath disabled nodes
       | Key                          | Value              |
       | nodeAggregateId              | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    Then I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{}
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -51,7 +51,8 @@ Feature: Creation of nodes underneath disabled nodes
     And I expect this node aggregate to disable dimension space points []
 
     When I am in dimension space point {"language":"mul"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"de"}
@@ -64,7 +65,8 @@ Feature: Creation of nodes underneath disabled nodes
     And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"en"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     And the command EnableNodeAggregate is executed with payload:
@@ -74,15 +76,18 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"ltz"}
 
   Scenario: Create a new node with parent disabled with strategy allVariants
@@ -120,21 +125,26 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeVariantSelectionStrategy | "allVariants"      |
 
     When I am in dimension space point {"language":"mul"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"ltz"}
 
     When I am in dimension space point {"language":"en"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to have path "document/pet-document"
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -55,13 +55,13 @@ Feature: Creation of nodes underneath disabled nodes
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"en"}
     And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
@@ -99,19 +99,19 @@ Feature: Creation of nodes underneath disabled nodes
     And I expect this node aggregate to disable dimension space points []
 
     When I am in dimension space point {"language":"mul"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     When I am in dimension space point {"language":"en"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
     And the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -48,7 +48,7 @@ Feature: Variation of hidden nodes
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
     And I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"gsw"}
     And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
@@ -71,10 +71,10 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"gsw"} |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"gsw"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -103,10 +103,10 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"mul"} |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"mul"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
   #cs-identifier;the-great-nodini;{"language":"mul"}
 
   Scenario: Generalize a node where the generalization target is disabled
@@ -133,10 +133,10 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"de"}  |
 
     When I am in dimension space point {"language":"ltz"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -165,7 +165,7 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"en"}  |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"en"}
     Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
@@ -193,10 +193,10 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"en"}  |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"en"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -51,7 +51,8 @@ Feature: Variation of hidden nodes
     And I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect this node to have path "court-magician"
 
   Scenario: Specialize a node where the specialization target is disabled
     Given I am in dimension space point {"language":"de"}
@@ -83,7 +84,8 @@ Feature: Variation of hidden nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"gsw"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect this node to have path "court-magician"
 
   Scenario: Generalize a node where the generalization target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -145,7 +147,8 @@ Feature: Variation of hidden nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to have path "court-magician"
 
   Scenario: Peer vary a node where the peer target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -168,7 +171,8 @@ Feature: Variation of hidden nodes
     Then I expect node aggregate identifier "the-great-nodini" to lead to no node
 
     When I am in dimension space point {"language":"en"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect this node to have path "court-magician"
 
   Scenario: Peer vary a node where the peer target is disabled
     Given I am in dimension space point {"language":"de"}
@@ -205,4 +209,5 @@ Feature: Variation of hidden nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"en"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect this node to have path "court-magician"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -52,7 +52,6 @@ Feature: Variation of hidden nodes
 
     When I am in dimension space point {"language":"gsw"}
     And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
-    And I expect this node to have path "court-magician"
 
   Scenario: Specialize a node where the specialization target is disabled
     Given I am in dimension space point {"language":"de"}
@@ -85,7 +84,6 @@ Feature: Variation of hidden nodes
 
     When I am in dimension space point {"language":"gsw"}
     Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
-    And I expect this node to have path "court-magician"
 
   Scenario: Generalize a node where the generalization target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -148,7 +146,6 @@ Feature: Variation of hidden nodes
 
     When I am in dimension space point {"language":"de"}
     Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
-    And I expect this node to have path "court-magician"
 
   Scenario: Peer vary a node where the peer target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -172,7 +169,6 @@ Feature: Variation of hidden nodes
 
     When I am in dimension space point {"language":"en"}
     Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
-    And I expect this node to have path "court-magician"
 
   Scenario: Peer vary a node where the peer target is disabled
     Given I am in dimension space point {"language":"de"}
@@ -210,4 +206,3 @@ Feature: Variation of hidden nodes
 
     When I am in dimension space point {"language":"en"}
     Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
-    And I expect this node to have path "court-magician"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -118,7 +118,7 @@ Feature: Remove NodeAggregate
     And I expect this node to not be referenced
     And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{}
     And I expect this node to have no references
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
   Scenario: Remove a node aggregate with descendants and expect all of them to be gone
     When the following CreateNodeAggregateWithNode commands are executed:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -59,7 +59,6 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no references
     And I expect the node aggregate "nodingers-cat" to not exist
@@ -98,10 +97,8 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
       | 1     | nodingers-cat          |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
-    And I expect this node to have path "pet"
     And I expect the node aggregate "nodingers-kitten" to not exist
 
   Scenario: Remove a node aggregate, recreate it and expect it to have no references
@@ -117,11 +114,9 @@ Feature: Remove NodeAggregate
       | nodeName              | "pet"                                     |
 
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to not be referenced
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
-    And I expect this node to have path "pet"
     And I expect this node to have no references
     And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/02-RemoveNodeAggregate_WithoutDimensions.feature
@@ -58,7 +58,8 @@ Feature: Remove NodeAggregate
       | Level | nodeAggregateId        |
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no references
     And I expect the node aggregate "nodingers-cat" to not exist
@@ -96,9 +97,11 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
       | 1     | nodingers-cat          |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to have path "pet"
     And I expect the node aggregate "nodingers-kitten" to not exist
 
   Scenario: Remove a node aggregate, recreate it and expect it to have no references
@@ -113,10 +116,12 @@ Feature: Remove NodeAggregate
       | parentNodeAggregateId | "lady-eleonode-rootford"                  |
       | nodeName              | "pet"                                     |
 
-    Then I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to not be referenced
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to have path "pet"
     And I expect this node to have no references
     And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -71,7 +71,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -94,7 +95,8 @@ Feature: Remove NodeAggregate
       | 1     | nodingers-cat          |
       | 2     | nodingers-kitten       |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -102,7 +104,8 @@ Feature: Remove NodeAggregate
       | Name       | Node                                          | Properties |
       | references | cs-identifier;nodingers-cat;{"language":"en"} | null       |
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name   | NodeDiscriminator                                |
@@ -112,7 +115,8 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;sir-david-nodenborough;{"language":"en"} | null       |
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect node aggregate identifier "nodingers-kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect this node to have path "pet/kitten"
     And I expect this node to be a child of node cs-identifier;nodingers-cat;{"language":"en"}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -129,7 +133,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -153,7 +158,8 @@ Feature: Remove NodeAggregate
       | 1     | nodingers-cat          |
       | 2     | nodingers-kitten       |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -161,7 +167,8 @@ Feature: Remove NodeAggregate
       | Name       | Node                                          | Properties |
       | references | cs-identifier;nodingers-cat;{"language":"en"} | null       |
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name   | NodeDiscriminator                                |
@@ -171,7 +178,8 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;sir-david-nodenborough;{"language":"en"} | null       |
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect node aggregate identifier "nodingers-kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect this node to have path "pet/kitten"
     And I expect this node to be a child of node cs-identifier;nodingers-cat;{"language":"en"}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -210,7 +218,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -230,7 +239,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -250,7 +260,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -270,7 +281,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -313,13 +325,15 @@ Feature: Remove NodeAggregate
       | 1     | nodingers-cat          |
       | 2     | nodingers-kitten       |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name   | NodeDiscriminator                                |
@@ -327,7 +341,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect node aggregate identifier "nodingers-kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect this node to have path "pet/kitten"
     And I expect this node to be a child of node cs-identifier;nodingers-cat;{"language":"en"}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -372,7 +387,8 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
       | 1     | nodingers-cat          |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -380,7 +396,8 @@ Feature: Remove NodeAggregate
       | Name       | Node                                          | Properties |
       | references | cs-identifier;nodingers-cat;{"language":"de"} | null       |
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"de"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"de"}
+    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following references:
@@ -404,7 +421,8 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
       | 1     | nodingers-cat          |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -412,7 +430,8 @@ Feature: Remove NodeAggregate
       | Name       | Node                                          | Properties |
       | references | cs-identifier;nodingers-cat;{"language":"de"} | null       |
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"de"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"de"}
+    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following references:
@@ -434,7 +453,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -455,7 +475,8 @@ Feature: Remove NodeAggregate
       | 0     | lady-eleonode-rootford |
       | 1     | sir-david-nodenborough |
 
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -72,7 +72,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -96,7 +95,6 @@ Feature: Remove NodeAggregate
       | 2     | nodingers-kitten       |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -105,7 +103,6 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;nodingers-cat;{"language":"en"} | null       |
 
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
-    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name   | NodeDiscriminator                                |
@@ -134,7 +131,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -159,7 +155,6 @@ Feature: Remove NodeAggregate
       | 2     | nodingers-kitten       |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -168,7 +163,6 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;nodingers-cat;{"language":"en"} | null       |
 
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
-    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name   | NodeDiscriminator                                |
@@ -219,7 +213,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -240,7 +233,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -261,7 +253,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -282,7 +273,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -326,14 +316,12 @@ Feature: Remove NodeAggregate
       | 2     | nodingers-kitten       |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
     And I expect this node to not be referenced
 
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
-    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
       | Name   | NodeDiscriminator                                |
@@ -388,7 +376,6 @@ Feature: Remove NodeAggregate
       | 1     | nodingers-cat          |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -397,7 +384,6 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;nodingers-cat;{"language":"de"} | null       |
 
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"de"}
-    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following references:
@@ -422,7 +408,6 @@ Feature: Remove NodeAggregate
       | 1     | nodingers-cat          |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -431,7 +416,6 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;nodingers-cat;{"language":"de"} | null       |
 
     And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"de"}
-    And I expect this node to have path "pet"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have the following references:
@@ -454,7 +438,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
@@ -476,7 +459,6 @@ Feature: Remove NodeAggregate
       | 1     | sir-david-nodenborough |
 
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -77,8 +77,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the generalization
     When I am in dimension space point {"language":"en"}
@@ -135,9 +135,9 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
 
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the peer
     When I am in dimension space point {"language":"fr"}
@@ -236,8 +236,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the specialization
     When I am in dimension space point {"language":"gsw"}
@@ -256,8 +256,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the peer
     When I am in dimension space point {"language":"fr"}
@@ -276,8 +276,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
   Scenario: Disable a node aggregate, completely remove it, recreate it and expect it to be enabled but have no references
     When the command DisableNodeAggregate is executed with payload:
@@ -388,7 +388,7 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;sir-david-nodenborough;{"language":"en"} | null       |
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the specialization
     When I am in dimension space point {"language":"gsw"}
@@ -420,7 +420,7 @@ Feature: Remove NodeAggregate
       | references | cs-identifier;sir-david-nodenborough;{"language":"en"} | null       |
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the generalization
     When I am in dimension space point {"language":"en"}
@@ -440,8 +440,8 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node
 
     # Check the peer variant
     When I am in dimension space point {"language":"fr"}
@@ -461,5 +461,5 @@ Feature: Remove NodeAggregate
     And I expect this node to have no references
     And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node
+    And I expect node aggregate identifier "nodingers-kitten" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -92,7 +92,6 @@ Feature: Recreate a node variant
 
     When I am in workspace "user-ws" and dimension space point {"language": "de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node new-user-cs-id;sir-david-nodenborough;{"language": "de"}
-    And I expect this node to have path "document"
     Then I expect node aggregate identifier "nodimus-prime" to lead to node new-user-cs-id;nodimus-prime;{"language": "de"}
     And I expect this node to have path "document/tethered-document"
     Then I expect node aggregate identifier "nodimus-mediocre" to lead to node new-user-cs-id;nodimus-mediocre;{"language": "de"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/04-VariantRecreation.feature
@@ -91,8 +91,12 @@ Feature: Recreate a node variant
       | targetOrigin    | {"language":"de"}  |
 
     When I am in workspace "user-ws" and dimension space point {"language": "de"}
-    Then I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node new-user-cs-id;sir-david-nodenborough;{"language": "de"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "document/tethered-document" to lead to node new-user-cs-id;nodimus-prime;{"language": "de"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "document/tethered-document/tethered" to lead to node new-user-cs-id;nodimus-mediocre;{"language": "de"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "document/tethered-document/grandchild-document" to lead to node new-user-cs-id;nody-mc-nodeface;{"language": "de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node new-user-cs-id;sir-david-nodenborough;{"language": "de"}
+    And I expect this node to have path "document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node new-user-cs-id;nodimus-prime;{"language": "de"}
+    And I expect this node to have path "document/tethered-document"
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to node new-user-cs-id;nodimus-mediocre;{"language": "de"}
+    And I expect this node to have path "document/tethered-document/tethered"
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node new-user-cs-id;nody-mc-nodeface;{"language": "de"}
+    And I expect this node to have path "document/tethered-document/grandchild-document"
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -150,7 +150,7 @@ Feature: Create node specialization
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
 
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
 
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
     And I expect this node to have the following preceding siblings:
@@ -210,7 +210,7 @@ Feature: Create node specialization
     And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
     And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
 
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "younger-document" to lead to no node
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
 
     And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
     And I expect this node to have the following preceding siblings:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -111,7 +111,6 @@ Feature: Create node specialization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -119,7 +118,6 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -129,7 +127,6 @@ Feature: Create node specialization
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -159,7 +156,6 @@ Feature: Create node specialization
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
 
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}   |
@@ -178,7 +174,6 @@ Feature: Create node specialization
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -186,7 +181,6 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -196,7 +190,6 @@ Feature: Create node specialization
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
 
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -226,7 +219,6 @@ Feature: Create node specialization
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
 
     And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
-    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}   |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/05-CreateNodeAfterDeletion.feature
@@ -110,14 +110,16 @@ Feature: Create node specialization
       | elder-document    | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -126,7 +128,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -139,7 +142,8 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
 
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                    |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"source"} |
@@ -147,12 +151,15 @@ Feature: Create node specialization
       | NodeDiscriminator                                         |
       | cs-identifier;invariable-mc-nodeface;{"example":"source"} |
 
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
 
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
 
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}   |
@@ -170,14 +177,16 @@ Feature: Create node specialization
       | elder-document    | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
       | document          | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -186,7 +195,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"source"}     |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
 
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name                | NodeDiscriminator                                         |
       | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"source"}      |
@@ -199,7 +209,8 @@ Feature: Create node specialization
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
 
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                    |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"source"} |
@@ -207,12 +218,15 @@ Feature: Create node specialization
       | NodeDiscriminator                                         |
       | cs-identifier;invariable-mc-nodeface;{"example":"source"} |
 
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
-    And I expect node aggregate identifier "invariable-mc-nodeface" and node path "document/invariable-document" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"source"}
+    And I expect this node to have path "document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "invariable-mc-nodeface" to lead to node cs-identifier;invariable-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/invariable-document"
 
     And I expect node aggregate identifier "younger-mc-nodeface" to lead to no node
 
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"source"}   |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -130,7 +130,8 @@ Feature: Create node specialization
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                         |
       | document          | cs-identifier;sir-david-nodenborough;{"example":"source"} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"example":"source"}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"example":"source"}
+    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                         |
       | eldest-document   | cs-identifier;eldest-mc-nodeface;{"example":"source"}     |
@@ -138,7 +139,8 @@ Feature: Create node specialization
       | child-document    | cs-identifier;nody-mc-nodeface;{"example":"spec"}         |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}    |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"}   |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "document/eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -146,7 +148,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "document/elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -155,7 +158,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-node | cs-identifier;nodewyn-tetherton;{"example":"spec"} |
@@ -169,13 +173,16 @@ Feature: Create node specialization
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect this node to exactly inherit the tags "tag-1"
     And I expect this node to be exactly explicitly tagged ""
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/child-document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/child-document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"spec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/child-document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/child-document/tethered-node/tethered-leaf"
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "document/younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -184,7 +191,8 @@ Feature: Create node specialization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "document/youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |
@@ -207,7 +215,8 @@ Feature: Create node specialization
       | child-document    | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "document/eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/eldest-document"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
@@ -215,7 +224,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "elder-mc-nodeface" and node path "document/elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "elder-mc-nodeface" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/elder-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
@@ -224,7 +234,8 @@ Feature: Create node specialization
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
       | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect this node to have path "document/child-document"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-node | cs-identifier;nodewyn-tetherton;{"example":"spec"} |
@@ -238,12 +249,15 @@ Feature: Create node specialization
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect this node to exactly inherit the tags "tag-1,tag-2"
     And I expect this node to be exactly explicitly tagged ""
-    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/child-document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect node aggregate identifier "nodewyn-tetherton" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/child-document/tethered-node"
     And I expect this node to have the following child nodes:
       | Name          | NodeDiscriminator                                  |
       | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"spec"} |
-    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/child-document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
-    And I expect node aggregate identifier "younger-mc-nodeface" and node path "document/younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "nodimer-tetherton" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect this node to have path "document/child-document/tethered-node/tethered-leaf"
+    And I expect node aggregate identifier "younger-mc-nodeface" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/younger-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
       | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
@@ -252,7 +266,8 @@ Feature: Create node specialization
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
-    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "document/youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect node aggregate identifier "youngest-mc-nodeface" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "document/youngest-document"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
       | cs-identifier;younger-mc-nodeface;{"example":"source"} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -131,7 +131,6 @@ Feature: Create node specialization
       | Name              | NodeDiscriminator                                         |
       | document          | cs-identifier;sir-david-nodenborough;{"example":"source"} |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"example":"source"}
-    And I expect this node to have path "document"
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                         |
       | eldest-document   | cs-identifier;eldest-mc-nodeface;{"example":"source"}     |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/02-MoveNodeAggregate_NoNewParent_Dimensions.feature
@@ -56,7 +56,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -67,7 +68,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -78,7 +80,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                         |
@@ -88,7 +91,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                         |
@@ -121,7 +125,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -132,7 +137,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -143,7 +149,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -153,7 +160,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -187,7 +195,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -199,7 +208,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -211,7 +221,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -221,7 +232,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -250,7 +262,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -262,7 +275,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -274,7 +288,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -286,7 +301,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -321,7 +337,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -333,7 +350,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -345,7 +363,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -356,7 +375,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -391,7 +411,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -403,7 +424,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -415,7 +437,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -427,7 +450,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -456,7 +480,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -467,7 +492,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -478,7 +504,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -489,7 +516,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -523,7 +551,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -534,7 +563,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -545,7 +575,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -555,7 +586,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -589,7 +621,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -601,7 +634,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -613,7 +647,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -623,7 +658,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -652,7 +688,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -664,7 +701,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -676,7 +714,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -688,7 +727,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -723,7 +763,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -735,7 +776,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -747,7 +789,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -758,7 +801,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -793,7 +837,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -805,7 +850,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -817,7 +863,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
     # The given preceding sibling cannot be resolved and since elder-mc-nodeface isn't given as a succeeding sibling, nothing is done
@@ -829,7 +876,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -860,7 +908,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -872,7 +921,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -883,7 +933,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                                         |
@@ -893,7 +944,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;elder-mc-nodeface;{"example": "general"}  |
@@ -927,7 +979,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -939,7 +992,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -950,7 +1004,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -960,7 +1015,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -995,7 +1051,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1007,7 +1064,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1019,7 +1077,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -1029,7 +1088,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1058,7 +1118,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1070,7 +1131,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1082,7 +1144,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1094,7 +1157,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1129,7 +1193,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1141,7 +1206,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1153,7 +1219,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1164,7 +1231,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1199,7 +1267,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1211,7 +1280,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1223,7 +1293,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
     # The given succeeding sibling cannot be resolved and since elder-mc-nodeface isn't given as a preceding sibling, nothing is done
@@ -1235,7 +1306,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1264,7 +1336,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1276,7 +1349,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1287,7 +1361,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1298,7 +1373,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1333,7 +1409,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1345,7 +1422,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1356,7 +1434,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1366,7 +1445,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1401,7 +1481,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1413,7 +1494,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1425,7 +1507,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1435,7 +1518,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1464,7 +1548,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1476,7 +1561,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1488,7 +1574,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1500,7 +1587,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1535,7 +1623,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1547,7 +1636,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1559,7 +1649,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1570,7 +1661,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1605,7 +1697,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1617,7 +1710,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1629,7 +1723,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
     # The given preceding sibling cannot be resolved and since elder-mc-nodeface isn't given as a succeeding sibling, nothing is done
@@ -1641,7 +1736,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1672,7 +1768,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1684,7 +1781,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -1695,7 +1793,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;elder-mc-nodeface;{"example": "general"}  |
@@ -1706,7 +1805,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
       | cs-identifier;elder-mc-nodeface;{"example": "general"}  |
@@ -1744,7 +1844,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1756,7 +1857,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -1766,7 +1868,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
@@ -1777,7 +1880,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1806,7 +1910,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1818,7 +1923,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1830,7 +1936,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1842,7 +1949,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1879,7 +1987,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1891,7 +2000,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1902,7 +2012,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1914,7 +2025,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1949,7 +2061,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1961,7 +2074,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1971,7 +2085,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1982,7 +2097,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -2017,7 +2133,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -2029,7 +2146,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -2039,7 +2157,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -2050,7 +2169,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -2079,7 +2199,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -2091,7 +2212,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -2103,7 +2225,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -2115,7 +2238,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document-n" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "document/child-document-n"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/03-MoveNodeAggregate_NewParent_Dimensions.feature
@@ -60,7 +60,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -71,7 +72,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -82,7 +84,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -93,7 +96,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -127,7 +131,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -138,7 +143,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -149,7 +155,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -159,7 +166,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -193,7 +201,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -205,7 +214,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -217,7 +227,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -227,7 +238,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -256,7 +268,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -268,7 +281,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -280,7 +294,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -292,7 +307,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -325,7 +341,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -337,7 +354,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -349,7 +367,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -360,7 +379,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -395,7 +415,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": "youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -407,7 +428,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -419,7 +441,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -429,7 +452,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -458,7 +482,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -469,7 +494,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -480,7 +506,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -491,7 +518,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -525,7 +553,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId": null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -536,7 +565,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -547,7 +577,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -557,7 +588,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -591,7 +623,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -603,7 +636,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -615,7 +649,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -625,7 +660,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -654,7 +690,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -666,7 +703,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -678,7 +716,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -690,7 +729,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -725,7 +765,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -737,7 +778,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -749,7 +791,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -760,7 +803,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -795,7 +839,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"general"},"nodeAggregateId":"elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"peer"},"nodeAggregateId":"elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -807,7 +852,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -819,7 +865,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     # The given preceding sibling cannot be resolved and since elder-mc-nodeface isn't given as a succeeding sibling, the node is moved at the end
     And I expect this node to have the following preceding siblings:
@@ -830,7 +877,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -861,7 +909,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -871,7 +920,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -882,7 +932,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -893,7 +944,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -926,7 +978,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "eldest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -936,7 +989,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -947,7 +1001,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -957,7 +1012,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -990,7 +1046,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1000,7 +1057,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1012,7 +1070,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -1022,7 +1081,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1049,7 +1109,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1059,7 +1120,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1071,7 +1133,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1083,7 +1146,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1116,7 +1180,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId": "elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId": "younger-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1126,7 +1191,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1138,7 +1204,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1149,7 +1216,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1182,7 +1250,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1192,7 +1261,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1204,7 +1274,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1214,7 +1285,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1241,7 +1313,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1251,7 +1324,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1262,7 +1336,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1273,7 +1348,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1306,7 +1382,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1316,7 +1393,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1327,7 +1405,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1337,7 +1416,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1370,7 +1450,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1380,7 +1461,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1392,7 +1474,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1402,7 +1485,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1429,7 +1513,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1439,7 +1524,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1451,7 +1537,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1463,7 +1550,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1496,7 +1584,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"youngest-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1506,7 +1595,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1518,7 +1608,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1529,7 +1620,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1562,7 +1654,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-mc-nodeface"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1572,7 +1665,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1584,7 +1678,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
     # The given preceding sibling cannot be resolved and since elder-mc-nodeface isn't given as a succeeding sibling, the node is moved to the end
@@ -1595,7 +1690,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1624,7 +1720,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"eldest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1634,7 +1731,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -1645,7 +1743,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1655,7 +1754,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1692,7 +1792,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1702,7 +1803,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1712,7 +1814,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -1722,7 +1825,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1749,7 +1853,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1759,7 +1864,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                       |
@@ -1771,7 +1877,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1781,7 +1888,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1816,7 +1924,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1826,7 +1935,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                         |
@@ -1837,7 +1947,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1847,7 +1958,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1880,7 +1992,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1890,7 +2003,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1900,7 +2014,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1910,7 +2025,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1943,7 +2059,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1953,7 +2070,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -1963,7 +2081,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -1973,7 +2092,8 @@ Feature: Move a node with content dimensions
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -2000,7 +2120,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"youngest-mc-nodeface"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -2010,7 +2131,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |
@@ -2020,7 +2142,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;source-younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                        |
@@ -2032,7 +2155,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;youngest-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                             |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/04-MoveNodeAggregate_ScatteredChildren.feature
@@ -64,7 +64,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"bustling-destinode"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"younger-destinode"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
@@ -74,7 +75,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -86,7 +88,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-destinode;{"example": "general"}  |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -97,7 +100,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-destinode;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
@@ -131,7 +135,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":null},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":null}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
@@ -141,19 +146,22 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-mc-nodeface;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/bustling-target-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/bustling-target-document/document"
     And I expect this node to be a child of node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/bustling-target-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "esquire/esquire-child/bustling-target-document/document"
     And I expect this node to be a child of node cs-identifier;bustling-destinode;{"example": "general"}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example": "general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                      |
@@ -187,7 +195,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"elder-destinode"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "bustling-destinode" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/bustling-target-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -198,7 +207,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-destinode;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "bustling-destinode" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/bustling-target-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -209,7 +219,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-destinode;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/esquire-child/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "bustling-destinode" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/esquire-child/bustling-target-document"
     And I expect this node to be a child of node cs-identifier;nodimus-mediocre;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                          |
@@ -219,7 +230,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-child-destinode;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "bustling-destinode" and node path "esquire/bustling-target-document" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "bustling-destinode" to lead to node cs-identifier;bustling-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/bustling-target-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -262,7 +274,8 @@ Feature: Move a node with content dimensions
       | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"example":"source"},"nodeAggregateId":"bustling-destinode"},{"dimensionSpacePoint":{"example":"spec"},"nodeAggregateId":"bustling-destinode"}] |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "elder-destinode" and node path "esquire/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "elder-destinode" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/elder-target-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -273,7 +286,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-destinode;{"example": "general"}  |
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "elder-destinode" and node path "esquire/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "elder-destinode" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/elder-target-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |
@@ -284,7 +298,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-destinode;{"example": "general"}  |
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "elder-destinode" and node path "esquire/esquire-child/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "elder-destinode" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/esquire-child/elder-target-document"
     And I expect this node to be a child of node cs-identifier;nodimus-mediocre;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                          |
@@ -295,7 +310,8 @@ Feature: Move a node with content dimensions
       | cs-identifier;younger-child-destinode;{"example": "general"} |
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "elder-destinode" and node path "esquire/elder-target-document" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    Then I expect node aggregate identifier "elder-destinode" to lead to node cs-identifier;elder-destinode;{"example": "general"}
+    And I expect this node to have path "esquire/elder-target-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example": "general"}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                                     |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/05-MoveNodeAggregate_SubtreeTags.feature
@@ -56,45 +56,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -115,45 +123,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -176,45 +192,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -235,45 +259,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -297,45 +329,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -357,45 +397,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -426,45 +474,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -493,45 +549,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -560,45 +624,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -627,45 +699,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -694,45 +774,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -761,45 +849,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -828,45 +924,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -895,45 +999,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -964,45 +1076,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1031,45 +1151,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1098,45 +1226,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1165,45 +1301,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1232,45 +1376,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1299,45 +1451,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1366,45 +1526,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1433,45 +1601,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged "tag1"
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1,tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1495,45 +1671,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1555,45 +1739,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations"      |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1624,45 +1816,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1691,45 +1891,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1758,45 +1966,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1825,45 +2041,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1892,45 +2116,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -1959,45 +2191,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2026,45 +2266,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2093,45 +2341,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2162,45 +2418,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2229,45 +2493,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2296,45 +2568,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2363,45 +2643,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag1"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2430,45 +2718,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2497,45 +2793,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2564,45 +2868,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
@@ -2631,45 +2943,53 @@ Feature: Move a node aggregate into and out of a tagged parent
       | relationDistributionStrategy | "gatherSpecializations" |
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/esquire-child/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document"
     And I expect this node to be a child of node cs-identifier;nodimus-prime;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "esquire/esquire-child/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "esquire/esquire-child/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags "tag2"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""
 
-    And I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/document/child-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"general"}
+    And I expect this node to have path "parent-document/document/child-document"
     And I expect this node to be a child of node cs-identifier;nody-mc-nodeface;{"example":"general"}
     And I expect this node to be exactly explicitly tagged ""
     And I expect this node to exactly inherit the tags ""

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
@@ -77,19 +77,22 @@ Feature: Move a node without content dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -111,19 +114,22 @@ Feature: Move a node without content dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -164,23 +170,27 @@ Feature: Move a node without content dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "lady-abigail-nodenborough" and node path "esquire/other-document" to lead to node cs-identifier;lady-abigail-nodenborough;{}
+    And I expect node aggregate identifier "lady-abigail-nodenborough" to lead to node cs-identifier;lady-abigail-nodenborough;{}
+    And I expect this node to have path "esquire/other-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "esquire/document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                          |
       | cs-identifier;lady-abigail-nodenborough;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -209,14 +219,16 @@ Feature: Move a node without content dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;nody-mc-nodeface;{}           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "child-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -224,7 +236,8 @@ Feature: Move a node without content dimensions
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/08-NodeMove/07-MoveNodeAggregateWithoutDimensions.feature
@@ -78,14 +78,12 @@ Feature: Move a node without content dimensions
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
@@ -115,14 +113,12 @@ Feature: Move a node without content dimensions
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
@@ -171,7 +167,6 @@ Feature: Move a node without content dimensions
 
     When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -220,7 +215,6 @@ Feature: Move a node without content dimensions
 
     When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -228,7 +222,6 @@ Feature: Move a node without content dimensions
       | cs-identifier;nody-mc-nodeface;{}           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
-    And I expect this node to have path "child-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -237,7 +230,6 @@ Feature: Move a node without content dimensions
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
@@ -63,23 +63,33 @@ Feature: Change node aggregate name
     And I expect the graph projection to consist of exactly 9 nodes
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"general"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
     Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered/grandchild-document"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered/grandchild-document"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
     Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node
 
   Scenario: Rename a scattered node aggregate
@@ -108,21 +118,31 @@ Feature: Change node aggregate name
     And I expect the graph projection to consist of exactly 9 nodes
 
     When I am in workspace "live" and dimension space point {"example": "general"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"general"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"general"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
     Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "source"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered/grandchild-document"
 
     When I am in workspace "live" and dimension space point {"example": "spec"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered"
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to node cs-identifier;nodimus-mediocre;{"example":"source"}
+    And I expect this node to have path "parent-document/renamed-document/tethered/grandchild-document"
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
-    Then I expect node aggregate identifier "nody-mc-nodeface" and node path "renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    Then I expect node aggregate identifier "nodimus-prime" and node path "renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
+    And I expect this node to have path "renamed-document"
+    Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
+    And I expect this node to have path "renamed-document/tethered"
     Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
@@ -65,7 +65,7 @@ Feature: Change node aggregate name
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"general"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to no node
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
@@ -80,7 +80,7 @@ Feature: Change node aggregate name
     When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
     Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to no node
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node
 
   Scenario: Rename a scattered node aggregate
     Given the command MoveNodeAggregate is executed with payload:
@@ -110,7 +110,7 @@ Feature: Change node aggregate name
     When I am in workspace "live" and dimension space point {"example": "general"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"general"}
     Then I expect node aggregate identifier "nodimus-prime" and node path "parent-document/renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"general"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "parent-document/renamed-document/tethered/grandchild-document" to lead to no node
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node
 
     When I am in workspace "live" and dimension space point {"example": "source"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "parent-document/renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"source"}
@@ -125,4 +125,4 @@ Feature: Change node aggregate name
     When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" and node path "renamed-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
     Then I expect node aggregate identifier "nodimus-prime" and node path "renamed-document/tethered" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
-    Then I expect node aggregate identifier "nodimus-mediocre" and node path "renamed-document/tethered/grandchild-document" to lead to no node
+    Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/09-NodeRenaming/02-ChangeNodeAggregateName.feature
@@ -142,7 +142,6 @@ Feature: Change node aggregate name
 
     When I am in workspace "live" and dimension space point {"example": "peer"}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"example":"peer"}
-    And I expect this node to have path "renamed-document"
     Then I expect node aggregate identifier "nodimus-prime" to lead to node cs-identifier;nodimus-prime;{"example":"peer"}
     And I expect this node to have path "renamed-document/tethered"
     Then I expect node aggregate identifier "nodimus-mediocre" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -81,5 +81,5 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
     And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
       | Level | nodeAggregateId        |
       | 0     | lady-eleonode-rootford |
-    And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
-    And I expect node aggregate identifier "nodingers-cat" and node path "court-magician/pet" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" to lead to no node

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -77,10 +77,12 @@ Feature: Disable a node aggregate
       | 1     | sir-david-nodenborough  |
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And the subtree for node aggregate "sir-david-nodenborough" with node types "" and 1 levels deep should be:
       | Level | nodeAggregateId        |
       | 0     | sir-david-nodenborough |
       | 1     | nody-mc-nodeface       |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -78,7 +78,6 @@ Feature: Disable a node aggregate
       | 2     | nody-mc-nodeface        |
       | 1     | succeeding-nodenborough |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And the subtree for node aggregate "sir-david-nodenborough" with node types "" and 1 levels deep should be:
       | Level | nodeAggregateId        |
       | 0     | sir-david-nodenborough |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
@@ -99,11 +99,15 @@ Feature: Remove NodeAggregate
     When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect the subgraph projection to consist of exactly 3 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"de"}
-    And I expect node aggregate identifier "nodimus-prime" and node path "document/child-document" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"de"}
+    And I expect this node to have path "document"
+    And I expect node aggregate identifier "nodimus-prime" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
+    And I expect this node to have path "document/child-document"
 
     When I am in workspace "live" and dimension space point {"language":"gsw"}
     Then I expect the subgraph projection to consist of exactly 3 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"gsw"}
-    And I expect node aggregate identifier "nodimus-prime" and node path "document/child-document" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"gsw"}
+    And I expect this node to have path "document"
+    And I expect node aggregate identifier "nodimus-prime" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
+    And I expect this node to have path "document/child-document"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateWithDimensions.feature
@@ -100,7 +100,6 @@ Feature: Remove NodeAggregate
     Then I expect the subgraph projection to consist of exactly 3 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"de"}
-    And I expect this node to have path "document"
     And I expect node aggregate identifier "nodimus-prime" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
     And I expect this node to have path "document/child-document"
 
@@ -108,6 +107,5 @@ Feature: Remove NodeAggregate
     Then I expect the subgraph projection to consist of exactly 3 nodes
     And I expect node aggregate identifier "lady-eleonode-nodesworth" to lead to node live-cs-identifier;lady-eleonode-nodesworth;{}
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node live-cs-identifier;nody-mc-nodeface;{"language":"gsw"}
-    And I expect this node to have path "document"
     And I expect node aggregate identifier "nodimus-prime" to lead to node live-cs-identifier;nodimus-prime;{"language":"de"}
     And I expect this node to have path "document/child-document"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -209,7 +209,8 @@ Feature: Tethered Nodes integrity violations
     When I am in workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
     Then I expect node aggregate identifier "nodewyn-tetherton" to lead to no node
     Then I expect node aggregate identifier "nodimer-tetherton" to lead to no node
-    And  I expect path "tethered-node" to lead to no node
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"market":"CH", "language":"gsw"}
+    And I expect this node to have no child nodes
 
   Scenario: Adjusting the schema changing the type of a tethered node leads to a InvalidTetheredNodeType integrity violation
     Given I change the node types in content repository "default" to:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodes.feature
@@ -144,15 +144,17 @@ Feature: Tethered Nodes integrity violations
     Then I expect no needed structure adjustments for type "Neos.ContentRepository:Root"
 
     When I am in workspace "live" and dimension space point {"market":"CH", "language":"gsw"}
-    And I get the node at path "document/some-new-child"
+
+    # TODO StructureAdjustments do not have the option for tethered deterministic node ids
+    And I get the node at path "/<Neos.ContentRepository:Root>/document/some-new-child"
     Then I expect this node to have the following properties:
       | Key | Value                |
       | foo | "my default applied" |
 
-    When I get the node at path "document/some-new-child/tethered-leaf"
+    When I get the node at path "/<Neos.ContentRepository:Root>/document/some-new-child/tethered-leaf"
     Then I expect this node to be of type "Neos.ContentRepository.Testing:TetheredLeaf"
 
-    When I get the node at path "tethered-node"
+    When I get the node at path "/<Neos.ContentRepository:Root>/tethered-node"
     Then I expect this node to have the following properties:
       | Key | Value                |
       | foo | "my default applied" |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/StructureAdjustment/TetheredNodesReordering.feature
@@ -39,7 +39,7 @@ Feature: Tethered Nodes Reordering Structure changes
 
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
-    And I get the node at path "document/tethered-node"
+    And I expect node aggregate identifier "tethered-node-agg" to lead to node cs-identifier;tethered-node-agg;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                        |
@@ -67,7 +67,7 @@ Feature: Tethered Nodes Reordering Structure changes
     Then I expect no needed structure adjustments for type "Neos.ContentRepository.Testing:Document"
 
     When I am in workspace "live" and dimension space point {}
-    And I get the node at path "document/tethered-node"
+    And I expect node aggregate identifier "tethered-node-agg" to lead to node cs-identifier;tethered-node-agg;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                        |
       | cs-identifier;other-tethered-node-agg;{} |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W6-WorkspaceRebasing/02-RebasingWithAutoCreatedNodes.feature
@@ -48,16 +48,18 @@ Feature: Rebasing auto-created nodes works
   Scenario: complex scenario (to reproduce the bug) -- see the feature description
     # USER workspace: create a new node with auto-created child nodes
     When the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                       | Value                                    |
-      | workspaceName             | "user-test"                              |
-      | nodeAggregateId           | "nody-mc-nodeface"                       |
-      | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
-      | nodeName                  | "mcnodeface"                             |
-      | originDimensionSpacePoint | {}                                       |
-      | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
+      | Key                                | Value                                    |
+      | workspaceName                      | "user-test"                              |
+      | nodeAggregateId                    | "nody-mc-nodeface"                       |
+      | nodeTypeName                       | "Neos.ContentRepository.Testing:Content" |
+      | nodeName                           | "mcnodeface"                             |
+      | originDimensionSpacePoint          | {}                                       |
+      | parentNodeAggregateId              | "lady-eleonode-rootford"                 |
+      | tetheredDescendantNodeAggregateIds | {"foo": "nodewyn-tetherton"}             |
     And I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
-    When I get the node at path "mcnodeface/foo"
+    Then I expect node aggregate identifier "nodewyn-tetherton" to lead to node user-cs-identifier;nodewyn-tetherton;{}
+    When I expect this node to have path "mcnodeface/foo"
     And I expect this node to be a child of node user-cs-identifier;nody-mc-nodeface;{}
 
     # - then, for the auto-created child node, set a property.

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/02-BasicFeatures.feature
@@ -47,11 +47,10 @@ Feature: Individual node publication
     And I am in dimension space point {}
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId        | nodeTypeName                            | parentNodeAggregateId  | nodeName | tetheredDescendantNodeAggregateIds |
-      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document | {}                                 |
-    And I remember NodeAggregateId of node "sir-david-nodenborough"s child "child2" as "child2Id"
+      | sir-david-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document | {"child2": "child2-agg"}           |
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId  | nodeTypeName                           | parentNodeAggregateId | nodeName | tetheredDescendantNodeAggregateIds |
-      | nody-mc-nodeface | Neos.ContentRepository.Testing:Content | $child2Id             | nody     | {}                                 |
+      | nody-mc-nodeface | Neos.ContentRepository.Testing:Content | child2-agg            | nody     | {}                                 |
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                             | Value                                                                                                    |
       | nodesToPublish                  | ["sir-david-nodenborough"] |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
@@ -89,19 +89,22 @@ Feature: Publishing moved nodes without dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -128,19 +131,22 @@ Feature: Publishing moved nodes without dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -178,23 +184,27 @@ Feature: Publishing moved nodes without dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "lady-abigail-nodenborough" and node path "esquire/other-document" to lead to node cs-identifier;lady-abigail-nodenborough;{}
+    And I expect node aggregate identifier "lady-abigail-nodenborough" to lead to node cs-identifier;lady-abigail-nodenborough;{}
+    And I expect this node to have path "esquire/other-document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "esquire/document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "esquire/document"
     And I expect this node to be a child of node cs-identifier;sir-nodeward-nodington-iii;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                          |
       | cs-identifier;lady-abigail-nodenborough;{} |
     And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "esquire/document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "esquire/document/child-document"
     And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -221,14 +231,16 @@ Feature: Publishing moved nodes without dimensions
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "live" and dimension space point {}
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;nody-mc-nodeface;{}           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have path "child-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -236,7 +248,8 @@ Feature: Publishing moved nodes without dimensions
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" and node path "esquire" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/05-PublishMovedNodesWithoutDimensions.feature
@@ -90,14 +90,12 @@ Feature: Publishing moved nodes without dimensions
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
@@ -132,14 +130,12 @@ Feature: Publishing moved nodes without dimensions
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
       | NodeDiscriminator                       |
       | cs-identifier;sir-david-nodenborough;{} |
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                           |
@@ -185,7 +181,6 @@ Feature: Publishing moved nodes without dimensions
 
     When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have no succeeding siblings
@@ -232,7 +227,6 @@ Feature: Publishing moved nodes without dimensions
 
     When I am in workspace "live" and dimension space point {}
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have path "document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -240,7 +234,6 @@ Feature: Publishing moved nodes without dimensions
       | cs-identifier;nody-mc-nodeface;{}           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
-    And I expect this node to have path "child-document"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |
@@ -249,7 +242,6 @@ Feature: Publishing moved nodes without dimensions
       | NodeDiscriminator                           |
       | cs-identifier;sir-nodeward-nodington-iii;{} |
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-    And I expect this node to have path "esquire"
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following preceding siblings:
       | NodeDiscriminator                       |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/Workspaces/NodeOperationsOnMultipleWorkspaces.feature
@@ -83,14 +83,16 @@ Feature: Single Node operations on multiple workspaces/content streams; e.g. cop
       | text | "Changed" |
 
     When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "nodingers-cat" and node path "child/pet" to lead to node cs-identifier;nodingers-cat;{}
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to have path "child/pet"
     When I go to the parent node of node aggregate "nodingers-cat"
     Then I expect this node to have the following properties:
       | Key  | Value      |
       | text | "Original" |
 
     When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "nodingers-cat" and node path "child/pet" to lead to node user-cs-identifier;nodingers-cat;{}
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node user-cs-identifier;nodingers-cat;{}
+    And I expect this node to have path "child/pet"
     When I go to the parent node of node aggregate "nodingers-cat"
     Then I expect this node to have the following properties:
       | Key  | Value     |

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -41,8 +41,6 @@ trait CRTestSuiteRuntimeVariables
 
     protected ?VisibilityConstraints $currentVisibilityConstraints = null;
 
-    protected ?NodeAggregateId $currentRootNodeAggregateId = null;
-
     protected ?\Exception $lastCommandException = null;
 
     protected ?Node $currentNode = null;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -48,11 +48,6 @@ trait CRTestSuiteRuntimeVariables
     protected ?NodeAggregate $currentNodeAggregate = null;
 
     /**
-     * @var array<string,NodeAggregateId>
-     */
-    protected array $rememberedNodeAggregateIds = [];
-
-    /**
      * @Given /^I am in content repository "([^"]*)"$/
      */
     public function iAmInContentRepository(string $contentRepositoryId): void
@@ -126,17 +121,6 @@ trait CRTestSuiteRuntimeVariables
             $this->currentDimensionSpacePoint,
             $this->currentVisibilityConstraints
         );
-    }
-
-    /**
-     * @Given /^I remember NodeAggregateId of node "([^"]*)"s child "([^"]*)" as "([^"]*)"$/
-     */
-    public function iRememberNodeAggregateIdOfNodesChildAs(string $parentNodeAggregateId, string $childNodeName, string $indexName): void
-    {
-        $this->rememberedNodeAggregateIds[$indexName] = $this->getCurrentSubgraph()->findNodeByPath(
-            NodePath::fromString($childNodeName),
-            NodeAggregateId::fromString($parentNodeAggregateId),
-        )->aggregateId;
     }
 
     protected function getCurrentNodeAggregateId(): ?NodeAggregateId

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -84,7 +84,6 @@ trait CRTestSuiteTrait
         $this->currentContentRepository = null;
         $this->currentVisibilityConstraints = VisibilityConstraints::default();
         $this->currentDimensionSpacePoint = null;
-        $this->currentRootNodeAggregateId = null;
         $this->currentWorkspaceName = null;
         $this->currentNodeAggregate = null;
         $this->currentNode = null;
@@ -239,17 +238,6 @@ trait CRTestSuiteTrait
 
         return $reflectedContentRepository->getProperty('eventStore')
             ->getValue($this->currentContentRepository);
-    }
-
-    protected function getRootNodeAggregateId(): ?NodeAggregateId
-    {
-        if ($this->currentRootNodeAggregateId) {
-            return $this->currentRootNodeAggregateId;
-        }
-
-        return $this->currentContentRepository->getContentGraph($this->currentWorkspaceName)->findRootNodeAggregateByType(
-            NodeTypeName::fromString('Neos.Neos:Sites')
-        )->nodeAggregateId;
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Features/NodeCreation.php
@@ -55,11 +55,9 @@ trait NodeCreation
     {
         $eventPayload = $this->readPayloadTable($payloadTable);
         $contentStreamId = ContentStreamId::fromString($eventPayload['contentStreamId']);
-        $nodeAggregateId = NodeAggregateId::fromString($eventPayload['nodeAggregateId']);
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentStreamId);
 
         $this->publishEvent('RootNodeAggregateWithNodeWasCreated', $streamName->getEventStreamName(), $eventPayload);
-        $this->currentRootNodeAggregateId = $nodeAggregateId;
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -364,9 +364,6 @@ trait GenericCommandExecutionAndEventPublication
     {
         $commandArguments = $this->addDefaultCommandArgumentValues($commandClassName, $commandArguments);
         $command = $commandClassName::fromArray($commandArguments);
-        if ($command instanceof CreateRootNodeAggregateWithNode) {
-            $this->currentRootNodeAggregateId = $command->nodeAggregateId;
-        }
         $this->currentContentRepository->handle($command);
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -378,9 +378,7 @@ trait GenericCommandExecutionAndEventPublication
             $commandArguments['coveredDimensionSpacePoint'] = \json_decode($commandArguments['coveredDimensionSpacePoint'], true, 512, JSON_THROW_ON_ERROR);
         }
         $commandArguments['dimensionSpacePoint'] = $commandArguments['dimensionSpacePoint'] ?? $this->currentDimensionSpacePoint?->coordinates;
-        if (is_string($commandArguments['nodeAggregateId'] ?? null) && str_starts_with($commandArguments['nodeAggregateId'], '$')) {
-            $commandArguments['nodeAggregateId'] = $this->rememberedNodeAggregateIds[substr($commandArguments['nodeAggregateId'], 1)]?->value;
-        } elseif (!isset($commandArguments['nodeAggregateId'])) {
+        if (!isset($commandArguments['nodeAggregateId'])) {
             $commandArguments['nodeAggregateId'] = $this->getCurrentNodeAggregateId()?->value;
         }
         if ($commandClassName === CreateNodeAggregateWithNode::class) {
@@ -391,9 +389,6 @@ trait GenericCommandExecutionAndEventPublication
             }
             if (isset($commandArguments['succeedingSiblingNodeAggregateId']) && $commandArguments['succeedingSiblingNodeAggregateId'] === '') {
                 unset($commandArguments['succeedingSiblingNodeAggregateId']);
-            }
-            if (is_string($commandArguments['parentNodeAggregateId'] ?? null) && str_starts_with($commandArguments['parentNodeAggregateId'], '$')) {
-                $commandArguments['parentNodeAggregateId'] = $this->rememberedNodeAggregateIds[substr($commandArguments['parentNodeAggregateId'], 1)]?->value;
             }
             if (empty($commandArguments['nodeName'])) {
                 unset($commandArguments['nodeName']);
@@ -426,9 +421,7 @@ trait GenericCommandExecutionAndEventPublication
             } elseif (!isset($commandArguments['sourceOriginDimensionSpacePoint'])) {
                 $commandArguments['sourceOriginDimensionSpacePoint'] = $this->currentDimensionSpacePoint?->coordinates;
             }
-            if (is_string($commandArguments['sourceNodeAggregateId'] ?? null) && str_starts_with($commandArguments['sourceNodeAggregateId'], '$')) {
-                $commandArguments['sourceNodeAggregateId'] = $this->rememberedNodeAggregateIds[substr($commandArguments['sourceNodeAggregateId'], 1)]?->value;
-            } elseif (!isset($commandArguments['sourceNodeAggregateId'])) {
+            if (!isset($commandArguments['sourceNodeAggregateId'])) {
                 $commandArguments['sourceNodeAggregateId'] = $this->currentNodeAggregate?->nodeAggregateId->value;
             }
         }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -18,14 +18,15 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Psr7\Uri;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\References;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -46,8 +47,6 @@ trait ProjectedNodeTrait
 {
     use CRTestSuiteRuntimeVariables;
 
-    abstract protected function getRootNodeAggregateId(): ?NodeAggregateId;
-
     /**
      * @When /^I go to the parent node of node aggregate "([^"]*)"$/
      * @param string $serializedNodeAggregateId
@@ -63,13 +62,13 @@ trait ProjectedNodeTrait
     /**
      * @Then /^I get the node at path "([^"]*)"$/
      * @param string $serializedNodePath
-     * @throws \Exception
+     * @deprecated use node-id based assertions and deterministic ids {@see iExpectANodeIdentifiedByXToExistInTheContentGraph}
      */
-    public function iGetTheNodeAtPath(string $serializedNodePath): void
+    public function iGetTheNodeAtPath(string $serializedAbsoluteNodePath): void
     {
-        $nodePath = NodePath::fromString($serializedNodePath);
-        $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodePath) {
-            return $subgraph->findNodeByPath($nodePath, $this->getRootNodeAggregateId());
+        $absoluteNodePath = AbsoluteNodePath::fromString($serializedAbsoluteNodePath);
+        $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($absoluteNodePath) {
+            return $subgraph->findNodeByAbsolutePath($absoluteNodePath);
         });
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -134,40 +134,6 @@ trait ProjectedNodeTrait
     }
 
     /**
-     * @param string $serializedNodePath
-     * @param string $serializedNodeDiscriminator
-     * @throws \Exception
-     */
-    public function iExpectPathToLeadToNode(string $serializedNodePath, string $serializedNodeDiscriminator): void
-    {
-        if (!$this->getRootNodeAggregateId()) {
-            throw new \Exception('ERROR: rootNodeAggregateId needed for running this step. You need to use "the event RootNodeAggregateWithNodeWasCreated was published with payload" to create a root node..');
-        }
-        $nodePath = NodePath::fromString($serializedNodePath);
-        $expectedDiscriminator = NodeDiscriminator::fromShorthand($serializedNodeDiscriminator);
-        $this->initializeCurrentNodeFromContentSubgraph(function (ContentSubgraphInterface $subgraph) use ($nodePath, $expectedDiscriminator) {
-            $currentNode = $subgraph->findNodeByPath($nodePath, $this->getRootNodeAggregateId());
-            Assert::assertNotNull($currentNode, 'No node could be found by node path "' . $nodePath->serializeToString() . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"');
-            $actualDiscriminator = NodeDiscriminator::fromNode($currentNode, $this->currentContentRepository);
-            Assert::assertTrue($expectedDiscriminator->equals($actualDiscriminator), 'Node discriminators do not match. Expected was ' . json_encode($expectedDiscriminator) . ' , given was ' . json_encode($actualDiscriminator));
-            return $currentNode;
-        });
-    }
-
-    /**
-     * @Then /^I expect node aggregate identifier "([^"]*)" and node path "([^"]*)" to lead to node (.*)$/
-     * @param string $serializedNodeAggregateId
-     * @param string $serializedNodePath
-     * @param string $serializedNodeDiscriminator
-     * @throws \Exception
-     */
-    public function iExpectNodeAggregateIdAndNodePathToLeadToNode(string $serializedNodeAggregateId, string $serializedNodePath, string $serializedNodeDiscriminator): void
-    {
-        $this->iExpectNodeAggregateIdToLeadToNode($serializedNodeAggregateId, $serializedNodeDiscriminator);
-        $this->iExpectPathToLeadToNode($serializedNodePath, $serializedNodeDiscriminator);
-    }
-
-    /**
      * @Then /^I expect the node with aggregate identifier "([^"]*)" to be explicitly tagged "([^"]*)"$/
      */
     public function iExpectTheNodeWithAggregateIdentifierToBeExplicitlyTagged(string $serializedNodeAggregateId, string $serializedTag): void
@@ -667,6 +633,26 @@ trait ProjectedNodeTrait
             $actualSiblings = $this->getCurrentSubgraph()
                 ->findSucceedingSiblingNodes($currentNode->aggregateId, FindSucceedingSiblingNodesFilter::create());
             Assert::assertCount(0, $actualSiblings, 'ContentSubgraph::findSucceedingSiblingNodes: No siblings were expected');
+        });
+    }
+
+    /**
+     * @Then /^I expect this node to have path "([^"]+)"/
+     * @deprecated path based assertions are deprecated {@see ContentSubgraphInterface::retrieveNodePath}
+     */
+    public function iExpectThisNodeToHavePath(string $serializedPath): void
+    {
+        $this->assertOnCurrentNode(function (Node $currentNode) use ($serializedPath) {
+            $subgraph = $this->getCurrentSubgraph();
+
+            $actualNode = $subgraph->findNodeByPath(NodePath::fromString($serializedPath), $this->getRootNodeAggregateId());
+            Assert::assertTrue($actualNode->equals($currentNode));
+
+            // Todo remove getRootNodeAggregateId() hack and use real absolute paths
+            // $ancestors = $subgraph->findAncestorNodes($currentNode->aggregateId, FindAncestorNodesFilter::create())
+            //     ->reverse();
+            // $actualPath = AbsoluteNodePath::fromLeafNodeAndAncestors($currentNode, $ancestors);
+            // Assert::assertEquals($serializedPath, $actualPath->serializeToString());
         });
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -134,7 +134,6 @@ trait ProjectedNodeTrait
     }
 
     /**
-     * @Then /^I expect path "([^"]*)" to lead to node (.*)$/
      * @param string $serializedNodePath
      * @param string $serializedNodeDiscriminator
      * @throws \Exception
@@ -156,7 +155,6 @@ trait ProjectedNodeTrait
     }
 
     /**
-     * @Then /^I expect path "([^"]*)" to lead to no node$/
      * @param string $serializedNodePath
      * @throws \Exception
      */

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -155,24 +155,6 @@ trait ProjectedNodeTrait
     }
 
     /**
-     * @param string $serializedNodePath
-     * @throws \Exception
-     */
-    public function iExpectPathToLeadToNoNode(string $serializedNodePath): void
-    {
-        if (!$this->getRootNodeAggregateId()) {
-            throw new \Exception('ERROR: rootNodeAggregateId needed for running this step. You need to use "the event RootNodeAggregateWithNodeWasCreated was published with payload" to create a root node..');
-        }
-        $nodePath = NodePath::fromString($serializedNodePath);
-        $nodeByPath = $this->getCurrentSubgraph()->findNodeByPath($nodePath, $this->getRootNodeAggregateId());
-        Assert::assertNull(
-            $nodeByPath,
-            'A node was found by node path "' . $nodePath->serializeToString()
-                . '" in content subgraph "' . $this->currentDimensionSpacePoint->toJson() . '@' . $this->currentWorkspaceName->value . '"'
-        );
-    }
-
-    /**
      * @Then /^I expect node aggregate identifier "([^"]*)" and node path "([^"]*)" to lead to node (.*)$/
      * @param string $serializedNodeAggregateId
      * @param string $serializedNodePath
@@ -183,18 +165,6 @@ trait ProjectedNodeTrait
     {
         $this->iExpectNodeAggregateIdToLeadToNode($serializedNodeAggregateId, $serializedNodeDiscriminator);
         $this->iExpectPathToLeadToNode($serializedNodePath, $serializedNodeDiscriminator);
-    }
-
-    /**
-     * @Then /^I expect node aggregate identifier "([^"]*)" and node path "([^"]*)" to lead to no node$/
-     * @param string $serializedNodeAggregateId
-     * @param string $serializedNodePath
-     * @throws \Exception
-     */
-    public function iExpectNodeAggregateIdAndNodePathToLeadToNoNode(string $serializedNodeAggregateId, string $serializedNodePath): void
-    {
-        $this->iExpectNodeAggregateIdToLeadToNoNode($serializedNodeAggregateId);
-        $this->iExpectPathToLeadToNoNode($serializedNodePath);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -25,8 +25,10 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReference
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindRootNodeAggregatesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\References;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -644,14 +646,29 @@ trait ProjectedNodeTrait
         $this->assertOnCurrentNode(function (Node $currentNode) use ($serializedPath) {
             $subgraph = $this->getCurrentSubgraph();
 
-            $actualNode = $subgraph->findNodeByPath(NodePath::fromString($serializedPath), $this->getRootNodeAggregateId());
-            Assert::assertTrue($actualNode->equals($currentNode));
+            $ancestors = $subgraph->findAncestorNodes($currentNode->aggregateId, FindAncestorNodesFilter::create())
+                ->reverse();
+            $actualAbsolutePath = AbsoluteNodePath::fromLeafNodeAndAncestors($currentNode, $ancestors);
 
-            // Todo remove getRootNodeAggregateId() hack and use real absolute paths
-            // $ancestors = $subgraph->findAncestorNodes($currentNode->aggregateId, FindAncestorNodesFilter::create())
-            //     ->reverse();
-            // $actualPath = AbsoluteNodePath::fromLeafNodeAndAncestors($currentNode, $ancestors);
-            // Assert::assertEquals($serializedPath, $actualPath->serializeToString());
+            $expectedAbsolutePath = AbsoluteNodePath::tryFromString($serializedPath);
+
+            if ($expectedAbsolutePath === null) {
+                // relative path assertion if non-ambiguous, reduces verbosity in test
+                $expectedRelativePath = NodePath::fromString($serializedPath);
+
+                $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
+                $rootNodeAggregates = $contentGraph->findRootNodeAggregates(FindRootNodeAggregatesFilter::create());
+                if ($rootNodeAggregates->count() > 1) {
+                    throw new \RuntimeException(sprintf('Relative path assertion of %s with %s is not possible because multiple root node aggregates exist. Use absolute comparison instead.', $expectedRelativePath->serializeToString(), $actualAbsolutePath->serializeToString()), 1777744498);
+                }
+
+                $expectedAbsolutePath = AbsoluteNodePath::fromRootNodeTypeNameAndRelativePath(
+                    $rootNodeAggregates->first()->nodeTypeName,
+                    $expectedRelativePath
+                );
+            }
+
+            Assert::assertTrue($expectedAbsolutePath->equals($actualAbsolutePath), sprintf('Absolute node path "%s" does not equal expected "%s"', $actualAbsolutePath->serializeToString(), $expectedAbsolutePath->serializeToString()));
         });
     }
 

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
@@ -281,9 +281,7 @@ trait RoutingTrait
             $this->currentContentRepository->id,
             WorkspaceName::forLive(),
             DimensionSpacePoint::fromJsonString($dimensionSpacePoint),
-            \str_starts_with($nodeAggregateId, '$')
-                ? $this->rememberedNodeAggregateIds[\mb_substr($nodeAggregateId, 1)]
-                : NodeAggregateId::fromString($nodeAggregateId)
+            NodeAggregateId::fromString($nodeAggregateId)
         );
         $httpRequest = $this->getObject(ServerRequestFactoryInterface::class)->createServerRequest('GET', $this->requestUrl);
         $httpRequest = $this->addRoutingParameters($httpRequest);

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/TetheredSiteChildDocuments.feature
@@ -37,8 +37,8 @@ Feature: Tests for site node child documents. These are special in that they hav
       | nodeTypeName    | "Neos.Neos:Sites"        |
     # We explicitly create a site node with a tethered child document without uriPathSegment, so its uriPath is empty, exactly as the site node's
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId | parentNodeAggregateId  | nodeTypeName                | initialPropertyValues | nodeName |
-      | shernode-homes  | lady-eleonode-rootford | Acme.Site:Document.Homepage | {}                    | site     |
+      | nodeAggregateId | parentNodeAggregateId  | nodeTypeName                | initialPropertyValues | nodeName | tetheredDescendantNodeAggregateIds |
+      | shernode-homes  | lady-eleonode-rootford | Acme.Site:Document.Homepage | {}                    | site     | {"notFound": "not-found-agg"}       |
     And A site exists for node name "site"
     And the sites configuration is:
     """yaml
@@ -54,11 +54,10 @@ Feature: Tests for site node child documents. These are special in that they hav
     """
 
   Scenario: Set tethered child uriPathSegment
-    When I remember NodeAggregateId of node "shernode-homes"s child "notFound" as "notFoundId"
     And the command SetNodeProperties is executed with payload:
       | Key             | Value                           |
-      | nodeAggregateId | "$notFoundId"                   |
+      | nodeAggregateId | "not-found-agg"                  |
       | propertyValues  | {"uriPathSegment": "not-found"} |
     And I am on URL "/"
     Then the matched node should be "shernode-homes" in dimension "{}"
-    And the node "$notFoundId" in dimension "{}" should resolve to URL "/not-found"
+    And the node "not-found-agg" in dimension "{}" should resolve to URL "/not-found"


### PR DESCRIPTION
Please review commit by commit, as some commits contain big replacements of just one kind.

- Remove last usage of "I expect path * to lead to no node"
- Simplify assertions that nodes not exists by only using node aggregate id

Merges

```    
I expect node aggregate identifier "([^"]*)" and node path "([^"]*)" to lead to no node
```

Into

```
I expect node aggregate identifier "([^"]*)" to lead to no node
```

- Split-up step "I expect node aggregate identifier ... and node path ... to lead to node

Instead we _retrieve_ the node path and make this assertion behave like all other assertions like "I expect this node to "

```
And I expect node aggregate identifier "eldest-mc-nodeface" to lead to node ...
And I expect this node to have path "eldest-document"
```

- Avoid using "I get the node at path" if possible

StructureAdjustments do not (yet) have the option for tethered deterministic node ids, so we still use it but with absolute paths to be unambiguous

We remove the odd getRootNodeAggregateId handling which is just another state and makes understanding tests harder

- Remove obsolete node aggregate id variables in behat
 
```
I remember NodeAggregateId of node "sir-david-nodenborough"s child "child2" as "child2Id"
```

Was used two times which does not justify this pattern

