### PR TITLE
Revert "BUGFIX: Prevent unnecessary `updateContentStreamVersion()` updates within transaction simulation"

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -85,13 +85,8 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     use SubtreeTagging;
     use Workspace;
 
-    public const RELATION_DEFAULT_OFFSET = 128;
 
-    /**
-     * It's not particular pretty to add mutable state. A new api contract will allow a more elegant approach:
-     * {@see https://github.com/neos/neos-development-collection/pull/5837}
-     */
-    private bool $isInSimulation = false;
+    public const RELATION_DEFAULT_OFFSET = 128;
 
     public function __construct(
         private readonly Connection $dbal,
@@ -186,10 +181,6 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $event instanceof ContentStreamWasForked
                 || $event instanceof ContentStreamWasCreated
             )
-            // Optimizes unnecessary writes to the connection which can cause problems when trying to acquire a lock.
-            // During command simulation we don't use the content stream version, and thus we can ignore updating this value in the transaction.
-            // See also https://github.com/neos/neos-development-collection/issues/5713
-            && !$this->isInSimulation
         ) {
             $this->updateContentStreamVersion($event->getContentStreamId(), $eventEnvelope->version, $event instanceof PublishableToWorkspaceInterface);
         }
@@ -202,11 +193,9 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         }
         $this->dbal->beginTransaction();
         $this->dbal->setRollbackOnly();
-        $this->isInSimulation = true;
         try {
             return $fn();
         } finally {
-            $this->isInSimulation = false;
             // unsets rollback only flag and allows the connection to work regular again
             $this->dbal->rollBack();
         }

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandSimulator.php
@@ -122,7 +122,6 @@ final class CommandSimulator
         // because this is only used in memory during the partial publish or rebase operation; so it cannot be written to
         // concurrently.
         // HINT: We cannot use $eventsToPublish->expectedVersion, because this is based on the PERSISTENT event stream (having different numbers)
-        // Also as part of an optimization a graph adapter might choose to not update the content stream version as its irrelevant during simulation.
         $this->inMemoryEventStore->commit(
             $eventsToPublish->streamName,
             $normalizedEvents,


### PR DESCRIPTION
Reverts neos/neos-development-collection#5838

Superseded by a global lock #5852
