### PR TITLE
BUGFIX: Deterministic ordering of NodeAggregates' Nodes for emitting events

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -174,7 +174,6 @@ final class ContentGraph implements ContentGraphInterface
     ): NodeAggregates {
         $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
             ->andWhere('n.nodeaggregateid in (:nodeAggregateIds)')
-            ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
                 'nodeAggregateIds' => $nodeAggregateIds->toStringArray(),
                 'contentStreamId' => $this->contentStreamId->value
@@ -340,7 +339,6 @@ final class ContentGraph implements ContentGraphInterface
             ->where('th.contentstreamid = :contentStreamId')
             ->andWhere('JSON_EXTRACT(th.subtreetags, :tagPath) LIKE "true"')
             ->andWhere('h.contentstreamid = :contentStreamId')
-            ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
                 'tagPath' => '$."' . $subtreeTag->value . '"',
                 'contentStreamId' => $this->contentStreamId->value

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -157,7 +157,6 @@ final class ContentGraph implements ContentGraphInterface
     ): ?NodeAggregate {
         $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
             ->andWhere('n.nodeaggregateid = :nodeAggregateId')
-            ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'contentStreamId' => $this->contentStreamId->value

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/NodeFactory.php
@@ -188,8 +188,7 @@ final class NodeFactory
                     $occupiedDimensionSpacePoint->toDimensionSpacePoint(),
                     $visibilityConstraints
                 );
-                // FIXME, sort and index by $occupiedDimensionSpacePoint->hash
-                $occupiedDimensionSpacePoints[] = $occupiedDimensionSpacePoint;
+                $occupiedDimensionSpacePoints[$occupiedDimensionSpacePoint->hash] = $occupiedDimensionSpacePoint;
                 $rawNodeAggregateId = $rawNodeAggregateId ?: $nodeRow['nodeaggregateid'];
                 $rawNodeTypeName = $rawNodeTypeName ?: $nodeRow['nodetypename'];
                 $rawNodeName = $rawNodeName ?: $nodeRow['name'];

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/03-ChangeNodeAggregateType_HappyPathStrategy.feature
@@ -246,8 +246,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceName                | "live"                                                    |
       | contentStreamId              | "cs-identifier"                                           |
       | nodeAggregateId              | "nody-mc-nodeface"                                        |
-      | originDimensionSpacePoint    | {"language":"gsw"}                                        |
-      | affectedDimensionSpacePoints | [{"language":"gsw"}]                                      |
+      | originDimensionSpacePoint    | {"language":"de"}                                         |
+      | affectedDimensionSpacePoints | [{"language":"de"}]                                       |
       | propertyValues               | {"defaultTextB":{"value":"defaultTextB","type":"string"}} |
       | propertiesToUnset            | ["defaultTextA"]                                          |
     And event at index 10 is of type "NodePropertiesWereSet" with payload:
@@ -255,8 +255,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceName                | "live"                                                    |
       | contentStreamId              | "cs-identifier"                                           |
       | nodeAggregateId              | "nody-mc-nodeface"                                        |
-      | originDimensionSpacePoint    | {"language":"de"}                                         |
-      | affectedDimensionSpacePoints | [{"language":"de"}]                                       |
+      | originDimensionSpacePoint    | {"language":"gsw"}                                        |
+      | affectedDimensionSpacePoints | [{"language":"gsw"}]                                      |
       | propertyValues               | {"defaultTextB":{"value":"defaultTextB","type":"string"}} |
       | propertiesToUnset            | ["defaultTextA"]                                          |
     And event at index 11 is of type "NodeAggregateWithNodeWasCreated" with payload:
@@ -265,40 +265,40 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | contentStreamId               | "cs-identifier"                                                                                                              |
       | nodeAggregateId               | "nodimer-tetherton"                                                                                                          |
       | nodeTypeName                  | "Neos.ContentRepository.Testing:ChildOfNodeTypeB"                                                                            |
-      | originDimensionSpacePoint     | {"language":"gsw"}                                                                                                           |
-      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId":null}]                                                          |
+      | originDimensionSpacePoint     | {"language":"de"}                                                                                                            |
+      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}]                                                           |
       | parentNodeAggregateId         | "nody-mc-nodeface"                                                                                                           |
       | nodeName                      | "child-of-type-b"                                                                                                            |
       | initialPropertyValues         | {"defaultTextB":{"value":"defaultTextB","type":"string"},"commonDefaultText":{"value":"commonDefaultTextB","type":"string"}} |
       | nodeAggregateClassification   | "tethered"                                                                                                                   |
-    And event at index 12 is of type "NodeGeneralizationVariantWasCreated" with payload:
-      | Key                       | Expected                                                           |
-      | workspaceName             | "live"                                                             |
-      | contentStreamId           | "cs-identifier"                                                    |
-      | nodeAggregateId           | "nodimer-tetherton"                                                |
-      | sourceOrigin              | {"language":"gsw"}                                                 |
-      | generalizationOrigin      | {"language":"de"}                                                  |
-      | variantSucceedingSiblings | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}] |
+    And event at index 12 is of type "NodeSpecializationVariantWasCreated" with payload:
+      | Key                    | Expected                                                            |
+      | workspaceName          | "live"                                                              |
+      | contentStreamId        | "cs-identifier"                                                     |
+      | nodeAggregateId        | "nodimer-tetherton"                                                 |
+      | sourceOrigin           | {"language":"de"}                                                   |
+      | specializationOrigin   | {"language":"gsw"}                                                  |
+      | specializationSiblings | [{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId":null}] |
     And event at index 13 is of type "NodeAggregateWithNodeWasCreated" with payload:
-      | Key                           | Expected                                                            |
-      | workspaceName                 | "live"                                                              |
-      | contentStreamId               | "cs-identifier"                                                     |
-      | nodeAggregateId               | "nodimer-tether-son"                                                |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Tethered"                           |
-      | originDimensionSpacePoint     | {"language":"gsw"}                                                  |
-      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId":null}] |
-      | parentNodeAggregateId         | "nodimer-tetherton"                                                 |
-      | nodeName                      | "tethered"                                                          |
-      | initialPropertyValues         | []                                                                  |
-      | nodeAggregateClassification   | "tethered"                                                          |
-    And event at index 14 is of type "NodeGeneralizationVariantWasCreated" with payload:
-      | Key                       | Expected                                                           |
-      | workspaceName             | "live"                                                             |
-      | contentStreamId           | "cs-identifier"                                                    |
-      | nodeAggregateId           | "nodimer-tether-son"                                               |
-      | sourceOrigin              | {"language":"gsw"}                                                 |
-      | generalizationOrigin      | {"language":"de"}                                                  |
-      | variantSucceedingSiblings | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}] |
+      | Key                           | Expected                                                           |
+      | workspaceName                 | "live"                                                             |
+      | contentStreamId               | "cs-identifier"                                                    |
+      | nodeAggregateId               | "nodimer-tether-son"                                               |
+      | nodeTypeName                  | "Neos.ContentRepository.Testing:Tethered"                          |
+      | originDimensionSpacePoint     | {"language":"de"}                                                  |
+      | succeedingSiblingsForCoverage | [{"dimensionSpacePoint":{"language":"de"},"nodeAggregateId":null}] |
+      | parentNodeAggregateId         | "nodimer-tetherton"                                                |
+      | nodeName                      | "tethered"                                                         |
+      | initialPropertyValues         | []                                                                 |
+      | nodeAggregateClassification   | "tethered"                                                         |
+    And event at index 14 is of type "NodeSpecializationVariantWasCreated" with payload:
+      | Key                    | Expected                                                            |
+      | workspaceName          | "live"                                                              |
+      | contentStreamId        | "cs-identifier"                                                     |
+      | nodeAggregateId        | "nodimer-tether-son"                                                |
+      | sourceOrigin           | {"language":"de"}                                                   |
+      | specializationOrigin   | {"language":"gsw"}                                                  |
+      | specializationSiblings | [{"dimensionSpacePoint":{"language":"gsw"},"nodeAggregateId":null}] |
 
     # the type has changed
     When I am in workspace "live" and dimension space point {"language":"de"}
@@ -514,8 +514,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceName                | "live"                                                      |
       | contentStreamId              | "cs-identifier"                                             |
       | nodeAggregateId              | "nody-mc-nodeface"                                          |
-      | originDimensionSpacePoint    | {"language":"gsw"}                                          |
-      | affectedDimensionSpacePoints | [{"language":"gsw"}]                                        |
+      | originDimensionSpacePoint    | {"language":"de"}                                           |
+      | affectedDimensionSpacePoints | [{"language":"de"}]                                         |
       | propertyValues               | {"defaultTextB2":{"value":"defaultTextB2","type":"string"}} |
       | propertiesToUnset            | ["defaultTextB"]                                            |
     And event at index 12 is of type "NodePropertiesWereSet" with payload:
@@ -523,8 +523,8 @@ Feature: Change node aggregate type - behavior of HAPPYPATH strategy
       | workspaceName                | "live"                                                      |
       | contentStreamId              | "cs-identifier"                                             |
       | nodeAggregateId              | "nody-mc-nodeface"                                          |
-      | originDimensionSpacePoint    | {"language":"de"}                                           |
-      | affectedDimensionSpacePoints | [{"language":"de"}]                                         |
+      | originDimensionSpacePoint    | {"language":"gsw"}                                          |
+      | affectedDimensionSpacePoints | [{"language":"gsw"}]                                        |
       | propertyValues               | {"defaultTextB2":{"value":"defaultTextB2","type":"string"}} |
       | propertiesToUnset            | ["defaultTextB"]                                            |
 

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeById.feature
@@ -107,9 +107,9 @@ Feature: Find nodes using the findNodeById query
 
     When I execute the findNodeAggregatesByIds query for node aggregate id "a,a2a1,b,home,non-existing" I expect the following node aggregates to be returned:
       | nodeAggregateId | nodeTypeName                            | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions          |
-      | b               | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
-      | a2a1            | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
       | a               | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
+      | a2a1            | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
+      | b               | Neos.ContentRepository.Testing:Page     | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
       | home            | Neos.ContentRepository.Testing:Homepage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | []                                    |
 
     # special case numeric node ids

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindNodeByTag.feature
@@ -109,9 +109,9 @@ Feature: Find nodes using the findNodeById query
 
     When I execute the findNodeAggregatesTaggedBy query for tag "disabled" I expect the following node aggregates to be returned:
       | nodeAggregateId | nodeTypeName                               | coveredDimensionSpacePoints           | occupiedDimensionSpacePoints | explicitlyDisabledDimensions          |
-      | b1              | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"ch"}]                   |
-      | a2a1            | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
       | a2a             | Neos.ContentRepository.Testing:SpecialPage | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
+      | a2a1            | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"de"},{"language":"ch"}] |
+      | b1              | Neos.ContentRepository.Testing:Page        | [{"language":"de"},{"language":"ch"}] | [{"language":"de"}]          | [{"language":"ch"}]                   |
 
 
     When I execute the findNodeAggregatesTaggedBy query for tag "tag1" I expect the following node aggregates to be returned:

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePointSet.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/DimensionSpacePointSet.php
@@ -147,13 +147,7 @@ final readonly class DimensionSpacePointSet implements
 
     public function equals(DimensionSpacePointSet $other): bool
     {
-        $thisPointHashes = $this->getPointHashes();
-        $otherPointHashes = $other->getPointHashes();
-
-        sort($thisPointHashes);
-        sort($otherPointHashes);
-
-        return $thisPointHashes === $otherPointHashes;
+        return count($this->points) === count($other->points) && array_diff_key($this->points, $other->points) === [];
     }
 
     public function getIterator(): \Traversable

--- a/Neos.ContentRepository.Core/Classes/DimensionSpace/OriginDimensionSpacePointSet.php
+++ b/Neos.ContentRepository.Core/Classes/DimensionSpace/OriginDimensionSpacePointSet.php
@@ -181,4 +181,9 @@ final class OriginDimensionSpacePointSet implements \JsonSerializable, \Iterator
     {
         return new OriginDimensionSpacePointSet(array_diff_key($this->points, $other->getPoints()));
     }
+
+    public function equals(OriginDimensionSpacePointSet $other): bool
+    {
+        return count($this->points) === count($other->points) && array_diff_key($this->points, $other->points) === [];
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/DimensionSpaceInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/DimensionSpaceInternals.php
@@ -6,6 +6,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
+use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 
 /**
  * @internal implementation details of command handlers
@@ -15,9 +16,20 @@ trait DimensionSpaceInternals
     /**
      * A node aggregate's order of {@see NodeAggregate::$occupiedDimensionSpacePoints} is undefined as returned from the database.
      * Before using this unorder to emit events we use the interdimensional variation graph to order them into a flattened tree according to configuration.
+     */
+    final protected function requireOrderedOccupiedDimensionSpacePoints(NodeAggregate $nodeAggregate): OriginDimensionSpacePointSet
+    {
+        if ($nodeAggregate->classification->isRoot()) {
+            /** Root nodes occupy @see OriginDimensionSpacePoint::createWithoutDimensions() which is not allowed in the subspace if other dimensions are defined */
+            return $nodeAggregate->occupiedDimensionSpacePoints;
+        }
+        return $this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints);
+    }
+
+    /**
      * FIXME: This method might make sense on the InterDimensionVariationGraph but for this an explicit distinctions of unordered Set and List value objects for dimension space points is required. Currently we have Set value objects that _still_ have sometimes an order with meaning.
      */
-    protected function requireOrderedOriginDimensionSpacePoints(OriginDimensionSpacePointSet $affectedOriginDimensionSpacePoints): OriginDimensionSpacePointSet
+    final protected function requireOrderedOriginDimensionSpacePoints(OriginDimensionSpacePointSet $affectedOriginDimensionSpacePoints): OriginDimensionSpacePointSet
     {
         $allowedOrderedDimensionSpacePoints = $this->interDimensionalVariationGraph->getDimensionSpacePoints();
 

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/DimensionSpaceInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/DimensionSpaceInternals.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\Common;
+
+use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
+
+/**
+ * @internal implementation details of command handlers
+ */
+trait DimensionSpaceInternals
+{
+    /**
+     * A node aggregate's order of {@see NodeAggregate::$occupiedDimensionSpacePoints} is undefined as returned from the database.
+     * Before using this unorder to emit events we use the interdimensional variation graph to order them into a flattened tree according to configuration.
+     * FIXME: This method might make sense on the InterDimensionVariationGraph but for this an explicit distinctions of unordered Set and List value objects for dimension space points is required. Currently we have Set value objects that _still_ have sometimes an order with meaning.
+     */
+    protected function requireOrderedOriginDimensionSpacePoints(OriginDimensionSpacePointSet $affectedOriginDimensionSpacePoints): OriginDimensionSpacePointSet
+    {
+        $allowedOrderedDimensionSpacePoints = $this->interDimensionalVariationGraph->getDimensionSpacePoints();
+
+        $orderedAffectedOriginDimensionSpacePoints = OriginDimensionSpacePointSet::fromDimensionSpacePointSet(
+            $allowedOrderedDimensionSpacePoints->getIntersection(
+                $affectedOriginDimensionSpacePoints->toDimensionSpacePointSet()
+            )
+        );
+
+        if (!$orderedAffectedOriginDimensionSpacePoints->equals($affectedOriginDimensionSpacePoints)) {
+            throw new DimensionSpacePointNotFound(
+                sprintf('The dimension space points %s were not found in the allowed dimension subspace %s', $affectedOriginDimensionSpacePoints->getDifference($orderedAffectedOriginDimensionSpacePoints)->toJson(), $allowedOrderedDimensionSpacePoints->toJson()),
+                1778587626
+            );
+        }
+        return $orderedAffectedOriginDimensionSpacePoints;
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -17,6 +17,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeGeneralizationVariantWasCreated;
@@ -348,5 +349,31 @@ trait NodeVariationInternals
             true,
             $excludedSet
         );
+    }
+
+    /**
+     * A node aggregate's order of {@see NodeAggregate::$occupiedDimensionSpacePoints} is undefined as returned from the database.
+     * Before using this unorder to emit events we use the interdimensional variation graph to order them into a flattened tree according to configuration.
+     * FIXME: This method might make sense on the InterDimensionVariationGraph but for this an explicit distinctions of unordered Set and List value objects for dimension spaceports is required.
+     */
+    protected function requireOrderedOriginDimensionSpacePoints(OriginDimensionSpacePointSet $affectedOriginDimensionSpacePoints): OriginDimensionSpacePointSet
+    {
+        $orderedAffectedOriginDimensionSpacePoints = OriginDimensionSpacePointSet::fromDimensionSpacePointSet(
+            $this->interDimensionalVariationGraph->getDimensionSpacePoints()->getIntersection(
+                $affectedOriginDimensionSpacePoints->toDimensionSpacePointSet()
+            )
+        );
+
+        //
+        // TODO Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
+        // TODO Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound: [{"language":"ch"}] was not found in the allowed dimension subspace
+        //
+        // if (!$orderedAffectedOriginDimensionSpacePoints->equals($affectedOriginDimensionSpacePoints)) {
+        //     throw new DimensionSpacePointNotFound(
+        //         sprintf('%s was not found in the allowed dimension subspace', $affectedOriginDimensionSpacePoints->getDifference($orderedAffectedOriginDimensionSpacePoints)->toJson()),
+        //         1778587626
+        //     );
+        // }
+        return $orderedAffectedOriginDimensionSpacePoints;
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -16,6 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
+use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
@@ -366,16 +367,12 @@ trait NodeVariationInternals
             )
         );
 
-        //
-        // TODO Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
-        // TODO Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound: [{"language":"ch"}] was not found in the allowed dimension subspace
-        //
-        // if (!$orderedAffectedOriginDimensionSpacePoints->equals($affectedOriginDimensionSpacePoints)) {
-        //     throw new DimensionSpacePointNotFound(
-        //         sprintf('%s was not found in the allowed dimension subspace', $affectedOriginDimensionSpacePoints->getDifference($orderedAffectedOriginDimensionSpacePoints)->toJson()),
-        //         1778587626
-        //     );
-        // }
+        if (!$orderedAffectedOriginDimensionSpacePoints->equals($affectedOriginDimensionSpacePoints)) {
+            throw new DimensionSpacePointNotFound(
+                sprintf('The dimension space points %s were not found in the allowed dimension subspace %s', $affectedOriginDimensionSpacePoints->getDifference($orderedAffectedOriginDimensionSpacePoints)->toJson(), $allowedOrderedDimensionSpacePoints->toJson()),
+                1778587626
+            );
+        }
         return $orderedAffectedOriginDimensionSpacePoints;
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -354,12 +354,14 @@ trait NodeVariationInternals
     /**
      * A node aggregate's order of {@see NodeAggregate::$occupiedDimensionSpacePoints} is undefined as returned from the database.
      * Before using this unorder to emit events we use the interdimensional variation graph to order them into a flattened tree according to configuration.
-     * FIXME: This method might make sense on the InterDimensionVariationGraph but for this an explicit distinctions of unordered Set and List value objects for dimension spaceports is required.
+     * FIXME: This method might make sense on the InterDimensionVariationGraph but for this an explicit distinctions of unordered Set and List value objects for dimension space points is required. Currently we have Set value objects that _still_ have sometimes an order with meaning.
      */
     protected function requireOrderedOriginDimensionSpacePoints(OriginDimensionSpacePointSet $affectedOriginDimensionSpacePoints): OriginDimensionSpacePointSet
     {
+        $allowedOrderedDimensionSpacePoints = $this->interDimensionalVariationGraph->getDimensionSpacePoints();
+
         $orderedAffectedOriginDimensionSpacePoints = OriginDimensionSpacePointSet::fromDimensionSpacePointSet(
-            $this->interDimensionalVariationGraph->getDimensionSpacePoints()->getIntersection(
+            $allowedOrderedDimensionSpacePoints->getIntersection(
                 $affectedOriginDimensionSpacePoints->toDimensionSpacePointSet()
             )
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -16,9 +16,7 @@ namespace Neos\ContentRepository\Core\Feature\Common;
 
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
-use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeGeneralizationVariantWasCreated;
@@ -35,6 +33,8 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
  */
 trait NodeVariationInternals
 {
+    use DimensionSpaceInternals;
+
     abstract protected function getInterDimensionalVariationGraph(): DimensionSpace\InterDimensionalVariationGraph;
 
     protected function createEventsForVariations(
@@ -350,29 +350,5 @@ trait NodeVariationInternals
             true,
             $excludedSet
         );
-    }
-
-    /**
-     * A node aggregate's order of {@see NodeAggregate::$occupiedDimensionSpacePoints} is undefined as returned from the database.
-     * Before using this unorder to emit events we use the interdimensional variation graph to order them into a flattened tree according to configuration.
-     * FIXME: This method might make sense on the InterDimensionVariationGraph but for this an explicit distinctions of unordered Set and List value objects for dimension space points is required. Currently we have Set value objects that _still_ have sometimes an order with meaning.
-     */
-    protected function requireOrderedOriginDimensionSpacePoints(OriginDimensionSpacePointSet $affectedOriginDimensionSpacePoints): OriginDimensionSpacePointSet
-    {
-        $allowedOrderedDimensionSpacePoints = $this->interDimensionalVariationGraph->getDimensionSpacePoints();
-
-        $orderedAffectedOriginDimensionSpacePoints = OriginDimensionSpacePointSet::fromDimensionSpacePointSet(
-            $allowedOrderedDimensionSpacePoints->getIntersection(
-                $affectedOriginDimensionSpacePoints->toDimensionSpacePointSet()
-            )
-        );
-
-        if (!$orderedAffectedOriginDimensionSpacePoints->equals($affectedOriginDimensionSpacePoints)) {
-            throw new DimensionSpacePointNotFound(
-                sprintf('The dimension space points %s were not found in the allowed dimension subspace %s', $affectedOriginDimensionSpacePoints->getDifference($orderedAffectedOriginDimensionSpacePoints)->toJson(), $allowedOrderedDimensionSpacePoints->toJson()),
-                1778587626
-            );
-        }
-        return $orderedAffectedOriginDimensionSpacePoints;
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -207,8 +207,10 @@ trait TetheredNodeInternals
             $tetheredNodeType,
             $this->getPropertyConverter()
         );
+
+        $orderedAffectedOriginDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($affectedOriginDimensionSpacePoints);
         $creationOrigin = null;
-        foreach ($affectedOriginDimensionSpacePoints as $originDimensionSpacePoint) {
+        foreach ($orderedAffectedOriginDimensionSpacePoints as $originDimensionSpacePoint) {
             $coverage = $coverageByOrigin->getCoverage($originDimensionSpacePoint);
             if (!$coverage) {
                 throw new \RuntimeException('Missing coverage for origin dimension space point ' . \json_encode($originDimensionSpacePoint));
@@ -306,7 +308,9 @@ trait TetheredNodeInternals
         );
 
         # Handle property adjustments
-        foreach ($nodeAggregate->getNodes() as $node) {
+        foreach ($this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints) as $originDimensionSpacePoint) {
+            $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
+
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
             $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
                 $tetheredNodeType,
@@ -325,8 +329,8 @@ trait TetheredNodeInternals
                     $contentGraph->getWorkspaceName(),
                     $contentGraph->getContentStreamId(),
                     $nodeAggregate->nodeAggregateId,
-                    $node->originDimensionSpacePoint,
-                    $nodeAggregate->getCoverageByOccupant($node->originDimensionSpacePoint),
+                    $originDimensionSpacePoint,
+                    $nodeAggregate->getCoverageByOccupant($originDimensionSpacePoint),
                     $complementaryPropertyValues,
                     $obsoletePropertyNames
                 );

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -208,6 +208,7 @@ trait TetheredNodeInternals
             $this->getPropertyConverter()
         );
 
+        // NodeTypeChange is not allowed on root, thus we don't handle the empty dimension case
         $orderedAffectedOriginDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($affectedOriginDimensionSpacePoints);
         $creationOrigin = null;
         foreach ($orderedAffectedOriginDimensionSpacePoints as $originDimensionSpacePoint) {
@@ -308,7 +309,8 @@ trait TetheredNodeInternals
         );
 
         # Handle property adjustments
-        foreach ($this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints) as $originDimensionSpacePoint) {
+        $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOccupiedDimensionSpacePoints($nodeAggregate);
+        foreach ($orderedOccupiedDimensionSpacePoints as $originDimensionSpacePoint) {
             $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
 
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -213,7 +213,9 @@ trait NodeTypeChange
 
         # Handle property adjustments
         $newNodeType = $this->requireNodeType($command->newNodeTypeName);
-        foreach ($this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints) as $originDimensionSpacePoint) {
+        // NodeTypeChange is not allowed on root, thus we don't handle the empty dimension case
+        $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints);
+        foreach ($orderedOccupiedDimensionSpacePoints as $originDimensionSpacePoint) {
             $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
 
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -213,8 +213,9 @@ trait NodeTypeChange
 
         # Handle property adjustments
         $newNodeType = $this->requireNodeType($command->newNodeTypeName);
-        foreach ($nodeAggregate->getNodes() as $node) {
-            $this->requireDimensionSpacePointToExist($node->originDimensionSpacePoint->toDimensionSpacePoint());
+        foreach ($this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints) as $originDimensionSpacePoint) {
+            $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
+
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
             $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
                 $newNodeType,
@@ -233,8 +234,8 @@ trait NodeTypeChange
                     $contentGraph->getWorkspaceName(),
                     $contentGraph->getContentStreamId(),
                     $nodeAggregate->nodeAggregateId,
-                    $node->originDimensionSpacePoint,
-                    $nodeAggregate->getCoverageByOccupant($node->originDimensionSpacePoint),
+                    $originDimensionSpacePoint,
+                    $nodeAggregate->getCoverageByOccupant($originDimensionSpacePoint),
                     $complementaryPropertyValues,
                     $obsoletePropertyNames
                 );

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -209,6 +209,7 @@ final readonly class NodeAggregate
     /**
      * Returns the nodes belonging to this aggregate, i.e. the "real materialized" node rows.
      *
+     * @deprecated Could already be moved but will definitely be moved with Neos 9.2
      * @internal Using this method to access all occupied nodes or possibly extract a single arbitrary node is not intended for use outside the core. The order is undefined.
      * @return iterable<int,Node>
      */

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/NodeAggregate.php
@@ -56,10 +56,10 @@ final readonly class NodeAggregate
      * @param NodeAggregateClassification $classification whether this node aggregate represents a root, regular or tethered node
      * @param NodeTypeName $nodeTypeName name of the node type of this node aggregate
      * @param NodeName|null $nodeName optional name of this node aggregate
-     * @param OriginDimensionSpacePointSet $occupiedDimensionSpacePoints dimension space points this node aggregate occupies
+     * @param OriginDimensionSpacePointSet $occupiedDimensionSpacePoints dimension space points this node aggregate occupies (Unordered)
      * @param non-empty-array<string,Node> $nodesByOccupiedDimensionSpacePoint At least one node will be occupied.
      * @param CoverageByOrigin $coverageByOccupant
-     * @param DimensionSpacePointSet $coveredDimensionSpacePoints This node aggregate will cover at least one dimension space.
+     * @param DimensionSpacePointSet $coveredDimensionSpacePoints This node aggregate will cover at least one dimension space. (Unordered)
      * @param OriginByCoverage $occupationByCovered
      * @param non-empty-array<string,NodeTags> $nodeTagsByCoveredDimensionSpacePoint node tags by every covered dimension space point
      */
@@ -209,7 +209,7 @@ final readonly class NodeAggregate
     /**
      * Returns the nodes belonging to this aggregate, i.e. the "real materialized" node rows.
      *
-     * @internal Using this method to access all occupied nodes or possibly extract a single arbitrary node is not intended for use outside the core.
+     * @internal Using this method to access all occupied nodes or possibly extract a single arbitrary node is not intended for use outside the core. The order is undefined.
      * @return iterable<int,Node>
      */
     public function getNodes(): iterable

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DimensionAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DimensionAdjustment.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\StructureAdjustment\Adjustment;
 
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\VariantType;
+use Neos\ContentRepository\Core\Feature\Common\DimensionSpaceInternals;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
-use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFound;
 
 class DimensionAdjustment
 {
+    use DimensionSpaceInternals;
+
     public function __construct(
         protected ContentGraphInterface $contentGraph,
         protected InterDimensionalVariationGraph $interDimensionalVariationGraph,
@@ -44,18 +45,19 @@ class DimensionAdjustment
             return [];
         }
         foreach ($this->contentGraph->findNodeAggregatesByType($nodeTypeName) as $nodeAggregate) {
-            foreach ($nodeAggregate->getNodes() as $node) {
+            $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints);
+            foreach ($orderedOccupiedDimensionSpacePoints as $occupiedDimensionSpacePoint) {
                 foreach (
                     $nodeAggregate->getCoverageByOccupant(
-                        $node->originDimensionSpacePoint
+                        $occupiedDimensionSpacePoint
                     ) as $coveredDimensionSpacePoint
                 ) {
                     $variantType = $this->interDimensionalVariationGraph->getVariantType(
                         $coveredDimensionSpacePoint,
-                        $node->originDimensionSpacePoint->toDimensionSpacePoint()
+                        $occupiedDimensionSpacePoint->toDimensionSpacePoint()
                     );
                     if (
-                        !$node->originDimensionSpacePoint->equals($coveredDimensionSpacePoint)
+                        !$occupiedDimensionSpacePoint->equals($coveredDimensionSpacePoint)
                         && $variantType !== VariantType::TYPE_SPECIALIZATION
                     ) {
                         $message = sprintf(
@@ -68,13 +70,15 @@ class DimensionAdjustment
 
                                 You need to write a node migration to update the database to fix this case.
                             ',
-                            $node->originDimensionSpacePoint->toJson(),
+                            $occupiedDimensionSpacePoint->toJson(),
                             $coveredDimensionSpacePoint->toJson(),
                             strtoupper($variantType->value)
                         );
 
-                        yield StructureAdjustment::createForNode(
-                            $node,
+                        yield StructureAdjustment::createForNodeIdentity(
+                            $nodeAggregate->workspaceName,
+                            $occupiedDimensionSpacePoint,
+                            $nodeAggregate->nodeAggregateId,
                             StructureAdjustment::NODE_COVERS_GENERALIZATION_OR_PEERS,
                             $message
                         );

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DimensionAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/DimensionAdjustment.php
@@ -45,7 +45,7 @@ class DimensionAdjustment
             return [];
         }
         foreach ($this->contentGraph->findNodeAggregatesByType($nodeTypeName) as $nodeAggregate) {
-            $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints);
+            $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOccupiedDimensionSpacePoints($nodeAggregate);
             foreach ($orderedOccupiedDimensionSpacePoints as $occupiedDimensionSpacePoint) {
                 foreach (
                     $nodeAggregate->getCoverageByOccupant(

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\StructureAdjustment\Adjustment;
 
+use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
+use Neos\ContentRepository\Core\Feature\Common\DimensionSpaceInternals;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
@@ -16,13 +18,15 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
 
 class PropertyAdjustment
 {
+    use DimensionSpaceInternals;
+
     public function __construct(
         private readonly ContentGraphInterface $contentGraph,
+        private readonly InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private readonly NodeTypeManager $nodeTypeManager
     ) {
     }
@@ -41,7 +45,9 @@ class PropertyAdjustment
         $expectedPropertiesFromNodeType = array_filter($nodeType->getProperties(), fn ($value) => $value !== null);
 
         foreach ($this->contentGraph->findNodeAggregatesByType($nodeTypeName) as $nodeAggregate) {
-            foreach ($nodeAggregate->getNodes() as $node) {
+            $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints);
+            foreach ($orderedOccupiedDimensionSpacePoints as $originDimensionSpacePoint) {
+                $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
                 $propertyKeysInNode = [];
 
                 $properties = $node->properties;

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/PropertyAdjustment.php
@@ -45,7 +45,7 @@ class PropertyAdjustment
         $expectedPropertiesFromNodeType = array_filter($nodeType->getProperties(), fn ($value) => $value !== null);
 
         foreach ($this->contentGraph->findNodeAggregatesByType($nodeTypeName) as $nodeAggregate) {
-            $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($nodeAggregate->occupiedDimensionSpacePoints);
+            $orderedOccupiedDimensionSpacePoints = $this->requireOrderedOccupiedDimensionSpacePoints($nodeAggregate);
             foreach ($orderedOccupiedDimensionSpacePoints as $originDimensionSpacePoint) {
                 $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
                 $propertyKeysInNode = [];

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -73,6 +73,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
         );
         $this->propertyAdjustment = new PropertyAdjustment(
             $this->liveContentGraph,
+            $interDimensionalVariationGraph,
             $nodeTypeManager
         );
         $this->dimensionAdjustment = new DimensionAdjustment(

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/NodeTraversalTrait.php
@@ -196,7 +196,7 @@ trait NodeTraversalTrait
         $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
         $actualNodeAggregates = $contentGraph->findNodeAggregatesByIds($entryNodeAggregateIds);
 
-        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), $actualNodeAggregates, 'findNodeAggregatesByIds returned an unexpected result');
+        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), self::sortNodeAggregatesById($actualNodeAggregates), 'findNodeAggregatesByIds returned an unexpected result');
     }
 
 
@@ -443,7 +443,7 @@ trait NodeTraversalTrait
         $contentGraph = $this->currentContentRepository->getContentGraph($this->currentWorkspaceName);
         $actualNodeAggregates = $contentGraph->findNodeAggregatesTaggedBy(SubtreeTag::fromString($subtreeTag));
 
-        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), $actualNodeAggregates, 'findNodeAggregatesTaggedBy returned an unexpected result');
+        self::assertNodeAggregatesEqualTable($expectedNodes->getHash(), self::sortNodeAggregatesById($actualNodeAggregates), 'findNodeAggregatesTaggedBy returned an unexpected result');
     }
 
     /**
@@ -458,6 +458,14 @@ trait NodeTraversalTrait
 
         $actualNode = $this->getCurrentSubgraphForQueries()->findRootNodeByType(NodeTypeName::fromString($serializedNodeTypeName));
         Assert::assertSame($actualNode?->aggregateId->value, $expectedNodeAggregateId?->value);
+    }
+
+    /** Do not apply to all query results, as some have a defined order! */
+    private static function sortNodeAggregatesById(NodeAggregates $nodeAggregates): NodeAggregates
+    {
+        $nodeAggregatesSorted = iterator_to_array($nodeAggregates);
+        usort($nodeAggregatesSorted, fn (NodeAggregate $a, NodeAggregate $b) => $a->nodeAggregateId->value <=> $b->nodeAggregateId->value);
+        return NodeAggregates::fromArray($nodeAggregatesSorted);
     }
 
     private static function assertNodeAggregatesEqualTable(array $expectedNodeAggregates, NodeAggregates $actualNodeAggregates, string $message): void

--- a/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovedNodes.php
+++ b/Neos.Neos/Classes/Domain/SubtreeTagging/SoftRemoval/SoftRemovedNodes.php
@@ -35,6 +35,9 @@ final readonly class SoftRemovedNodes implements \IteratorAggregate, \Countable
         foreach ($items as $item) {
             $indexedItems[$item->nodeAggregateId->value] = $item;
         }
+        // Sort the random ordered nodes, to have a for testing deterministic order
+        // Sorted based on node aggregate ids which are explicitly given during testing.
+        ksort($indexedItems);
         return new self($indexedItems);
     }
 

--- a/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/00-WithoutImpendingConflicts.feature
+++ b/Neos.Neos/Tests/Behavior/Features/SoftRemovalGarbageCollection/00-WithoutImpendingConflicts.feature
@@ -117,16 +117,16 @@ Feature: Tests for soft removal garbage collection without impending conflicts
 
   Scenario: Garbage collection will transform nested soft removals of a node that only exists in a root workspace
     When the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId             | parentNodeAggregateId | nodeTypeName       |
-      | nodingers-kitten            | nodingers-cat         | Neos.Neos:Document |
-      | nodingers-kittens-plaything | nodingers-kitten      | Neos.Neos:Document |
+      | nodeAggregateId               | parentNodeAggregateId | nodeTypeName       |
+      | nodingers-kitten              | nodingers-cat         | Neos.Neos:Document |
+      | a-nodingers-kittens-plaything | nodingers-kitten      | Neos.Neos:Document |
     And the command TagSubtree is executed with payload:
-      | Key                          | Value                         |
-      | workspaceName                | "live"                        |
-      | nodeAggregateId              | "nodingers-kittens-plaything" |
-      | coveredDimensionSpacePoint   | {"example": "source"}         |
-      | nodeVariantSelectionStrategy | "allSpecializations"          |
-      | tag                          | "removed"                     |
+      | Key                          | Value                           |
+      | workspaceName                | "live"                          |
+      | nodeAggregateId              | "a-nodingers-kittens-plaything" |
+      | coveredDimensionSpacePoint   | {"example": "source"}           |
+      | nodeVariantSelectionStrategy | "allSpecializations"            |
+      | tag                          | "removed"                       |
     And the command TagSubtree is executed with payload:
       | Key                          | Value                 |
       | workspaceName                | "live"                |
@@ -137,13 +137,16 @@ Feature: Tests for soft removal garbage collection without impending conflicts
     Then I expect the following hard removal conflicts to be impending:
       | nodeAggregateId | dimensionSpacePoints |
 
+    # we could issue the removal in a random order, but to make the tests deterministic we sort by node aggregate id,
+    # meaning the node a- is found first and thus we first issue the removal of the child node
+
     When soft removal garbage collection is run for content repository default
     Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
     And event at index 8 is of type "NodeAggregateWasRemoved" with payload:
       | Key                                  | Expected                                        |
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |
-      | nodeAggregateId                      | "nodingers-kittens-plaything"                   |
+      | nodeAggregateId                      | "a-nodingers-kittens-plaything"                   |
       | affectedCoveredDimensionSpacePoints  | [{"example": "source"}, {"example": "special"}] |
     And event at index 9 is of type "NodeAggregateWasRemoved" with payload:
       | Key                                  | Expected                                        |
@@ -159,24 +162,15 @@ Feature: Tests for soft removal garbage collection without impending conflicts
 
   Scenario: Garbage collection will transform nested soft removals of a node that only exists in a root workspace
   by also considering that the parent node might be removed first and skipping the removal of the child
-
-    # we need to have movements in the tree which will lead to the node returned by creation order does
-    # not match the inversed hierarchy and we run into the case of deleting the parent first
     When the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId             | parentNodeAggregateId  | nodeTypeName       |
-      | nodingers-kittens-plaything | sir-david-nodenborough | Neos.Neos:Document |
-      | nodingers-kitten            | nodingers-cat          | Neos.Neos:Document |
-    When the command MoveNodeAggregate is executed with payload:
-      | Key                          | Value                         |
-      | nodeAggregateId              | "nodingers-kittens-plaything" |
-      | dimensionSpacePoint          | {"example": "source"}         |
-      | newParentNodeAggregateId     | "nodingers-kitten"            |
-      | relationDistributionStrategy | "gatherAll"                   |
+      | nodeAggregateId             | parentNodeAggregateId | nodeTypeName       |
+      | nodingers-kitten            | nodingers-cat         | Neos.Neos:Document |
+      | x-nodingers-kittens-plaything | nodingers-kitten      | Neos.Neos:Document |
 
     And the command TagSubtree is executed with payload:
       | Key                          | Value                         |
       | workspaceName                | "live"                        |
-      | nodeAggregateId              | "nodingers-kittens-plaything" |
+      | nodeAggregateId              | "x-nodingers-kittens-plaything" |
       | coveredDimensionSpacePoint   | {"example": "source"}         |
       | nodeVariantSelectionStrategy | "allSpecializations"          |
       | tag                          | "removed"                     |
@@ -190,9 +184,12 @@ Feature: Tests for soft removal garbage collection without impending conflicts
     Then I expect the following hard removal conflicts to be impending:
       | nodeAggregateId | dimensionSpacePoints |
 
+    # we could issue the removal in a random order, but to make the tests deterministic we sort by node aggregate id,
+    # meaning the node x- is found last and we first issue the removal of in this case its parent
+
     When soft removal garbage collection is run for content repository default
-    Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
-    And event at index 9 is of type "NodeAggregateWasRemoved" with payload:
+    Then I expect exactly 9 events to be published on stream "ContentStream:cs-identifier"
+    And event at index 8 is of type "NodeAggregateWasRemoved" with payload:
       | Key                                  | Expected                                        |
       | workspaceName                        | "live"                                          |
       | contentStreamId                      | "cs-identifier"                                 |


### PR DESCRIPTION
Requires https://github.com/neos/neos-development-collection/pull/5883

Due to the removed `ORDER BY` we might also see slight query performance improvements

### Query `findNodeAggregatesById()`

This PR now insures that we order Nodes `$occupiedDimensionSpacePoints` before emitting events based on order.

Before the order returned from the database was used. This was determined by `ORDER BY n.relationanchorpoint DESC`.
But this order is highly adapter specific in this case it depends on internal (relationanchorpoint) from the M*SQL graph implementation that has no public defined behaviour.

Nodes in an aggregate are unordered!!!

Related https://github.com/neos/neos-development-collection/pull/5817

### Query `findNodeAggregatesByIds()` and `findNodeAggregatesTaggedBy()`

Tests were now adjusted to sort the results alphabetically before comparing them to avoid any ordering mismatches as the database does not define an order.

Also the soft-removal-garbage-collector was adjusted to sort the result from `findNodeAggregatesTaggedBy()` alphabetically to have a deterministic order for testing.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
