### PR TITLE
TASK: Allow dynamic flow or event store dependency for ci testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,13 +146,21 @@ jobs:
       - name: Set alias branch name
         run: if [ "${NEOS_TARGET_VERSION}" == "master" ]; then echo "NEOS_BRANCH_ALIAS=dev-master"; else echo "NEOS_BRANCH_ALIAS=${NEOS_TARGET_VERSION}.x-dev"; fi >> $GITHUB_ENV
 
+      - name : Define dynamic CI_* variables via PR body
+        if: ${{ github.event.pull_request }}
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          php -r 'echo preg_match_all("/^\s*((?:CI_FLOW|CI_EVENTSTORE|CI_EVENTSTORE_DBAL)=[a-zA-Z0-9\/\.-]++)\s*\$/m", getenv("PR_BODY"), $matches) ? join("\n", $matches[1]) : "";' >> $GITHUB_ENV
+
       - name: Update composer.json
         run: |
           git -C ../${{ env.NEOS_FOLDER }} checkout -b build
           composer config repositories.neos '{ "type": "path", "url": "../${{ env.NEOS_FOLDER }}", "options": { "symlink": false } }'
           composer require --no-update neos/neos-development-collection:"dev-build as ${{ env.NEOS_BRANCH_ALIAS }}"
-          # enable this line to require a specific flow version for testing
-          # composer require --no-update neos/flow-development-collection:"dev-your-flow-branch-name as ${{ env.NEOS_BRANCH_ALIAS }}"
+          ${{ env.CI_FLOW && 'composer require --no-update neos/flow-development-collection:"dev-$CI_FLOW as $NEOS_BRANCH_ALIAS"' }}
+          ${{ env.CI_EVENTSTORE && 'composer require --no-update "neos/eventstore:dev-$CI_EVENTSTORE as 1.0"' }}
+          ${{ env.CI_EVENTSTORE_DBAL && 'composer require --no-update "neos/eventstore-doctrineadapter:dev-$CI_EVENTSTORE_DBAL as 2.0"' }}
 
       - name: Cache Composer packages
         id: composer-cache


### PR DESCRIPTION
This solves us work adding a dummy commit modifying the CI which is must always carefully be dropped before merging

The feature works as follows. We regex this pr body:)

The markdown fence 

````
```
````

is totally optional but makes it more readable.

```
CI_FLOW=test-branch-remove-me
CI_EVENTSTORE=task/minimum-php82-compatiblity
CI_EVENTSTORE_DBAL=task/minimum-php82-compatiblity
```

Via the use of environment variables and the restricted regex no unsafe injection is possible.

The environment variables allowed are defined in the CI and they must be the start of the line.


**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
