### PR TITLE
TASK: (Slightly) improve workspace / publishing test coverage

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -206,7 +206,6 @@ Feature: Publishing hide/show scenario of nodes
       | text1mod | sir-david-nodenborough     |
       | imagemod | sir-nodeward-nodington-iii |
 
-
   Scenario: (RemoveNodeAggregate) It is possible to publish a node removal
     Given the command CreateWorkspace is executed with payload:
       | Key                | Value                |
@@ -244,44 +243,6 @@ Feature: Publishing hide/show scenario of nodes
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
-
-
-  Scenario: (RemoveNodeAggregate) It is possible to publish a node removal
-    Given the command CreateWorkspace is executed with payload:
-      | Key                | Value                |
-      | workspaceName      | "user-test"          |
-      | baseWorkspaceName  | "live"               |
-      | newContentStreamId | "user-cs-identifier" |
-
-    # SETUP: remove two nodes in USER workspace
-    When the command RemoveNodeAggregate is executed with payload:
-      | Key                          | Value                    |
-      | workspaceName                | "user-test"              |
-      | nodeAggregateId              | "sir-david-nodenborough" |
-      | coveredDimensionSpacePoint   | {}                       |
-      | nodeVariantSelectionStrategy | "allVariants"            |
-    When the command RemoveNodeAggregate is executed with payload:
-      | Key                          | Value                        |
-      | workspaceName                | "user-test"                  |
-      | nodeAggregateId              | "sir-nodeward-nodington-iii" |
-      | coveredDimensionSpacePoint   | {}                           |
-      | nodeVariantSelectionStrategy | "allVariants"                |
-
-    When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key            | Value                                                                                                    |
-      | workspaceName  | "user-test"                                                                                              |
-      | nodesToPublish | ["sir-david-nodenborough"] |
-
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
-
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
-
 
   Scenario: (SetNodeReferences) It is possible to publish setting node references
     Given the command CreateWorkspace is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -247,6 +247,10 @@ Feature: Publishing hide/show scenario of nodes
       | newNodeName     | "imagemod"                   |
 
     When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be named "text1"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be named "image"
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name  | nodeAggregateId            |
@@ -254,6 +258,10 @@ Feature: Publishing hide/show scenario of nodes
       | image | sir-nodeward-nodington-iii |
 
     When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be named "text1mod"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be named "imagemod"
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name     | nodeAggregateId            |
@@ -267,6 +275,10 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
 
     When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be named "text1mod"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be named "image"
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name     | nodeAggregateId            |
@@ -274,11 +286,67 @@ Feature: Publishing hide/show scenario of nodes
       | image    | sir-nodeward-nodington-iii |
 
     When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be named "text1mod"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be named "imagemod"
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier-remaining;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name     | nodeAggregateId            |
       | text1mod | sir-david-nodenborough     |
       | imagemod | sir-nodeward-nodington-iii |
+
+  Scenario: (ChangeNodeAggregateType) It is possible to publish changing the node type name.
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    # SETUP: change two node types in USER workspace
+    Given the command ChangeNodeAggregateType is executed with payload:
+      | Key             | Value                                  |
+      | workspaceName   | "user-test"                            |
+      | nodeAggregateId | "sir-david-nodenborough"               |
+      | newNodeTypeName | "Neos.ContentRepository.Testing:Image" |
+      | strategy        | "delete"                               |
+
+    Given the command ChangeNodeAggregateType is executed with payload:
+      | Key             | Value                                    |
+      | workspaceName   | "user-test"                              |
+      | nodeAggregateId | "sir-nodeward-nodington-iii"             |
+      | newNodeTypeName | "Neos.ContentRepository.Testing:Content" |
+      | strategy        | "delete"                                 |
+
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Content"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Image"
+
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Image"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Content"
+
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                          |
+      | workspaceName                   | "user-test"                    |
+      | nodesToPublish                  | ["sir-david-nodenborough"]     |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
+
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Image"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Image"
+
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Image"
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to be of type "Neos.ContentRepository.Testing:Content"
 
   Scenario: (RemoveNodeAggregate) It is possible to publish a node removal
     Given the command CreateWorkspace is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -54,8 +54,8 @@ Feature: Publishing hide/show scenario of nodes
       | Key                       | Value                                    |
       | workspaceName             | "live"                                   |
       | nodeAggregateId           | "sir-david-nodenborough"                 |
+      | nodeName                  | "text1"                                  |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
-      | nodeName                    | "text1"                                             |
       | originDimensionSpacePoint | {}                                       |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | initialPropertyValues     | {"text": "Initial t1"}                   |
@@ -71,8 +71,8 @@ Feature: Publishing hide/show scenario of nodes
       | Key                       | Value                                  |
       | workspaceName             | "live"                                 |
       | nodeAggregateId           | "sir-nodeward-nodington-iii"           |
+      | nodeName                  | "image"                                |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Image" |
-      | nodeName                    | "image"                                                |
       | originDimensionSpacePoint | {}                                     |
       | parentNodeAggregateId     | "lady-eleonode-rootford"               |
       | initialPropertyValues     | {"image": "Initial image"}             |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -581,6 +581,70 @@ Feature: Publishing hide/show scenario of nodes
     Then I expect node aggregate identifier "new1-root-agg" to lead to node user-cs-identifier-modified;new1-root-agg;{}
     Then I expect node aggregate identifier "new2-root-agg" to lead to node user-cs-identifier-modified;new2-root-agg;{}
 
+  Scenario: (UpdateRootNodeAggregateDimensions) It is possible to publish updating root nodes
+    Given the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                          |
+      | workspaceName   | "live"                         |
+      | nodeAggregateId | "sire-frode-rootford"          |
+      | nodeTypeName    | "Neos.ContentRepository:Root1" |
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+    And I change the content dimensions in content repository "default" to:
+      | Identifier | Values          | Generalizations |
+      | language   | gsw, de, fr, dk | gsw->de         |
+
+    # SETUP: update two root nodes in USER workspace
+    And the command UpdateRootNodeAggregateDimensions is executed with payload:
+      | Key             | Value                    |
+      | workspaceName   | "user-test"              |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+    # TODO its not possible to publish updating of two root nodes (see https://github.com/neos/neos-development-collection/pull/5814)
+    # And the command UpdateRootNodeAggregateDimensions is executed with payload:
+    #   | Key             | Value                 |
+    #   | workspaceName   | "user-test"           |
+    #   | nodeAggregateId | "sire-frode-rootford" |
+
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+    Then I expect the node aggregate "sire-frode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}, {"language":"dk"}]
+    # Then I expect the node aggregate "sire-frode-rootford" to exist
+    # And I expect this node aggregate to occupy dimension space points [{}]
+    # And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}, {"language":"dk"}]
+
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["lady-eleonode-rootford"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
+
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}, {"language":"dk"}]
+    Then I expect the node aggregate "sire-frode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}, {"language":"dk"}]
+    # Then I expect the node aggregate "sire-frode-rootford" to exist
+    # And I expect this node aggregate to occupy dimension space points [{}]
+    # And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}, {"language":"dk"}]
+
   Scenario: (CreateNodeAggregateWithNode) It is possible to publish new nodes
     Given the command CreateWorkspace is executed with payload:
       | Key                | Value                |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -17,7 +17,9 @@ Feature: Publishing hide/show scenario of nodes
 
 
   Background:
-    Given using no content dimensions
+    Given using the following content dimensions:
+      | Identifier | Values      | Generalizations |
+      | language   | gsw, de, fr | gsw->de         |
     And using the following node types:
     """yaml
     Neos.ContentRepository:Root: {}
@@ -44,7 +46,7 @@ Feature: Publishing hide/show scenario of nodes
       | Key                | Value           |
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
-    And I am in workspace "live" and dimension space point {}
+    And I am in workspace "live" and dimension space point {"language":"de"}
     And VisibilityConstraints are set to "empty"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
@@ -56,7 +58,7 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId           | "sir-david-nodenborough"                 |
       | nodeName                  | "text1"                                  |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
-      | originDimensionSpacePoint | {}                                       |
+      | originDimensionSpacePoint | {"language":"de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | initialPropertyValues     | {"text": "Initial t1"}                   |
     And the command CreateNodeAggregateWithNode is executed with payload:
@@ -64,7 +66,7 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName             | "live"                                   |
       | nodeAggregateId           | "nody-mc-nodeface"                       |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
-      | originDimensionSpacePoint | {}                                       |
+      | originDimensionSpacePoint | {"language":"de"}                        |
       | parentNodeAggregateId     | "sir-david-nodenborough"                 |
       | initialPropertyValues     | {"text": "Initial t2"}                   |
     And the command CreateNodeAggregateWithNode is executed with payload:
@@ -73,7 +75,7 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId           | "sir-nodeward-nodington-iii"           |
       | nodeName                  | "image"                                |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Image" |
-      | originDimensionSpacePoint | {}                                     |
+      | originDimensionSpacePoint | {"language":"de"}                      |
       | parentNodeAggregateId     | "lady-eleonode-rootford"               |
       | initialPropertyValues     | {"image": "Initial image"}             |
 
@@ -89,17 +91,17 @@ Feature: Publishing hide/show scenario of nodes
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
-      | coveredDimensionSpacePoint   | {}                       |
+      | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allVariants"            |
       | tag                          | "disabled"               |
     And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
-      | coveredDimensionSpacePoint   | {}                           |
+      | coveredDimensionSpacePoint   | {"language":"de"}            |
       | nodeVariantSelectionStrategy | "allVariants"                |
       | tag                          | "disabled"                   |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -108,8 +110,8 @@ Feature: Publishing hide/show scenario of nodes
      sir-nodeward-nodington-iii
     """
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -119,12 +121,12 @@ Feature: Publishing hide/show scenario of nodes
     """
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                                    |
-      | workspaceName                   | "user-test"                                                                                              |
+      | Key                             | Value                      |
+      | workspaceName                   | "user-test"                |
       | nodesToPublish                  | ["sir-david-nodenborough"] |
-      | contentStreamIdForRemainingPart | "remaining-cs-id"                                                                                        |
+      | contentStreamIdForRemainingPart | "remaining-cs-id"          |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -133,9 +135,9 @@ Feature: Publishing hide/show scenario of nodes
      sir-nodeward-nodington-iii
     """
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     # Ensure that we are in content stream remaining-cs-id
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node remaining-cs-id;sir-david-nodenborough;{}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node remaining-cs-id;sir-david-nodenborough;{"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -149,13 +151,13 @@ Feature: Publishing hide/show scenario of nodes
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
-      | coveredDimensionSpacePoint   | {}                       |
+      | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allVariants"            |
       | tag                          | "disabled"               |
     Given the command TagSubtree is executed with payload:
       | Key                          | Value                        |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
-      | coveredDimensionSpacePoint   | {}                           |
+      | coveredDimensionSpacePoint   | {"language":"de"}            |
       | nodeVariantSelectionStrategy | "allVariants"                |
       | tag                          | "disabled"                   |
     Given the command CreateWorkspace is executed with payload:
@@ -169,18 +171,18 @@ Feature: Publishing hide/show scenario of nodes
       | Key                          | Value                    |
       | workspaceName                | "user-test"              |
       | nodeAggregateId              | "sir-david-nodenborough" |
-      | coveredDimensionSpacePoint   | {}                       |
+      | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allVariants"            |
       | tag                          | "disabled"               |
     Given the command UntagSubtree is executed with payload:
       | Key                          | Value                        |
       | workspaceName                | "user-test"                  |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
-      | coveredDimensionSpacePoint   | {}                           |
+      | coveredDimensionSpacePoint   | {"language":"de"}            |
       | nodeVariantSelectionStrategy | "allVariants"                |
       | tag                          | "disabled"                   |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -189,8 +191,8 @@ Feature: Publishing hide/show scenario of nodes
      sir-nodeward-nodington-iii (disabled*)
     """
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -205,8 +207,8 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish                  | ["sir-david-nodenborough"]    |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -215,8 +217,8 @@ Feature: Publishing hide/show scenario of nodes
      sir-nodeward-nodington-iii (disabled*)
     """
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{"language":"de"}
     When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
     """
     lady-eleonode-rootford
@@ -244,14 +246,14 @@ Feature: Publishing hide/show scenario of nodes
       | nodeAggregateId | "sir-nodeward-nodington-iii" |
       | newNodeName     | "imagemod"                   |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
-      | Name     | nodeAggregateId            |
-      | text1    | sir-david-nodenborough     |
-      | image    | sir-nodeward-nodington-iii |
+      | Name  | nodeAggregateId            |
+      | text1 | sir-david-nodenborough     |
+      | image | sir-nodeward-nodington-iii |
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name     | nodeAggregateId            |
@@ -264,14 +266,14 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish                  | ["sir-david-nodenborough"]     |
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name     | nodeAggregateId            |
       | text1mod | sir-david-nodenborough     |
       | image    | sir-nodeward-nodington-iii |
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier-remaining;lady-eleonode-rootford;{}
     Then I expect this node to have the following child nodes:
       | Name     | nodeAggregateId            |
@@ -290,22 +292,22 @@ Feature: Publishing hide/show scenario of nodes
       | Key                          | Value                    |
       | workspaceName                | "user-test"              |
       | nodeAggregateId              | "sir-david-nodenborough" |
-      | coveredDimensionSpacePoint   | {}                       |
+      | coveredDimensionSpacePoint   | {"language":"de"}        |
       | nodeVariantSelectionStrategy | "allVariants"            |
 
     When the command RemoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
       | workspaceName                | "user-test"                  |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
-      | coveredDimensionSpacePoint   | {}                           |
+      | coveredDimensionSpacePoint   | {"language":"de"}            |
       | nodeVariantSelectionStrategy | "allVariants"                |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"de"}
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
@@ -316,12 +318,12 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish                  | ["sir-david-nodenborough"]    |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"de"}
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
@@ -338,57 +340,57 @@ Feature: Publishing hide/show scenario of nodes
       | Key                       | Value                    |
       | workspaceName             | "user-test"              |
       | nodeAggregateId           | "sir-david-nodenborough" |
-      | originDimensionSpacePoint | {}                       |
+      | originDimensionSpacePoint | {"language":"de"}        |
       | propertyValues            | {"text": "Modified t1"}  |
     And the command SetNodeProperties is executed with payload:
       | Key                       | Value                   |
       | workspaceName             | "user-test"             |
       | nodeAggregateId           | "nody-mc-nodeface"      |
-      | originDimensionSpacePoint | {}                      |
+      | originDimensionSpacePoint | {"language":"de"}       |
       | propertyValues            | {"text": "Modified t2"} |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value        |
       | text | "Initial t1" |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value        |
       | text | "Initial t2" |
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value         |
       | text | "Modified t1" |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value         |
       | text | "Modified t2" |
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                                    |
-      | workspaceName                   | "user-test"                                                                                              |
-      | nodesToPublish                  | ["sir-david-nodenborough"] |
-      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                            |
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["sir-david-nodenborough"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following properties:
-      | Key  | Value        |
+      | Key  | Value         |
       | text | "Modified t1" |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value        |
       | text | "Initial t2" |
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value         |
       | text | "Modified t1" |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have the following properties:
       | Key  | Value         |
       | text | "Modified t2" |
@@ -402,72 +404,72 @@ Feature: Publishing hide/show scenario of nodes
 
     # SETUP: set two node references in USER workspace
     When the command SetNodeReferences is executed with payload:
-      | Key                             | Value                                     |
-      | workspaceName                   | "user-test"                               |
-      | sourceNodeAggregateId           | "sir-david-nodenborough"                  |
-      | sourceOriginDimensionSpacePoint | {}                                        |
+      | Key                             | Value                                                                                             |
+      | workspaceName                   | "user-test"                                                                                       |
+      | sourceNodeAggregateId           | "sir-david-nodenborough"                                                                          |
+      | sourceOriginDimensionSpacePoint | {"language":"de"}                                                                                 |
       | references                      | [{"referenceName": "referenceProperty", "references": [{"target":"sir-nodeward-nodington-iii"}]}] |
     And the command SetNodeReferences is executed with payload:
-      | Key                             | Value                                     |
-      | workspaceName                   | "user-test"                               |
-      | sourceNodeAggregateId           | "nody-mc-nodeface"                        |
-      | sourceOriginDimensionSpacePoint | {}                                        |
+      | Key                             | Value                                                                                             |
+      | workspaceName                   | "user-test"                                                                                       |
+      | sourceNodeAggregateId           | "nody-mc-nodeface"                                                                                |
+      | sourceOriginDimensionSpacePoint | {"language":"de"}                                                                                 |
       | references                      | [{"referenceName": "referenceProperty", "references": [{"target":"sir-nodeward-nodington-iii"}]}] |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have no references
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have no references
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"de"}
     And I expect this node to have no references
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following references:
-      | Name              | Node                                             | Properties |
-      | referenceProperty | user-cs-identifier;sir-nodeward-nodington-iii;{} | null       |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+      | Name              | Node                                                            | Properties |
+      | referenceProperty | user-cs-identifier;sir-nodeward-nodington-iii;{"language":"de"} | null       |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have the following references:
-      | Name              | Node                                             | Properties |
-      | referenceProperty | user-cs-identifier;sir-nodeward-nodington-iii;{} | null       |
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier;sir-nodeward-nodington-iii;{}
+      | Name              | Node                                                            | Properties |
+      | referenceProperty | user-cs-identifier;sir-nodeward-nodington-iii;{"language":"de"} | null       |
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier;sir-nodeward-nodington-iii;{"language":"de"}
     And I expect this node to have no references
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                                    |
-      | workspaceName                   | "user-test"                                                                                              |
-      | nodesToPublish                  | ["sir-david-nodenborough"] |
-      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                            |
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["sir-david-nodenborough"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following references:
-      | Name              | Node                                        | Properties |
-      | referenceProperty | cs-identifier;sir-nodeward-nodington-iii;{} | null       |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+      | Name              | Node                                                       | Properties |
+      | referenceProperty | cs-identifier;sir-nodeward-nodington-iii;{"language":"de"} | null       |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have no references
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{"language":"de"}
     And I expect this node to have no references
     And I expect this node to be referenced by:
-      | Name              | Node                                    | Properties |
-      | referenceProperty | cs-identifier;sir-david-nodenborough;{} | null       |
+      | Name              | Node                                                   | Properties |
+      | referenceProperty | cs-identifier;sir-david-nodenborough;{"language":"de"} | null       |
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{"language":"de"}
     And I expect this node to have the following references:
-      | Name              | Node                                                      | Properties |
-      | referenceProperty | user-cs-identifier-modified;sir-nodeward-nodington-iii;{} | null       |
-    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
+      | Name              | Node                                                                     | Properties |
+      | referenceProperty | user-cs-identifier-modified;sir-nodeward-nodington-iii;{"language":"de"} | null       |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{"language":"de"}
     And I expect this node to have the following references:
-      | Name              | Node                                                      | Properties |
-      | referenceProperty | user-cs-identifier-modified;sir-nodeward-nodington-iii;{} | null       |
-    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier-modified;sir-nodeward-nodington-iii;{}
+      | Name              | Node                                                                     | Properties |
+      | referenceProperty | user-cs-identifier-modified;sir-nodeward-nodington-iii;{"language":"de"} | null       |
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier-modified;sir-nodeward-nodington-iii;{"language":"de"}
     And I expect this node to have no references
     And I expect this node to be referenced by:
-      | Name              | Node                                                  | Properties |
-      | referenceProperty | user-cs-identifier-modified;nody-mc-nodeface;{}       | null       |
-      | referenceProperty | user-cs-identifier-modified;sir-david-nodenborough;{} | null       |
+      | Name              | Node                                                                 | Properties |
+      | referenceProperty | user-cs-identifier-modified;nody-mc-nodeface;{"language":"de"}       | null       |
+      | referenceProperty | user-cs-identifier-modified;sir-david-nodenborough;{"language":"de"} | null       |
 
   Scenario: (CreateRootNodeAggregateWithNode) It is possible to publish new root nodes
     Given the command CreateWorkspace is executed with payload:
@@ -487,27 +489,27 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName             | "user-test"                    |
       | nodeAggregateId           | "new2-root-agg"                |
       | nodeTypeName              | "Neos.ContentRepository:Root2" |
-      | originDimensionSpacePoint | {}                             |
+      | originDimensionSpacePoint | {"language":"de"}              |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "new1-root-agg" to lead to no node
     Then I expect node aggregate identifier "new2-root-agg" to lead to no node
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "new1-root-agg" to lead to node user-cs-identifier;new1-root-agg;{}
     Then I expect node aggregate identifier "new2-root-agg" to lead to node user-cs-identifier;new2-root-agg;{}
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                      |
-      | workspaceName                   | "user-test"                                                                                |
-      | nodesToPublish                  | ["new1-root-agg"] |
-      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                              |
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["new1-root-agg"]             |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "new1-root-agg" to lead to node cs-identifier;new1-root-agg;{}
     Then I expect node aggregate identifier "new2-root-agg" to lead to no node
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "new1-root-agg" to lead to node user-cs-identifier-modified;new1-root-agg;{}
     Then I expect node aggregate identifier "new2-root-agg" to lead to node user-cs-identifier-modified;new2-root-agg;{}
 
@@ -524,7 +526,7 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName             | "user-test"                              |
       | nodeAggregateId           | "new1-agg"                               |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
-      | originDimensionSpacePoint | {}                                       |
+      | originDimensionSpacePoint | {"language":"de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | nodeName                  | "foo"                                    |
     When the command CreateNodeAggregateWithNode is executed with payload:
@@ -532,31 +534,31 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName             | "user-test"                              |
       | nodeAggregateId           | "new2-agg"                               |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
-      | originDimensionSpacePoint | {}                                       |
+      | originDimensionSpacePoint | {"language":"de"}                        |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | nodeName                  | "foo2"                                   |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "new1-agg" to lead to no node
     Then I expect node aggregate identifier "new2-agg" to lead to no node
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier;new1-agg;{}
-    Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier;new2-agg;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier;new1-agg;{"language":"de"}
+    Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier;new2-agg;{"language":"de"}
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                      |
-      | workspaceName                   | "user-test"                                                                                |
-      | nodesToPublish                  | ["new1-agg"] |
-      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                              |
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["new1-agg"]                  |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
-    Then I expect node aggregate identifier "new1-agg" to lead to node cs-identifier;new1-agg;{}
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "new1-agg" to lead to node cs-identifier;new1-agg;{"language":"de"}
     Then I expect node aggregate identifier "new2-agg" to lead to no node
 
-    When I am in workspace "user-test" and dimension space point {}
-    Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier-modified;new1-agg;{}
-    Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier-modified;new2-agg;{}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier-modified;new1-agg;{"language":"de"}
+    Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier-modified;new2-agg;{"language":"de"}
 
   Scenario: (MoveNodeAggregate) It is possible to publish moving nodes
     Given the command CreateWorkspace is executed with payload:
@@ -569,19 +571,19 @@ Feature: Publishing hide/show scenario of nodes
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                        |
       | workspaceName                | "user-test"                  |
-      | dimensionSpacePoint          | {}                           |
+      | dimensionSpacePoint          | {"language":"de"}            |
       | relationDistributionStrategy | "gatherAll"                  |
       | nodeAggregateId              | "sir-david-nodenborough"     |
       | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
     When the command MoveNodeAggregate is executed with payload:
       | Key                          | Value                    |
       | workspaceName                | "user-test"              |
-      | dimensionSpacePoint          | {}                       |
+      | dimensionSpacePoint          | {"language":"de"}        |
       | relationDistributionStrategy | "gatherAll"              |
       | nodeAggregateId              | "nody-mc-nodeface"       |
       | newParentNodeAggregateId     | "lady-eleonode-rootford" |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
     And I expect this node aggregate to have the child node aggregates ["nody-mc-nodeface"]
@@ -592,7 +594,7 @@ Feature: Publishing hide/show scenario of nodes
     And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
     And I expect this node aggregate to have no child node aggregates
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to have the parent node aggregates ["sir-nodeward-nodington-iii"]
     And I expect this node aggregate to have no child node aggregates
@@ -609,7 +611,7 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish                  | ["sir-david-nodenborough"]    |
       | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
-    When I am in workspace "live" and dimension space point {}
+    When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to have the parent node aggregates ["sir-nodeward-nodington-iii"]
     And I expect this node aggregate to have the child node aggregates ["nody-mc-nodeface"]
@@ -620,7 +622,7 @@ Feature: Publishing hide/show scenario of nodes
     And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
     And I expect this node aggregate to have the child node aggregates ["sir-david-nodenborough"]
 
-    When I am in workspace "user-test" and dimension space point {}
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to have the parent node aggregates ["sir-nodeward-nodington-iii"]
     And I expect this node aggregate to have no child node aggregates

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -7,7 +7,7 @@ Feature: Publishing hide/show scenario of nodes
   -- sir-nodeward-nodington-iii (name=image) <== this one is modified
 
   The setup is always as follows:
-  - we modify two nodes using a certain command (e.g. DisableNode) in the USER workspace
+  - we modify two nodes using a certain command (e.g. TagSubtree) in the USER workspace
   - we publish one of them
   - we check that the user workspace still sees both nodes as hidden; and the live workspace only sees one of the changes.
 
@@ -69,7 +69,7 @@ Feature: Publishing hide/show scenario of nodes
       | parentNodeAggregateId     | "lady-eleonode-rootford"               |
       | initialPropertyValues     | {"image": "Initial image"}             |
 
-  Scenario: (DisableNode) It is possible to publish hiding of a node.
+  Scenario: (TagSubtree) It is possible to publish hiding of a node.
     Given the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
@@ -108,18 +108,20 @@ Feature: Publishing hide/show scenario of nodes
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 
-  Scenario: (ShowNode) It is possible to publish showing of a node.
+  Scenario: (UntagSubtree) It is possible to publish showing of a node.
     # BEFORE: ensure two nodes are hidden in live (and user WS)
-    Given the command DisableNodeAggregate is executed with payload:
+    Given the command TagSubtree is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    Given the command DisableNodeAggregate is executed with payload:
+      | tag                          | "disabled"               |
+    Given the command TagSubtree is executed with payload:
       | Key                          | Value                        |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "disabled"                   |
     Given the command CreateWorkspace is executed with payload:
       | Key                | Value                |
       | workspaceName      | "user-test"          |
@@ -127,24 +129,26 @@ Feature: Publishing hide/show scenario of nodes
       | newContentStreamId | "user-cs-identifier" |
 
     # SETUP: enable two nodes in USER workspace
-    Given the command EnableNodeAggregate is executed with payload:
+    Given the command UntagSubtree is executed with payload:
       | Key                          | Value                    |
       | workspaceName                | "user-test"              |
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    Given the command EnableNodeAggregate is executed with payload:
+      | tag                          | "disabled"               |
+    Given the command UntagSubtree is executed with payload:
       | Key                          | Value                        |
       | workspaceName                | "user-test"                  |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "disabled"                   |
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                                    |
-      | workspaceName                   | "user-test"                                                                                              |
-      | nodesToPublish                  | ["sir-david-nodenborough"] |
-      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                            |
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["sir-david-nodenborough"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -47,6 +47,7 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName             | "live"                                   |
       | nodeAggregateId           | "sir-david-nodenborough"                 |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Content" |
+      | nodeName                    | "text1"                                             |
       | originDimensionSpacePoint | {}                                       |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | initialPropertyValues     | {"text": "Initial t1"}                   |
@@ -63,6 +64,7 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName             | "live"                                 |
       | nodeAggregateId           | "sir-nodeward-nodington-iii"           |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Image" |
+      | nodeName                    | "image"                                                |
       | originDimensionSpacePoint | {}                                     |
       | parentNodeAggregateId     | "lady-eleonode-rootford"               |
       | initialPropertyValues     | {"image": "Initial image"}             |
@@ -154,47 +156,51 @@ Feature: Publishing hide/show scenario of nodes
     And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
     And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier-modified;sir-nodeward-nodington-iii;{}
 
-
-    # @todo check why these won't run
-
-  #Scenario: (ChangeNodeAggregateName) It is possible to publish changing the node name.
-  #  Given the command CreateWorkspace is executed with payload:
-  #    | Key                        | Value                |
-   ##   | workspaceName              | "user-test"          |
-   #   | baseWorkspaceName          | "live"               |
-   #   | newContentStreamId | "user-cs-identifier" |
-   # And the graph projection is fully up to date
+  Scenario: (ChangeNodeAggregateName) It is possible to publish changing the node name.
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
 
     # SETUP: change two node names in USER workspace
-    #Given the command "ChangeNodeAggregateName" is executed with payload:
-    #  | Key                     | Value                    |
-    #  | contentStreamId | "user-cs-identifier"     |
-    #  | nodeAggregateId | "sir-david-nodenborough" |
-    #  | newNodeName             | "text1mod"               |
-    #Given the command "ChangeNodeAggregateName" is executed with payload:
-    #  | Key                     | Value                        |
-    #  | contentStreamId | "user-cs-identifier"         |
-    #  | nodeAggregateId | "sir-nodeward-nodington-iii" |
-     # | newNodeName             | "imagemod"                   |
-   # And the graph projection is fully up to date
+    Given the command ChangeNodeAggregateName is executed with payload:
+      | Key             | Value                    |
+      | workspaceName   | "user-test"              |
+      | nodeAggregateId | "sir-david-nodenborough" |
+      | newNodeName     | "text1mod"               |
+    Given the command ChangeNodeAggregateName is executed with payload:
+      | Key             | Value                        |
+      | workspaceName   | "user-test"                  |
+      | nodeAggregateId | "sir-nodeward-nodington-iii" |
+      | newNodeName     | "imagemod"                   |
 
-   # When the command PublishIndividualNodesFromWorkspace is executed with payload:
-   #   | Key           | Value                                                                                                                               |
-   #   | workspaceName | "user-test"                                                                                                                         |
-    #  | nodesToPublish | ["sir-david-nodenborough"] |
-    #And the graph projection is fully up to date
+    When I am in workspace "live" and dimension space point {}
+    And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    Then I expect this node to have the following child nodes:
+      | Name     | nodeAggregateId            |
+      | text1    | sir-david-nodenborough     |
+      | image    | sir-nodeward-nodington-iii |
 
-   # When I am in workspace "live" and dimension space point {}
-   ## Then I expect the node aggregate "lady-eleonode-rootford" to have the following child nodes:
-    #  | Name     | nodeAggregateId    |
-    #  | text1mod | sir-david-nodenborough     |
-     # | image    | sir-nodeward-nodington-iii |
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                          |
+      | workspaceName                   | "user-test"                    |
+      | nodesToPublish                  | ["sir-david-nodenborough"]     |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-remaining" |
 
-   # When I am in workspace "user-test" and dimension space point {}
-   # Then I expect the node aggregate "lady-eleonode-rootford" to have the following child nodes:
-   #   | Name     | nodeAggregateId    |
-   #   | text1mod | sir-david-nodenborough     |
-   #   | imagemod | sir-nodeward-nodington-iii |
+    When I am in workspace "live" and dimension space point {}
+    And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    Then I expect this node to have the following child nodes:
+      | Name     | nodeAggregateId            |
+      | text1mod | sir-david-nodenborough     |
+      | image    | sir-nodeward-nodington-iii |
+
+    When I am in workspace "user-test" and dimension space point {}
+    And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier-remaining;lady-eleonode-rootford;{}
+    Then I expect this node to have the following child nodes:
+      | Name     | nodeAggregateId            |
+      | text1mod | sir-david-nodenborough     |
+      | imagemod | sir-nodeward-nodington-iii |
 
 
   Scenario: (RemoveNodeAggregate) It is possible to publish a node removal

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -558,6 +558,77 @@ Feature: Publishing hide/show scenario of nodes
     Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier-modified;new1-agg;{}
     Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier-modified;new2-agg;{}
 
+  Scenario: (MoveNodeAggregate) It is possible to publish moving nodes
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
 
-  # TODO: implement MoveNodeAggregate testcase
+    # SETUP: move two new nodes in USER workspace
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                        |
+      | workspaceName                | "user-test"                  |
+      | dimensionSpacePoint          | {}                           |
+      | relationDistributionStrategy | "gatherAll"                  |
+      | nodeAggregateId              | "sir-david-nodenborough"     |
+      | newParentNodeAggregateId     | "sir-nodeward-nodington-iii" |
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                          | Value                    |
+      | workspaceName                | "user-test"              |
+      | dimensionSpacePoint          | {}                       |
+      | relationDistributionStrategy | "gatherAll"              |
+      | nodeAggregateId              | "nody-mc-nodeface"       |
+      | newParentNodeAggregateId     | "lady-eleonode-rootford" |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have the child node aggregates ["nody-mc-nodeface"]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to have the parent node aggregates ["sir-david-nodenborough"]
+    And I expect this node aggregate to have no child node aggregates
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have no child node aggregates
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to have the parent node aggregates ["sir-nodeward-nodington-iii"]
+    And I expect this node aggregate to have no child node aggregates
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have no child node aggregates
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have the child node aggregates ["sir-david-nodenborough"]
+
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["sir-david-nodenborough"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to have the parent node aggregates ["sir-nodeward-nodington-iii"]
+    And I expect this node aggregate to have the child node aggregates ["nody-mc-nodeface"]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to have the parent node aggregates ["sir-david-nodenborough"]
+    And I expect this node aggregate to have no child node aggregates
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have the child node aggregates ["sir-david-nodenborough"]
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to have the parent node aggregates ["sir-nodeward-nodington-iii"]
+    And I expect this node aggregate to have no child node aggregates
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have no child node aggregates
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
+    And I expect this node aggregate to have the child node aggregates ["sir-david-nodenborough"]
+
   # TODO: implement CreateNodeVariant testcase

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -21,6 +21,12 @@ Feature: Publishing hide/show scenario of nodes
     And using the following node types:
     """yaml
     Neos.ContentRepository:Root: {}
+    Neos.ContentRepository:Root1:
+      superTypes:
+        Neos.ContentRepository:Root: true
+    Neos.ContentRepository:Root2:
+      superTypes:
+        Neos.ContentRepository:Root: true
     'Neos.ContentRepository.Testing:Content':
       properties:
         text:
@@ -320,6 +326,73 @@ Feature: Publishing hide/show scenario of nodes
     Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
 
+  Scenario: (SetNodeProperties) It is possible to publish setting node references
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    # SETUP: set two node properties in USER workspace
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                    |
+      | workspaceName             | "user-test"              |
+      | nodeAggregateId           | "sir-david-nodenborough" |
+      | originDimensionSpacePoint | {}                       |
+      | propertyValues            | {"text": "Modified t1"}  |
+    And the command SetNodeProperties is executed with payload:
+      | Key                       | Value                   |
+      | workspaceName             | "user-test"             |
+      | nodeAggregateId           | "nody-mc-nodeface"      |
+      | originDimensionSpacePoint | {}                      |
+      | propertyValues            | {"text": "Modified t2"} |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have the following properties:
+      | Key  | Value        |
+      | text | "Initial t1" |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following properties:
+      | Key  | Value        |
+      | text | "Initial t2" |
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have the following properties:
+      | Key  | Value         |
+      | text | "Modified t1" |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following properties:
+      | Key  | Value         |
+      | text | "Modified t2" |
+
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                                                                                                    |
+      | workspaceName                   | "user-test"                                                                                              |
+      | nodesToPublish                  | ["sir-david-nodenborough"] |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                            |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have the following properties:
+      | Key  | Value        |
+      | text | "Modified t1" |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following properties:
+      | Key  | Value        |
+      | text | "Initial t2" |
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
+    And I expect this node to have the following properties:
+      | Key  | Value         |
+      | text | "Modified t1" |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
+    And I expect this node to have the following properties:
+      | Key  | Value         |
+      | text | "Modified t2" |
+
   Scenario: (SetNodeReferences) It is possible to publish setting node references
     Given the command CreateWorkspace is executed with payload:
       | Key                | Value                |
@@ -395,6 +468,48 @@ Feature: Publishing hide/show scenario of nodes
       | Name              | Node                                                  | Properties |
       | referenceProperty | user-cs-identifier-modified;nody-mc-nodeface;{}       | null       |
       | referenceProperty | user-cs-identifier-modified;sir-david-nodenborough;{} | null       |
+
+  Scenario: (CreateRootNodeAggregateWithNode) It is possible to publish new root nodes
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    # SETUP: set two new root nodes in USER workspace
+    When the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                          |
+      | workspaceName   | "user-test"                    |
+      | nodeAggregateId | "new1-root-agg"                |
+      | nodeTypeName    | "Neos.ContentRepository:Root1" |
+    When the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                          |
+      | workspaceName             | "user-test"                    |
+      | nodeAggregateId           | "new2-root-agg"                |
+      | nodeTypeName              | "Neos.ContentRepository:Root2" |
+      | originDimensionSpacePoint | {}                             |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "new1-root-agg" to lead to no node
+    Then I expect node aggregate identifier "new2-root-agg" to lead to no node
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "new1-root-agg" to lead to node user-cs-identifier;new1-root-agg;{}
+    Then I expect node aggregate identifier "new2-root-agg" to lead to node user-cs-identifier;new2-root-agg;{}
+
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                                                                                      |
+      | workspaceName                   | "user-test"                                                                                |
+      | nodesToPublish                  | ["new1-root-agg"] |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                              |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "new1-root-agg" to lead to node cs-identifier;new1-root-agg;{}
+    Then I expect node aggregate identifier "new2-root-agg" to lead to no node
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "new1-root-agg" to lead to node user-cs-identifier-modified;new1-root-agg;{}
+    Then I expect node aggregate identifier "new2-root-agg" to lead to node user-cs-identifier-modified;new2-root-agg;{}
 
   Scenario: (CreateNodeAggregateWithNode) It is possible to publish new nodes
     Given the command CreateWorkspace is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -8,11 +8,12 @@ Feature: Publishing hide/show scenario of nodes
 
   The setup is always as follows:
   - we modify two nodes using a certain command (e.g. TagSubtree) in the USER workspace
+  - assert the change only affected the USER workspace
   - we publish one of them
   - we check that the user workspace still sees both nodes as hidden; and the live workspace only sees one of the changes.
 
   We do the same for other commands. This way, we ensure that both the command works generally;
-  and the matchesNodeAddress() address of the command is actually implemented somehow properly.
+  and the separation of nodes to publish and keep is actually implemented somehow properly.
 
 
   Background:
@@ -38,6 +39,7 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And I am in workspace "live" and dimension space point {}
+    And VisibilityConstraints are set to "empty"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -78,16 +80,37 @@ Feature: Publishing hide/show scenario of nodes
     And I am in workspace "user-test"
 
     # SETUP: hide two nodes in USER workspace
-    Given the command DisableNodeAggregate is executed with payload:
+    Given the command TagSubtree is executed with payload:
       | Key                          | Value                    |
       | nodeAggregateId              | "sir-david-nodenborough" |
       | coveredDimensionSpacePoint   | {}                       |
       | nodeVariantSelectionStrategy | "allVariants"            |
-    And the command DisableNodeAggregate is executed with payload:
+      | tag                          | "disabled"               |
+    And the command TagSubtree is executed with payload:
       | Key                          | Value                        |
       | nodeAggregateId              | "sir-nodeward-nodington-iii" |
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
+      | tag                          | "disabled"                   |
+
+    When I am in workspace "live" and dimension space point {}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+      nody-mc-nodeface
+     sir-nodeward-nodington-iii
+    """
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     sir-nodeward-nodington-iii (disabled*)
+    """
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                             | Value                                                                                                    |
@@ -95,18 +118,25 @@ Feature: Publishing hide/show scenario of nodes
       | nodesToPublish                  | ["sir-david-nodenborough"] |
       | contentStreamIdForRemainingPart | "remaining-cs-id"                                                                                        |
 
-    When I am in workspace "live"
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    When I am in workspace "live" and dimension space point {}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     sir-nodeward-nodington-iii
+    """
 
-    When I am in workspace "user-test"
+    When I am in workspace "user-test" and dimension space point {}
     # Ensure that we are in content stream remaining-cs-id
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node remaining-cs-id;lady-eleonode-rootford;{}
-
-    And I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node remaining-cs-id;sir-david-nodenborough;{}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     sir-nodeward-nodington-iii (disabled*)
+    """
 
   Scenario: (UntagSubtree) It is possible to publish showing of a node.
     # BEFORE: ensure two nodes are hidden in live (and user WS)
@@ -144,6 +174,25 @@ Feature: Publishing hide/show scenario of nodes
       | nodeVariantSelectionStrategy | "allVariants"                |
       | tag                          | "disabled"                   |
 
+    When I am in workspace "live" and dimension space point {}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     sir-nodeward-nodington-iii (disabled*)
+    """
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+      nody-mc-nodeface
+     sir-nodeward-nodington-iii
+    """
+
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                             | Value                         |
       | workspaceName                   | "user-test"                   |
@@ -152,13 +201,23 @@ Feature: Publishing hide/show scenario of nodes
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+      nody-mc-nodeface
+     sir-nodeward-nodington-iii (disabled*)
+    """
 
     When I am in workspace "user-test" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{}
-    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier-modified;nody-mc-nodeface;{}
-    And I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier-modified;sir-nodeward-nodington-iii;{}
+    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+      nody-mc-nodeface
+     sir-nodeward-nodington-iii
+    """
 
   Scenario: (ChangeNodeAggregateName) It is possible to publish changing the node name.
     Given the command CreateWorkspace is executed with payload:
@@ -185,6 +244,13 @@ Feature: Publishing hide/show scenario of nodes
       | Name     | nodeAggregateId            |
       | text1    | sir-david-nodenborough     |
       | image    | sir-nodeward-nodington-iii |
+
+    When I am in workspace "user-test" and dimension space point {}
+    And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
+    Then I expect this node to have the following child nodes:
+      | Name     | nodeAggregateId            |
+      | text1mod | sir-david-nodenborough     |
+      | imagemod | sir-nodeward-nodington-iii |
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                             | Value                          |
@@ -228,11 +294,21 @@ Feature: Publishing hide/show scenario of nodes
       | coveredDimensionSpacePoint   | {}                           |
       | nodeVariantSelectionStrategy | "allVariants"                |
 
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to no node
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to no node
+
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
-      | Key                             | Value                                                                                                    |
-      | workspaceName                   | "user-test"                                                                                              |
-      | nodesToPublish                  | ["sir-david-nodenborough"] |
-      | contentStreamIdForRemainingPart | "user-cs-identifier-modified"                                                                            |
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["sir-david-nodenborough"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
 
     When I am in workspace "live" and dimension space point {}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
@@ -265,6 +341,26 @@ Feature: Publishing hide/show scenario of nodes
       | sourceOriginDimensionSpacePoint | {}                                        |
       | references                      | [{"referenceName": "referenceProperty", "references": [{"target":"sir-nodeward-nodington-iii"}]}] |
 
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have no references
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have no references
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have no references
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have the following references:
+      | Name              | Node                                             | Properties |
+      | referenceProperty | user-cs-identifier;sir-nodeward-nodington-iii;{} | null       |
+    Then I expect node aggregate identifier "nody-mc-nodeface" to lead to node user-cs-identifier;nody-mc-nodeface;{}
+    And I expect this node to have the following references:
+      | Name              | Node                                             | Properties |
+      | referenceProperty | user-cs-identifier;sir-nodeward-nodington-iii;{} | null       |
+    Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier;sir-nodeward-nodington-iii;{}
+    And I expect this node to have no references
+
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                             | Value                                                                                                    |
       | workspaceName                   | "user-test"                                                                                              |
@@ -294,6 +390,7 @@ Feature: Publishing hide/show scenario of nodes
       | Name              | Node                                                      | Properties |
       | referenceProperty | user-cs-identifier-modified;sir-nodeward-nodington-iii;{} | null       |
     Then I expect node aggregate identifier "sir-nodeward-nodington-iii" to lead to node user-cs-identifier-modified;sir-nodeward-nodington-iii;{}
+    And I expect this node to have no references
     And I expect this node to be referenced by:
       | Name              | Node                                                  | Properties |
       | referenceProperty | user-cs-identifier-modified;nody-mc-nodeface;{}       | null       |
@@ -323,6 +420,14 @@ Feature: Publishing hide/show scenario of nodes
       | originDimensionSpacePoint | {}                                       |
       | parentNodeAggregateId     | "lady-eleonode-rootford"                 |
       | nodeName                  | "foo2"                                   |
+
+    When I am in workspace "live" and dimension space point {}
+    Then I expect node aggregate identifier "new1-agg" to lead to no node
+    Then I expect node aggregate identifier "new2-agg" to lead to no node
+
+    When I am in workspace "user-test" and dimension space point {}
+    Then I expect node aggregate identifier "new1-agg" to lead to node user-cs-identifier;new1-agg;{}
+    Then I expect node aggregate identifier "new2-agg" to lead to node user-cs-identifier;new2-agg;{}
 
     When the command PublishIndividualNodesFromWorkspace is executed with payload:
       | Key                             | Value                                                                                      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -633,4 +633,73 @@ Feature: Publishing hide/show scenario of nodes
     And I expect this node aggregate to have the parent node aggregates ["lady-eleonode-rootford"]
     And I expect this node aggregate to have the child node aggregates ["sir-david-nodenborough"]
 
-  # TODO: implement CreateNodeVariant testcase
+  Scenario: (CreateNodeVariant) It is possible to varying nodes
+    Given the command CreateWorkspace is executed with payload:
+      | Key                | Value                |
+      | workspaceName      | "user-test"          |
+      | baseWorkspaceName  | "live"               |
+      | newContentStreamId | "user-cs-identifier" |
+
+    # SETUP: vary two new nodes in USER workspace
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value                    |
+      | workspaceName   | "user-test"              |
+      | nodeAggregateId | "sir-david-nodenborough" |
+      | sourceOrigin    | {"language":"de"}        |
+      | targetOrigin    | {"language":"fr"}        |
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value              |
+      | workspaceName   | "user-test"        |
+      | nodeAggregateId | "nody-mc-nodeface" |
+      | sourceOrigin    | {"language":"de"}  |
+      | targetOrigin    | {"language":"fr"}  |
+
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]
+
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}, {"language":"fr"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}, {"language":"fr"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]
+
+    When the command PublishIndividualNodesFromWorkspace is executed with payload:
+      | Key                             | Value                         |
+      | workspaceName                   | "user-test"                   |
+      | nodesToPublish                  | ["sir-david-nodenborough"]    |
+      | contentStreamIdForRemainingPart | "user-cs-identifier-modified" |
+
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}, {"language":"fr"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]
+
+    When I am in workspace "user-test" and dimension space point {"language":"de"}
+    Then I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}, {"language":"fr"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+    Then I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}, {"language":"fr"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}, {"language":"fr"}]
+    Then I expect the node aggregate "sir-nodeward-nodington-iii" to exist
+    And I expect this node aggregate to occupy dimension space points [{"language":"de"}]
+    And I expect this node aggregate to cover dimension space points [{"language":"de"}, {"language":"gsw"}]

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -593,7 +593,7 @@ trait ProjectedNodeTrait
             foreach ($expectedChildNodesTable->getHash() as $index => $row) {
                 $expectedNodeName = NodeName::fromString($row['Name']);
                 $actualNodeName = $actualChildNodes[$index]->name;
-                Assert::assertTrue($expectedNodeName->equals($actualNodeName), 'ContentSubgraph::findChildNodes: Node name in index ' . $index . ' does not match. Expected: "' . $expectedNodeName->value . '" Actual: "' . $actualNodeName->value . '"');
+                Assert::assertTrue($actualNodeName?->equals($expectedNodeName), 'ContentSubgraph::findChildNodes: Node name in index ' . $index . ' does not match. Expected: "' . $expectedNodeName->value . '" Actual: "' . $actualNodeName?->value . '"');
                 if (isset($row['NodeDiscriminator'])) {
                     $expectedNodeDiscriminator = NodeDiscriminator::fromShorthand($row['NodeDiscriminator']);
                     $actualNodeDiscriminator = NodeDiscriminator::fromNode(


### PR DESCRIPTION
Required for #5776
We need to improve test-coverage for publication to ensure all commands only affect the one workspace they were applied in.
This is only natural in the current 9.0 forking model where we copy the whole hierarchy but with optimisations the code becomes more complex and some tests might still pass when modifying all workspaces simultaneously accidentally.


 - CreateRootNodeAggregateWithNode (Added)
 - CreateNodeAggregateWithNodeAndSerializedProperties (9.0)
 - SetSerializedNodeProperties (Added)
 - MoveNodeAggregate (Todo, Added)
 - RemoveNodeAggregate (9.0) One duplicate historical case removed (where RemoveNodesFromAggregate was a separate command)
 - ChangeNodeAggregateName (Commented) Testcase repaired and enabled
 - ChangeNodeAggregateType (Added)
 - CreateNodeVariant (Todo)
 - TagSubtree (9.0)
 - UntagSubtree (9.0)
 - UpdateRootNodeAggregateDimensions
 - SetSerializedNodeReferences (9.0)




**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
