### PR TITLE
PoC: Hierarchy Relation Ids without holes and without Database's `AUTO_INCREMENT`

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/DoctrineDbalProjectionIntegrityViolatorTrait.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/DoctrineDbalProjectionIntegrityViolatorTrait.php
@@ -92,7 +92,10 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
         $record = $this->transformDatasetToHierarchyRelationRecord($dataset);
         $this->dbal->insert(
             $this->tableNames()->hierarchyRelation(),
-            $record
+            [
+                'id' => 1000, // FIXME should not be hardcoded if two hierarchies are to be added for testing
+                ...$record
+            ]
         );
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -437,10 +437,13 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         $contentStreamLayers = $this->getContentStreamLayers($event);
         $this->dimensionSpacePointsRepository->insertDimensionSpacePoint($event->target);
 
+        $newHierarchyIdOffset = $this->determineNextHierarchyRelationId();
+
         // 1) hierarchy relations
         $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($event->source);
         $insertHierarchyRelationsStatement = <<<SQL
             INSERT INTO {$this->tableNames->hierarchyRelation()} (
+              id,
               contentstreamlayer,
               parentnodeanchor,
               childnodeanchor,
@@ -449,6 +452,8 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               dimensionspacepointhash
             )
             SELECT
+              -- auto-increment the new hierarchy ids - order does not matter
+              ROW_NUMBER() OVER () + :newHierarchyIdOffset as id,
               :targetContentStreamLayer as contentstreamlayer,
               h.parentnodeanchor,
               h.childnodeanchor,
@@ -462,6 +467,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             $this->dbal->executeStatement($insertHierarchyRelationsStatement, [
                 'newDimensionSpacePointHash' => $event->target->hash,
                 'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
+                'newHierarchyIdOffset' => $newHierarchyIdOffset->value,
                 ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
             ], [
                 ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
@@ -1131,7 +1137,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             $inheritedSubtreeTags = NodeTags::create(SubtreeTags::createEmpty(), $parentSubtreeTags->all());
 
             $hierarchyRelation = new HierarchyRelation(
-                HierarchyRelationId::createAutoIncremented(),
+                $this->determineNextHierarchyRelationId(),
                 $contentStreamLayers->getWriteLayer(),
                 $parentNodeAnchorPoint,
                 $childNodeAnchorPoint,
@@ -1232,7 +1238,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         $parentSubtreeTags = $this->subtreeTagsForHierarchyRelation($contentStreamLayers, $newParent, $dimensionSpacePoint);
         $inheritedSubtreeTags = NodeTags::create($sourceHierarchyRelation->subtreeTags->withoutInherited()->all(), $parentSubtreeTags->withoutInherited()->all());
         $copy = new HierarchyRelation(
-            HierarchyRelationId::createAutoIncremented(),
+            $this->determineNextHierarchyRelationId(),
             $contentStreamLayers->getWriteLayer(),
             $newParent,
             $newChild,
@@ -1274,5 +1280,38 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 null,
             ),
         );
+    }
+
+    /**
+     * Each hierarchy relation must have a unique id within its live-cycle.
+     *
+     * During creation a global new id is assigned by selecting the previous highest and incrementing.
+     * When the hierarchy is modified - either in its originating layer or any child layer the id is preserved, only its layer may change.
+     * The full identity of a hierarchy for a content stream is assembled through both id _and_ layer {@see HierarchyRelation::getDatabaseId()}
+     *
+     * We are not using auto-incrementing columns as they put more load on the database during upserts and also inserts.
+     * As it's forbidden to invoke apply() concurrently and commit the transaction its safe and simple to increment in PHP.
+     *
+     * Also, during the simulation {@see DoctrineDbalContentGraphProjection::inSimulation} auto-increments will likely cause deadlocks on the transaction.
+     * This is because during simulation we _are_ allowed to use apply() concurrently but without ever commiting the transaction.
+     * The database has to ensure not to hand out the same new auto increment to multiple transactions and also locks heavily.
+     */
+    private function determineNextHierarchyRelationId(): HierarchyRelationId
+    {
+        // TODO cache value within apply()?
+        $highestHierarchyRelationIdStatement = <<<SQL
+            SELECT id FROM {$this->tableNames->hierarchyRelation()}
+            ORDER BY id DESC
+            LIMIT 1
+            SQL;
+        try {
+            $highestHierarchyRelationId = HierarchyrelationId::fromInt((int)$this->dbal->fetchOne(
+                $highestHierarchyRelationIdStatement
+            ));
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to determine highest hierarchy relation id: %s', $e->getMessage()), 1779391601, $e);
+        }
+
+        return $highestHierarchyRelationId->next();
     }
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -62,7 +62,8 @@ class DoctrineDbalContentGraphSchemaBuilder
     private function createHierarchyRelationTable(AbstractPlatform $platform): Table
     {
         $table = self::createTable($this->tableNames->hierarchyRelation(), [
-            (new Column('id', Type::getType(Types::INTEGER)))->setAutoincrement(true)->setNotnull(true),
+            /** No auto-increment see {@see \Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphProjection::determineNextHierarchyRelationId()} */
+            (new Column('id', Type::getType(Types::INTEGER)))->setNotnull(true),
             (new Column('contentstreamlayer', self::type(Types::INTEGER)))->setNotnull(true),
             (new Column('position', self::type(Types::INTEGER)))->setNotnull(false),
             DbalSchemaFactory::columnForDimensionSpacePointHash('dimensionspacepointhash', $platform)->setNotnull(false),

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeVariation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeVariation.php
@@ -6,7 +6,6 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamLayers;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
-use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelationId;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
@@ -97,7 +96,7 @@ trait NodeVariation
                     : null;
 
                 $hierarchyRelation = new HierarchyRelation(
-                    HierarchyRelationId::createAutoIncremented(),
+                    $this->determineNextHierarchyRelationId(),
                     $contentStreamLayers->getWriteLayer(),
                     $parentNode->relationAnchorPoint,
                     $specializedNode->relationAnchorPoint,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
@@ -157,14 +157,6 @@ final readonly class HierarchyRelation
      */
     public function getDatabaseId(): array
     {
-        if (!$this->hierarchyRelationId->value) {
-            throw new \RuntimeException(sprintf('Hierarchy relation was not created in the database and does not have an id: %s', json_encode([
-                'parentnodeanchor' => $this->parentNodeAnchor->value,
-                'childnodeanchor' => $this->childNodeAnchor->value,
-                'contentstreamlayer' => $this->contentStreamLayer->value,
-                'dimensionspacepointhash' => $this->dimensionSpacePointHash
-            ])), 1775979706);
-        }
         return [
             'id' => $this->hierarchyRelationId->value,
             'contentstreamlayer' => $this->contentStreamLayer->value,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelationId.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelationId.php
@@ -10,21 +10,21 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection;
 class HierarchyRelationId
 {
     private function __construct(
-        public ?int $value
+        public int $value
     ) {
-        if ($value !== null && $value < 0) {
+        if ($value < 0) {
             throw new \InvalidArgumentException('A HierarchyRelationId cannot be negative, got %d', $value);
         }
-    }
-
-    public static function createAutoIncremented(): self
-    {
-        return new self(null);
     }
 
     public function equals(HierarchyRelationId $id): bool
     {
         return $this->value === $id->value;
+    }
+
+    public function next(): self
+    {
+        return new self($this->value + 1);
     }
 
     public static function fromInt(int $value): self


### PR DESCRIPTION
Based on https://github.com/neos/neos-development-collection/pull/5776 

Alternative implementation of the hierarchy DB Ids introduced as DB auto-increment via #5776 

To see if there is performance to gain or to reduce parallel load and locks due to auto-increment generation this was moved into PHP as an experiment

Auto increments seem to acquire quite some locks on the rows which might be the reason parallel transactions can fail.
As MariaDB does not allow to set `innodb_autoinc_lock_mode=2` via Session which seems to cause less locking - and is the default for MySQL https://mariadb.com/docs/server/server-usage/storage-engines/innodb/auto_increment-handling-in-innodb  this change attempts to reduce the locking and load from the database.

The persistent state of the database is ONLY ever created by a single process. No parallelism is allowed by definition for the projections. Thus an autoincrement ala fetch the last value and increment does not look atomic but is totally safe. All parallel transactions are guaranteed to be rolled back and only for publishing. 

The most note worthy difference is that a DB auto incremented column WILL have holes in the hierarchy relations because of each publish simulation as auto-increments are globally unique if the transaction is committed or not: https://mariadb.com/docs/server/reference/data-types/auto_increment#missing-values
A side effect of this change moving that fully state based would ensure no holes to be committed.