### PR TITLE
TASK: Fix typos and grammar mistakes in documentation

### DIFF
--- a/Neos.Fusion.Afx/README.md
+++ b/Neos.Fusion.Afx/README.md
@@ -5,7 +5,7 @@
 __This repository is a **read-only subsplit** of a package that is part of the Neos project (learn more on `www.neos.io <https://www.neos.io/>`_).__
 
 This package provides a fusion preprocessor that expands a compact xml-ish syntax to pure fusion code. This allows
-to write compact components that do'nt need a seperate template file and enables unplanned extensibility for the defined
+to write compact components that don't need a separate template file and enables unplanned extensibility for the defined
 prototypes because the generated fusion-code can be overwritten and controlled from the outside if needed.
 
 ## Installation
@@ -40,7 +40,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
 }
 ```
 
-Will be transpiled, parsed and then cached and evaluated as beeing equivalent to the following fusion-code
+Will be transpiled, parsed and then cached and evaluated as being equivalent to the following fusion-code
 
 ```
 prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
@@ -73,7 +73,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
 
 ## AFX Language Rules
 
-All whitepaces around the outer elements are ignored. Whitepaces that are connected to a newline are considered irrelevant and are ignored.
+All whitespaces around the outer elements are ignored. Whitespaces that are connected to a newline are considered irrelevant and are ignored.
 
 ### HTML-Tags (Tags without Namespace)
 
@@ -209,8 +209,8 @@ Neos.Fusion:Tag {
 }
 ```
 
-The `@key`-property of tag-children inside alters the name of the fusion-attribute to recive render the array-child into.
-If no `@key`-property is given `index_x` is used starting by `x=1`.
+The `@key`-property of a tag-child sets the name of the fusion property the child is rendered into.
+If no `@key`-property is given `index_x` is used starting at `x=1`.
 
 ```
 <Vendor.Site:Prototype @children="text">
@@ -235,7 +235,7 @@ Vendor.Site:Prototype {
 ```
 
 The `@path`-property of tag-children can be used to render a specific afx-child into the given fusion path
-instead of beeing included into the `content`. This allows to render AFX children into different props and
+instead of being included into the `content`. This allows to render AFX children into different props and
 to assign Fusion-prototypes to props.
 
 ```
@@ -263,13 +263,13 @@ Vendor.Site:Prototype {
 In general all meta-attributes start with an @-sign.
 
 The `@path`-attribute can be used to render a child node directly into the given path below the parent Fusion:Object
-instead of beeing included into the `content` property.
+instead of being included into the `content` property.
 
 The `@children`-attribute defined the property that is used to render the content/children of the current tag into.
 The default property name for the children is `content`.
 
 The `@key`-attribute can be used to define the property name of an item among its siblings if an array is rendered.
-If no `@key` is defined `index_x` is used starting at `x=1.
+If no `@key` is defined `index_x` is used starting at `x=1`.
 
 Attention: `@path`, `@children` and `@key` only support string-values and no expressions.
 
@@ -339,7 +339,7 @@ Neos.Fusion:Tag {
 ```
 ### HTML Comments
 
-AFX accepts html comments but they are not transpiled to any fusion. However if you are converting html to afx it is allowed to have comments inside and you can use comments for disabeling parts of your afx during testing.
+AFX accepts html comments but they are not transpiled to fusion. However if you are converting html to afx it is allowed to have comments inside and you can use comments for disabling parts of your afx during testing.
 
 ```
 foo<!-- comment -->bar
@@ -356,7 +356,7 @@ Neos.Fusion:Join {
 
 ### Rendering of Collections with `Neos.Fusion:Collection`
 
-For rendering of lists or menus a presentational-component usually will recieve arrays of
+For rendering of lists or menus a presentational-component usually will receive arrays of
 preprocessed data as prop. To iterate over such an array the `Neos.Fusion:Collection`
 can be used in afx.
 

--- a/Neos.Media/Classes/Validator/ImageOrientationValidator.php
+++ b/Neos.Media/Classes/Validator/ImageOrientationValidator.php
@@ -18,7 +18,7 @@ use Neos\Media\Domain\Model\ImageInterface;
 /**
  * Validator that checks the orientation (square, portrait, landscape) of a given image.
  *
- * Supported validator options are (array)allowedOrientations with one or two out of 'square', 'landcape' or 'portrait'.
+ * Supported validator options are (array)allowedOrientations with one or two out of 'square', 'landscape' or 'portrait'.
  *
  * *Example*::
  *
@@ -33,7 +33,7 @@ class ImageOrientationValidator extends \Neos\Flow\Validation\Validator\Abstract
      * @var array
      */
     protected $supportedOptions = [
-        'allowedOrientations' => [[], 'Array of image orientations, one or two out of \'square\', \'landcape\' or \'portrait\'', 'array', true]
+        'allowedOrientations' => [[], 'Array of image orientations, one or two out of \'square\', \'landscape\' or \'portrait\'', 'array', true]
     ];
 
     /**

--- a/Neos.Media/Documentation/ConfigureImageGeneration.rst
+++ b/Neos.Media/Documentation/ConfigureImageGeneration.rst
@@ -44,8 +44,8 @@ If you have configured a Imagine driver that support alternative filter (this th
           defaultOptions:
             resizeFilter: '%\Imagine\Image\ImageInterface::FILTER_UNDEFINED%'
 
-Unfortunatly Gd does not support other filter than the default one. Good candidate can be FILTER_BOX or FILTER_CATROOM. You can check the documentation of your image driver for
-more informations about each filter. Check the \Imagine\Image\ImageInterface to know with filter are supported by Imagine.
+Unfortunately Gd does not support other filters than the default one. A good candidate can be FILTER_BOX or FILTER_CATROOM. You can check the documentation of your image driver for
+more information about each filter. Check the \Imagine\Image\ImageInterface to learn which filters are supported by Imagine.
 
 Produce interlaced images
 =========================

--- a/Neos.Media/Documentation/ThumbnailGenerator/Configuration.rst
+++ b/Neos.Media/Documentation/ThumbnailGenerator/Configuration.rst
@@ -5,15 +5,15 @@ Configuration
 How to configure Generator Priority
 ===================================
 
-In some cases, you need to replace the current Generator by your own implementation or for exemple to replace
-the PDF Thumbnail Generator by the Icon Generator for a specific project.
+In some cases, you might need to replace the current Generator with an alternative implementation. For example, you may want to replace
+the PDF Thumbnail Generator with the Icon Generator.
 
-You can do that by configuring each Generator priority.
+You may achieve this by configuring each Generator's priority.
 
 Change the priority of an existing Generator
 --------------------------------------------
 
-You can change the priority (higher is better) for an existing Generator, by editing you ``Settings.yaml``::
+You may change the priority (highest takes precedence) for an existing Generator, by editing your ``Settings.yaml``::
 
     Neos:
       Media:

--- a/Neos.Neos/Documentation/Contribute/Documentation/BeginnersGuide.rst
+++ b/Neos.Neos/Documentation/Contribute/Documentation/BeginnersGuide.rst
@@ -10,15 +10,15 @@ Contribute to the Neos-Documentation
 ====================================
 
 This Documentation aims to get you started quite from the ground up.
-A lot of explainations here can of cause be used to work on the whole repository, it just seems
+A lot of explanations here can of course be used to work on the whole repository, it just seems
 to be a good starting point to explain the workflow concerning the documentation first.
 
 Imagine you would like to contribute to the Documentation but you haven't worked with github yet,
-you don't know how a proper workflow looks like and you are not sure how to start contributing.
+you don't know what a proper workflow looks like and you are not sure how to start contributing.
 The problem is, that even while explaining some of the basic steps, there always is the need for
-some kind of basic setup you will have to take care of yourself. You can of cause commit by using
+some kind of basic setup you will have to take care of yourself. You can of course commit by using
 GitHub itself. The aim of this document is focusing on working with git locally.
-You need for eg. a Linux Console and git to get started. [#f1]_
+You need a Linux Console and git to get started. [#f1]_
 
 
 What are the goals?
@@ -94,7 +94,7 @@ Start with one of the following codes:
   Anything not covered by the above categories, e.g. coding style cleanup or documentation changes. Usually only used if there’s no corresponding ticket.
 
   SECURITY
-  A security related change. Those are only commited by active team members in the security community of practice.
+  A security related change. Those are only committed by active team members in the security community of practice.
 
   MERGE
   Used for a branch upmerges by the team (or CI server) not something you usually would need to use.
@@ -109,9 +109,9 @@ If there is more to say about a change add a new paragraph with background infor
 In case of breaking changes give a hint on what needs to be changed by the user.
 If corresponding tickets exist, mention the ticket number(s) using footer lines after another blank line and use the following actions:
 
-<issue number> #close Some additional info if needed If the change resolves a ticket by fixing a bug, implemeting a feature or doing a task.
+<issue number> #close Some additional info if needed If the change resolves a ticket by fixing a bug, implementing a feature or doing a task.
 <issue number> #comment Some info why this is related If the change relates to an issue but does not resolve or fix it.
-This follows Jiras smart commit footers, see more details in the Jira documentation3
+This follows Jira's smart commit footers, see more details in the Jira documentation.
 
 A commit messages following the rules...:
 
@@ -313,7 +313,7 @@ reStructuredText (rST)
 Now you can start improving the documentation. If you haven't worked with reStructuredText (rST)
 it's pretty simple and gives you quite some options. Just have a look at the Documentation files
 available, they give you a good understanding of what is possible. It has a lot of capabilities.
-Checkout their documentation for more informations `Sphinx docs`_.
+Check out their documentation for more information `Sphinx docs`_.
 
 .. _Sphinx docs: http://www.sphinx-doc.org/en/stable/rest.html
 
@@ -326,7 +326,7 @@ what still needs to be done...
 .. note::
   Every following line which is indented by two spaces now, is part of the note.
   If you would replace it with todo instead of (*.. note::* -> *.. todo::*), it wouldn't be
-  visible in the frontend/browser anymore, but just just visible for you and others, when editing these files.
+  visible in the frontend/browser anymore, but just visible for you and others, when editing these files.
 
   There is also the possibility to see all the todos with its positions by putting *.. todolist::* into the document.
   Both features (the todo itself and their collection) can be made visible in the browser

--- a/Neos.Neos/Documentation/Operations/index.rst
+++ b/Neos.Neos/Documentation/Operations/index.rst
@@ -1,7 +1,7 @@
 Neos Operations
 ===============
 
-.. all kind of Informations regarding the Installation, Deployment, Maintenance and Optimization of Neos.
+.. all kind of information regarding the installation, deployment, maintenance and optimization of Neos.
 
 .. toctree::
 	:maxdepth: 2

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -58,7 +58,7 @@ other named element, using ``before`` and ``after`` syntax as follows:
   ``after [namedElement]`` statements exist. Statements without ``[optionalPriority]``
   are added farthest after the element.
 
-  If ``[namedElement]`` does not exist, the element is added before all all ``end`` positions.
+  If ``[namedElement]`` does not exist, the element is added before all ``end`` positions.
 
 Example Ordering::
 
@@ -675,7 +675,7 @@ Neos.Fusion:ActionUri
 
 Built a URI to a controller action
 
-:request: (ActionRequest, defaults to the the current ``request``) The action request the uri is build from.
+:request: (ActionRequest, defaults to the current ``request``) The action request the uri is build from.
 :package: (string) The package key (e.g. ``'My.Package'``)
 :subpackage: (string) The subpackage, empty by default
 :controller: (string) The controller name (e.g. ``'Registration'``)
@@ -1125,7 +1125,7 @@ Render a menu with items for nodes. Extends :ref:`Neos_Fusion__Template`.
 :current.attributes: (:ref:`Neos_Fusion__Attributes`) Attributes for current state
 
 .. note:: The ``items`` of the ``Menu`` are internally calculated with the prototype :ref:`Neos_Neos__MenuItems` which
-   you can use directly aswell.
+   you can use directly as well.
 
 Menu item properties:
 ^^^^^^^^^^^^^^^^^^^^^
@@ -1182,7 +1182,7 @@ Example::
 	breadcrumb = Neos.Neos:BreadcrumbMenu
 
 .. note:: The ``items`` of the ``BreadcrumbMenu`` are internally calculated with the prototype :ref:`Neos_Neos__MenuItems` which
-   you can use directly aswell.
+   you can use directly as well.
 
 .. _Neos_Neos__DimensionMenu:
 .. _Neos_Neos__DimensionsMenu:
@@ -1201,7 +1201,7 @@ If no node variant exists for the preset combination, a ``NULL`` node will be in
 :dimension: (optional, string): name of the dimension which this menu should be based on. Example: "language".
 :presets: (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
 :includeAllPresets: (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
-:renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
+:renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidden-in-index"
 
 In the template for the menu, each ``item`` has the following properties:
 
@@ -1215,7 +1215,7 @@ In the template for the menu, each ``item`` has the following properties:
 .. note:: The ``DimensionMenu`` is an alias to ``DimensionsMenu``, available for compatibility reasons only.
 
 .. note:: The ``items`` of the ``DimensionsMenu`` are internally calculated with the prototype :ref:`Neos_Neos__DimensionsMenuItems` which
-   you can use directly aswell.
+   you can use directly as well.
 
 Examples
 ^^^^^^^^
@@ -1362,7 +1362,7 @@ If no node variant exists for the preset combination, a ``NULL`` node will be in
 :dimension: (optional, string): name of the dimension which this menu should be based on. Example: "language".
 :presets: (optional, array): If set, the presets rendered will be taken from this list of preset identifiers
 :includeAllPresets: (boolean, default **false**) If TRUE, include all presets, not only allowed combinations
-:renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
+:renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidden-in-index"
 
 Each ``item`` has the following properties:
 
@@ -1573,7 +1573,7 @@ Neos.Neos:ContentElementEditable
 
 Processor to augment an HTML tag with metadata for inline editing to make a rendered representation of a property editable.
 
-The processor expects beeing applied to an HTML tag with the content of the edited property.
+The processor expects being applied to an HTML tag with the content of the edited property.
 
 :node: (Node) The node of the content element. Optional, will use the Fusion context variable ``node`` by default.
 :property: (string) Node property that should be editable

--- a/Neos.Neos/Documentation/References/NodeMigrations.rst
+++ b/Neos.Neos/Documentation/References/NodeMigrations.rst
@@ -169,7 +169,7 @@ This would prefix existing value and then apply search/replace on the result:
         search: 'something'
         replace: 'something else'
 
-And in case your value contains the magic string "{current}" and you need to leav it intact, this would prefix the existing
+And in case your value contains the magic string "{current}" and you need to leave it intact, this would prefix the existing
 value but use a different placeholder:
 
 .. code-block:: yaml

--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -110,7 +110,7 @@ The following options are allowed for defining a NodeType:
 
       If ``options.fusion.prototypeGenerator`` is set to ``null`` no prototype is created for this type.
 
-      By default Neos has generators for all nodes of type ``Neos.Neos:Node`` and creates protoypes based on
+      By default Neos has generators for all nodes of type ``Neos.Neos:Node`` and creates prototypes based on
       ``Neos.Fusion:Template``. A template path is assumed based on the package-prefix and the nodetype-name. All properties
       of the node are passed to the template. For the nodeTypes of type ``Neos.Neos:Document``, ``Neos.Neos:Content`` and
       ``Neos.Neos:Plugin`` the corresponding prototype is used as base-prototype.
@@ -251,7 +251,7 @@ The following options are allowed for defining a NodeType:
         The human-readable label for this view
 
       ``group``
-        Identifier of the *inspector group* this view is categorized into in the content editing user interface. If none is given, the view is not visibile in the property inspector of the user interface.
+        Identifier of the *inspector group* this view is categorized into in the content editing user interface. If none is given, the view is not visible in the property inspector of the user interface.
 
         The value here must reference a group configured in the ``ui.inspector.groups`` element of the node type this view belongs to.
 


### PR DESCRIPTION
Hi!

I tried to fix as many typos and grammar mistakes as I could (within reasonable time). There are still many other mistakes but I needed to call it done. I used cspell, Claude and regular expressions (`\b(\w+)\s\1\b`) to find them. Note that I did not use Claude to generate new text.

**Upgrade instructions**

n/a

**Review instructions**

I picked 9.2 as the base (not 8.3, as instructed) simply because that's where I started working before coming across that requirement. I also didn't generate the docs because I assume that is done by your pipeline. Please let me know if I should cherry-pick my changes to an 8.3 based branch.

**Checklist**

- [~] Code follows the PSR-2 coding style
- [~] Tests have been created, run and adjusted as needed
- [~] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
