### PR TITLE
TASK: Guide devs to use correct behat step for singular command handling

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -350,11 +350,42 @@ trait GenericCommandExecutionAndEventPublication
     /**
      * @When the following :shortCommandName commands are executed:
      */
-    public function theFollowingCreateNodeAggregateWithNodeCommandsAreExecuted(string $shortCommandName, TableNode $table): void
+    public function theFollowingCommandsAreExecuted(string $shortCommandName, TableNode $table): void
     {
-        foreach ($table->getHash() as $row) {
+        $hash = $table->getHash();
+        if ($hash === []) {
+            Assert::fail(sprintf('Cannot handle %s without any arguments', $shortCommandName));
+        }
+        if (count($hash) === 1) {
+            $singleCommandArguments = $hash[0];
+            $joined = str_replace("\n", "\n    ", $this->prettyFormatCommandPayload($singleCommandArguments));
+
+            Assert::fail(<<<EOF
+            For single exececuted commands please use the simple version for readability:
+
+              And the command $shortCommandName is executed with payload:
+                $joined
+            
+            EOF);
+        }
+        foreach ($hash as $row) {
             $this->handleCommand(self::resolveShortCommandName($shortCommandName), $row);
         }
+    }
+
+    private function prettyFormatCommandPayload(array $commandArguments): string
+    {
+        $keys = ['Key', ...array_keys($commandArguments)];
+        $values = ['Value', ...array_map(
+            fn(string $value) => str_starts_with($value, '{') || str_starts_with($value, '[') ? $value : json_encode($value),
+            array_values($commandArguments)
+        )];
+        $maxKeyLength = max(array_map('strlen', $keys));
+        $maxValueLength = max(array_map('strlen', $values));
+
+        $concatenated = array_map(fn ($key, $value) => sprintf('| %s | %s |', str_pad($key, $maxKeyLength), str_pad($value, $maxValueLength)), $keys, $values);
+
+        return join("\n", $concatenated);
     }
 
     /**


### PR DESCRIPTION
Often we use the step to handle multiple node creations at the start.

Now when further creating a new node on is tempted to copy that step and use it with a single line ... because its easy

```
And the following CreateNodeAggregateWithNode commands are executed:
  | nodeAggregateId | parentNodeAggregateId | nodeTypeName                  | initialPropertyValues                                                | nodeName |
  | a2              | a                     | Neos.Neos:Test.DocumentType1  | {"uriPathSegment": "a2", "title": "Node a2"}                         | a2       |

```

But its not intended this way. Instead, the explicit creation should be used.

<img width="983" height="244" alt="image" src="https://github.com/user-attachments/assets/8a87ab5a-650f-4617-976f-fa0f90deeb86" />


```
And the command CreateNodeAggregateWithNode is executed with payload:                                                                                                                    
  | Key                   | Value                                        |                                                                                                               
  | nodeAggregateId       | "a2"                                         |                                                                                                               
  | parentNodeAggregateId | "a"                                          |                                                                                                               
  | nodeTypeName          | "Neos.Neos:Test.DocumentType1"               |                                                                                                               
  | initialPropertyValues | {"uriPathSegment": "a2", "title": "Node a2"} |                                                                                                               
  | nodeName              | "a2"                                         |                                                                                                               
```

Now we validate this and print helpful output to migrate the step. Also its not validated that empty is not allowed.

### Why?

I often manually pivot the rows which is especially frustrating because the single representation wants all fields in json and not simple strings.

Im not sure if its a good idea to emit an error as now a lot of our tests fail, but maybe as warning? Or if we dont like this at all ill write me just a shell script or sth^^ 

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
