### PR TITLE
TASK: Cleanup contract for content graph simulation and allow more diverse implementations

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -63,6 +63,7 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeTags;
+use Neos\ContentRepository\Core\Projection\ContentGraph\SimulationContentGraphProjectionInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Timestamps;
 use Neos\ContentRepository\Core\Projection\ProjectionStatus;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateClassification;
@@ -76,7 +77,7 @@ use Neos\EventStore\Model\EventEnvelope;
 /**
  * @internal but the graph projection is api
  */
-final class DoctrineDbalContentGraphProjection implements ContentGraphProjectionInterface
+final class DoctrineDbalContentGraphProjection implements ContentGraphProjectionInterface, SimulationContentGraphProjectionInterface
 {
     use ContentStream;
     use NodeMove;
@@ -93,7 +94,8 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         private readonly ProjectionContentGraph $projectionContentGraph,
         private readonly ContentGraphTableNames $tableNames,
         private readonly DimensionSpacePointsRepository $dimensionSpacePointsRepository,
-        private readonly ContentGraphReadModelInterface $contentGraphReadModel
+        private readonly ContentGraphReadModelAdapter $contentGraphReadModel,
+        private readonly bool $isInSimulation
     ) {
     }
 
@@ -186,19 +188,28 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         }
     }
 
-    public function inSimulation(\Closure $fn): mixed
+    public function stopSimulation(): void
     {
-        if ($this->dbal->isTransactionActive()) {
-            throw new \RuntimeException(sprintf('Invoking %s is not allowed to be invoked recursively. Current transaction nesting %d.', __FUNCTION__, $this->dbal->getTransactionNestingLevel()));
+        $this->dbal->rollBack();
+    }
+
+    public function withSimulation(): SimulationContentGraphProjectionInterface
+    {
+        if ($this->isInSimulation) {
+            throw new \RuntimeException('DBAL ContentGraph Projection is in simulation already', 1778705684);
         }
+
         $this->dbal->beginTransaction();
         $this->dbal->setRollbackOnly();
-        try {
-            return $fn();
-        } finally {
-            // unsets rollback only flag and allows the connection to work regular again
-            $this->dbal->rollBack();
-        }
+
+        return new self(
+            dbal: $this->dbal,
+            projectionContentGraph: $this->projectionContentGraph,
+            tableNames: $this->tableNames,
+            dimensionSpacePointsRepository: $this->dimensionSpacePointsRepository,
+            contentGraphReadModel: $this->contentGraphReadModel,
+            isInSimulation: true,
+        );
     }
 
     private function whenContentStreamWasClosed(ContentStreamWasClosed $event): void

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjectionFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjectionFactory.php
@@ -54,7 +54,8 @@ final class DoctrineDbalContentGraphProjectionFactory implements ContentGraphPro
             ),
             $tableNames,
             $dimensionSpacePointsRepository,
-            $contentGraphReadModel
+            $contentGraphReadModel,
+            isInSimulation: false
         );
     }
 }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
@@ -8,13 +8,14 @@ use Neos\ContentRepository\Core\EventStore\DecoratedEvent;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\EventNormalizer;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
+use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
 use Neos\ContentRepository\Core\Feature\RebaseableCommand;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\ConflictingEvents;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\ConflictingEvent;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\SimulationContentGraphProjectionInterface;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Helper\InMemoryEventStore;
-use Neos\EventStore\Model\Event\EventMetadata;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\Events;
 use Neos\EventStore\Model\EventStream\EventStreamInterface;
@@ -50,7 +51,7 @@ final class CommandSimulator
     private readonly InMemoryEventStore $inMemoryEventStore;
 
     public function __construct(
-        private readonly ContentGraphProjectionInterface $contentRepositoryProjection,
+        private readonly SimulationContentGraphProjectionInterface $simulatedContentGraphProjection,
         private readonly EventNormalizer $eventNormalizer,
         private readonly CommandBus $commandBus,
         private readonly WorkspaceName $workspaceNameToSimulateIn,
@@ -59,16 +60,9 @@ final class CommandSimulator
         $this->conflictingEvents = new ConflictingEvents();
     }
 
-    /**
-     * Start the simulation for the passed function which receives as argument the {@see handle} function.
-     *
-     * @template T
-     * @param callable(callable(RebaseableCommand): void): T $fn
-     * @return T the return value of $fn
-     */
-    public function run(callable $fn): mixed
+    public function close(): void
     {
-        return $this->contentRepositoryProjection->inSimulation(fn () => $fn($this->handle(...)));
+        $this->simulatedContentGraphProjection->stopSimulation();
     }
 
     /**
@@ -77,7 +71,7 @@ final class CommandSimulator
      * We will automatically copy given commands to the workspace this simulation
      * is running in to ensure consistency in the simulations constraint checks.
      */
-    private function handle(RebaseableCommand $rebaseableCommand): void
+    public function handle(RebaseableCommand $rebaseableCommand): void
     {
         // FIXME: Check if workspace already matches and skip this, e.g. $commandInWorkspace = $command->getWorkspaceName()->equals($this->workspaceNameToSimulateIn) ? $command : $command->createCopyForWorkspace($this->workspaceNameToSimulateIn);
         // when https://github.com/neos/neos-development-collection/pull/5298 is merged
@@ -122,6 +116,7 @@ final class CommandSimulator
         // because this is only used in memory during the partial publish or rebase operation; so it cannot be written to
         // concurrently.
         // HINT: We cannot use $eventsToPublish->expectedVersion, because this is based on the PERSISTENT event stream (having different numbers)
+        // Also as part of an optimization a graph adapter might choose to not update the content stream version as its irrelevant during simulation.
         $this->inMemoryEventStore->commit(
             $eventsToPublish->streamName,
             $normalizedEvents,
@@ -136,7 +131,10 @@ final class CommandSimulator
 
         foreach ($eventStream as $eventEnvelope) {
             $event = $this->eventNormalizer->denormalize($eventEnvelope->event);
-            $this->contentRepositoryProjection->apply($event, $eventEnvelope);
+            if (!$event instanceof PublishableToWorkspaceInterface) {
+                throw new \RuntimeException(sprintf('Fatal rebaseable command yielded non publishable event %s', $event::class), 1778750125);
+            }
+            $this->simulatedContentGraphProjection->apply($event, $eventEnvelope);
         }
     }
 

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
@@ -73,8 +73,6 @@ final class CommandSimulator
      */
     public function handle(RebaseableCommand $rebaseableCommand): void
     {
-        // FIXME: Check if workspace already matches and skip this, e.g. $commandInWorkspace = $command->getWorkspaceName()->equals($this->workspaceNameToSimulateIn) ? $command : $command->createCopyForWorkspace($this->workspaceNameToSimulateIn);
-        // when https://github.com/neos/neos-development-collection/pull/5298 is merged
         $commandInWorkspace = $rebaseableCommand->originalCommand->createCopyForWorkspace($this->workspaceNameToSimulateIn);
 
         try {

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulatorFactory.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulatorFactory.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\CommandHandler;
 
+use Neos\ContentRepository\Core\DimensionSpace\ContentDimensionZookeeper;
+use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
 use Neos\ContentRepository\Core\EventStore\EventNormalizer;
+use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\DimensionSpaceCommandHandler;
+use Neos\ContentRepository\Core\Feature\NodeAggregateCommandHandler;
+use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
+use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionInterface;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 
@@ -16,16 +22,37 @@ final readonly class CommandSimulatorFactory
     public function __construct(
         private ContentGraphProjectionInterface $contentRepositoryProjection,
         private EventNormalizer $eventNormalizer,
-        private CommandBus $commandBus
+        private NodeTypeManager $nodeTypeManager,
+        private ContentDimensionZookeeper $contentDimensionZookeeper,
+        private InterDimensionalVariationGraph $interDimensionalVariationGraph,
+        private PropertyConverter $propertyConverter,
     ) {
     }
 
     public function createSimulatorForWorkspace(WorkspaceName $workspaceNameToSimulateIn): CommandSimulator
     {
+        $simulatedContentGraphProjection = $this->contentRepositoryProjection->withSimulation();
+
+        $commandHandlingDependencies = new CommandHandlingDependencies($simulatedContentGraphProjection->getState());
+
+        $commandBusForRebaseableCommands = new CommandBus(
+            $commandHandlingDependencies,
+            new NodeAggregateCommandHandler(
+                $this->nodeTypeManager,
+                $this->contentDimensionZookeeper,
+                $this->interDimensionalVariationGraph,
+                $this->propertyConverter,
+            ),
+            new DimensionSpaceCommandHandler(
+                $this->interDimensionalVariationGraph,
+                $this->nodeTypeManager,
+            )
+        );
+
         return new CommandSimulator(
-            $this->contentRepositoryProjection,
+            $simulatedContentGraphProjection,
             $this->eventNormalizer,
-            $this->commandBus,
+            $commandBusForRebaseableCommands,
             $workspaceNameToSimulateIn,
         );
     }

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -149,6 +149,7 @@ final class ContentRepositoryFactory
         $commandHandlingDependencies = new CommandHandlingDependencies($contentGraphReadModel);
 
         // we dont need full recursion in rebase - e.g apply workspace commands - and thus we can use this set for simulation
+        // todo
         $commandBusForRebaseableCommands = new CommandBus(
             $commandHandlingDependencies,
             new NodeAggregateCommandHandler(
@@ -166,7 +167,10 @@ final class ContentRepositoryFactory
         $commandSimulatorFactory = new CommandSimulatorFactory(
             $this->contentGraphProjection,
             $this->eventNormalizer,
-            $commandBusForRebaseableCommands
+            $this->nodeTypeManager,
+            $this->contentDimensionZookeeper,
+            $this->interDimensionalVariationGraph,
+            $this->propertyConverter,
         );
 
         $publicCommandBus = $commandBusForRebaseableCommands->withAdditionalHandlers(

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -214,11 +214,13 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        foreach ($rebaseableCommands as $rebaseableCommand) {
-            $commandSimulator->handle($rebaseableCommand);
+        try {
+            foreach ($rebaseableCommands as $rebaseableCommand) {
+                $commandSimulator->handle($rebaseableCommand);
+            }
+        } finally {
+            $commandSimulator->close();
         }
-
-        $commandSimulator->close();
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = WorkspaceRebaseFailed::duringPublish($commandSimulator->getConflictingEvents());
@@ -382,11 +384,13 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        foreach ($rebaseableCommands as $rebaseableCommand) {
-            $commandSimulator->handle($rebaseableCommand);
+        try {
+            foreach ($rebaseableCommands as $rebaseableCommand) {
+                $commandSimulator->handle($rebaseableCommand);
+            }
+        } finally {
+            $commandSimulator->close();
         }
-
-        $commandSimulator->close();
 
         if (
             $command->rebaseErrorHandlingStrategy === RebaseErrorHandlingStrategy::STRATEGY_FAIL
@@ -469,15 +473,17 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        foreach ($matchingCommands as $matchingCommand) {
-            $commandSimulator->handle($matchingCommand);
+        try {
+            foreach ($matchingCommands as $matchingCommand) {
+                $commandSimulator->handle($matchingCommand);
+            }
+            $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
+            foreach ($remainingCommands as $remainingCommand) {
+                $commandSimulator->handle($remainingCommand);
+            }
+        } finally {
+            $commandSimulator->close();
         }
-        $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
-        foreach ($remainingCommands as $remainingCommand) {
-            $commandSimulator->handle($remainingCommand);
-        }
-
-        $commandSimulator->close();
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = match ($workspace->status) {
@@ -602,11 +608,13 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        foreach ($commandsToKeep as $matchingCommand) {
-            $commandSimulator->handle($matchingCommand);
+        try {
+            foreach ($commandsToKeep as $matchingCommand) {
+                $commandSimulator->handle($matchingCommand);
+            }
+        } finally {
+            $commandSimulator->close();
         }
-
-        $commandSimulator->close();
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = match ($workspace->status) {

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -214,13 +214,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $commandSimulator->run(
-            static function ($handle) use ($rebaseableCommands): void {
-                foreach ($rebaseableCommands as $rebaseableCommand) {
-                    $handle($rebaseableCommand);
-                }
-            }
-        );
+        foreach ($rebaseableCommands as $rebaseableCommand) {
+            $commandSimulator->handle($rebaseableCommand);
+        }
+
+        $commandSimulator->close();
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = WorkspaceRebaseFailed::duringPublish($commandSimulator->getConflictingEvents());
@@ -384,13 +382,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $commandSimulator->run(
-            static function ($handle) use ($rebaseableCommands): void {
-                foreach ($rebaseableCommands as $rebaseableCommand) {
-                    $handle($rebaseableCommand);
-                }
-            }
-        );
+        foreach ($rebaseableCommands as $rebaseableCommand) {
+            $commandSimulator->handle($rebaseableCommand);
+        }
+
+        $commandSimulator->close();
 
         if (
             $command->rebaseErrorHandlingStrategy === RebaseErrorHandlingStrategy::STRATEGY_FAIL
@@ -473,18 +469,15 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $highestSequenceNumberForMatching = $commandSimulator->run(
-            static function ($handle) use ($commandSimulator, $matchingCommands, $remainingCommands): SequenceNumber {
-                foreach ($matchingCommands as $matchingCommand) {
-                    $handle($matchingCommand);
-                }
-                $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
-                foreach ($remainingCommands as $remainingCommand) {
-                    $handle($remainingCommand);
-                }
-                return $highestSequenceNumberForMatching;
-            }
-        );
+        foreach ($matchingCommands as $matchingCommand) {
+            $commandSimulator->handle($matchingCommand);
+        }
+        $highestSequenceNumberForMatching = $commandSimulator->currentSequenceNumber();
+        foreach ($remainingCommands as $remainingCommand) {
+            $commandSimulator->handle($remainingCommand);
+        }
+
+        $commandSimulator->close();
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = match ($workspace->status) {
@@ -609,13 +602,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $commandSimulator = $this->commandSimulatorFactory->createSimulatorForWorkspace($baseWorkspace->workspaceName);
 
-        $commandSimulator->run(
-            static function ($handle) use ($commandsToKeep): void {
-                foreach ($commandsToKeep as $matchingCommand) {
-                    $handle($matchingCommand);
-                }
-            }
-        );
+        foreach ($commandsToKeep as $matchingCommand) {
+            $commandSimulator->handle($matchingCommand);
+        }
+
+        $commandSimulator->close();
 
         if ($commandSimulator->hasConflicts()) {
             $workspaceRebaseFailed = match ($workspace->status) {

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphProjectionInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphProjectionInterface.php
@@ -15,7 +15,7 @@ interface ContentGraphProjectionInterface extends ProjectionInterface
     public function getState(): ContentGraphReadModelInterface;
 
     /**
-     * Dedicated method for simulated rebasing
+     * Dedicated method for simulated rebasing TODO
      *
      * The implementation must ensure that the function passed is invoked
      * and that any changes via {@see ContentGraphProjectionInterface::apply()}
@@ -27,10 +27,6 @@ interface ContentGraphProjectionInterface extends ProjectionInterface
      * This is generally done by leveraging a transaction and rollback.
      *
      * Used to simulate commands for publishing: {@see \Neos\ContentRepository\Core\CommandHandler\CommandSimulator}
-     *
-     * @template T
-     * @param \Closure(): T $fn
-     * @return T the return value of $fn
      */
-    public function inSimulation(\Closure $fn): mixed;
+    public function withSimulation(): SimulationContentGraphProjectionInterface;
 }

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphProjectionInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphProjectionInterface.php
@@ -15,16 +15,9 @@ interface ContentGraphProjectionInterface extends ProjectionInterface
     public function getState(): ContentGraphReadModelInterface;
 
     /**
-     * Dedicated method for simulated rebasing TODO
+     * Dedicated method to initiate a simulated rebasing/publishing
      *
-     * The implementation must ensure that the function passed is invoked
-     * and that any changes via {@see ContentGraphProjectionInterface::apply()}
-     * are executed "in simulation" e.g. NOT persisted after returning.
-     *
-     * The projection state {@see ContentGraphReadModelInterface} must reflect the
-     * current changes of the simulation as well during the execution of the function.
-     *
-     * This is generally done by leveraging a transaction and rollback.
+     * Must be implemented as specified {@see SimulationContentGraphProjectionInterface}
      *
      * Used to simulate commands for publishing: {@see \Neos\ContentRepository\Core\CommandHandler\CommandSimulator}
      */

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/SimulationContentGraphProjectionInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/SimulationContentGraphProjectionInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Projection\ContentGraph;
+
+use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
+use Neos\EventStore\Model\EventEnvelope;
+
+interface SimulationContentGraphProjectionInterface
+{
+    public function getState(): ContentGraphReadModelInterface;
+
+    public function apply(PublishableToWorkspaceInterface $event, EventEnvelope $eventEnvelope): void;
+
+    public function stopSimulation(): void;
+}

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/SimulationContentGraphProjectionInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/SimulationContentGraphProjectionInterface.php
@@ -5,13 +5,41 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Projection\ContentGraph;
 
 use Neos\ContentRepository\Core\Feature\Common\PublishableToWorkspaceInterface;
+use Neos\ContentRepository\Core\Projection\ProjectionInterface;
 use Neos\EventStore\Model\EventEnvelope;
 
+/**
+ * Dedicated projection like interface for simulated rebasing/publishing
+ *
+ * The implementation must ensure that any changes via {@see self::apply()}
+ * are executed "in simulation" e.g. NOT persisted.
+ *
+ * This simulations projection state {@see ContentGraphReadModelInterface} must reflect the
+ * current changes of the simulation as well.
+ *
+ * After stopping the simulation {@see self::stopSimulation} no further methods are to be invoked.
+ *
+ * This is generally done by leveraging a transaction and rollback.
+ *
+ * This interface does not extend the {@see ProjectionInterface} wich defines setup, resetState and further as within
+ * simulation these methods are neither used nor allowed.
+ *
+ * Used to simulate commands for publishing: {@see \Neos\ContentRepository\Core\CommandHandler\CommandSimulator}
+ */
 interface SimulationContentGraphProjectionInterface
 {
+    /**
+     * Returns a read model which must be aware of any events applied in the simulation
+     */
     public function getState(): ContentGraphReadModelInterface;
 
+    /**
+     * Only events that are publishable are to be handled - no workspace was created or any other "global" events
+     */
     public function apply(PublishableToWorkspaceInterface $event, EventEnvelope $eventEnvelope): void;
 
+    /**
+     * Simulation can only be stopped but not further nested
+     */
     public function stopSimulation(): void;
 }


### PR DESCRIPTION

Currently the method `inSimulation()` which accepts a closure can sensibly only be implemented as transaction. And here its quite a stretch that the _earlier_ fetched `getState()` -> e.g. the content graph read-model must use the same transaction and be on the same state.

Now instead we specify a new `withSimulation()` method which is free to return a new implementation of that interface or in our case it could be the even the same instance or just a new flag set.

The experiments in

https://github.com/neos/neos-development-collection/pull/5826

Show that this can now be leveraged to use a new database connection or do more wild things like persisting the simulated state to prevent the transaction form becoming to huge.

Overall the new interface better conveys what can and is only allowed to happen within a so called simulation:

- only events that are publishable are to be handled - no workspace was created or any other "global" events
- simulation can only be stopped but not further nested
- the state can be fetched with `getState()` and here it is expected to get an instance which is aware of any new applied changes
- aside from that no other methods from a projection interface like resetState, setup or the like are allowed to be called or would make sense


TODO:
- [ ] figure out which version to target, bugfix would allow the postgresql adapter and other to be adjusted ONCE and be compatible after


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
