### PR TITLE
BUGFIX: Migration with two `UpdateRootNodeAggregateDimensions` cannot be published

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/EventSourced/Migration/UpdateRootNodeAggregateDimensions.feature
@@ -11,6 +11,10 @@ Feature: Update root node aggregate dimensions
       | language   | mul, de, en, ch | ch->de->mul, en->mul |
     And using the following node types:
     """yaml
+    Neos.ContentRepository:Root: {}
+    Neos.ContentRepository:SecondRoot:
+      superTypes:
+        Neos.ContentRepository:Root: true
     'Neos.ContentRepository.Testing:Document':
       properties:
         title:
@@ -125,7 +129,7 @@ Feature: Update root node aggregate dimensions
     1 warnings: commands UpdateRootNodeAggregateDimensions require confirmation: Updating the dimensions of root node lady-eleonode-rootford will remove all its descendants in dimensions [{"language":"en"}]
     """
 
-    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", with force and publishing on success:
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", with force and without publishing on success:
     """yaml
     migration:
       -
@@ -150,3 +154,39 @@ Feature: Update root node aggregate dimensions
 
     When I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 0 errors
+
+  Scenario: Run migration on two root nodes after adding a new dimension value and publish
+    # add a root node
+    Given the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                          |
+      | workspaceName   | "live"                         |
+      | nodeAggregateId | "sire-frode-rootford"          |
+      | nodeTypeName    | "Neos.ContentRepository:SecondRoot" |
+
+    # we change the dimension configuration
+    Given I change the content dimensions in content repository "default" to:
+      | Identifier | Values              | Generalizations      |
+      | language   | mul, de, en, ch, fr | ch->de->mul, en->mul |
+
+    When I run the following node migration for workspace "live", creating target workspace "migration-workspace" on contentStreamId "migration-cs", with publishing on success:
+    """yaml
+    migration:
+      -
+        transformations:
+          -
+            type: 'UpdateRootNodeAggregateDimensions'
+            settings:
+              nodeType: 'Neos.ContentRepository:Root'
+          -
+            type: 'UpdateRootNodeAggregateDimensions'
+            settings:
+              nodeType: 'Neos.ContentRepository:SecondRoot'
+    """
+
+    When I am in workspace "live"
+    Then I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"mul"},{"language":"de"},{"language":"en"},{"language":"ch"},{"language":"fr"}]
+    Then I expect the node aggregate "sire-frode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"language":"mul"},{"language":"de"},{"language":"en"},{"language":"ch"},{"language":"fr"}]

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/MigrationsTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/MigrationsTrait.php
@@ -75,7 +75,7 @@ trait MigrationsTrait
     }
 
     /**
-     * @When I run the following node migration for workspace :sourceWorkspaceName, creating target workspace :targetWorkspaceName on contentStreamId :contentStreamId, with force and publishing on success:
+     * @When I run the following node migration for workspace :sourceWorkspaceName, creating target workspace :targetWorkspaceName on contentStreamId :contentStreamId, with force and without publishing on success:
      */
     public function iRunTheFollowingNodeMigrationWithForceWithPublishingOnSuccess(string $sourceWorkspaceName, string $targetWorkspaceName, string $contentStreamId, PyStringNode $string): void
     {


### PR DESCRIPTION
WIP, because adds only failing test.

its only possible to update two root node aggregates when writing the commands directly in live.

Otherwise, a restriction prevents this:

> the content stream cs-identifier already contained nodes in dimension space point {"language":"fr"} - this is not allowed.

See https://github.com/neos/neos-development-collection/commit/7122d7107bdcb5f0348e38494b8c603582c20f70 which was part of https://github.com/neos/neos-development-collection/pull/5514 as to why restriction exists.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
