### PR TITLE
BUGFIX: Update enshrined/svg-sanitize to ^0.22.0 (CVE-2025-55166)

### DIFF
--- a/Neos.Media.Browser/composer.json
+++ b/Neos.Media.Browser/composer.json
@@ -24,7 +24,7 @@
         "neos/error-messages": "*",
         "doctrine/common": "^2.7 || ^3.0",
         "doctrine/orm": "^2.6",
-        "enshrined/svg-sanitize": "^0.16.0"
+        "enshrined/svg-sanitize": "^0.22.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Backport of #5609 to the 7.3 branch. See #5818 for the backport request and discussion.

Resolves the security issue from CVE-2025-55166 ([GHSA-22wq-q86m-83fh](https://github.com/advisories/GHSA-22wq-q86m-83fh)) on the 7.3 branch by bumping the `enshrined/svg-sanitize` constraint from `^0.16.0` to `^0.22.0`.

## Compatibility

- The Sanitizer public API used by `Neos.Media.Browser/Classes/Controller/AssetController.php` (`new Sanitizer()`, `sanitize()`, `getXmlIssues()`) is unchanged between 0.16.0 and 0.22.0, so this is a drop-in dependency update with no Neos code changes required.
- `enshrined/svg-sanitize` `0.22.0` requires PHP `^7.1 || ^8.0`, which is compatible with the existing `Neos.Media.Browser` PHP constraint of `^7.3 || ^8.0`.

## Note on branch

I am aware that 8.3 is the lowest officially maintained branch per the release roadmap. Opening this as a draft for visibility — see #5818 for the backport request.

## Checklist

- [x] Code follows the PSR-2 coding style — dependency-only change
- [x] Tests have been created, run and adjusted as needed — N/A, dependency-only
- [ ] The PR is created against the lowest maintained branch — intentionally **not**, this is a backport to 7.3 (see #5818)
