### PR TITLE
BUGFIX: Recover from unexpected error during command simulation

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -214,13 +214,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $commandSimulator->run(
-            static function ($handle) use ($rebaseableCommands): void {
-                foreach ($rebaseableCommands as $rebaseableCommand) {
-                    $handle($rebaseableCommand);
+        try {
+            $commandSimulator->run(
+                static function ($handle) use ($rebaseableCommands): void {
+                    foreach ($rebaseableCommands as $rebaseableCommand) {
+                        $handle($rebaseableCommand);
+                    }
                 }
-            }
-        );
+            );
+        } catch (\Throwable $unexpectedException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('unexpected error %d: %s', $unexpectedException->getCode(), $unexpectedException->getMessage())
+            );
+            throw $unexpectedException;
+        }
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = WorkspaceRebaseFailed::duringPublish($commandSimulator->getConflictingEvents());
@@ -384,13 +392,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $commandSimulator->run(
-            static function ($handle) use ($rebaseableCommands): void {
-                foreach ($rebaseableCommands as $rebaseableCommand) {
-                    $handle($rebaseableCommand);
+        try {
+            $commandSimulator->run(
+                static function ($handle) use ($rebaseableCommands): void {
+                    foreach ($rebaseableCommands as $rebaseableCommand) {
+                        $handle($rebaseableCommand);
+                    }
                 }
-            }
-        );
+            );
+        } catch (\Throwable $unexpectedException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('unexpected error %d: %s', $unexpectedException->getCode(), $unexpectedException->getMessage())
+            );
+            throw $unexpectedException;
+        }
 
         if (
             $command->rebaseErrorHandlingStrategy === RebaseErrorHandlingStrategy::STRATEGY_FAIL
@@ -473,18 +489,26 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $highestSequenceNumberForMatching = $commandSimulator->run(
-            static function ($handle) use ($commandSimulator, $matchingCommands, $remainingCommands): SequenceNumber {
-                foreach ($matchingCommands as $matchingCommand) {
-                    $handle($matchingCommand);
+        try {
+            $highestSequenceNumberForMatching = $commandSimulator->run(
+                static function ($handle) use ($commandSimulator, $matchingCommands, $remainingCommands): SequenceNumber {
+                    foreach ($matchingCommands as $matchingCommand) {
+                        $handle($matchingCommand);
+                    }
+                    $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
+                    foreach ($remainingCommands as $remainingCommand) {
+                        $handle($remainingCommand);
+                    }
+                    return $highestSequenceNumberForMatching;
                 }
-                $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
-                foreach ($remainingCommands as $remainingCommand) {
-                    $handle($remainingCommand);
-                }
-                return $highestSequenceNumberForMatching;
-            }
-        );
+            );
+        } catch (\Throwable $unexpectedException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('unexpected error %d: %s', $unexpectedException->getCode(), $unexpectedException->getMessage())
+            );
+            throw $unexpectedException;
+        }
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = match ($workspace->status) {
@@ -609,13 +633,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $commandSimulator->run(
-            static function ($handle) use ($commandsToKeep): void {
-                foreach ($commandsToKeep as $matchingCommand) {
-                    $handle($matchingCommand);
+        try {
+            $commandSimulator->run(
+                static function ($handle) use ($commandsToKeep): void {
+                    foreach ($commandsToKeep as $matchingCommand) {
+                        $handle($matchingCommand);
+                    }
                 }
-            }
-        );
+            );
+        } catch (\Throwable $unexpectedException) {
+            yield $this->reopenContentStreamWithoutConstraintChecks(
+                $workspace->currentContentStreamId,
+                sprintf('unexpected error %d: %s', $unexpectedException->getCode(), $unexpectedException->getMessage())
+            );
+            throw $unexpectedException;
+        }
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = match ($workspace->status) {


### PR DESCRIPTION
Adds automatic recovery for the problem described in https://github.com/neos/neos-development-collection/issues/5713 where content streams are left closed

Invocations to `$this->contentRepositoryProjection->apply()` which are part of `$commandSimulator->handle()` and thus the `$handle` function might throw any DBAL exception if something went wrong. For example when the transaction died due to a lock. The actual transaction is rolled back via `withSimulation()` but we also need to commit a new event that undos the previous closing.

You might think locking - e.g. closing and reopening - must not be done in this way as a fatal connection crash or the php process dying would still not recover from that but for this #5827 solves it for the future.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
