### PR TITLE
TASK: Finally remove `removalAttachmentPoint`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Command/RemoveNodeAggregate.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Command/RemoveNodeAggregate.php
@@ -32,11 +32,6 @@ final readonly class RemoveNodeAggregate implements
     RebasableToOtherWorkspaceInterface
 {
     /**
-     * @deprecated with Neos 9 Beta 19. Must not be specified any longer. Might get removed at any point. Only part of the command to handle rebasing legacy events.
-     */
-    public ?NodeAggregateId $removalAttachmentPoint;
-
-    /**
      * @param WorkspaceName $workspaceName The workspace in which the remove operation is to be performed
      * @param NodeAggregateId $nodeAggregateId The identifier of the node aggregate to remove
      * @param DimensionSpacePoint $coveredDimensionSpacePoint One of the dimension space points covered by the node aggregate in which the user intends to remove it
@@ -47,9 +42,7 @@ final readonly class RemoveNodeAggregate implements
         public NodeAggregateId $nodeAggregateId,
         public DimensionSpacePoint $coveredDimensionSpacePoint,
         public NodeVariantSelectionStrategy $nodeVariantSelectionStrategy,
-        ?NodeAggregateId $removalAttachmentPoint
     ) {
-        $this->removalAttachmentPoint = $removalAttachmentPoint;
     }
 
     /**
@@ -60,7 +53,7 @@ final readonly class RemoveNodeAggregate implements
      */
     public static function create(WorkspaceName $workspaceName, NodeAggregateId $nodeAggregateId, DimensionSpacePoint $coveredDimensionSpacePoint, NodeVariantSelectionStrategy $nodeVariantSelectionStrategy): self
     {
-        return new self($workspaceName, $nodeAggregateId, $coveredDimensionSpacePoint, $nodeVariantSelectionStrategy, null);
+        return new self($workspaceName, $nodeAggregateId, $coveredDimensionSpacePoint, $nodeVariantSelectionStrategy);
     }
 
     public static function fromArray(array $array): self
@@ -70,9 +63,6 @@ final readonly class RemoveNodeAggregate implements
             NodeAggregateId::fromString($array['nodeAggregateId']),
             DimensionSpacePoint::fromArray($array['coveredDimensionSpacePoint']),
             NodeVariantSelectionStrategy::from($array['nodeVariantSelectionStrategy']),
-            isset($array['removalAttachmentPoint'])
-                ? NodeAggregateId::fromString($array['removalAttachmentPoint'])
-                : null
         );
     }
 
@@ -92,7 +82,6 @@ final readonly class RemoveNodeAggregate implements
             $this->nodeAggregateId,
             $this->coveredDimensionSpacePoint,
             $this->nodeVariantSelectionStrategy,
-            $this->removalAttachmentPoint
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Event/NodeAggregateWasRemoved.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/Event/NodeAggregateWasRemoved.php
@@ -35,19 +35,12 @@ final readonly class NodeAggregateWasRemoved implements
     EmbedsNodeAggregateId,
     EmbedsWorkspaceName
 {
-    /**
-     * @deprecated with Neos 9 Beta 19. Must not be specified any longer. Might get removed at any point.
-     */
-    public ?NodeAggregateId $removalAttachmentPoint;
-
     public function __construct(
         public WorkspaceName $workspaceName,
         public ContentStreamId $contentStreamId,
         public NodeAggregateId $nodeAggregateId,
         public DimensionSpacePointSet $affectedCoveredDimensionSpacePoints,
-        ?NodeAggregateId $removalAttachmentPoint = null
     ) {
-        $this->removalAttachmentPoint = $removalAttachmentPoint;
     }
 
     public function getContentStreamId(): ContentStreamId
@@ -72,7 +65,6 @@ final readonly class NodeAggregateWasRemoved implements
             $contentStreamId,
             $this->nodeAggregateId,
             $this->affectedCoveredDimensionSpacePoints,
-            $this->removalAttachmentPoint
         );
     }
 
@@ -83,9 +75,6 @@ final readonly class NodeAggregateWasRemoved implements
             ContentStreamId::fromString($values['contentStreamId']),
             NodeAggregateId::fromString($values['nodeAggregateId']),
             DimensionSpacePointSet::fromArray($values['affectedCoveredDimensionSpacePoints']),
-            isset($values['removalAttachmentPoint'])
-                ? NodeAggregateId::fromString($values['removalAttachmentPoint'])
-                : null,
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/NodeRemoval.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/NodeRemoval.php
@@ -74,7 +74,6 @@ trait NodeRemoval
                     $nodeAggregate,
                     $this->getInterDimensionalVariationGraph()
                 ),
-                $command->removalAttachmentPoint
             )
         );
 

--- a/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
@@ -401,7 +401,7 @@ final class WorkspacePublishingService
             // A Change is publishable if the respective node has a closest ancestor that matches our
             // current ancestor scope (Document/Site)
             $actualAncestorNode = $subgraph->findClosestNode(
-                $change->getLegacyRemovalAttachmentPoint() ?? $change->nodeAggregateId,
+                $change->nodeAggregateId,
                 FindClosestNodeFilter::create(nodeTypes: $ancestorNodeTypeName->value)
             );
 

--- a/Neos.Neos/Classes/PendingChangesProjection/Change.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/Change.php
@@ -42,25 +42,7 @@ final class Change
         public bool $changed,
         public bool $moved,
         public bool $deleted,
-        private ?NodeAggregateId $removalAttachmentPoint = null
     ) {
-    }
-
-    /**
-     * Before soft removals the removalAttachmentPoint was metadata reached through from command to the final event.
-     *
-     * It stored the document node id of the removed node, as that was needed later for the change display and publication.
-     *
-     * See also https://github.com/neos/neos-development-collection/issues/4487
-     *
-     * We continue to have {@see RemoveNodeAggregate::$removalAttachmentPoint} and {@see NodeAggregateWasRemoved::$removalAttachmentPoint}
-     * in the core to allow publishing and rebasing the legacy removals as in previous betas.
-     *
-     * @deprecated with Neos 9 Beta 19, obsolete via soft removals. Might be removed at any point.
-     */
-    public function getLegacyRemovalAttachmentPoint(): ?NodeAggregateId
-    {
-        return $this->removalAttachmentPoint;
     }
 
     /**
@@ -79,7 +61,6 @@ final class Change
                 'changed' => (int)$this->changed,
                 'moved' => (int)$this->moved,
                 'deleted' => (int)$this->deleted,
-                $qi('removalAttachmentPoint') => $this->removalAttachmentPoint?->value
             ]);
         } catch (DbalException $e) {
             throw new \RuntimeException(sprintf('Failed to insert Change to database: %s', $e->getMessage()), 1727272723, $e);
@@ -97,7 +78,6 @@ final class Change
                     'changed' => (int)$this->changed,
                     'moved' => (int)$this->moved,
                     'deleted' => (int)$this->deleted,
-                    $qi('removalAttachmentPoint') => $this->removalAttachmentPoint?->value
                 ],
                 [
                     $qi('contentStreamId') => $this->contentStreamId->value,
@@ -125,9 +105,6 @@ final class Change
             (bool)$databaseRow['changed'],
             (bool)$databaseRow['moved'],
             (bool)$databaseRow['deleted'],
-            isset($databaseRow['removalAttachmentPoint'])
-                ? NodeAggregateId::fromString(self::binaryToString($databaseRow['removalAttachmentPoint']))
-                : null
         );
     }
 

--- a/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
+++ b/Neos.Neos/Classes/PendingChangesProjection/ChangeProjection.php
@@ -108,8 +108,6 @@ class ChangeProjection implements ProjectionInterface
             DbalSchemaFactory::columnForDimensionSpacePoint($connection->quoteIdentifier('originDimensionSpacePoint'), $platform)->setNotnull(false),
             DbalSchemaFactory::columnForDimensionSpacePointHash($connection->quoteIdentifier('originDimensionSpacePointHash'), $platform)->setNotnull(true),
             (new Column('deleted', Type::getType(Types::BOOLEAN)))->setNotnull(true),
-            // Despite the name suggesting this might be an anchor point of sorts, this is a nodeAggregateId type
-            DbalSchemaFactory::columnForNodeAggregateId($connection->quoteIdentifier('removalAttachmentPoint'), $platform)->setNotnull(false)
         ]);
 
         $changeTable->setPrimaryKey([
@@ -293,7 +291,6 @@ class ChangeProjection implements ProjectionInterface
                 changed: false,
                 moved: false,
                 deleted: true,
-                removalAttachmentPoint: $event->removalAttachmentPoint
             );
             $removalChange->addToDatabase($this->dbal, $this->tableNamePrefix);
         }


### PR DESCRIPTION
with soft-removal the removalAttachmentPoint became obsolete but was kept to allow beta-users to upgrade 2b45a2d

See also the issue for a complete history as to what happened.

https://github.com/neos/neos-development-collection/issues/4487

TLTR: It was planned to remove this, and we can safely do that now with 9.2 as its non-breaking

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
