### PR TITLE
PoC: BUGFIX: Close base workspace during command simulation

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphReadModelAdapter.php
@@ -142,7 +142,8 @@ final readonly class ContentGraphReadModelAdapter implements ContentGraphReadMod
         $queryBuilder = $this->dbal->createQueryBuilder();
 
         return $queryBuilder
-            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.hasChanges, cs.sourceContentStreamVersion = scs.version as upToDateWithBase')
+            // TODO is >= correct or do we need to store the changesVersion of the source during fork??
+            ->select('ws.name, ws.baseWorkspaceName, ws.currentContentStreamId, cs.hasChanges, cs.sourceContentStreamVersion >= scs.changesVersion as upToDateWithBase')
             ->from($this->tableNames->workspace(), 'ws')
             ->join('ws', $this->tableNames->contentStream(), 'cs', 'cs.id = ws.currentcontentstreamid')
             ->leftJoin('cs', $this->tableNames->contentStream(), 'scs', 'scs.id = cs.sourceContentStreamId');

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -182,7 +182,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 || $event instanceof ContentStreamWasCreated
             )
         ) {
-            $this->updateContentStreamVersion($event->getContentStreamId(), $eventEnvelope->version, $event instanceof PublishableToWorkspaceInterface);
+            $this->updateContentStreamVersion($event->getContentStreamId(), $eventEnvelope->version, $event instanceof PublishableToWorkspaceInterface ? $eventEnvelope->version : null);
         }
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -126,6 +126,7 @@ class DoctrineDbalContentGraphSchemaBuilder
             (new Column('sourceContentStreamVersion', Type::getType(Types::INTEGER)))->setNotnull(false),
             (new Column('closed', Type::getType(Types::BOOLEAN)))->setNotnull(true),
             (new Column('hasChanges', Type::getType(Types::BOOLEAN)))->setNotnull(true),
+            (new Column('changesVersion', Type::getType(Types::INTEGER)))->setNotnull(true),
         ]);
 
         return $contentStreamTable->setPrimaryKey(['id']);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php
@@ -22,7 +22,8 @@ trait ContentStream
             'sourceContentStreamId' => $sourceContentStreamId?->value,
             'sourceContentStreamVersion' => $sourceVersion?->value,
             'closed' => 0,
-            'hasChanges' => 0
+            'hasChanges' => 0,
+            'changesVersion' => 0,
         ]);
     }
 
@@ -51,13 +52,15 @@ trait ContentStream
         ]);
     }
 
-    private function updateContentStreamVersion(ContentStreamId $contentStreamId, Version $version, bool $markAsDirty): void
+    private function updateContentStreamVersion(ContentStreamId $contentStreamId, Version $version, ?Version $publishableChangeVersion): void
     {
         $updatePayload = [
             'version' => $version->value,
         ];
-        if ($markAsDirty) {
+        if ($publishableChangeVersion) {
+            // TODO can be removed in favour of version === changesVersion
             $updatePayload['hasChanges'] = 1;
+            $updatePayload['changesVersion'] = $publishableChangeVersion->value;
         }
         $this->dbal->update($this->tableNames->contentStream(), $updatePayload, [
             'id' => $contentStreamId->value,

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/W8-IndividualNodePublication/03-MoreBasicFeatures.feature
@@ -261,15 +261,21 @@ Feature: Publishing individual nodes (basics)
       | nodesToPublish                  | ["sir-nodeward-nodington-iii", "sir-david-nodenborough"] |
       | contentStreamIdForRemainingPart | "user-cs-identifier-remaining"                                                                               |
 
-    Then I expect exactly 8 events to be published on stream "ContentStream:cs-identifier"
-    And event at index 6 is of type "NodePropertiesWereSet" with payload:
+    Then I expect exactly 10 events to be published on stream "ContentStream:cs-identifier"
+    And event at index 6 is of type "ContentStreamWasClosed" with payload:
       | Key                           | Expected                                                |
       | contentStreamId               | "cs-identifier"                                         |
-      | nodeAggregateId               | "sir-david-nodenborough"                                |
     And event at index 7 is of type "NodePropertiesWereSet" with payload:
       | Key                           | Expected                                                |
       | contentStreamId               | "cs-identifier"                                         |
+      | nodeAggregateId               | "sir-david-nodenborough"                                |
+    And event at index 8 is of type "NodePropertiesWereSet" with payload:
+      | Key                           | Expected                                                |
+      | contentStreamId               | "cs-identifier"                                         |
       | nodeAggregateId               | "sir-nodeward-nodington-iii"                            |
+    And event at index 9 is of type "ContentStreamWasReopened" with payload:
+      | Key                           | Expected                                                |
+      | contentStreamId               | "cs-identifier"                                         |
 
     Then I expect exactly 4 events to be published on stream "ContentStream:user-cs-identifier-remaining"
     And event at index 0 is of type "ContentStreamWasForked" with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.BehavioralTests package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\PublishingDuringPublishing;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\WorkspacePublicationDuringWriting\WorkspacePublicationDuringWritingTest;
+use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\EventStore\Exception\ConcurrencyException;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Test that no DeadlockException like: An exception occurred while executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
+ * Is thrown during catchup as this would lead to projection failure which cannot be properly recovered from other than a replay.
+ */
+class PublishingDuringPublishingTest extends AbstractParallelTestCase
+{
+    private const SETUP_LOCK_PATH = __DIR__ . '/setup-lock';
+    private const WRITING_IS_RUNNING_FLAG_PATH = __DIR__ . '/write-is-running-flag';
+
+    private ContentRepository $contentRepository;
+
+    protected ObjectManagerInterface $objectManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->log('------ process started ------');
+
+        $debugProjection = new DebugEventProjection(
+            'cr_test_parallel_debug_projection',
+            $this->objectManager->get(Connection::class)
+        );
+        FakeProjectionFactory::setProjection(
+            'debug',
+            $debugProjection
+        );
+
+        FakeContentDimensionSourceFactory::setWithoutDimensions();
+        FakeNodeTypeManagerFactory::setConfiguration([
+            'Neos.ContentRepository:Root' => [],
+            'Neos.ContentRepository.Testing:Content' => [],
+            'Neos.ContentRepository.Testing:Document' => [
+                'properties' => [
+                    'title' => [
+                        'type' => 'string'
+                    ]
+                ],
+                'childNodes' => [
+                    'tethered-a' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-b' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-c' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-d' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ],
+                    'tethered-e' => [
+                        'type' => 'Neos.ContentRepository.Testing:Content'
+                    ]
+                ]
+            ]
+        ]);
+
+        $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
+
+        $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);
+        if ($exclusiveNonBlockingLockResult === false) {
+            $this->log('waiting for setup');
+            if (!flock($setupLockResource, LOCK_SH)) {
+                throw new \RuntimeException('failed to acquire blocking shared lock');
+            }
+            $this->contentRepository = $this->contentRepositoryRegistry
+                ->get(ContentRepositoryId::fromString('test_parallel'));
+            $this->log('wait for setup finished');
+            return;
+        }
+
+        $this->log('setup started');
+        $contentRepository = $this->setUpContentRepository(ContentRepositoryId::fromString('test_parallel'));
+
+        $origin = OriginDimensionSpacePoint::createWithoutDimensions();
+        $contentRepository->handle(CreateRootWorkspace::create(
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('live-cs-id')
+        ));
+        $contentRepository->handle(CreateRootNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)
+        ));
+        $contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('nody-mc-nodeface'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            $origin,
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            initialPropertyValues: PropertyValuesToWrite::fromArray([
+                'title' => 'title-original'
+            ])
+        ));
+        $contentRepository->handle(CreateWorkspace::create(
+            WorkspaceName::fromString('user-test-one'),
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('user-test-cs-one')
+        ));
+        $contentRepository->handle(CreateWorkspace::create(
+            WorkspaceName::fromString('user-test-two'),
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('user-test-cs-two')
+        ));
+
+        $this->contentRepository = $contentRepository;
+
+        if (!flock($setupLockResource, LOCK_UN)) {
+            throw new \RuntimeException('failed to release setup lock');
+        }
+
+        $this->log('setup finished');
+    }
+
+    /**
+     * @test
+     */
+    public function whileANodesArWrittenOnLive(): void
+    {
+        $this->log('1. writing & publishing started');
+
+        touch(self::WRITING_IS_RUNNING_FLAG_PATH);
+
+        try {
+            for ($i = 0; $i <= 500; $i++) {
+                $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                    WorkspaceName::fromString('user-test-one'),
+                    NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
+                    NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                    OriginDimensionSpacePoint::createWithoutDimensions(),
+                    NodeAggregateId::fromString('lady-eleonode-rootford'),
+                    initialPropertyValues: PropertyValuesToWrite::fromArray([
+                        'title' => 'title'
+                    ])
+                ));
+
+                try {
+                    $this->contentRepository->handle(PublishWorkspace::create(
+                        WorkspaceName::fromString('user-test-one')
+                    )->withNewContentStreamId(
+                        ContentStreamId::fromString('user-test-cs-one-' . $i)
+                    ));
+                } catch (ConcurrencyException $concurrencyException) {
+                    /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
+                    $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
+                }
+            }
+        } finally {
+            unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
+        }
+
+        $this->log('1. writing & publishing finished');
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('nody-mc-nodeface-500'));
+        Assert::assertNotNull($node);
+    }
+
+    /**
+     * @test
+     */
+    public function thenConcurrentPublishAreNotDeadlocked(): void
+    {
+        if (!is_file(self::WRITING_IS_RUNNING_FLAG_PATH)) {
+            $this->log('waiting for 2. writing');
+
+            $this->awaitFile(self::WRITING_IS_RUNNING_FLAG_PATH);
+            // If write is the process that does the (slowish) setup, and then waits for the rebase to start,
+            // We give the CR some time to close the content stream
+            // TODO find another way than to randomly wait!!!
+            // The problem is, if we dont sleep it happens often that the modification works only then the rebase is startet _really_
+            // Doing the modification several times in hope that the second one fails will likely just stop the rebase thread as it cannot close
+            usleep(10000);
+        }
+
+        $this->log('2. writing & publishing started');
+
+        for ($i = 0; $i <= 500; $i++) {
+            $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
+                WorkspaceName::fromString('user-test-two'),
+                NodeAggregateId::fromString('sir-david-nodenborough-' . $i),
+                NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                OriginDimensionSpacePoint::createWithoutDimensions(),
+                NodeAggregateId::fromString('lady-eleonode-rootford'),
+                initialPropertyValues: PropertyValuesToWrite::fromArray([
+                    'title' => 'title'
+                ])
+            ));
+            try {
+                $this->contentRepository->handle(PublishWorkspace::create(
+                    WorkspaceName::fromString('user-test-two')
+                )->withNewContentStreamId(
+                    ContentStreamId::fromString('user-test-cs-two-' . $i)
+                ));
+            } catch (ConcurrencyException $concurrencyException) {
+                /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
+                $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
+            }
+        }
+
+        $this->log('2. writing & publishing finished');
+
+        Assert::assertTrue(true, 'No exception was thrown ;)');
+
+        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
+        $node = $subgraph->findNodeById(NodeAggregateId::fromString('sir-david-nodenborough-500'));
+        Assert::assertNotNull($node);
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
@@ -27,9 +27,11 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeA
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Exception\WorkspaceRebaseFailed;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Exception\ContentStreamIsClosed;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -182,7 +184,8 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
                     )->withNewContentStreamId(
                         ContentStreamId::fromString('user-test-cs-one-' . $i)
                     ));
-                } catch (ConcurrencyException $concurrencyException) {
+                } catch (ConcurrencyException|ContentStreamIsClosed|WorkspaceRebaseFailed $concurrencyException) {
+                    // TODO WorkspaceRebaseFailed can be thrown wrapping a "Content stream "live-cs-id" is closed."
                     /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
                     $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
                 }
@@ -235,7 +238,8 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
                 )->withNewContentStreamId(
                     ContentStreamId::fromString('user-test-cs-two-' . $i)
                 ));
-            } catch (ConcurrencyException $concurrencyException) {
+            } catch (ConcurrencyException|ContentStreamIsClosed|WorkspaceRebaseFailed $concurrencyException) {
+                // TODO WorkspaceRebaseFailed can be thrown wrapping a "Content stream "live-cs-id" is closed."
                 /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
                 $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -37,9 +37,12 @@ trait ContentStreamHandling
         return new EventsToPublish(
             $streamName,
             Events::with(
-                new ContentStreamWasClosed(
-                    $contentStreamId,
-                ),
+                DecoratedEvent::create(
+                    new ContentStreamWasClosed(
+                        $contentStreamId,
+                    ),
+                    // todo add debug metadata: array_filter(['debug_reason' => ...])
+                )
             ),
             ExpectedVersion::fromVersion($contentStreamVersion)
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -212,6 +212,19 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $workspaceContentStreamVersion
         );
 
+        try {
+            yield $this->closeContentStream(
+                $baseWorkspace->currentContentStreamId,
+                $baseWorkspaceContentStreamVersion
+            );
+            $baseWorkspaceContentStreamVersion = $baseWorkspaceContentStreamVersion->next();
+        } catch (ConcurrencyException $concurrencyException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
+            );
+        }
+
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
         $commandSimulator->run(
@@ -226,6 +239,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $workspaceRebaseFailed = WorkspaceRebaseFailed::duringPublish($commandSimulator->getConflictingEvents());
             yield $this->reopenContentStreamWithoutConstraintChecks(
                 $workspace->currentContentStreamId,
+                sprintf('conflicts %d: %s', $workspaceRebaseFailed->getCode(), $workspaceRebaseFailed->getMessage())
+            );
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $baseWorkspace->currentContentStreamId,
                 sprintf('conflicts %d: %s', $workspaceRebaseFailed->getCode(), $workspaceRebaseFailed->getMessage())
             );
             throw $workspaceRebaseFailed;
@@ -250,6 +267,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $workspace->currentContentStreamId,
                     sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
                 );
+                yield $this->reopenContentStreamWithoutConstraintChecks(
+                    $baseWorkspace->currentContentStreamId,
+                    sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
+                );
                 throw $concurrencyException;
             }
         }
@@ -259,6 +280,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $baseWorkspace->currentContentStreamId,
             Version::fromInteger($baseWorkspaceContentStreamVersion->value + ($eventsOfWorkspaceToPublish?->count() ?? 0)),
             sprintf('Publish workspace %s and fork base %s', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value)
+        );
+
+        yield $this->reopenContentStreamWithoutConstraintChecks(
+            $baseWorkspace->currentContentStreamId,
+            sprintf('publish finished')
         );
 
         yield new EventsToPublish(
@@ -471,6 +497,19 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $workspaceContentStreamVersion
         );
 
+        try {
+            yield $this->closeContentStream(
+                $baseWorkspace->currentContentStreamId,
+                $baseWorkspaceContentStreamVersion
+            );
+            $baseWorkspaceContentStreamVersion = $baseWorkspaceContentStreamVersion->next();
+        } catch (ConcurrencyException $concurrencyException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
+            );
+        }
+
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
         $highestSequenceNumberForMatching = $commandSimulator->run(
@@ -499,6 +538,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $workspace->currentContentStreamId,
                 sprintf('conflicts %d: %s', $workspaceRebaseFailed->getCode(), $workspaceRebaseFailed->getMessage())
             );
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $baseWorkspace->currentContentStreamId,
+                sprintf('conflicts %d: %s', $workspaceRebaseFailed->getCode(), $workspaceRebaseFailed->getMessage())
+            );
             throw $workspaceRebaseFailed;
         }
 
@@ -519,6 +562,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             } catch (ConcurrencyException $concurrencyException) {
                 yield $this->reopenContentStreamWithoutConstraintChecks(
                     $workspace->currentContentStreamId,
+                    sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
+                );
+                yield $this->reopenContentStreamWithoutConstraintChecks(
+                    $baseWorkspace->currentContentStreamId,
                     sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
                 );
                 throw $concurrencyException;
@@ -551,6 +598,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
+
+        yield $this->reopenContentStreamWithoutConstraintChecks(
+            $baseWorkspace->currentContentStreamId,
+            sprintf('publish finished')
+        );
     }
 
     /**
@@ -596,6 +648,19 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             $workspaceContentStreamVersion
         );
 
+        try {
+            yield $this->closeContentStream(
+                $baseWorkspace->currentContentStreamId,
+                $baseWorkspaceContentStreamVersion
+            );
+            $baseWorkspaceContentStreamVersion = $baseWorkspaceContentStreamVersion->next();
+        } catch (ConcurrencyException $concurrencyException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('concurrency %d: %s', $concurrencyException->getCode(), $concurrencyException->getMessage())
+            );
+        }
+
         if ($commandsToKeep->isEmpty()) {
             // quick path everything was discarded
             yield from $this->discardWorkspace(
@@ -630,6 +695,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $workspace->currentContentStreamId,
                 sprintf('conflicts %d: %s', $workspaceRebaseFailed->getCode(), $workspaceRebaseFailed->getMessage())
             );
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $baseWorkspace->currentContentStreamId,
+                sprintf('conflicts %d: %s', $workspaceRebaseFailed->getCode(), $workspaceRebaseFailed->getMessage())
+            );
             throw $workspaceRebaseFailed;
         }
 
@@ -658,6 +727,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         );
 
         yield $this->removeContentStreamWithoutConstraintChecks($workspace->currentContentStreamId);
+
+        yield $this->reopenContentStreamWithoutConstraintChecks(
+            $baseWorkspace->currentContentStreamId,
+            sprintf('discard finished')
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes deadlocks as per - see test: https://github.com/neos/neos-development-collection/pull/5513
Should (TM) also fix: https://github.com/neos/neos-development-collection/issues/5713

This change is a safeguard to ensure simulation is only executed one at a time per base-workspace.
Leveraging content stream closing via the eventstore we prevent any writes or other publish/rebase operation on the base workspace.

This means that only one user at time can Discard individual or Rebase their own workspace. Publishing to one common base-workspace was always by concept restricted as only one changeset can come first (`ConcurrencyException: Expected version: 2625, actual version: 2626`).

Before multiple users could rebase / discard individual simultaneously and might just end up being outdated still. Those users will now face one of these exceptions:

- ContentStreamIsClosed: Content stream "live-cs-id" is closed.
- WorkspaceRebaseFailed: Publication failed: "Content stream "live-cs-id" is closed." and 46 further conflicts

As effect of closing and also reopening the base workspace we cannot calculate the workspace state anymore correctly and end up being more often outdated due to the two additional events on the base which where added after the fork.

### Problem, we close and reopen now even more often ...

... closing and reopening the base workspace might turn out even more fatal as the operation is not atomic. A suddenly dead connection WILL corrupt the system and leave live closed until manually forced open - which leaves us to provide tooling. Content stream closing IS NOT a good idea and must be removed eventually. See https://github.com/neos/neos-development-collection/issues/5827

TODO:
- [ ] Migrate new `changesVersion` column - needs value / default value for existing projects
- [ ] Find out if `changesVersion` makes sense^^
- [ ] Remove now obsolete `bool` `hasChanges` column and replace with `version = changesVersion`
- [ ] Evaluate to rethrow `ContentStreamIsClosed` instead of wrapping as `WorkspaceRebaseFailed`

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
