### PR TITLE
BUGFIX: Prevent unnecessary `updateContentStreamVersion()` updates within transaction simulation

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -85,8 +85,13 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     use SubtreeTagging;
     use Workspace;
 
-
     public const RELATION_DEFAULT_OFFSET = 128;
+
+    /**
+     * It's not particular pretty to add mutable state. A new api contract will allow a more elegant approach:
+     * {@see https://github.com/neos/neos-development-collection/pull/5837}
+     */
+    private bool $isInSimulation = false;
 
     public function __construct(
         private readonly Connection $dbal,
@@ -181,6 +186,10 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $event instanceof ContentStreamWasForked
                 || $event instanceof ContentStreamWasCreated
             )
+            // Optimizes unnecessary writes to the connection which can cause problems when trying to acquire a lock.
+            // During command simulation we don't use the content stream version, and thus we can ignore updating this value in the transaction.
+            // See also https://github.com/neos/neos-development-collection/issues/5713
+            && !$this->isInSimulation
         ) {
             $this->updateContentStreamVersion($event->getContentStreamId(), $eventEnvelope->version, $event instanceof PublishableToWorkspaceInterface);
         }
@@ -193,9 +202,11 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         }
         $this->dbal->beginTransaction();
         $this->dbal->setRollbackOnly();
+        $this->isInSimulation = true;
         try {
             return $fn();
         } finally {
+            $this->isInSimulation = false;
             // unsets rollback only flag and allows the connection to work regular again
             $this->dbal->rollBack();
         }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
@@ -122,6 +122,7 @@ final class CommandSimulator
         // because this is only used in memory during the partial publish or rebase operation; so it cannot be written to
         // concurrently.
         // HINT: We cannot use $eventsToPublish->expectedVersion, because this is based on the PERSISTENT event stream (having different numbers)
+        // Also as part of an optimization a graph adapter might choose to not update the content stream version as its irrelevant during simulation.
         $this->inMemoryEventStore->commit(
             $eventsToPublish->streamName,
             $normalizedEvents,


### PR DESCRIPTION

... depending on the database setup this can cause conflicts.

A local database with low latency does pass the parallel tests but mariadb docker-virtualised runs already slower and might fail - also in CI:

```
Class: Doctrine\DBAL\Exception\LockWaitTimeoutException
Message: An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction
Code: 1205
File: Packages/Libraries/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php
Line: 44

...
#4 Packages/Neos/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/ContentStream.php(62): Doctrine\DBAL\Connection->update('cr_test_paralle...', Array, Array)
...
```

For a full description of the error see  https://github.com/neos/neos-development-collection/issues/5713#issuecomment-4519261505

**Review instructions**

This change was part of the experiments in https://github.com/neos/neos-development-collection/pull/5825

And becomes especially relevant for 9.2 - the layers - where there is more load on this method - probably because forking will be too fast:)

See https://github.com/neos/neos-development-collection/pull/5776 and `WorkspacePublicationDuringWriting` test

Implementation detail: The new introduced state on the DoctrineDbalContentGraphProjection is not something i like to keep forever thus i have already prepared a refactoring - but this change is kept minimal to prevent it from being delayed: https://github.com/neos/neos-development-collection/pull/5837
