### PR TITLE
BUGFIX: Use actual occupied node rows in node aggregate (as subtree tags are hierarchy)

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/Domain/Repository/NodeFactoryTest.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/Domain/Repository/NodeFactoryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Tests\Domain\Repository;
+
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\DimensionSpacePointsRepository;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Serializer;
+
+class NodeFactoryTest extends TestCase
+{
+    /** @test */
+    public function nodeAggregatesAreBuiltOnlyWithTheActualOccupiedNodeRows(): void
+    {
+        $rows = <<<JSON
+        [{
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{}",
+            "covereddimensionspacepoint": "{\"language\":\"de\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{\"disabled\": null}",
+            "covereddimensionspacepoint": "{\"language\":\"en\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{}",
+            "covereddimensionspacepoint": "{\"language\":\"ltz\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{\"disabled\": null}",
+            "covereddimensionspacepoint": "{\"language\":\"mul\"}"
+        },
+        {
+            "relationanchorpoint": 5,
+            "nodeaggregateid": "nody-mc-nodeface",
+            "origindimensionspacepointhash": "81e25df248aa99d536dba0be7ddf2ac5",
+            "nodetypename": "Neos.ContentRepository.Testing:Document",
+            "name": "child-document",
+            "properties": "[]",
+            "classification": "regular",
+            "created": "2026-05-04 21:40:49",
+            "originalcreated": "2026-05-04 21:40:49",
+            "lastmodified": null,
+            "originallastmodified": null,
+            "contentstreamid": "cs-identifier",
+            "subtreetags": "{}",
+            "covereddimensionspacepoint": "{\"language\":\"gsw\"}"
+        }]
+        JSON;
+
+        $dspRepository = $this->getMockBuilder(DimensionSpacePointsRepository::class)->onlyMethods(['getOriginDimensionSpacePointByHash'])->disableOriginalConstructor()->disableAutoReturnValueGeneration()->getMock();
+
+        $dspRepository->method('getOriginDimensionSpacePointByHash')->with('81e25df248aa99d536dba0be7ddf2ac5')->willReturn(OriginDimensionSpacePoint::fromArray(['language' => 'mul']));
+
+        $nodeFactory = new NodeFactory(
+            ContentRepositoryId::fromString('testing'),
+            new PropertyConverter(new Serializer()),
+            $dspRepository,
+        );
+
+        $nodeAggregate = $nodeFactory->mapNodeRowsToNodeAggregate(
+            json_decode($rows, true),
+            WorkspaceName::forLive(),
+            VisibilityConstraints::createEmpty()
+        );
+
+        self::assertSame('nody-mc-nodeface', $nodeAggregate->nodeAggregateId->value);
+
+        // As subtree tags reside on edges we must pick the correct node row to get this occupied node.
+        // If we don't use the row where origindimensionspacepoint equals covereddimensionspacepoint we use subtree tags from a random other edge which is not expected.
+        $mulVariant = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint(OriginDimensionSpacePoint::fromArray(['language' => 'mul']));
+        self::assertSame([], $mulVariant->tags->withoutInherited()->toStringArray());
+        self::assertSame(['disabled'], $mulVariant->tags->onlyInherited()->toStringArray());
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/DimensionSpacePointsRepository.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/DimensionSpacePointsRepository.php
@@ -25,7 +25,7 @@ use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
  *
  * @internal you should never need this in userland code
  */
-final class DimensionSpacePointsRepository
+class DimensionSpacePointsRepository
 {
     /**
      * @var array<string, string>

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -167,8 +167,11 @@ final class NodeFactory
 
         foreach ($nodeRows as $nodeRow) {
             // A node can occupy exactly one DSP and cover multiple ones...
+            $coveredDimensionSpacePoint = DimensionSpacePoint::fromJsonString(
+                $nodeRow['covereddimensionspacepoint']
+            );
             $occupiedDimensionSpacePoint = $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']);
-            if (!isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])) {
+            if ($coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash || $nodeRow['classification'] === 'root') {
                 // ... so we handle occupation exactly once ...
                 $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
                     $nodeRow,
@@ -183,9 +186,6 @@ final class NodeFactory
                 $rawNodeAggregateClassification = $rawNodeAggregateClassification ?: $nodeRow['classification'];
             }
             // ... and coverage always ...
-            $coveredDimensionSpacePoint = DimensionSpacePoint::fromJsonString(
-                $nodeRow['covereddimensionspacepoint']
-            );
             $coveredDimensionSpacePoints[$coveredDimensionSpacePoint->hash] = $coveredDimensionSpacePoint;
 
             $coverageByOccupants[$occupiedDimensionSpacePoint->hash][$coveredDimensionSpacePoint->hash]

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -172,8 +172,13 @@ final class NodeFactory
             );
             $occupiedDimensionSpacePoint = $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']);
             if (
+                // FIXME This condition should be exactly ONCE given for every occupation in a node aggregate
                 $coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash
-                // Todo hack, support for partial NodeAggregates by picking an arbitrary node row for occupation. See https://github.com/neos/neos-development-collection/pull/5489
+                // FIXME ... but, if poorly fetched a node aggregate does not include its occupation rows.
+                // as hack we support partial node aggregates by picking the first node row for an occupation which might not be the actual occupation
+                // The reason this is hacky is that edge information like subtree tags are not deterministic but dependent on the database returning rows.
+                // See https://github.com/neos/neos-development-collection/pull/5489
+                // This unfortunate hack condition means that the if-body is executed at most 2 times for regular cases.
                 || !isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])
             ) {
                 // ... so we handle occupation exactly once ...
@@ -183,6 +188,7 @@ final class NodeFactory
                     $occupiedDimensionSpacePoint->toDimensionSpacePoint(),
                     $visibilityConstraints
                 );
+                // FIXME, sort and index by $occupiedDimensionSpacePoint->hash
                 $occupiedDimensionSpacePoints[] = $occupiedDimensionSpacePoint;
                 $rawNodeAggregateId = $rawNodeAggregateId ?: $nodeRow['nodeaggregateid'];
                 $rawNodeTypeName = $rawNodeTypeName ?: $nodeRow['nodetypename'];

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -198,7 +198,9 @@ final class NodeFactory
         ksort($coveredDimensionSpacePoints);
 
         // a nodeAggregate only exists if it at least contains one node
-        assert($nodesByOccupiedDimensionSpacePoint !== []);
+        if ($nodesByOccupiedDimensionSpacePoint === []) {
+            throw new \RuntimeException(sprintf('Fatal, no occupation found in fetched node rows for aggregate "%s"', $nodeRows[0]['nodeaggregateid'] ?? ''), 1778049288);
+        }
 
         return NodeAggregate::create(
             $this->contentRepositoryId,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -171,7 +171,11 @@ final class NodeFactory
                 $nodeRow['covereddimensionspacepoint']
             );
             $occupiedDimensionSpacePoint = $this->dimensionSpacePointRepository->getOriginDimensionSpacePointByHash($nodeRow['origindimensionspacepointhash']);
-            if ($coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash || $nodeRow['classification'] === 'root') {
+            if (
+                $coveredDimensionSpacePoint->hash === $occupiedDimensionSpacePoint->hash
+                // Todo hack, support for partial NodeAggregates by picking an arbitrary node row for occupation. See https://github.com/neos/neos-development-collection/pull/5489
+                || !isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])
+            ) {
                 // ... so we handle occupation exactly once ...
                 $nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash] = $this->mapNodeRowToNode(
                     $nodeRow,


### PR DESCRIPTION

Previously, the subtree tags were only correctly determined if the first row of the query result is also the actual occupation node row.

See

> !isset($nodesByOccupiedDimensionSpacePoint[$occupiedDimensionSpacePoint->hash])

The attached unit tests shows that the occupations are now correctly determined.

The old behaviour is still partially in place as a (temporary) hack until we find out how to continue with https://github.com/neos/neos-development-collection/pull/5489. Because if we were strict - which we should have been in the first place - building node aggregates should not be possible without all covered rows returned. Unfortunately that exactly happens when using child queries on node aggregates with multiple parents.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
