### PR TITLE
BUGFIX: `DimensionSpacePointsRepository`'s runtime cache creates invalid state after replay

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/DimensionSpacePointsRepository.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/DimensionSpacePointsRepository.php
@@ -40,10 +40,6 @@ class DimensionSpacePointsRepository
 
     public function insertDimensionSpacePoint(AbstractDimensionSpacePoint $dimensionSpacePoint): void
     {
-        if ($this->getCoordinatesByHashFromRuntimeCache($dimensionSpacePoint->hash) !== null) {
-            return;
-        }
-
         $this->dimensionSpacePointsRuntimeCache[$dimensionSpacePoint->hash] = $dimensionSpacePoint->toJson();
         $this->writeDimensionSpacePoint($dimensionSpacePoint->hash, $dimensionSpacePoint->toJson());
     }
@@ -53,10 +49,6 @@ class DimensionSpacePointsRepository
      */
     public function insertDimensionSpacePointByHashAndCoordinates(string $hash, array $dimensionSpacePointCoordinates): void
     {
-        if ($this->getCoordinatesByHashFromRuntimeCache($hash) !== null) {
-            return;
-        }
-
         try {
             $dimensionSpacePointCoordinatesJson = json_encode($dimensionSpacePointCoordinates, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {


### PR DESCRIPTION

If the content repository was used in the same PHP instance as a replay was issued its possible to have a corrupted state and missing entries for the dimension space points.

How is this possible if projections are pure? If we rely on runtime caches to see if a write is necessary. Ironically the runtime cache for writing only "optimizes" the events `DimensionShineThroughWasAdded` and  `DimensionSpacePointWasMoved` where there is not much to optimise as these are developer only emitted events.

The actual frequent inserts in the DimensionSpacePointsRepository for updated or new hierarchies and node rows where done always via `INSERT IGNORE` as a new instance of the `DimensionSpacePointsRepository` was created via `new` and thus the cache not shared.

This problem was noticed by accident during running the projection integrity violation detection after each scenario

https://github.com/neos/neos-development-collection/pull/5808

The feature

```
Neos.Neos/Tests/Behavior/Features/AssetUsage/DimensionSpacePoints/01-MoveDimensionSpacePoints.feature:103
```

Tests exactly just that, that after replay of the `MoveDimensionSpacePoint` everything is "OK" which failed before.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
