### PR TITLE
BUGFIX: Vary (copy) node becomes enabled if disabled before

### DIFF
--- a/Neos.Neos/Classes/Controller/Service/NodesController.php
+++ b/Neos.Neos/Classes/Controller/Service/NodesController.php
@@ -16,19 +16,13 @@ namespace Neos\Neos\Controller\Service;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
-use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
-use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
 use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ContentGraph\AbsoluteNodePath;
-use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\ExpandedNodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTerm;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\SearchTerm\SearchTermMatcher;
-use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
-use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAddress;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -38,6 +32,7 @@ use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\FluidAdaptor\View\TemplateView;
 use Neos\Neos\Controller\BackendUserTranslationTrait;
+use Neos\Neos\Domain\Service\NodeDuplicationService;
 use Neos\Neos\Domain\Service\NodeTypeNameFactory;
 use Neos\Neos\FrontendRouting\SiteDetection\SiteDetectionResult;
 use Neos\Neos\Ui\Domain\Service\NodePropertyConverterService;
@@ -57,6 +52,12 @@ class NodesController extends ActionController
      * @var NodePropertyConverterService
      */
     protected $nodePropertyConverterService;
+
+    /**
+     * @Flow\Inject
+     * @var NodeDuplicationService
+     */
+    protected $nodeDuplicationService;
 
     /**
      * @Flow\Inject
@@ -286,7 +287,7 @@ class NodesController extends ActionController
         $targetSubgraph = $contentRepository->getContentSubgraph($workspaceName, $targetDimensionSpacePoint);
 
         if ($mode === 'adoptFromAnotherDimension' || $mode === 'adoptFromAnotherDimensionAndCopyContent') {
-            $this->adoptNodeAndParents(
+            $this->nodeDuplicationService->adoptNodeAndParents(
                 $workspaceName,
                 $nodeAggregateId,
                 $sourceSubgraph,
@@ -351,114 +352,6 @@ class NodesController extends ActionController
                     );
                 }
             }
-        }
-    }
-
-    /**
-     * Adopt (translate) the given node and parents that are not yet visible to the given context
-     *
-     * @param WorkspaceName $workspaceName
-     * @param NodeAggregateId $nodeAggregateId
-     * @param ContentSubgraphInterface $sourceSubgraph
-     * @param ContentSubgraphInterface $targetSubgraph
-     * @param DimensionSpacePoint $targetDimensionSpacePoint
-     * @param ContentRepository $contentRepository
-     * @param boolean $copyContent true if the content from the nodes that are translated should be copied
-     * @return void
-     */
-    protected function adoptNodeAndParents(
-        WorkspaceName $workspaceName,
-        NodeAggregateId $nodeAggregateId,
-        ContentSubgraphInterface $sourceSubgraph,
-        ContentSubgraphInterface $targetSubgraph,
-        DimensionSpacePoint $targetDimensionSpacePoint,
-        ContentRepository $contentRepository,
-        bool $copyContent
-    ): void {
-        $identifiersFromRootlineToTranslate = [];
-        while (
-            $nodeAggregateId
-            && $targetSubgraph->findNodeById($nodeAggregateId) === null
-        ) {
-            $identifiersFromRootlineToTranslate[] = $nodeAggregateId;
-            $nodeAggregateId = $sourceSubgraph->findParentNode($nodeAggregateId)
-                ?->aggregateId;
-        }
-        // $identifiersFromRootlineToTranslate is now bottom-to-top; so we need to reverse
-        // them to know what we need to create.
-        // TODO: TEST THAT AUTO CREATED CHILD NODES WORK (though this should not have influence)
-
-        foreach (array_reverse($identifiersFromRootlineToTranslate) as $identifier) {
-            assert($identifier instanceof NodeAggregateId);
-            // NOTE: for creating node variants, we need to find the ORIGIN DSP
-            // of the source node (in order to unambiguously identify it);
-            // so we need to load it from the source subgraph
-            $sourceNode = $sourceSubgraph->findNodeById($identifier);
-            if (!$sourceNode) {
-                throw new \RuntimeException('Source node for Node Aggregate ID ' . $identifier->value
-                    . ' not found. This should never happen.', 1660905374);
-            }
-            $contentRepository->handle(
-                CreateNodeVariant::create(
-                    $workspaceName,
-                    $identifier,
-                    $sourceNode->originDimensionSpacePoint,
-                    OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
-                )
-            );
-
-            if ($copyContent === true) {
-                $contentNodeConstraint = NodeTypeCriteria::fromFilterString('!' . NodeTypeNameFactory::NAME_DOCUMENT);
-                $this->createNodeVariantsForChildNodes(
-                    $workspaceName,
-                    $identifier,
-                    $contentNodeConstraint,
-                    $sourceSubgraph,
-                    $targetSubgraph,
-                    $targetDimensionSpacePoint,
-                    $contentRepository
-                );
-            }
-        }
-    }
-
-    private function createNodeVariantsForChildNodes(
-        WorkspaceName $workspaceName,
-        NodeAggregateId $parentNodeId,
-        NodeTypeCriteria $constraints,
-        ContentSubgraphInterface $sourceSubgraph,
-        ContentSubgraphInterface $targetSubgraph,
-        DimensionSpacePoint $targetDimensionSpacePoint,
-        ContentRepository $contentRepository
-    ): void {
-        foreach (
-            $sourceSubgraph->findChildNodes(
-                $parentNodeId,
-                FindChildNodesFilter::create(nodeTypes: $constraints)
-            ) as $childNode
-        ) {
-            if ($childNode->classification->isRegular()) {
-                // Tethered nodes' variants are automatically created when the parent is translated.
-                // TODO: DOES THIS MAKE SENSE?
-                $contentRepository->handle(
-                    CreateNodeVariant::create(
-                        $workspaceName,
-                        $childNode->aggregateId,
-                        $childNode->originDimensionSpacePoint,
-                        OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
-                    )
-                );
-            }
-
-            $this->createNodeVariantsForChildNodes(
-                $workspaceName,
-                $childNode->aggregateId,
-                $constraints,
-                $sourceSubgraph,
-                $targetSubgraph,
-                $targetDimensionSpacePoint,
-                $contentRepository
-            );
         }
     }
 }

--- a/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\Neos\Domain\Service;
 
 use Neos\ContentRepository\Core\CommandHandler\Commands;
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
@@ -19,6 +20,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindReferencesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindSubtreeFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\References;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Subtree;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
@@ -33,6 +35,7 @@ use Neos\Neos\Domain\Exception\TetheredNodesCannotBePartiallyCopied;
 use Neos\Neos\Domain\Service\NodeDuplication\NodeAggregateIdMapping;
 use Neos\Neos\Domain\Service\NodeDuplication\TransientNodeCopy;
 use Neos\Neos\Domain\SubtreeTagging\NeosVisibilityConstraints;
+use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
 
 /**
  * Service to copy node recursively - as there is no equivalent content repository core command.
@@ -336,5 +339,137 @@ final class NodeDuplicationService
         }
 
         return NodeReferencesToWrite::fromArray($serializedReferences);
+    }
+
+    /**
+     * Adopt (translate) the given node and parents that are not yet visible to the given context
+     *
+     * @param WorkspaceName $workspaceName
+     * @param NodeAggregateId $nodeAggregateId
+     * @param ContentSubgraphInterface $sourceSubgraph
+     * @param ContentSubgraphInterface $targetSubgraph
+     * @param DimensionSpacePoint $targetDimensionSpacePoint
+     * @param ContentRepository $contentRepository
+     * @param boolean $copyContent true if the content from the nodes that are translated should be copied
+     * @return void
+     */
+    public function adoptNodeAndParents(
+        WorkspaceName $workspaceName,
+        NodeAggregateId $nodeAggregateId,
+        ContentSubgraphInterface $sourceSubgraph,
+        ContentSubgraphInterface $targetSubgraph,
+        DimensionSpacePoint $targetDimensionSpacePoint,
+        ContentRepository $contentRepository,
+        bool $copyContent
+    ): void {
+        $identifiersFromRootlineToTranslate = [];
+        while (
+            $nodeAggregateId
+            && $targetSubgraph->findNodeById($nodeAggregateId) === null
+        ) {
+            $identifiersFromRootlineToTranslate[] = $nodeAggregateId;
+            $nodeAggregateId = $sourceSubgraph->findParentNode($nodeAggregateId)
+                ?->aggregateId;
+        }
+        // $identifiersFromRootlineToTranslate is now bottom-to-top; so we need to reverse
+        // them to know what we need to create.
+        // TODO: TEST THAT AUTO CREATED CHILD NODES WORK (though this should not have influence)
+
+        foreach (array_reverse($identifiersFromRootlineToTranslate) as $identifier) {
+            assert($identifier instanceof NodeAggregateId);
+            // NOTE: for creating node variants, we need to find the ORIGIN DSP
+            // of the source node (in order to unambiguously identify it);
+            // so we need to load it from the source subgraph
+            $sourceNode = $sourceSubgraph->findNodeById($identifier);
+            if (!$sourceNode) {
+                throw new \RuntimeException('Source node for Node Aggregate ID ' . $identifier->value
+                    . ' not found. This should never happen.', 1660905374);
+            }
+            $contentRepository->handle(
+                CreateNodeVariant::create(
+                    $workspaceName,
+                    $identifier,
+                    $sourceNode->originDimensionSpacePoint,
+                    OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
+                )
+            );
+
+            foreach ($sourceNode->tags->withoutInherited() as $explicitTag) {
+                $contentRepository->handle(
+                    TagSubtree::create(
+                        $workspaceName,
+                        $identifier,
+                        $targetDimensionSpacePoint,
+                        NodeVariantSelectionStrategy::STRATEGY_ALL_VARIANTS,
+                        $explicitTag
+                    )
+                );
+            }
+
+            if ($copyContent === true) {
+                $contentNodeConstraint = NodeTypeCriteria::fromFilterString('!' . NodeTypeNameFactory::NAME_DOCUMENT);
+                $this->createNodeVariantsForChildNodes(
+                    $workspaceName,
+                    $identifier,
+                    $contentNodeConstraint,
+                    $sourceSubgraph,
+                    $targetSubgraph,
+                    $targetDimensionSpacePoint,
+                    $contentRepository
+                );
+            }
+        }
+    }
+
+    private function createNodeVariantsForChildNodes(
+        WorkspaceName $workspaceName,
+        NodeAggregateId $parentNodeId,
+        NodeTypeCriteria $constraints,
+        ContentSubgraphInterface $sourceSubgraph,
+        ContentSubgraphInterface $targetSubgraph,
+        DimensionSpacePoint $targetDimensionSpacePoint,
+        ContentRepository $contentRepository
+    ): void {
+        foreach (
+            $sourceSubgraph->findChildNodes(
+                $parentNodeId,
+                FindChildNodesFilter::create(nodeTypes: $constraints)
+            ) as $childNode
+        ) {
+            if ($childNode->classification->isRegular()) {
+                // Tethered nodes' variants are automatically created when the parent is translated.
+                // TODO: DOES THIS MAKE SENSE?
+                $contentRepository->handle(
+                    CreateNodeVariant::create(
+                        $workspaceName,
+                        $childNode->aggregateId,
+                        $childNode->originDimensionSpacePoint,
+                        OriginDimensionSpacePoint::fromDimensionSpacePoint($targetDimensionSpacePoint),
+                    )
+                );
+
+                foreach ($childNode->tags->withoutInherited() as $explicitTag) {
+                    $contentRepository->handle(
+                        TagSubtree::create(
+                            $workspaceName,
+                            $childNode->aggregateId,
+                            $targetDimensionSpacePoint,
+                            NodeVariantSelectionStrategy::STRATEGY_ALL_VARIANTS,
+                            $explicitTag
+                        )
+                    );
+                }
+            }
+
+            $this->createNodeVariantsForChildNodes(
+                $workspaceName,
+                $childNode->aggregateId,
+                $constraints,
+                $sourceSubgraph,
+                $targetSubgraph,
+                $targetDimensionSpacePoint,
+                $contentRepository
+            );
+        }
     }
 }

--- a/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
+++ b/Neos.Neos/Classes/Domain/Service/NodeDuplicationService.php
@@ -468,7 +468,7 @@ final class NodeDuplicationService
             );
         }
     }
-  
+
     private function filterPropertiesToWrite(ContentRepositoryId $contentRepositoryId, Node $node): PropertyValuesToWrite
     {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/NodeDuplicationTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/NodeDuplicationTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 use Behat\Gherkin\Node\TableNode;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -75,6 +76,47 @@ trait NodeDuplicationTrait
                 NodeAggregateId::fromString($commandArguments['targetParentNodeAggregateId']),
                 $targetSucceedingSiblingNodeAggregateId,
                 NodeAggregateIdMapping::fromArray($commandArguments['nodeAggregateIdMapping'] ?? [])
+            )
+        );
+    }
+
+    /**
+     * @When dimension variants are created recursively in :contentRepositoryId content repository with payload:
+     */
+    public function dimensionVariantsAreCreatedRecursivelyInContentRepositoryWithPayload(string $contentRepositoryId, TableNode $payloadTable): void
+    {
+        $commandArguments = $this->readPayloadTable($payloadTable);
+
+        $workspaceName = isset($commandArguments['workspaceName'])
+            ? WorkspaceName::fromString($commandArguments['workspaceName'])
+            : $this->currentWorkspaceName;
+
+        $nodeAggregateId = isset($commandArguments['nodeAggregateId'])
+            ? NodeAggregateId::fromString($commandArguments['nodeAggregateId'])
+            : null;
+    
+        $contentRepository = $this->getContentRepository(ContentRepositoryId::fromString($contentRepositoryId));
+
+        $sourceDimensionSpacePoint = isset($commandArguments['sourceDimensionSpacePoint'])
+            ? DimensionSpacePoint::fromArray($commandArguments['sourceDimensionSpacePoint'])
+            : $this->currentDimensionSpacePoint;
+
+        $sourceSubgraph = $contentRepository->getContentSubgraph($workspaceName, $sourceDimensionSpacePoint);
+
+        $targetDimensionSpacePoint = DimensionSpacePoint::fromArray($commandArguments['targetDimensionSpacePoint']);
+
+        $targetSubgraph = $contentRepository->getContentSubgraph($workspaceName, $targetDimensionSpacePoint);
+
+
+        $this->tryCatchingExceptions(
+            fn () => $this->getObject(NodeDuplicationService::class)->adoptNodeAndParents(
+                $workspaceName,
+                $nodeAggregateId,
+                $sourceSubgraph,
+                $targetSubgraph,
+                $targetDimensionSpacePoint,
+                $contentRepository,
+                (bool)$commandArguments['withContent']
             )
         );
     }

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_AcrossDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_AcrossDimensions.feature
@@ -1,0 +1,52 @@
+Feature: Copy nodes (without dimensions)
+
+  Background:
+    Given using no content dimensions
+    Given using the following content dimensions:
+      | Identifier | Values | Generalizations |
+      | language   | de, en |                 |
+    And using the following node types:
+    """yaml
+    'Neos.ContentRepository.Testing:Document': {}
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+
+    And I am in workspace "live" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                         | Value                                     |
+      | workspaceName               | "live"                                    |
+      | nodeAggregateId             | "sir-david-nodenborough"                  |
+      | nodeTypeName                | "Neos.ContentRepository.Testing:Document" |
+      | originDimensionSpacePoint   | {"language":"de"}                         |
+      | parentNodeAggregateId       | "lady-eleonode-rootford"                  |
+
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value                      |
+      | nodeAggregateId              | "sir-david-nodenborough"   |
+      | coveredDimensionSpacePoint   | {"language":"de"}          |
+      | nodeVariantSelectionStrategy | "allSpecializations"       |
+
+  Scenario: Simple node aggregate is copied across dimmensions
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    When copy nodes recursively is executed with payload:
+      | Key                                    | Value                                                     |
+      | sourceDimensionSpacePoint              | {"language":"de"}                                         |
+      | sourceNodeAggregateId                  | "sir-david-nodenborough"                                  |
+      | targetDimensionSpacePoint              | {"language":"en"}                                         |
+      | targetParentNodeAggregateId            | "lady-eleonode-rootford"                                  |
+      | targetSucceedingSiblingnodeAggregateId | null                                                      |
+      | nodeAggregateIdMapping                 | {"sir-david-nodenborough": "sir-david-nodenborough-copy"} |
+
+    When I am in workspace "live" and dimension space point {"language":"en"}
+    Then I expect node aggregate identifier "sir-david-nodenborough-copy" to lead to node cs-identifier;sir-david-nodenborough-copy;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged "disabled"

--- a/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_AcrossDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentRepository/NodeCopying/CopyNode_AcrossDimensions.feature
@@ -36,6 +36,28 @@ Feature: Copy nodes (without dimensions)
       | coveredDimensionSpacePoint   | {"language":"de"}          |
       | nodeVariantSelectionStrategy | "allSpecializations"       |
 
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                         | Value                                     |
+      | workspaceName               | "live"                                    |
+      | nodeAggregateId             | "nody-mc-nodeface"                        |
+      | nodeTypeName                | "Neos.ContentRepository.Testing:Document" |
+      | originDimensionSpacePoint   | {"language":"de"}                         |
+      | parentNodeAggregateId       | "lady-eleonode-rootford"                  |
+
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                         | Value                                     |
+      | workspaceName               | "live"                                    |
+      | nodeAggregateId             | "node-wan-kenody"                         |
+      | nodeTypeName                | "Neos.ContentRepository.Testing:Document" |
+      | originDimensionSpacePoint   | {"language":"de"}                         |
+      | parentNodeAggregateId       | "nody-mc-nodeface"                        |
+
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value                      |
+      | nodeAggregateId              | "node-wan-kenody"          |
+      | coveredDimensionSpacePoint   | {"language":"de"}          |
+      | nodeVariantSelectionStrategy | "allSpecializations"       |
+
   Scenario: Simple node aggregate is copied across dimmensions
     When I am in workspace "live" and dimension space point {"language":"de"}
     When copy nodes recursively is executed with payload:
@@ -49,4 +71,28 @@ Feature: Copy nodes (without dimensions)
 
     When I am in workspace "live" and dimension space point {"language":"en"}
     Then I expect node aggregate identifier "sir-david-nodenborough-copy" to lead to node cs-identifier;sir-david-nodenborough-copy;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+
+  Scenario: Simple node aggregate variant is recursively created in another dimension
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    When dimension variants are created recursively in "default" content repository with payload:
+      | Key                        | Value                     |
+      | nodeAggregateId            | "sir-david-nodenborough"  |
+      | targetDimensionSpacePoint  | {"language":"en"}         |
+      | withContent                | false                     |
+
+    When I am in workspace "live" and dimension space point {"language":"en"}
+    Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"language":"en"}
+    And I expect this node to be exactly explicitly tagged "disabled"
+
+  Scenario: Simple node aggregate variant is recursively created in another dimension with content
+    When I am in workspace "live" and dimension space point {"language":"de"}
+    When dimension variants are created recursively in "default" content repository with payload:
+      | Key                        | Value               |
+      | nodeAggregateId            | "nody-mc-nodeface"  |
+      | targetDimensionSpacePoint  | {"language":"en"}   |
+      | withContent                | true                |
+
+    When I am in workspace "live" and dimension space point {"language":"en"}
+    Then I expect node aggregate identifier "node-wan-kenody" to lead to node cs-identifier;node-wan-kenody;{"language":"en"}
     And I expect this node to be exactly explicitly tagged "disabled"


### PR DESCRIPTION
BUGFIX: Add Test to check if node copied across dimensions stays hidden
BUGFIX: Extract Node Variant creation to Node Duplication Service and add handling for tags of duplicated node
TASK: Add Tests for node aggregate variation creation across dimensions and ensure tags are kept for node and node children

FIXES: #5595 