### PR TITLE
TASK: Sane visibility constraints in behaviour tests

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/02-DisableNodeAggregate_WithoutDimensions.feature
@@ -50,85 +50,33 @@ Feature: Disable a node aggregate
       | affectedDimensionSpacePoints | [[]]                     |
       | tag                          | "disabled"               |
 
-    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;preceding-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;succeeding-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
+    And I am in workspace "live"
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points [{}]
 
-    When I am in workspace "live" and dimension space point {}
-    And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{}  |
-      | document            | cs-identifier;sir-david-nodenborough;{}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;sir-david-nodenborough;{}  |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to have the following references:
-      | Name       | Node                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;sir-david-nodenborough;{} |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
-
-    When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/03-DisableNodeAggregate_WithDimensions.feature
@@ -63,239 +63,86 @@ Feature: Disable a node aggregate
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 6 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"ltz"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;succeeding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
 
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points [{"language":"de"}, {"language":"ltz"}, {"language":"gsw"}]
 
     # Tests for the given variant
     When I am in dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-
-    When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+     succeeding-nodenborough
+    """
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+     succeeding-nodenborough
+    """
 
   Scenario: Disable node aggregate with strategy allVariants
     When the command DisableNodeAggregate is executed with payload:
@@ -311,203 +158,86 @@ Feature: Disable a node aggregate
       | affectedDimensionSpacePoints | [{"language":"ltz"}, {"language":"mul"}, {"language":"de"}, {"language":"en"}, {"language":"gsw"}] |
       | tag                          | "disabled"                                                                                         |
 
-    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 6 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"ltz"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;succeeding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
+    And I am in workspace "live"
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points [{"language":"mul"}, {"language":"de"}, {"language":"ltz"}, {"language":"gsw"}, {"language":"en"}]
 
     # Tests for the given variant
     When I am in dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-
-    When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/05-EnableNodeAggregate_WithoutDimensions.feature
@@ -55,62 +55,35 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [[]]                     |
       | tag                          | "disabled"               |
 
-    And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 5 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;preceding-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;succeeding-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
 
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points []
 
-    When I am in workspace "live" and dimension space point {}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{}  |
-      | document            | cs-identifier;sir-david-nodenborough;{}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;sir-david-nodenborough;{}  |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to have the following references:
-      | Name       | Node                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;sir-david-nodenborough;{} |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+     succeeding-nodenborough
+    """
 
   Scenario: Enable a previously disabled node with explicitly disabled child nodes with arbitrary strategy since dimensions are not involved
     Given the command DisableNodeAggregate is executed with payload:
@@ -121,6 +94,23 @@ Feature: Enable a node aggregate
       | Key                          | Value              |
       | nodeAggregateId              | "nody-mc-nodeface" |
       | nodeVariantSelectionStrategy | "allVariants"      |
+
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled*)
+     succeeding-nodenborough
+    """
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                    |
@@ -134,58 +124,37 @@ Feature: Enable a node aggregate
       | affectedDimensionSpacePoints | [[]]                     |
       | tag                          | "disabled"               |
 
-    And I am in workspace "live"
+    Then I expect the graph projection to consist of exactly 5 nodes
+    And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;preceding-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;succeeding-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     Then I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points []
     And I expect the node aggregate "nody-mc-nodeface" to exist
     And I expect this node aggregate to disable dimension space points [{}]
 
-    When I am in workspace "live" and dimension space point {}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{}  |
-      | document            | cs-identifier;sir-david-nodenborough;{}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to have no child nodes
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;sir-david-nodenborough;{}  |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to have the following references:
-      | Name       | Node                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                        |
-      | cs-identifier;succeeding-nodenborough;{} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                       |
-      | cs-identifier;sir-david-nodenborough;{} |
-      | cs-identifier;preceding-nodenborough;{} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface (disabled*)
+     succeeding-nodenborough
+    """
 
   Scenario: Enable a previously disabled node with explicitly disabled parent node with arbitrary strategy since dimensions are not involved
     Given the command DisableNodeAggregate is executed with payload:
@@ -196,6 +165,13 @@ Feature: Enable a node aggregate
       | Key                          | Value              |
       | nodeAggregateId              | "nody-mc-nodeface" |
       | nodeVariantSelectionStrategy | "allVariants"      |
+
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |
@@ -216,17 +192,19 @@ Feature: Enable a node aggregate
     And I expect the node aggregate "nody-mc-nodeface" to exist
     And I expect this node aggregate to disable dimension space points []
 
-    When I am in workspace "live" and dimension space point {}
-    And VisibilityConstraints are set to "default"
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
+
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+     succeeding-nodenborough
+    """

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/06-EnableNodeAggregate_WithDimensions.feature
@@ -75,12 +75,26 @@ Feature: Enable a node aggregate
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 7 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"ltz"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;succeeding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
     And I expect a node identified by cs-identifier;the-great-nodini;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points [{"language":"mul"},{"language":"en"}]
@@ -90,267 +104,67 @@ Feature: Enable a node aggregate
 
     # Tests for the given variant
     When I am in dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 2     | the-great-nodini        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-      | court-magician | cs-identifier;the-great-nodini;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-
-    When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"ltz"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"ltz"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"ltz"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"ltz"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
-    And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no references
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to no node
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to no node
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
   Scenario: Enable node aggregate with strategy allVariants
     When I am in dimension space point {"language":"de"}
@@ -370,12 +184,26 @@ Feature: Enable a node aggregate
     And I am in workspace "live"
     Then I expect the graph projection to consist of exactly 7 nodes
     And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"ltz"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;succeeding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect a node identified by cs-identifier;the-great-nodini;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     And I expect the node aggregate "sir-david-nodenborough" to exist
     And I expect this node aggregate to disable dimension space points []
@@ -385,307 +213,68 @@ Feature: Enable a node aggregate
 
     # Tests for the given variant
     When I am in dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 2     | the-great-nodini        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-      | court-magician | cs-identifier;the-great-nodini;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-
-    When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"ltz"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"ltz"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"ltz"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"ltz"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have no succeeding siblings
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"ltz"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
-    And VisibilityConstraints are set to "default"
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name                | NodeDiscriminator                                        |
-      | preceding-document  | cs-identifier;preceding-nodenborough;{"language":"mul"}  |
-      | document            | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | succeeding-document | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId         |
-      | 0     | lady-eleonode-rootford  |
-      | 1     | preceding-nodenborough  |
-      | 1     | sir-david-nodenborough  |
-      | 2     | nody-mc-nodeface        |
-      | 1     | succeeding-nodenborough |
-    And I expect node aggregate identifier "preceding-nodenborough" and node path "preceding-document" to lead to node cs-identifier;preceding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no preceding siblings
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"}  |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following references:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;sir-david-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect this node to have the following succeeding siblings:
-      | NodeDiscriminator                                        |
-      | cs-identifier;succeeding-nodenborough;{"language":"mul"} |
-    And I expect this node to be referenced by:
-      | Name       | Node                                                    | Properties |
-      | references | cs-identifier;preceding-nodenborough;{"language":"mul"} | null       |
-    And I expect node aggregate identifier "succeeding-nodenborough" and node path "succeeding-document" to lead to node cs-identifier;succeeding-nodenborough;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following preceding siblings:
-      | NodeDiscriminator                                       |
-      | cs-identifier;sir-david-nodenborough;{"language":"mul"} |
-      | cs-identifier;preceding-nodenborough;{"language":"mul"} |
-    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough
+      nody-mc-nodeface
+      the-great-nodini (disabled*)
+     succeeding-nodenborough
+    """
 
   Scenario: Enable node aggregate with hidden ancestors
     When I am in dimension space point {"language":"de"}
@@ -694,46 +283,98 @@ Feature: Enable a node aggregate
       | nodeAggregateId              | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
 
+    Then I expect the graph projection to consist of exactly 7 nodes
+    And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;preceding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"ltz"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;succeeding-nodenborough;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
+    And I expect a node identified by cs-identifier;the-great-nodini;{"language":"mul"} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
+
     And I am in workspace "live"
+
+    And I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to disable dimension space points [{"language":"mul"},{"language":"de"},{"language":"ltz"},{"language":"gsw"},{"language":"en"}]
 
     Then I expect the node aggregate "the-great-nodini" to exist
     And I expect this node aggregate to disable dimension space points []
 
     # Tests for the given variant
     When I am in dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "withoutRestrictions"
-    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                                 |
-      | child-document | cs-identifier;nody-mc-nodeface;{"language":"mul"} |
-      | court-magician | cs-identifier;the-great-nodini;{"language":"mul"} |
-    And the subtree for node aggregate "sir-david-nodenborough" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | sir-david-nodenborough |
-      | 1     | nody-mc-nodeface       |
-      | 1     | the-great-nodini       |
-    And I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
-    And I expect this node to be a child of node cs-identifier;sir-david-nodenborough;{"language":"mul"}
-
-    When VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the generalization
     When I am in dimension space point {"language":"mul"}
-    And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the virtual specialization
     When I am in dimension space point {"language":"gsw"}
-    And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the real specialization
     When I am in dimension space point {"language":"ltz"}
-    And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled)
+     succeeding-nodenborough
+    """
 
     # Tests for the peer variant
     When I am in dimension space point {"language":"en"}
-    And VisibilityConstraints are set to "default"
-    Then I expect node aggregate identifier "the-great-nodini" and node path "document/court-magician" to lead to no node
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     preceding-nodenborough
+     sir-david-nodenborough (disabled*)
+      nody-mc-nodeface (disabled)
+      the-great-nodini (disabled)
+     succeeding-nodenborough
+    """

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/07-CreateNodeAggregateWithNodeWithDisabledAncestor_WithoutDimensions.feature
@@ -37,11 +37,17 @@ Feature: Creation of nodes underneath disabled nodes
       | nodingers-cat   | Neos.ContentRepository.Testing:Document | the-great-nodini      | pet-document |
     Then I expect the node aggregate "nodingers-cat" to exist
     And I expect this node aggregate to disable dimension space points []
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |
       | nodeAggregateId              | "the-great-nodini" |
       | nodeVariantSelectionStrategy | "allVariants"      |
-    Then I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{}
+
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/08-CreateNodeAggregateWithNodeWithDisabledAncestor_WithDimensions.feature
@@ -34,7 +34,6 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeAggregateId | "the-great-nodini" |
       | sourceOrigin    | {"language":"mul"} |
       | targetOrigin    | {"language":"ltz"} |
-    And VisibilityConstraints are set to "default"
 
   Scenario: Create a new node with parent disabled with strategy allSpecializations
     Given the command DisableNodeAggregate is executed with payload:
@@ -50,20 +49,30 @@ Feature: Creation of nodes underneath disabled nodes
     And I expect this node aggregate to disable dimension space points []
 
     When I am in dimension space point {"language":"mul"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"en"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     And the command EnableNodeAggregate is executed with payload:
@@ -73,15 +82,21 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"ltz"}
 
   Scenario: Create a new node with parent disabled with strategy allVariants
@@ -98,19 +113,29 @@ Feature: Creation of nodes underneath disabled nodes
     And I expect this node aggregate to disable dimension space points []
 
     When I am in dimension space point {"language":"mul"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     When I am in dimension space point {"language":"en"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to no node
+    Then I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     And the command EnableNodeAggregate is executed with payload:
       | Key                          | Value              |
@@ -119,21 +144,31 @@ Feature: Creation of nodes underneath disabled nodes
       | nodeVariantSelectionStrategy | "allVariants"      |
 
     When I am in dimension space point {"language":"mul"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}
 
     When I am in dimension space point {"language":"ltz"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"ltz"}
 
     When I am in dimension space point {"language":"en"}
-    And I expect node aggregate identifier "nodingers-cat" and node path "document/pet-document" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect node aggregate identifier "nodingers-cat" to lead to node cs-identifier;nodingers-cat;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
     And I expect this node to be a child of node cs-identifier;the-great-nodini;{"language":"mul"}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/06-NodeDisabling/09-CreateNodeVariantOfDisabledNode.feature
@@ -23,7 +23,6 @@ Feature: Variation of hidden nodes
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
-    And VisibilityConstraints are set to "default"
 
   Scenario: Specialize a node where the specialization target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -47,10 +46,14 @@ Feature: Variation of hidden nodes
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
     And I am in dimension space point {"language":"de"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I am in dimension space point {"language":"gsw"}
-    And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
 
   Scenario: Specialize a node where the specialization target is disabled
     Given I am in dimension space point {"language":"de"}
@@ -70,10 +73,14 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"gsw"} |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    Then I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I am in dimension space point {"language":"gsw"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -82,7 +89,9 @@ Feature: Variation of hidden nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"gsw"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"gsw"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
 
   Scenario: Generalize a node where the generalization target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -102,11 +111,14 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"mul"} |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I am in dimension space point {"language":"mul"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
-  #cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"mul"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
   Scenario: Generalize a node where the generalization target is disabled
     Given I am in dimension space point {"language":"ltz"}
@@ -132,10 +144,14 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"de"}  |
 
     When I am in dimension space point {"language":"ltz"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"ltz"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -144,7 +160,9 @@ Feature: Variation of hidden nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
 
   Scenario: Peer vary a node where the peer target is enabled
     Given I am in dimension space point {"language":"de"}
@@ -164,10 +182,14 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"en"}  |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I am in dimension space point {"language":"en"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
 
   Scenario: Peer vary a node where the peer target is disabled
     Given I am in dimension space point {"language":"de"}
@@ -192,10 +214,14 @@ Feature: Variation of hidden nodes
       | targetOrigin    | {"language":"en"}  |
 
     When I am in dimension space point {"language":"de"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I am in dimension space point {"language":"en"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When the command EnableNodeAggregate is executed with payload:
       | Key                          | Value                |
@@ -204,4 +230,6 @@ Feature: Variation of hidden nodes
       | nodeVariantSelectionStrategy | "allSpecializations" |
 
     When I am in dimension space point {"language":"en"}
-    Then I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect node aggregate identifier "the-great-nodini" to lead to node cs-identifier;the-great-nodini;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/03-RemoveNodeAggregate_WithDimensions.feature
@@ -361,15 +361,12 @@ Feature: Remove NodeAggregate
     When I am in dimension space point {"language":"de"}
 
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name     | NodeDiscriminator                                      |
-      | document | cs-identifier;sir-david-nodenborough;{"language":"en"} |
-      | pet      | cs-identifier;nodingers-cat;{"language":"de"}          |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | lady-eleonode-rootford |
-      | 1     | sir-david-nodenborough |
-      | 1     | nodingers-cat          |
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+     nodingers-cat
+    """
 
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
@@ -393,15 +390,12 @@ Feature: Remove NodeAggregate
     When I am in dimension space point {"language":"gsw"}
 
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name     | NodeDiscriminator                                      |
-      | document | cs-identifier;sir-david-nodenborough;{"language":"en"} |
-      | pet      | cs-identifier;nodingers-cat;{"language":"de"}          |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | lady-eleonode-rootford |
-      | 1     | sir-david-nodenborough |
-      | 1     | nodingers-cat          |
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+     nodingers-cat
+    """
 
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
@@ -425,40 +419,47 @@ Feature: Remove NodeAggregate
     When I am in dimension space point {"language":"en"}
 
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name     | NodeDiscriminator                                      |
-      | document | cs-identifier;sir-david-nodenborough;{"language":"en"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | lady-eleonode-rootford |
-      | 1     | sir-david-nodenborough |
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+     nodingers-cat (disabled*)
+      nodingers-kitten (disabled)
+    """
 
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no child nodes
-    And I expect this node to have no references
-    And I expect this node to not be referenced
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
 
     # Check the peer variant
     When I am in dimension space point {"language":"fr"}
 
     And I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name     | NodeDiscriminator                                      |
-      | document | cs-identifier;sir-david-nodenborough;{"language":"en"} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | lady-eleonode-rootford |
-      | 1     | sir-david-nodenborough |
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     sir-david-nodenborough
+     nodingers-cat (disabled*)
+      nodingers-kitten (disabled)
+    """
 
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
     And I expect this node to be a child of node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have no child nodes
     And I expect this node to have no references
-    And I expect this node to not be referenced
+    And I expect this node to be referenced by:
+      | Name       | Node                                          | Properties |
+      | references | cs-identifier;nodingers-cat;{"language":"en"} | null       |
 
-    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to no node
-    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to no node
+    And I expect node aggregate identifier "nodingers-cat" and node path "pet" to lead to node cs-identifier;nodingers-cat;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect node aggregate identifier "nodingers-kitten" and node path "pet/kitten" to lead to node cs-identifier;nodingers-kitten;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/ContentStreamForking/ForkContentStreamWithDisabledNodesWithoutDimensions.feature
@@ -57,22 +57,24 @@ Feature: On forking a content stream, hidden nodes should be correctly copied as
     # node aggregate occupation and coverage is not relevant without dimensions and thus not tested
 
     When I am in workspace "user-test" and dimension space point {}
-    And VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have the following child nodes:
-      | Name           | NodeDiscriminator                      |
-      | court-magician | user-cs-identifier;the-great-nodini;{} |
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | lady-eleonode-rootford |
-      | 1     | the-great-nodini       |
-      | 2     | nodingers-cat          |
 
-    And VisibilityConstraints are set to "default"
+    And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;the-great-nodini;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect a node identified by cs-identifier;nodingers-cat;{} to exist in the content graph
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
+
+    And I expect the node aggregate "the-great-nodini" to exist
+    And I expect this node aggregate to disable dimension space points [{}]
+
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
-    And I expect this node to have no child nodes
-    And the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
-      | Level | nodeAggregateId        |
-      | 0     | lady-eleonode-rootford |
-    And I expect node aggregate identifier "the-great-nodini" and node path "court-magician" to lead to no node
-    And I expect node aggregate identifier "nodingers-cat" and node path "court-magician/pet" to lead to no node
+    And I expect this node to have the following subtree with tags:
+    """
+    lady-eleonode-rootford
+     the-great-nodini (disabled*)
+      nodingers-cat (disabled)
+    """

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D1-AddDimensionShineThrough/AddDimensionShineThrough.feature
@@ -136,10 +136,9 @@ Feature: Add Dimension Specialization
 
     # ensure the node is disabled
     When I am in workspace "live" and dimension space point {"language": "de"}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    When VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"de"} to exist in the content graph
-    When VisibilityConstraints are set to "default"
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     # we change the dimension configuration
     When I change the content dimensions in content repository "default" to:
@@ -159,18 +158,18 @@ Feature: Add Dimension Specialization
     """
 
     # the original content stream has not been touched
-    When I am in workspace "migration-workspace" and dimension space point {"language": "de"}
+    When I am in workspace "live" and dimension space point {"language": "de"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    When I am in dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    When VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"de"} to exist in the content graph
-    When VisibilityConstraints are set to "default"
 
     # The visibility edges were modified
     When I am in workspace "migration-workspace" and dimension space point {"language": "ch"}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    When VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language":"de"} to exist in the content graph
-    When VisibilityConstraints are set to "default"
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     When I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 0 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
@@ -166,10 +166,9 @@ Feature: Move dimension space point
 
     # ensure the node is disabled
     When I am in workspace "live" and dimension space point {"language": "de"}
-    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    When VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    When VisibilityConstraints are set to "default"
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
 
     # we change the dimension configuration
     When I change the content dimensions in content repository "default" to:
@@ -190,17 +189,19 @@ Feature: Move dimension space point
 
     # the original content stream has not been touched
     When I am in workspace "live" and dimension space point {"language": "ch"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    When I am in dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    When VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    When VisibilityConstraints are set to "default"
 
     # The subtree tags were modified
     When I am in workspace "migration-workspace" and dimension space point {"language": "gsw"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{"language":"de"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    When I am in dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
-    When VisibilityConstraints are set to "withoutRestrictions"
-    Then I expect a node identified by migration-cs;sir-david-nodenborough;{"language": "de"} to exist in the content graph
-    When VisibilityConstraints are set to "default"
 
     When I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 0 errors

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeRemoval/RemoveNodeAggregateAfterDisabling.feature
@@ -67,7 +67,6 @@ Feature: Disable a node aggregate
     And I expect this node aggregate to disable dimension space points []
 
     When I am in workspace "live" and dimension space point {}
-    And VisibilityConstraints are set to "default"
     Then the subtree for node aggregate "lady-eleonode-rootford" with node types "" and 2 levels deep should be:
       | Level | nodeAggregateId         |
       | 0     | lady-eleonode-rootford  |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/AncestorNodes.feature
@@ -81,6 +81,8 @@ Feature: Find and count nodes using the findAncestorNodes, countAncestorNodes an
       | relationDistributionStrategy | "scatter"               |
       | nodeAggregateId              | "a2a2c"                 |
       | newParentNodeAggregateId     | "b"                     |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
+
   Scenario:
     Subgraph queries
     # findAncestorNodes queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ChildNodes.feature
@@ -91,6 +91,7 @@ Feature: Find and count nodes using the findChildNodes and countChildNodes queri
       | Key                          | Value           |
       | nodeAggregateId              | "a2a3-disabled" |
       | nodeVariantSelectionStrategy | "allVariants"   |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
       # Child nodes without filter

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/ClosestNode.feature
@@ -73,6 +73,7 @@ Feature: Find nodes using the findClosestNode query
       | Key                          | Value         |
       | nodeAggregateId              | "a2b"         |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # findClosestNode queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/CountNodes.feature
@@ -65,6 +65,7 @@ Feature: Find nodes using the countNodes query
       | a3              | a3       | Neos.ContentRepository.Testing:Page        | a                      | {"text": "a3"}        | {}                                       |
       | b               | b        | Neos.ContentRepository.Testing:Page        | home                   | {"text": "b"}         | {}                                       |
       | b1              | b1       | Neos.ContentRepository.Testing:Page        | b                      | {"text": "b1"}        | {}                                       |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # count all nodes

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -88,6 +88,7 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"       |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -80,6 +80,7 @@ Feature: Find nodes using the findNodeById query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a1"        |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     Subgraph queries

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPath.feature
@@ -84,6 +84,7 @@ Feature: Find nodes using the findNodeByPath query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2"        |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # absolute paths without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByPathAsNodeName.feature
@@ -81,6 +81,7 @@ Feature: Find nodes using the findNodeByPath query with node name as path argume
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2"        |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # findNodeByPath queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
@@ -102,6 +102,7 @@ Feature: Find nodes using the findNodeById query
       | nodeAggregateId              | "b"           |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag1"        |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
   ContentGraph queries

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindParentNode.feature
@@ -86,6 +86,7 @@ Feature: Find nodes using the findParentNodes query
       | dimensionSpacePoint          | {"language": "ch"} |
       | newParentNodeAggregateId     | "a"                |
       | relationDistributionStrategy | "scatter"          |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     Subgraph queries

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindRootNodeByType.feature
@@ -29,6 +29,7 @@ Feature: Find root nodes by type
       | Key             | Value                                 |
       | nodeAggregateId | "lady-eleonode-rootfords-evil-sister" |
       | nodeTypeName    | "Neos.ContentRepository:AnotherRoot"  |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     When I execute the findRootNodeByType query for node type "Neos.ContentRepository:Root" I expect the node "lady-eleonode-rootford" to be returned

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
@@ -71,6 +71,7 @@ Feature: Find nodes using the findSubtree query
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2a"       |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # findSubtree queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/References.feature
@@ -129,6 +129,7 @@ Feature: Find and count references and their target nodes using the findReferenc
       | Key                          | Value         |
       | nodeAggregateId              | "a2a3"        |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario: Check consistency of findReferences results
     # findReferences queries without results

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/RetrieveNodePath.feature
@@ -79,6 +79,7 @@ Feature: Find nodes using the retrieveNodePath query
       | Key                          | Value         |
       | nodeAggregateId              | "b1"          |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # retrieveNodePath queries without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/SiblingNodes.feature
@@ -85,6 +85,7 @@ Feature: Find sibling nodes using the findPrecedingSiblingNodes and findSucceedi
       | Key                          | Value         |
       | nodeAggregateId              | "a2a2"        |
       | nodeVariantSelectionStrategy | "allVariants" |
+    And I restrict the visibility of nodes tagged "disabled" in subgraph queries
 
   Scenario:
     # findPrecedingSiblingNodes queries without result

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/Timestamps.feature
@@ -300,7 +300,6 @@ Feature: Behavior of Node timestamp properties "created", "originalCreated", "la
       | nodeAggregateId              | "a"                  |
       | nodeVariantSelectionStrategy | "allSpecializations" |
     And I am in workspace "user-test" and dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "withoutRestrictions"
     Then I expect the node "a" to have the following timestamps:
       | created             | originalCreated     | lastModified | originalLastModified |
       | 2023-03-16 12:00:00 | 2023-03-16 12:00:00 |              |                      |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -58,7 +58,8 @@ Feature: Tag subtree with dimensions
       | targetOrigin    | {"language":"mul"} |
 
 
-    When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
     """
     a
      a1 (tag1*)
@@ -66,7 +67,8 @@ Feature: Tag subtree with dimensions
     """
 
     When I am in dimension space point {"language":"mul"}
-    And I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
     """
     a
      a1
@@ -102,14 +104,16 @@ Feature: Tag subtree with dimensions
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"mul"} |
 
-    When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
     """
     a (tag2*)
      a1 (tag2)
     """
 
     When I am in dimension space point {"language":"de"}
-    And I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"de"}
+    And I expect this node to have the following subtree with tags:
     """
     a (tag1*,tag2*)
      a1 (tag1,tag2)
@@ -167,7 +171,8 @@ Feature: Tag subtree with dimensions
       | sourceOrigin    | {"language":"de"}  |
       | targetOrigin    | {"language":"gsw"} |
     And I am in workspace "user-ws" and dimension space point {"language":"gsw"}
-    And I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node new-user-cs-id;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
     """
     a (tag1*)
      a1 (tag1)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithoutDimensions.feature
@@ -85,7 +85,8 @@ Feature: Tag subtree without dimensions
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag4"        |
 
-    When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{}
+    And I expect this node to have the following subtree with tags:
     """
     a
      a1 (tag1*)
@@ -97,7 +98,8 @@ Feature: Tag subtree without dimensions
       a1b (tag1)
      a2
     """
-    When I execute the findSubtree query for entry node aggregate id "b" I expect the following tree with tags:
+    Then I expect node aggregate identifier "b" to lead to node cs-identifier;b;{}
+    And I expect this node to have the following subtree with tags:
     """
     b (tag2*)
      b1 (tag3*,tag2)
@@ -107,14 +109,16 @@ Feature: Tag subtree without dimensions
       | Key                      | Value |
       | nodeAggregateId          | "a1a" |
       | newParentNodeAggregateId | "b1"  |
-    When I execute the findSubtree query for entry node aggregate id "a" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{}
+    And I expect this node to have the following subtree with tags:
     """
     a
      a1 (tag1*)
       a1b (tag1)
      a2
     """
-    When I execute the findSubtree query for entry node aggregate id "b" I expect the following tree with tags:
+    Then I expect node aggregate identifier "b" to lead to node cs-identifier;b;{}
+    And I expect this node to have the following subtree with tags:
     """
     b (tag2*)
      b1 (tag3*,tag2)
@@ -130,7 +134,8 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId       | "a1a3"                                    |
       | nodeTypeName          | "Neos.ContentRepository.Testing:Document" |
       | parentNodeAggregateId | "a1a"                                     |
-    When I execute the findSubtree query for entry node aggregate id "b" I expect the following tree with tags:
+    Then I expect node aggregate identifier "b" to lead to node cs-identifier;b;{}
+    And I expect this node to have the following subtree with tags:
     """
     b (tag2*)
      b1 (tag3*,tag2)
@@ -147,7 +152,8 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId              | "a1a"         |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag4"        |
-    When I execute the findSubtree query for entry node aggregate id "b" I expect the following tree with tags:
+    Then I expect node aggregate identifier "b" to lead to node cs-identifier;b;{}
+    And I expect this node to have the following subtree with tags:
     """
     b (tag2*)
      b1 (tag3*,tag2)
@@ -165,7 +171,8 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId              | "root"       |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag1"        |
-    When I execute the findSubtree query for entry node aggregate id "root" I expect the following tree with tags:
+    Then I expect node aggregate identifier "root" to lead to node cs-identifier;root;{}
+    And I expect this node to have the following subtree with tags:
     """
     root (tag1*)
      a (tag1)
@@ -187,7 +194,8 @@ Feature: Tag subtree without dimensions
       | nodeAggregateId              | "a1a1a"       |
       | nodeVariantSelectionStrategy | "allVariants" |
       | tag                          | "tag1"        |
-    When I execute the findSubtree query for entry node aggregate id "a1a1" I expect the following tree with tags:
+    Then I expect node aggregate identifier "a1a1" to lead to node cs-identifier;a1a1;{}
+    And I expect this node to have the following subtree with tags:
     """
     a1a1
      a1a1a (tag1*)

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/04-AllFeaturePublication.feature
@@ -47,7 +47,6 @@ Feature: Publishing hide/show scenario of nodes
       | workspaceName      | "live"          |
       | newContentStreamId | "cs-identifier" |
     And I am in workspace "live" and dimension space point {"language":"de"}
-    And VisibilityConstraints are set to "empty"
     And the command CreateRootNodeAggregateWithNode is executed with payload:
       | Key             | Value                         |
       | nodeAggregateId | "lady-eleonode-rootford"      |
@@ -102,7 +101,8 @@ Feature: Publishing hide/show scenario of nodes
       | tag                          | "disabled"                   |
 
     When I am in workspace "live" and dimension space point {"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough
@@ -112,7 +112,8 @@ Feature: Publishing hide/show scenario of nodes
 
     When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough (disabled*)
@@ -127,7 +128,8 @@ Feature: Publishing hide/show scenario of nodes
       | contentStreamIdForRemainingPart | "remaining-cs-id"          |
 
     When I am in workspace "live" and dimension space point {"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough (disabled*)
@@ -138,7 +140,8 @@ Feature: Publishing hide/show scenario of nodes
     When I am in workspace "user-test" and dimension space point {"language":"de"}
     # Ensure that we are in content stream remaining-cs-id
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node remaining-cs-id;sir-david-nodenborough;{"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node remaining-cs-id;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough (disabled*)
@@ -183,7 +186,8 @@ Feature: Publishing hide/show scenario of nodes
       | tag                          | "disabled"                   |
 
     When I am in workspace "live" and dimension space point {"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough (disabled*)
@@ -193,7 +197,8 @@ Feature: Publishing hide/show scenario of nodes
 
     When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier;sir-david-nodenborough;{"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough
@@ -209,7 +214,8 @@ Feature: Publishing hide/show scenario of nodes
 
     When I am in workspace "live" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough
@@ -219,7 +225,8 @@ Feature: Publishing hide/show scenario of nodes
 
     When I am in workspace "user-test" and dimension space point {"language":"de"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-modified;sir-david-nodenborough;{"language":"de"}
-    When I execute the findSubtree query for entry node aggregate id "lady-eleonode-rootford" I expect the following tree with tags:
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node user-cs-identifier-modified;lady-eleonode-rootford;{}
+    When I expect this node to have the following subtree with tags:
     """
     lady-eleonode-rootford
      sir-david-nodenborough

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/06-PublishNodeTypeChangeWithTetheredNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/06-PublishNodeTypeChangeWithTetheredNodes.feature
@@ -76,14 +76,12 @@ Feature: Partial publish after node type change tagging tethered children
     # Step 5: Assert the publish succeeded — page exists in live as Shortcut, tethered child is tagged (not removed)
     # nody-mc-nodeface was only created in user-test and was not in nodesToPublish, so it does not exist in live
     Then I am in workspace "live" and dimension space point {}
-    When VisibilityConstraints are set to "empty"
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Shortcut"
     And I expect the node with aggregate identifier "main-collection-id" to be explicitly tagged "removed"
 
     # User workspace remaining — nody-mc-nodeface still exists (was not published) and inherits the "removed" tag
     And I am in workspace "user-test" and dimension space point {}
-    When VisibilityConstraints are set to "empty"
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node user-cs-identifier-remaining;sir-david-nodenborough;{}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Shortcut"
     And I expect the node with aggregate identifier "main-collection-id" to be explicitly tagged "removed"

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteRuntimeVariables.php
@@ -39,8 +39,6 @@ trait CRTestSuiteRuntimeVariables
 
     protected ?DimensionSpacePoint $currentDimensionSpacePoint = null;
 
-    protected ?VisibilityConstraints $currentVisibilityConstraints = null;
-
     protected ?NodeAggregateId $currentRootNodeAggregateId = null;
 
     protected ?\Exception $lastCommandException = null;
@@ -109,24 +107,15 @@ trait CRTestSuiteRuntimeVariables
         $this->iAmInDimensionSpacePoint($dimensionSpacePoint);
     }
 
-    /**
-     * @When /^VisibilityConstraints are set to "(withoutRestrictions|empty|default)"$/
-     */
-    public function visibilityConstraintsAreSetTo(string $restrictionType): void
-    {
-        $this->currentVisibilityConstraints = match ($restrictionType) {
-            'withoutRestrictions' => VisibilityConstraints::withoutRestrictions(),
-            'empty' => VisibilityConstraints::createEmpty(),
-            'default' => VisibilityConstraints::default(),
-            default => throw new \InvalidArgumentException('Visibility constraint "' . $restrictionType . '" not supported.'),
-        };
-    }
-
     public function getCurrentSubgraph(): ContentSubgraphInterface
     {
         return $this->currentContentRepository->getContentGraph($this->currentWorkspaceName)->getSubgraph(
             $this->currentDimensionSpacePoint,
-            $this->currentVisibilityConstraints
+            /**
+             * We don't restrict visibility for most cases to simplify test assertions and reasoning. Visibility constraints are not relevant for command execution and general assertions. They are only tested during Node Querying / Traversal
+             * See {@see NodeTraversalTrait::getCurrentSubgraphForQueries()}
+             */
+            VisibilityConstraints::createEmpty(),
         );
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryDependencies;
@@ -26,7 +25,6 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInt
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
-use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainerFactory;
 use Neos\ContentRepository\Core\Service\ContentStreamPrunerFactory;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -76,13 +74,12 @@ trait CRTestSuiteTrait
      * @BeforeScenario
      * @throws \Exception
      */
-    public function beforeEventSourcedScenarioDispatcher(BeforeScenarioScope $scope): void
+    public function beforeEventSourcedScenarioDispatcher(): void
     {
         if (isset($this->contentRepositories)) {
             $this->contentRepositories = [];
         }
         $this->currentContentRepository = null;
-        $this->currentVisibilityConstraints = VisibilityConstraints::default();
         $this->currentDimensionSpacePoint = null;
         $this->currentRootNodeAggregateId = null;
         $this->currentWorkspaceName = null;

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -328,9 +328,8 @@ trait NodeTraversalTrait
      * @When I execute the findSubtree query for entry node aggregate id :entryNodeIdSerialized I expect no results
      * @When I execute the findSubtree query for entry node aggregate id :entryNodeIdSerialized and filter :filterSerialized I expect the following tree:
      * @When I execute the findSubtree query for entry node aggregate id :entryNodeIdSerialized and filter :filterSerialized I expect no results
-     * @When /^I execute the findSubtree query for entry node aggregate id "(?<entryNodeIdSerialized>[^"]*)" I expect the following tree (?<withTags>with tags):$/
      */
-    public function iExecuteTheFindSubtreeQueryIExpectTheFollowingTrees(string $entryNodeIdSerialized, ?string $filterSerialized = null, ?PyStringNode $expectedTree = null, ?string $withTags = null): void
+    public function iExecuteTheFindSubtreeQueryIExpectTheFollowingTrees(string $entryNodeIdSerialized, ?string $filterSerialized = null, ?PyStringNode $expectedTree = null): void
     {
         $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
@@ -345,15 +344,7 @@ trait NodeTraversalTrait
         while ($subtreeStack !== []) {
             /** @var Subtree $subtree */
             $subtree = array_shift($subtreeStack);
-            $tags = [];
-            if ($withTags !== null) {
-                $explicitTags = $subtree->node->tags->withoutInherited()->toStringArray();
-                sort($explicitTags);
-                $inheritedTags = $subtree->node->tags->onlyInherited()->toStringArray();
-                sort($inheritedTags);
-                $tags = [...array_map(static fn(string $tag) => $tag . '*', $explicitTags), ...$inheritedTags];
-            }
-            $result[] = str_repeat(' ', $subtree->level) . $subtree->node->aggregateId->value . ($tags !== [] ? ' (' . implode(',', $tags) . ')' : '');
+            $result[] = str_repeat(' ', $subtree->level) . $subtree->node->aggregateId->value;
             $subtreeStack = [...$subtree->children, ...$subtreeStack];
         }
         Assert::assertSame($expectedTree?->getRaw() ?? '', implode(chr(10), $result));

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -16,10 +16,11 @@ namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTags;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
+use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountAncestorNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountBackReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountChildNodesFilter;
@@ -40,6 +41,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregates;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Reference;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
@@ -53,6 +55,48 @@ trait NodeTraversalTrait
 {
     use CRTestSuiteRuntimeVariables;
 
+    protected ?VisibilityConstraints $currentSubgraphQueryVisibilityConstraints = null;
+
+    /**
+     * @BeforeScenario
+     */
+    public function setupNodeTraversalTrait(): void
+    {
+        $this->currentSubgraphQueryVisibilityConstraints = VisibilityConstraints::createEmpty();
+    }
+
+    /**
+     * TODO REMOVE
+     * @When /^VisibilityConstraints are set to "(withoutRestrictions|empty|default)"$/
+     */
+    public function visibilityConstraintsAreSetTo(string $restrictionType): void
+    {
+        $this->currentSubgraphQueryVisibilityConstraints = match ($restrictionType) {
+            'withoutRestrictions' => VisibilityConstraints::withoutRestrictions(),
+            'empty' => VisibilityConstraints::createEmpty(),
+            'default' => VisibilityConstraints::default(),
+            default => throw new \InvalidArgumentException('Visibility constraint "' . $restrictionType . '" not supported.'),
+        };
+    }
+
+    /**
+     * @When /^I restrict the visibility of nodes tagged "([^"]+)" in subgraph queries$/
+     */
+    public function iRestrictTheVisibilityOfNodesTaggedInSubgraphQueries(string $excludedSubtreeTagsSerialized): void
+    {
+        $this->currentSubgraphQueryVisibilityConstraints = VisibilityConstraints::excludeSubtreeTags(
+            SubtreeTags::fromStrings(...explode(',', $excludedSubtreeTagsSerialized))
+        );
+    }
+
+    public function getCurrentSubgraphForQueries(): ContentSubgraphInterface
+    {
+        return $this->currentContentRepository->getContentGraph($this->currentWorkspaceName)->getSubgraph(
+            $this->currentDimensionSpacePoint,
+            $this->currentSubgraphQueryVisibilityConstraints,
+        );
+    }
+
     /**
      * @When /^I execute the findChildNodes query for parent node aggregate id "(?<parentNodeIdSerialized>[^"]*)"(?: and filter '(?<filterSerialized>[^']*)')? I expect (?:the nodes "(?<expectedNodeIdsSerialized>[^"]*)"|no nodes) to be returned( and the total count to be (?<expectedTotalCount>\d+))?$/
      */
@@ -62,7 +106,7 @@ trait NodeTraversalTrait
         $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindChildNodesFilter::create(...$filterValues);
-        $subgraph = $this->getCurrentSubgraph();
+        $subgraph = $this->getCurrentSubgraphForQueries();
 
         $actualNodeIds = array_map(static fn(Node $node) => $node->aggregateId->value, iterator_to_array($subgraph->findChildNodes($parentNodeAggregateId, $filter)));
         Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findChildNodes returned an unexpected result');
@@ -79,7 +123,7 @@ trait NodeTraversalTrait
         $expectedReferences = $referencesSerialized !== null ? json_decode($referencesSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindReferencesFilter::create(...$filterValues);
-        $subgraph = $this->getCurrentSubgraph();
+        $subgraph = $this->getCurrentSubgraphForQueries();
 
         $actualReferences = array_map(static fn(Reference $reference) => [
             'nodeAggregateId' => $reference->node->aggregateId->value,
@@ -99,7 +143,7 @@ trait NodeTraversalTrait
         $expectedReferences = $referencesSerialized !== null ? json_decode($referencesSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindBackReferencesFilter::create(...$filterValues);
-        $subgraph = $this->getCurrentSubgraph();
+        $subgraph = $this->getCurrentSubgraphForQueries();
         $actualReferences = array_map(static fn(Reference $reference) => [
             'nodeAggregateId' => $reference->node->aggregateId->value,
             'name' => $reference->name->value,
@@ -118,7 +162,7 @@ trait NodeTraversalTrait
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
-        $actualNode = $this->getCurrentSubgraph()->findNodeById($nodeAggregateId);
+        $actualNode = $this->getCurrentSubgraphForQueries()->findNodeById($nodeAggregateId);
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
@@ -130,7 +174,7 @@ trait NodeTraversalTrait
         $entryNodeAggregateIds = NodeAggregateIds::fromArray(explode(',', $entryNodeIdsSerialized));
         $expectedNodeAggregateIds = NodeAggregateIds::fromArray(explode(',', $expectedNodeIdsSerialized));
 
-        $actualNodes = $this->getCurrentSubgraph()->findNodesByIds($entryNodeAggregateIds);
+        $actualNodes = $this->getCurrentSubgraphForQueries()->findNodesByIds($entryNodeAggregateIds);
         Assert::assertEquals($actualNodes->toNodeAggregateIds(), $expectedNodeAggregateIds);
     }
 
@@ -168,7 +212,7 @@ trait NodeTraversalTrait
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
-        $actualParentNode = $this->getCurrentSubgraph()->findParentNode($nodeAggregateId);
+        $actualParentNode = $this->getCurrentSubgraphForQueries()->findParentNode($nodeAggregateId);
         Assert::assertSame($actualParentNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
@@ -194,7 +238,7 @@ trait NodeTraversalTrait
         $startingNodeAggregateId = NodeAggregateId::fromString($startingNodeIdSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
-        $actualNode = $this->getCurrentSubgraph()->findNodeByPath($path, $startingNodeAggregateId);
+        $actualNode = $this->getCurrentSubgraphForQueries()->findNodeByPath($path, $startingNodeAggregateId);
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
@@ -207,7 +251,7 @@ trait NodeTraversalTrait
         $path = AbsoluteNodePath::fromString($pathSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
-        $actualNode = $this->getCurrentSubgraph()->findNodeByAbsolutePath($path);
+        $actualNode = $this->getCurrentSubgraphForQueries()->findNodeByAbsolutePath($path);
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
@@ -221,7 +265,7 @@ trait NodeTraversalTrait
         $edgeName = NodeName::fromString($edgeNameSerialized);
         $expectedNodeAggregateId = $expectedNodeIdSerialized !== null ? NodeAggregateId::fromString($expectedNodeIdSerialized) : null;
 
-        $actualNode = $this->getCurrentSubgraph()->findNodeByPath($edgeName, $parentNodeAggregateId);
+        $actualNode = $this->getCurrentSubgraphForQueries()->findNodeByPath($edgeName, $parentNodeAggregateId);
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 
@@ -237,7 +281,7 @@ trait NodeTraversalTrait
 
         $actualNodeIds = array_map(
             static fn(Node $node) => $node->aggregateId->value,
-            iterator_to_array($this->getCurrentSubgraph()->findSucceedingSiblingNodes($siblingNodeAggregateId, $filter))
+            iterator_to_array($this->getCurrentSubgraphForQueries()->findSucceedingSiblingNodes($siblingNodeAggregateId, $filter))
         );
         Assert::assertSame($expectedNodeIds, $actualNodeIds);
     }
@@ -254,7 +298,7 @@ trait NodeTraversalTrait
 
         $actualNodeIds = array_map(
             static fn(Node $node) => $node->aggregateId->value,
-            iterator_to_array($this->getCurrentSubgraph()->findPrecedingSiblingNodes($siblingNodeAggregateId, $filter))
+            iterator_to_array($this->getCurrentSubgraphForQueries()->findPrecedingSiblingNodes($siblingNodeAggregateId, $filter))
         );
         Assert::assertSame($expectedNodeIds, $actualNodeIds);
     }
@@ -266,7 +310,7 @@ trait NodeTraversalTrait
     public function iExecuteTheRetrieveNodePathQueryIExpectTheFollowingNodes(string $nodeIdSerialized, ?string $expectedPathSerialized = null, ?string $expectedExceptionMessage = null): void
     {
         try {
-            $actualNodePath = $this->getCurrentSubgraph()->retrieveNodePath(NodeAggregateId::fromString($nodeIdSerialized));
+            $actualNodePath = $this->getCurrentSubgraphForQueries()->retrieveNodePath(NodeAggregateId::fromString($nodeIdSerialized));
             if ($expectedExceptionMessage !== null) {
                 Assert::fail('Expected an exception but none was thrown');
             }
@@ -294,7 +338,7 @@ trait NodeTraversalTrait
 
         $result = [];
         $subtreeStack = [];
-        $subtree = $this->getCurrentSubgraph()->findSubtree($entryNodeAggregateId, $filter);
+        $subtree = $this->getCurrentSubgraphForQueries()->findSubtree($entryNodeAggregateId, $filter);
         if ($subtree !== null) {
             $subtreeStack[] = $subtree;
         }
@@ -324,7 +368,7 @@ trait NodeTraversalTrait
         $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindDescendantNodesFilter::create(...$filterValues);
-        $subgraph = $this->getCurrentSubgraph();
+        $subgraph = $this->getCurrentSubgraphForQueries();
 
         $actualNodeIds = array_map(static fn(Node $node) => $node->aggregateId->value, iterator_to_array($subgraph->findDescendantNodes($entryNodeAggregateId, $filter)));
         Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findDescendantNodes returned an unexpected result');
@@ -341,7 +385,7 @@ trait NodeTraversalTrait
         $expectedNodeIds = array_filter(explode(',', $expectedNodeIdsSerialized));
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindAncestorNodesFilter::create(...$filterValues);
-        $subgraph = $this->getCurrentSubgraph();
+        $subgraph = $this->getCurrentSubgraphForQueries();
         $actualNodeIds = array_map(static fn(Node $node) => $node->aggregateId->value, iterator_to_array($subgraph->findAncestorNodes($entryNodeAggregateId, $filter)));
         Assert::assertSame($expectedNodeIds, $actualNodeIds, 'findAncestorNodes returned an unexpected result');
         $actualCount = $subgraph->countAncestorNodes($entryNodeAggregateId, CountAncestorNodesFilter::fromFindAncestorNodesFilter($filter));
@@ -368,7 +412,7 @@ trait NodeTraversalTrait
         $entryNodeAggregateId = NodeAggregateId::fromString($entryNodeIdSerialized);
         $filterValues = !empty($filterSerialized) ? json_decode($filterSerialized, true, 512, JSON_THROW_ON_ERROR) : [];
         $filter = FindClosestNodeFilter::create(...$filterValues);
-        $subgraph = $this->getCurrentSubgraph();
+        $subgraph = $this->getCurrentSubgraphForQueries();
         $actualNodeId = $subgraph->findClosestNode($entryNodeAggregateId, $filter)?->aggregateId->value;
         Assert::assertSame($expectedNodeId, $actualNodeId, 'findClosestNode returned an unexpected result');
     }
@@ -378,7 +422,7 @@ trait NodeTraversalTrait
      */
     public function iExecuteTheCountNodesQueryIExpectTheFollowingResult(int $expectedResult): void
     {
-        Assert::assertSame($expectedResult, $this->getCurrentSubgraph()->countNodes());
+        Assert::assertSame($expectedResult, $this->getCurrentSubgraphForQueries()->countNodes());
     }
 
     /**
@@ -389,7 +433,7 @@ trait NodeTraversalTrait
         $nodeAggregateId = NodeAggregateId::fromString($nodeIdSerialized);
         $expectedTimestamps = array_map(static fn (string $timestamp) => $timestamp === '' ? null : \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $timestamp), $expectedTimestampsTable->getHash()[0]);
 
-        $node = $this->getCurrentSubgraph()->findNodeById($nodeAggregateId);
+        $node = $this->getCurrentSubgraphForQueries()->findNodeById($nodeAggregateId);
         if ($node === null) {
             Assert::fail(sprintf('Failed to find node with aggregate id "%s"', $nodeAggregateId->value));
         }
@@ -423,7 +467,7 @@ trait NodeTraversalTrait
             ? NodeAggregateId::fromString($serializedExpectedNodeId)
             : null;
 
-        $actualNode = $this->getCurrentSubgraph()->findRootNodeByType(NodeTypeName::fromString($serializedNodeTypeName));
+        $actualNode = $this->getCurrentSubgraphForQueries()->findRootNodeByType(NodeTypeName::fromString($serializedNodeTypeName));
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -67,11 +67,11 @@ trait NodeTraversalTrait
 
     /**
      * @When /^VisibilityConstraints are set to "(withoutRestrictions|empty|default)"$/
-     * @deprecated remove with Neos 10
+     * @deprecated remove with Neos 9.2
      */
     public function visibilityConstraintsAreSetTo(string $restrictionType): void
     {
-        throw new \RuntimeException('Testing of visibility constraints and node disabling was simplified. Please use steps `And I expect this node to be exactly explicitly tagged "disabled"` or `I expect this node to exactly inherit the tags "disabled" instead`', 1777837694);
+        throw new \RuntimeException('Testing of legacy visibility constraints (node disabling) was simplified. Please use steps `And I expect this node to be exactly explicitly tagged "disabled"` or `inherit the tags` instead. To revert to the old behaviour apply this snippet: https://github.com/neos/neos-development-collection/pull/5815#issuecomment-4412441003', 1777837694);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -66,17 +66,12 @@ trait NodeTraversalTrait
     }
 
     /**
-     * TODO REMOVE
      * @When /^VisibilityConstraints are set to "(withoutRestrictions|empty|default)"$/
+     * @deprecated remove with Neos 10
      */
     public function visibilityConstraintsAreSetTo(string $restrictionType): void
     {
-        $this->currentSubgraphQueryVisibilityConstraints = match ($restrictionType) {
-            'withoutRestrictions' => VisibilityConstraints::withoutRestrictions(),
-            'empty' => VisibilityConstraints::createEmpty(),
-            'default' => VisibilityConstraints::default(),
-            default => throw new \InvalidArgumentException('Visibility constraint "' . $restrictionType . '" not supported.'),
-        };
+        throw new \RuntimeException('Testing of visibility constraints and node disabling was simplified. Please use steps `And I expect this node to be exactly explicitly tagged "disabled"` or `I expect this node to exactly inherit the tags "disabled" instead`', 1777837694);
     }
 
     /**

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -257,7 +257,8 @@ trait ProjectedNodeTrait
             sort($actualTags);
             Assert::assertSame(
                 ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
-                $actualTags
+                $actualTags,
+                sprintf('Node "%s" in workspace "%s" and dsp %s is tagged with {%s}', $currentNode->aggregateId->value, $currentNode->workspaceName->value, $currentNode->dimensionSpacePoint->toJson(), join(',', $currentNode->tags->map(fn (SubtreeTag $tag, bool $inherited) => sprintf('%s%s', $tag->value, $inherited ? '' : '*'))))
             );
         });
     }
@@ -274,6 +275,7 @@ trait ProjectedNodeTrait
             Assert::assertSame(
                 ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
                 $actualTags,
+                sprintf('Node "%s" in workspace "%s" and dsp %s is tagged with {%s}', $currentNode->aggregateId->value, $currentNode->workspaceName->value, $currentNode->dimensionSpacePoint->toJson(), join(',', $currentNode->tags->map(fn (SubtreeTag $tag, bool $inherited) => sprintf('%s%s', $tag->value, $inherited ? '' : '*'))))
             );
         });
     }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap;
 
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Psr7\Uri;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
@@ -23,10 +24,12 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindBackReference
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindPrecedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSucceedingSiblingNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\Projection\ContentGraph\References;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
@@ -272,6 +275,33 @@ trait ProjectedNodeTrait
                 ($expectedTagList === '') ? [] : explode(',', $expectedTagList),
                 $actualTags,
             );
+        });
+    }
+
+    /**
+     * @Then /^I expect this node to have the following subtree with tags:$/
+     */
+    public function iExpectThisNodeToHaveTheFollowingSubtreeWithTags(PyStringNode $expectedTree): void
+    {
+        $this->assertOnCurrentNode(function (Node $currentNode) use ($expectedTree) {
+            $result = [];
+            $subtreeStack = [];
+            $subtree = $this->getCurrentSubgraph()->findSubtree($currentNode->aggregateId, FindSubtreeFilter::create());
+            if ($subtree !== null) {
+                $subtreeStack[] = $subtree;
+            }
+            while ($subtreeStack !== []) {
+                /** @var Subtree $subtree */
+                $subtree = array_shift($subtreeStack);
+                $explicitTags = $subtree->node->tags->withoutInherited()->toStringArray();
+                sort($explicitTags);
+                $inheritedTags = $subtree->node->tags->onlyInherited()->toStringArray();
+                sort($inheritedTags);
+                $tags = [...array_map(static fn(string $tag) => $tag . '*', $explicitTags), ...$inheritedTags];
+                $result[] = str_repeat(' ', $subtree->level) . $subtree->node->aggregateId->value . ($tags !== [] ? ' (' . implode(',', $tags) . ')' : '');
+                $subtreeStack = [...$subtree->children, ...$subtreeStack];
+            }
+            Assert::assertSame($expectedTree?->getRaw() ?? '', implode(chr(10), $result));
         });
     }
 

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
  */
 
 use Behat\Gherkin\Node\PyStringNode;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTags;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteRuntimeVariables;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\ProjectedNodeTrait;
@@ -26,6 +28,7 @@ use Neos\Fusion\Core\RuntimeFactory;
 use Neos\Fusion\Exception\RuntimeException;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\Domain\Service\RenderingModeService;
+use Neos\Neos\Domain\SubtreeTagging\NeosVisibilityConstraints;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Neos\Fusion\Core\Cache\ContentCache;
@@ -81,10 +84,18 @@ trait FusionTrait
 
     /**
      * @When the Fusion context node is :nodeAggregateId
+     * @When /^the Fusion context node is "([^"]+)" with visibility constraints "([^"]+)"$/
      */
-    public function theFusionContextNodeIs(string $nodeAggregateId): void
+    public function theFusionContextNodeIs(string $nodeAggregateId, ?string $excludedSubtreeTagsSerialized = null): void
     {
-        $subgraph = $this->getCurrentSubgraph();
+        $visibilityConstraints = $excludedSubtreeTagsSerialized !== null ? VisibilityConstraints::excludeSubtreeTags(
+            SubtreeTags::fromStrings(...explode(',', $excludedSubtreeTagsSerialized))
+        ) : NeosVisibilityConstraints::excludeRemoved()->merge(NeosVisibilityConstraints::excludeDisabled());
+
+        $subgraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName)->getSubgraph(
+            $this->currentDimensionSpacePoint,
+            $visibilityConstraints
+        );
         $this->fusionContext['node'] = $subgraph->findNodeById(NodeAggregateId::fromString($nodeAggregateId));
         if ($this->fusionContext['node'] === null) {
             throw new InvalidArgumentException(sprintf('Node with aggregate id "%s" could not be found in the current subgraph', $nodeAggregateId), 1696700222);

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_NoDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_NoDimensions.feature
@@ -125,8 +125,6 @@ Feature: Copy nodes (without dimensions)
       | nodeVariantSelectionStrategy | "allVariants"     |
       | tag                          | "parent-tag"      |
 
-    And VisibilityConstraints are set to "withoutRestrictions"
-
     # we inherit the tag here but DONT copy it!
     Then I expect the node with aggregate identifier "sir-nodeward-nodington-iii" to inherit the tag "parent-tag"
 

--- a/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/05-PublishNodeTypeChangeWithTetheredNodes_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/PendingChanges/W01-WorkspacePublication/05-PublishNodeTypeChangeWithTetheredNodes_WithoutDimensions.feature
@@ -87,7 +87,6 @@ Feature: Partial publish after node type change tagging tethered nodes (without 
     # Step 6: Assert page is Shortcut in live and tethered child is tagged (not hard-deleted)
     # nody-mc-nodeface was not in the published set so it does not exist in live
     Then I am in workspace "live" and dimension space point {}
-    When VisibilityConstraints are set to "empty"
     And I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{}
     And I expect this node to be of type "Neos.ContentRepository.Testing:Shortcut"
     And I expect the node with aggregate identifier "main-collection-id" to be explicitly tagged "removed"


### PR DESCRIPTION
Requires: https://github.com/neos/neos-development-collection/pull/5817


### Use visibility constraints only for testing queries (see  NodeTraversal)

and not for general node assertions

if mixed together understanding the tests becomes quickly absurd as there are lot-of checks asserting a node does not exist, but they mean they are _hidden_. Which becomes really fun to read if the visibility constraints are multiple times modified in a test.

instead writing tests should always take into account that the nodes **exist**

In combination with the following steps assertions should become more readable

before

```
I expect node aggregate identifier "mc-nodeface" to lead to no node
```

after

```
I expect node aggregate identifier "mc-nodeface" to lead to node cs-identifier;mc-nodeface;{}
I expect this node to be exactly explicitly tagged "disabled"
I expect this node to exactly inherit the tags "disabled"
```

----

completely separate from that are assertions for queries. While internally the findNodeById query is also used for

> I expect node aggregate identifier "mc-nodeface" to lead to node cs-identifier;mc-nodeface;{}

the test describes just the expectation and the test-writer should not think about any possible filtering or exact queries.

for testing queries explicitly it makes sense to take visibility constraints into account

```
And I restrict the visibility of nodes tagged "disabled" in subgraph queries
When I execute the findChildNodes query for parent node aggregate id ...
```

TODO:
- [ ] Ensure by no longer using VisibilityConstraints for node disabling assertions we add capable tests for NodeTraversal
  - [ ] Add for NodeTraversal second tag on a parent node which is excluded in another scenario to show inheritance works