### PR TITLE
BUGFIX: Neos.Neos:Site add label and icon

### DIFF
--- a/Neos.Neos/NodeTypes/Root/Sites.yaml
+++ b/Neos.Neos/NodeTypes/Root/Sites.yaml
@@ -11,4 +11,4 @@
       'Neos.Neos:Site': true
   ui:
     label: i18n
-    icon: 'globe'
+    icon: 'circle-dot'

--- a/Neos.Neos/NodeTypes/Root/Sites.yaml
+++ b/Neos.Neos/NodeTypes/Root/Sites.yaml
@@ -3,6 +3,7 @@
 # Any Neos Site node must be its direct child.
 #
 'Neos.Neos:Sites':
+  label: 'Sites'
   superTypes:
     'Neos.ContentRepository:Root': true
   constraints:

--- a/Neos.Neos/NodeTypes/Root/Sites.yaml
+++ b/Neos.Neos/NodeTypes/Root/Sites.yaml
@@ -9,3 +9,6 @@
     nodeTypes:
       '*': false
       'Neos.Neos:Site': true
+  ui:
+    label: i18n
+    icon: 'globe'

--- a/Neos.Neos/Resources/Private/Translations/de/NodeTypes/Sites.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/NodeTypes/Sites.xlf
@@ -5,6 +5,9 @@
 			<trans-unit id="ui.label" xml:space="preserve">
 				<source>Seiten</source>
 			</trans-unit>
+			<trans-unit id="ui.label" xml:space="preserve" approved="yes">
+						<source>Sites</source>
+					<target state="final">Seiten</target></trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Neos.Neos/Resources/Private/Translations/de/NodeTypes/Sites.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/NodeTypes/Sites.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Neos" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="ui.label" xml:space="preserve">
+				<source>Seiten</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Neos.Neos/Resources/Private/Translations/en/NodeTypes/Sites.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/NodeTypes/Sites.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Neos.Neos" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="ui.label" xml:space="preserve">
+				<source>Sites</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
Required for the `Neos.Neos/Inspector/Editors/LinkEditor` when specifying

```
linking:
    linkTypes:
      Node:
        startingPoint: '/<Neos.Neos:Sites>'
```

instead of just `/<Neos.Neos:Sites>/my-site`

As this allows the sites node to be shown in the Ui then :)