### PR TITLE
TASK: Allow configuration yaml format in behaviour tests

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRBehavioralTestsSubjectProvider.php
@@ -19,6 +19,7 @@ use Behat\Gherkin\Node\TableNode;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Dimension\ConfigurationBasedContentDimensionSource;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngine;
@@ -74,6 +75,18 @@ trait CRBehavioralTestsSubjectProvider
     {
         FakeContentDimensionSourceFactory::setContentDimensionSource(
             GherkinTableNodeBasedContentDimensionSource::fromGherkinTableNode($contentDimensions)
+        );
+    }
+
+    /**
+     * @Given /^using the following content dimensions yaml configuration:$/
+     */
+    public function usingTheFollowingContentDimensionsFromYAML(PyStringNode $pyStringNode): void
+    {
+        FakeContentDimensionSourceFactory::setContentDimensionSource(
+            new ConfigurationBasedContentDimensionSource(
+                Yaml::parse($pyStringNode->getRaw())
+            )
         );
     }
 

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/GherkinTableNodeBasedContentDimensionSource.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/GherkinTableNodeBasedContentDimensionSource.php
@@ -52,9 +52,6 @@ final readonly class GherkinTableNodeBasedContentDimensionSource implements Cont
             $specializationDepths = [];
             $dimensionValues = [];
             $variationEdges = [];
-            $configuration = array_key_exists('Configuration', $row)
-                ? \json_decode($row['Configuration'], true, 512, JSON_THROW_ON_ERROR)
-                : [];
             foreach (Arrays::trimExplode(',', $row['Generalizations']) as $variationExpression) {
                 $currentGeneralization = null;
                 foreach (array_reverse(Arrays::trimExplode('->', $variationExpression)) as $specializationDepth => $rawDimensionValue) {
@@ -68,7 +65,7 @@ final readonly class GherkinTableNodeBasedContentDimensionSource implements Cont
 
             foreach (Arrays::trimExplode(',', $row['Values']) as $rawDimensionValue) {
                 /** @var string $rawDimensionValue */
-                $dimensionValueConfiguration = $configuration['values'][$rawDimensionValue] ?? [];
+                $dimensionValueConfiguration = [];
                 $dimensionValues[$rawDimensionValue] = new ContentDimensionValue(
                     $rawDimensionValue,
                     new ContentDimensionValueSpecializationDepth($specializationDepths[$rawDimensionValue] ?? 0),
@@ -81,10 +78,7 @@ final readonly class GherkinTableNodeBasedContentDimensionSource implements Cont
                 $variationEdges[] = new ContentDimensionValueVariationEdge($dimensionValues[$rawSpecializationValue], $dimensionValues[$rawGeneralizationValue]);
             }
 
-            $dimensionConfiguration = $configuration;
-            if (array_key_exists('values', $dimensionConfiguration)) {
-                unset($dimensionConfiguration['values']);
-            }
+            $dimensionConfiguration = [];
             /** @var string $dimensionId */
             $dimensionId = $row['Identifier'];
             $dimensions[$dimensionId] = new ContentDimension(

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/GherkinTableNodeBasedContentDimensionSource.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/Helpers/GherkinTableNodeBasedContentDimensionSource.php
@@ -52,6 +52,9 @@ final readonly class GherkinTableNodeBasedContentDimensionSource implements Cont
             $specializationDepths = [];
             $dimensionValues = [];
             $variationEdges = [];
+            $configuration = array_key_exists('Configuration', $row)
+                ? \json_decode($row['Configuration'], true, 512, JSON_THROW_ON_ERROR)
+                : [];
             foreach (Arrays::trimExplode(',', $row['Generalizations']) as $variationExpression) {
                 $currentGeneralization = null;
                 foreach (array_reverse(Arrays::trimExplode('->', $variationExpression)) as $specializationDepth => $rawDimensionValue) {
@@ -65,7 +68,7 @@ final readonly class GherkinTableNodeBasedContentDimensionSource implements Cont
 
             foreach (Arrays::trimExplode(',', $row['Values']) as $rawDimensionValue) {
                 /** @var string $rawDimensionValue */
-                $dimensionValueConfiguration = [];
+                $dimensionValueConfiguration = $configuration['values'][$rawDimensionValue] ?? [];
                 $dimensionValues[$rawDimensionValue] = new ContentDimensionValue(
                     $rawDimensionValue,
                     new ContentDimensionValueSpecializationDepth($specializationDepths[$rawDimensionValue] ?? 0),
@@ -78,7 +81,10 @@ final readonly class GherkinTableNodeBasedContentDimensionSource implements Cont
                 $variationEdges[] = new ContentDimensionValueVariationEdge($dimensionValues[$rawSpecializationValue], $dimensionValues[$rawGeneralizationValue]);
             }
 
-            $dimensionConfiguration = [];
+            $dimensionConfiguration = $configuration;
+            if (array_key_exists('values', $dimensionConfiguration)) {
+                unset($dimensionConfiguration['values']);
+            }
             /** @var string $dimensionId */
             $dimensionId = $row['Identifier'];
             $dimensions[$dimensionId] = new ContentDimension(

--- a/Neos.ContentRepository.TestSuite/Tests/Unit/GherkinTableNodeBasedContentDimensionSourceTest.php
+++ b/Neos.ContentRepository.TestSuite/Tests/Unit/GherkinTableNodeBasedContentDimensionSourceTest.php
@@ -12,6 +12,7 @@ use Neos\ContentRepository\Core\Dimension\ContentDimensionValue;
 use Neos\ContentRepository\Core\Dimension\ContentDimensionValueSpecializationDepth;
 use Neos\ContentRepository\Core\Tests\Unit\Dimension\ConfigurationBasedContentDimensionSourceTest;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Helpers\GherkinTableNodeBasedContentDimensionSource;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
@@ -39,9 +40,9 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
          */
         // parsed gherkin table shape:
         $table = [
-            ['Identifier', 'Values'                   , 'Generalizations'   ],
-            ['dimensionA', 'valueA1,valueA1.1,valueA2', 'valueA1.1->valueA1'],
-            ['dimensionB', 'valueB1,valueB2,valueB3'  , ''                  ],
+            ['Identifier', 'Values'                   , 'Generalizations'   , 'Configuration'],
+            ['dimensionA', 'valueA1,valueA1.1,valueA2', 'valueA1.1->valueA1', '{"myDimensionAConfig": "valueA", "values": {"valueA1": {"myValueA1Config": "valueA1"}}}'],
+            ['dimensionB', 'valueB1,valueB2,valueB3'  , ''                  , '{"values": {"valueB2": {"myValueB2Config": "valueB2"}}}'],
         ];
         $this->subject = GherkinTableNodeBasedContentDimensionSource::fromGherkinTableNode(new TableNode($table));
     }
@@ -72,7 +73,9 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
                 'valueA1',
                 new ContentDimensionValueSpecializationDepth(0),
                 ContentDimensionConstraintSet::createEmpty(),
-                []
+                [
+                    'myValueA1Config' => 'valueA1'
+                ]
             ),
             $dimensionA->getValue('valueA1')
         );
@@ -103,7 +106,10 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
         $this->assertEquals(
             new ContentDimensionValue(
                 'valueB2',
-                new ContentDimensionValueSpecializationDepth(0)
+                new ContentDimensionValueSpecializationDepth(0),
+                configuration: [
+                    'myValueB2Config' => 'valueB2'
+                ]
             ),
             $dimensionB->getValue('valueB2')
         );
@@ -232,5 +238,16 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
             ContentDimensionConstraintSet::createEmpty(),
             $valueB3->constraints
         );
+    }
+
+    public function testConfigurationIsCorrectlyApplied(): void
+    {
+        $dimensionA = $this->subject->getDimension(new ContentDimensionId('dimensionA'));
+        $dimensionB = $this->subject->getDimension(new ContentDimensionId('dimensionB'));
+
+        Assert::assertSame(['myDimensionAConfig' => 'valueA'], $dimensionA->configuration);
+        Assert::assertSame(['myValueA1Config' => 'valueA1'], $dimensionA->getValue('valueA1')->configuration);
+        Assert::assertSame([], $dimensionB->configuration);
+        Assert::assertSame(['myValueB2Config' => 'valueB2'], $dimensionB->getValue('valueB2')->configuration);
     }
 }

--- a/Neos.ContentRepository.TestSuite/Tests/Unit/GherkinTableNodeBasedContentDimensionSourceTest.php
+++ b/Neos.ContentRepository.TestSuite/Tests/Unit/GherkinTableNodeBasedContentDimensionSourceTest.php
@@ -12,7 +12,6 @@ use Neos\ContentRepository\Core\Dimension\ContentDimensionValue;
 use Neos\ContentRepository\Core\Dimension\ContentDimensionValueSpecializationDepth;
 use Neos\ContentRepository\Core\Tests\Unit\Dimension\ConfigurationBasedContentDimensionSourceTest;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\Helpers\GherkinTableNodeBasedContentDimensionSource;
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
@@ -40,9 +39,9 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
          */
         // parsed gherkin table shape:
         $table = [
-            ['Identifier', 'Values'                   , 'Generalizations'   , 'Configuration'],
-            ['dimensionA', 'valueA1,valueA1.1,valueA2', 'valueA1.1->valueA1', '{"myDimensionAConfig": "valueA", "values": {"valueA1": {"myValueA1Config": "valueA1"}}}'],
-            ['dimensionB', 'valueB1,valueB2,valueB3'  , ''                  , '{"values": {"valueB2": {"myValueB2Config": "valueB2"}}}'],
+            ['Identifier', 'Values'                   , 'Generalizations'],
+            ['dimensionA', 'valueA1,valueA1.1,valueA2', 'valueA1.1->valueA1'],
+            ['dimensionB', 'valueB1,valueB2,valueB3'  , ''                  ],
         ];
         $this->subject = GherkinTableNodeBasedContentDimensionSource::fromGherkinTableNode(new TableNode($table));
     }
@@ -73,9 +72,7 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
                 'valueA1',
                 new ContentDimensionValueSpecializationDepth(0),
                 ContentDimensionConstraintSet::createEmpty(),
-                [
-                    'myValueA1Config' => 'valueA1'
-                ]
+                []
             ),
             $dimensionA->getValue('valueA1')
         );
@@ -106,10 +103,7 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
         $this->assertEquals(
             new ContentDimensionValue(
                 'valueB2',
-                new ContentDimensionValueSpecializationDepth(0),
-                configuration: [
-                    'myValueB2Config' => 'valueB2'
-                ]
+                new ContentDimensionValueSpecializationDepth(0)
             ),
             $dimensionB->getValue('valueB2')
         );
@@ -238,16 +232,5 @@ class GherkinTableNodeBasedContentDimensionSourceTest extends TestCase
             ContentDimensionConstraintSet::createEmpty(),
             $valueB3->constraints
         );
-    }
-
-    public function testConfigurationIsCorrectlyApplied(): void
-    {
-        $dimensionA = $this->subject->getDimension(new ContentDimensionId('dimensionA'));
-        $dimensionB = $this->subject->getDimension(new ContentDimensionId('dimensionB'));
-
-        Assert::assertSame(['myDimensionAConfig' => 'valueA'], $dimensionA->configuration);
-        Assert::assertSame(['myValueA1Config' => 'valueA1'], $dimensionA->getValue('valueA1')->configuration);
-        Assert::assertSame([], $dimensionB->configuration);
-        Assert::assertSame(['myValueB2Config' => 'valueB2'], $dimensionB->getValue('valueB2')->configuration);
     }
 }


### PR DESCRIPTION
The GherkinTableNodeBasedContentDimensionSource currently does not allow configuration values, which prevents tests from being written that need this.

~This adds an arbitrary amount of JSON that can be used as config for dimensions and dimension values~

This adds a new step which can be used as replacement:

```feature
Given using the following content dimensions yaml configuration:
"""yaml
language:
  label: 'Neos.Demo:Main:contentDimensions.language'
  icon: language
  values:
    'en_US':
      label: English (US)
      specializations:
        'en_UK':
          label: English (UK)
    'de':
      label: Deutsch
"""
```

**Upgrade instructions**

none

**Review instructions**

mainly check the JSON format

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the correct branch: I consider this a bug, so 9.0
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
