### PR TITLE
TASK: Fix migrations for MariaDB 12.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,7 @@ jobs:
           - { php: '8.4', db: { engine: mysql, image: 'mysql:8.0', port: 3306, options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3' } }
           - { php: '8.4', db: { engine: mysql, image: 'mysql:8.4', port: 3306, options: '--health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3' } }
           # Bleeding-edge engines.
-          # TODO: Enable MariaDB 12 after fixing migrations
-          # - { php: '8.5', db: { engine: mysql, image: 'mariadb:12.2', port: 3306, options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3' } }
+          - { php: '8.5', db: { engine: mysql, image: 'mariadb:12.2', port: 3306, options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3' } }
           - { php: '8.5', db: { engine: pgsql, image: 'postgres:18-alpine', port: 5432, options: '--health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3' } }
     services:
       database:

--- a/Neos.ContentRepository/Migrations/Mysql/Version20110923125537.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20110923125537.php
@@ -17,20 +17,38 @@ class Version20110923125537 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY typo3_typo3cr_domain_model_workspace_ibfk_2");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY typo3_typo3cr_domain_model_workspace_ibfk_1");
-        $this->addSql("DROP INDEX IDX_60E859EC60E859EC ON typo3_typo3cr_domain_model_workspace");
-        $this->addSql("DROP INDEX IDX_60E859EC45EB1A10 ON typo3_typo3cr_domain_model_workspace");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_workspace') as $foreignKey) {
+            if (in_array('typo3cr_workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                || in_array('typo3cr_node', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3cr_domain_model_workspace');
+        if (array_key_exists('idx_60e859ec60e859ec', $indexes)) {
+            $this->addSql("DROP INDEX IDX_60E859EC60E859EC ON typo3_typo3cr_domain_model_workspace");
+        }
+        if (array_key_exists('idx_60e859ec45eb1a10', $indexes)) {
+            $this->addSql("DROP INDEX IDX_60E859EC45EB1A10 ON typo3_typo3cr_domain_model_workspace");
+        }
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace CHANGE typo3cr_workspace baseworkspace VARCHAR(40) DEFAULT NULL, CHANGE typo3cr_node rootnode VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace ADD CONSTRAINT typo3_typo3cr_domain_model_workspace_ibfk_1 FOREIGN KEY (baseworkspace) REFERENCES typo3_typo3cr_domain_model_workspace(flow3_persistence_identifier)");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace ADD CONSTRAINT typo3_typo3cr_domain_model_workspace_ibfk_2 FOREIGN KEY (rootnode) REFERENCES typo3_typo3cr_domain_model_node(flow3_persistence_identifier)");
         $this->addSql("CREATE INDEX IDX_71DE9CFBE9BFE681 ON typo3_typo3cr_domain_model_workspace (baseworkspace)");
         $this->addSql("CREATE INDEX IDX_71DE9CFB750166F ON typo3_typo3cr_domain_model_workspace (rootnode)");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node DROP FOREIGN KEY typo3_typo3cr_domain_model_node_ibfk_2");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node DROP FOREIGN KEY typo3_typo3cr_domain_model_node_ibfk_1");
-        $this->addSql("DROP INDEX IDX_45EB1A1060E859EC ON typo3_typo3cr_domain_model_node");
-        $this->addSql("DROP INDEX IDX_45EB1A105E2A1F07 ON typo3_typo3cr_domain_model_node");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_node') as $foreignKey) {
+            if (in_array('typo3cr_workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                || in_array('typo3cr_contentobjectproxy', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3cr_domain_model_node');
+        if (array_key_exists('idx_45eb1a1060e859ec', $indexes)) {
+            $this->addSql("DROP INDEX IDX_45EB1A1060E859EC ON typo3_typo3cr_domain_model_node");
+        }
+        if (array_key_exists('idx_45eb1a105e2a1f07', $indexes)) {
+            $this->addSql("DROP INDEX IDX_45EB1A105E2A1F07 ON typo3_typo3cr_domain_model_node");
+        }
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node CHANGE typo3cr_workspace workspace VARCHAR(40) DEFAULT NULL, CHANGE typo3cr_contentobjectproxy contentobjectproxy VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node ADD CONSTRAINT typo3_typo3cr_domain_model_node_ibfk_1 FOREIGN KEY (workspace) REFERENCES typo3_typo3cr_domain_model_workspace(flow3_persistence_identifier) ON DELETE SET NULL");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node ADD CONSTRAINT typo3_typo3cr_domain_model_node_ibfk_2 FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy(flow3_persistence_identifier)");
@@ -46,20 +64,38 @@ class Version20110923125537 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node DROP FOREIGN KEY typo3_typo3cr_domain_model_node_ibfk_2");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node DROP FOREIGN KEY typo3_typo3cr_domain_model_node_ibfk_1");
-        $this->addSql("DROP INDEX IDX_820CADC88D940019 ON typo3_typo3cr_domain_model_node");
-        $this->addSql("DROP INDEX IDX_820CADC84930C33C ON typo3_typo3cr_domain_model_node");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_node') as $foreignKey) {
+            if (in_array('workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                || in_array('contentobjectproxy', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3cr_domain_model_node');
+        if (array_key_exists('idx_820cadc88d940019', $indexes)) {
+            $this->addSql("DROP INDEX IDX_820CADC88D940019 ON typo3_typo3cr_domain_model_node");
+        }
+        if (array_key_exists('idx_820cadc84930c33c', $indexes)) {
+            $this->addSql("DROP INDEX IDX_820CADC84930C33C ON typo3_typo3cr_domain_model_node");
+        }
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node CHANGE contentobjectproxy typo3cr_contentobjectproxy VARCHAR(40) DEFAULT NULL, CHANGE workspace typo3cr_workspace VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node ADD CONSTRAINT typo3_typo3cr_domain_model_node_ibfk_2 FOREIGN KEY (typo3cr_contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy(flow3_persistence_identifier)");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_node ADD CONSTRAINT typo3_typo3cr_domain_model_node_ibfk_1 FOREIGN KEY (typo3cr_workspace) REFERENCES typo3_typo3cr_domain_model_workspace(flow3_persistence_identifier) ON DELETE SET NULL");
         $this->addSql("CREATE INDEX IDX_45EB1A1060E859EC ON typo3_typo3cr_domain_model_node (typo3cr_workspace)");
         $this->addSql("CREATE INDEX IDX_45EB1A105E2A1F07 ON typo3_typo3cr_domain_model_node (typo3cr_contentobjectproxy)");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY typo3_typo3cr_domain_model_workspace_ibfk_2");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY typo3_typo3cr_domain_model_workspace_ibfk_1");
-        $this->addSql("DROP INDEX IDX_71DE9CFBE9BFE681 ON typo3_typo3cr_domain_model_workspace");
-        $this->addSql("DROP INDEX IDX_71DE9CFB750166F ON typo3_typo3cr_domain_model_workspace");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_workspace') as $foreignKey) {
+            if (in_array('baseworkspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                || in_array('rootnode', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3cr_domain_model_workspace');
+        if (array_key_exists('idx_71de9cfbe9bfe681', $indexes)) {
+            $this->addSql("DROP INDEX IDX_71DE9CFBE9BFE681 ON typo3_typo3cr_domain_model_workspace");
+        }
+        if (array_key_exists('idx_71de9cfb750166f', $indexes)) {
+            $this->addSql("DROP INDEX IDX_71DE9CFB750166F ON typo3_typo3cr_domain_model_workspace");
+        }
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace CHANGE rootnode typo3cr_node VARCHAR(40) DEFAULT NULL, CHANGE baseworkspace typo3cr_workspace VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace ADD CONSTRAINT typo3_typo3cr_domain_model_workspace_ibfk_2 FOREIGN KEY (typo3cr_node) REFERENCES typo3_typo3cr_domain_model_node(flow3_persistence_identifier)");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace ADD CONSTRAINT typo3_typo3cr_domain_model_workspace_ibfk_1 FOREIGN KEY (typo3cr_workspace) REFERENCES typo3_typo3cr_domain_model_workspace(flow3_persistence_identifier)");

--- a/Neos.ContentRepository/Migrations/Mysql/Version20131129110302.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20131129110302.php
@@ -17,8 +17,16 @@ class Version20131129110302 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY typo3_typo3cr_domain_model_nodedata_ibfk_1");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY FK_71DE9CFBE9BFE681");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_nodedata') as $foreignKey) {
+            if (in_array('workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_workspace') as $foreignKey) {
+            if (in_array('baseworkspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $this->addSql("DROP INDEX flow3_identity_typo3_typo3cr_domain_model_workspace ON typo3_typo3cr_domain_model_workspace");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP PRIMARY KEY, ADD PRIMARY KEY (name)");
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata CHANGE workspace workspace VARCHAR(255) DEFAULT NULL");
@@ -41,8 +49,16 @@ class Version20131129110302 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY FK_71DE9CFBE9BFE681");
-        $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_nodedata') as $foreignKey) {
+            if (in_array('workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_workspace') as $foreignKey) {
+            if (in_array('baseworkspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
 
         $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_workspace ADD persistence_object_identifier VARCHAR(40) NOT NULL");
 

--- a/Neos.ContentRepository/Migrations/Mysql/Version20150309215316.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20150309215316.php
@@ -17,15 +17,20 @@ class Version20150309215316 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_nodedata') as $foreignKey) {
+            if (in_array('workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+            || in_array('contentobjectproxy', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+            ) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $indexes = $this->sm->listTableIndexes('typo3_typo3cr_domain_model_nodedata');
         if (array_key_exists('idx_820cadc88d940019', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019");
             $this->addSql("DROP INDEX idx_820cadc88d940019 ON typo3_typo3cr_domain_model_nodedata");
             $this->addSql("CREATE INDEX IDX_60A956B98D940019 ON typo3_typo3cr_domain_model_nodedata (workspace)");
             $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B98D940019 FOREIGN KEY (workspace) REFERENCES typo3_typo3cr_domain_model_workspace (name) ON DELETE SET NULL");
         }
         if (array_key_exists('idx_820cadc84930c33c', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY typo3_typo3cr_domain_model_nodedata_ibfk_2");
             $this->addSql("DROP INDEX idx_820cadc84930c33c ON typo3_typo3cr_domain_model_nodedata");
             $this->addSql("CREATE INDEX IDX_60A956B94930C33C ON typo3_typo3cr_domain_model_nodedata (contentobjectproxy)");
             $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT typo3_typo3cr_domain_model_nodedata_ibfk_2 FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy (persistence_object_identifier)");
@@ -40,15 +45,21 @@ class Version20150309215316 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3cr_domain_model_nodedata') as $foreignKey) {
+            if (in_array('workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                || in_array('contentobjectproxy', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+            ) {
+                $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $indexes = $this->sm->listTableIndexes('typo3_typo3cr_domain_model_nodedata');
         if (array_key_exists('idx_60a956b98d940019', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019");
             $this->addSql("DROP INDEX idx_60a956b98d940019 ON typo3_typo3cr_domain_model_nodedata");
             $this->addSql("CREATE INDEX IDX_820CADC88D940019 ON typo3_typo3cr_domain_model_nodedata (workspace)");
             $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT FK_60A956B98D940019 FOREIGN KEY (workspace) REFERENCES typo3_typo3cr_domain_model_workspace (name) ON DELETE SET NULL");
         }
         if (array_key_exists('idx_60a956b94930c33c', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata DROP FOREIGN KEY typo3_typo3cr_domain_model_nodedata_ibfk_2");
             $this->addSql("DROP INDEX idx_60a956b94930c33c ON typo3_typo3cr_domain_model_nodedata");
             $this->addSql("CREATE INDEX IDX_820CADC84930C33C ON typo3_typo3cr_domain_model_nodedata (contentobjectproxy)");
             $this->addSql("ALTER TABLE typo3_typo3cr_domain_model_nodedata ADD CONSTRAINT typo3_typo3cr_domain_model_nodedata_ibfk_2 FOREIGN KEY (contentobjectproxy) REFERENCES typo3_typo3cr_domain_model_contentobjectproxy (persistence_object_identifier)");

--- a/Neos.ContentRepository/Migrations/Mysql/Version20170110130113.php
+++ b/Neos.ContentRepository/Migrations/Mysql/Version20170110130113.php
@@ -36,9 +36,14 @@ class Version20170110130113 extends AbstractMigration
             $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedimension RENAME INDEX idx_6c144d3693bdc8e2 TO IDX_C4713BFF93BDC8E2');
             $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedimension RENAME INDEX uniq_6c144d3693bdc8e25e237e061d775834 TO UNIQ_C4713BFF93BDC8E25E237E061D775834');
         } else {
-            $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP FOREIGN KEY FK_60A956B92D45FE4D');
-            $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP FOREIGN KEY FK_60A956B98D940019');
-            $this->addSql('ALTER TABLE neos_contentrepository_domain_model_nodedata DROP FOREIGN KEY neos_contentrepository_domain_model_nodedata_ibfk_2');
+            foreach ($this->sm->listTableForeignKeys('neos_contentrepository_domain_model_nodedata') as $foreignKey) {
+                if (in_array('movedto', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                    || in_array('workspace', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                    || in_array('contentobjectproxy', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                ) {
+                    $this->addSql("ALTER TABLE neos_contentrepository_domain_model_nodedata DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql('DROP INDEX idx_60a956b98d940019 ON neos_contentrepository_domain_model_nodedata');
             $this->addSql('CREATE INDEX IDX_CE6515698D940019 ON neos_contentrepository_domain_model_nodedata (workspace)');
             $this->addSql('DROP INDEX idx_60a956b94930c33c ON neos_contentrepository_domain_model_nodedata');

--- a/Neos.Neos/Migrations/Mysql/Version20110923125538.php
+++ b/Neos.Neos/Migrations/Mysql/Version20110923125538.php
@@ -17,20 +17,41 @@ class Version20110923125538 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain DROP FOREIGN KEY typo3_typo3_domain_model_domain_ibfk_1");
-        $this->addSql("DROP INDEX IDX_64D1A917E12C6E67 ON typo3_typo3_domain_model_domain");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3_domain_model_domain') as $foreignKey) {
+            if (in_array('typo3_site', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3_domain_model_domain');
+        if (array_key_exists('idx_64d1a917e12c6e67', $indexes)) {
+            $this->addSql("DROP INDEX IDX_64D1A917E12C6E67 ON typo3_typo3_domain_model_domain");
+        }
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain CHANGE typo3_site site VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain ADD CONSTRAINT typo3_typo3_domain_model_domain_ibfk_1 FOREIGN KEY (site) REFERENCES typo3_typo3_domain_model_site(flow3_persistence_identifier)");
         $this->addSql("CREATE INDEX IDX_F227E8F6694309E4 ON typo3_typo3_domain_model_domain (site)");
 
-        $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image DROP FOREIGN KEY typo3_typo3_domain_model_media_image_ibfk_1");
-        $this->addSql("DROP INDEX UNIQ_E5EA82E211FFD19F ON typo3_typo3_domain_model_media_image");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3_domain_model_media_image') as $foreignKey) {
+            if (in_array('flow3_resource_resource', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3_domain_model_media_image');
+        if (array_key_exists('uniq_e5ea82e211ffd19f', $indexes)) {
+            $this->addSql("DROP INDEX UNIQ_E5EA82E211FFD19F ON typo3_typo3_domain_model_media_image");
+        }
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image CHANGE flow3_resource_resource resource VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image ADD CONSTRAINT typo3_typo3_domain_model_media_image_ibfk_1 FOREIGN KEY (resource) REFERENCES typo3_flow3_resource_resource(flow3_persistence_identifier)");
         $this->addSql("CREATE UNIQUE INDEX UNIQ_E5EA82E2BC91F416 ON typo3_typo3_domain_model_media_image (resource)");
 
-        $this->addSql("ALTER TABLE typo3_typo3_domain_model_user DROP FOREIGN KEY typo3_typo3_domain_model_user_ibfk_1");
-        $this->addSql("DROP INDEX UNIQ_5FCB1CAF3210CEC ON typo3_typo3_domain_model_user");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3_domain_model_user') as $foreignKey) {
+            if (in_array('typo3_userpreferences', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3_domain_model_user DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3_domain_model_user');
+        if (array_key_exists('uniq_5fcb1caf3210cec', $indexes)) {
+            $this->addSql("DROP INDEX UNIQ_5FCB1CAF3210CEC ON typo3_typo3_domain_model_user");
+        }
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_user CHANGE typo3_userpreferences preferences VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_user ADD CONSTRAINT typo3_typo3_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_typo3_domain_model_userpreferences(flow3_persistence_identifier)");
         $this->addSql("CREATE UNIQUE INDEX UNIQ_E3F98B13E931A6F5 ON typo3_typo3_domain_model_user (preferences)");
@@ -44,20 +65,41 @@ class Version20110923125538 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain DROP FOREIGN KEY typo3_typo3_domain_model_domain_ibfk_1");
-        $this->addSql("DROP INDEX IDX_F227E8F6694309E4 ON typo3_typo3_domain_model_domain");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3_domain_model_domain') as $foreignKey) {
+            if (in_array('site', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3_domain_model_domain');
+        if (array_key_exists('idx_f227e8f6694309e4', $indexes)) {
+            $this->addSql("DROP INDEX IDX_F227E8F6694309E4 ON typo3_typo3_domain_model_domain");
+        }
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain CHANGE site typo3_site VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_domain ADD CONSTRAINT typo3_typo3_domain_model_domain_ibfk_1 FOREIGN KEY (typo3_site) REFERENCES typo3_typo3_domain_model_site(flow3_persistence_identifier)");
         $this->addSql("CREATE INDEX IDX_64D1A917E12C6E67 ON typo3_typo3_domain_model_domain (typo3_site)");
 
-        $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image DROP FOREIGN KEY typo3_typo3_domain_model_media_image_ibfk_1");
-        $this->addSql("DROP INDEX UNIQ_E5EA82E2BC91F416 ON typo3_typo3_domain_model_media_image");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3_domain_model_media_image') as $foreignKey) {
+            if (in_array('resource', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3_domain_model_media_image');
+        if (array_key_exists('uniq_e5ea82e2bc91f416', $indexes)) {
+            $this->addSql("DROP INDEX UNIQ_E5EA82E2BC91F416 ON typo3_typo3_domain_model_media_image");
+        }
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image CHANGE resource flow3_resource_resource VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_media_image ADD CONSTRAINT typo3_typo3_domain_model_media_image_ibfk_1 FOREIGN KEY (flow3_resource_resource) REFERENCES typo3_flow3_resource_resource(flow3_persistence_identifier)");
         $this->addSql("CREATE UNIQUE INDEX UNIQ_E5EA82E211FFD19F ON typo3_typo3_domain_model_media_image (flow3_resource_resource)");
 
-        $this->addSql("ALTER TABLE typo3_typo3_domain_model_user DROP FOREIGN KEY typo3_typo3_domain_model_user_ibfk_1");
-        $this->addSql("DROP INDEX UNIQ_E3F98B13E931A6F5 ON typo3_typo3_domain_model_user");
+        foreach ($this->sm->listTableForeignKeys('typo3_typo3_domain_model_user') as $foreignKey) {
+            if (in_array('preferences', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_typo3_domain_model_user DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_typo3_domain_model_user');
+        if (array_key_exists('uniq_e3f98b13e931a6f5', $indexes)) {
+            $this->addSql("DROP INDEX UNIQ_E3F98B13E931A6F5 ON typo3_typo3_domain_model_user");
+        }
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_user CHANGE preferences typo3_userpreferences VARCHAR(40) DEFAULT NULL");
         $this->addSql("ALTER TABLE typo3_typo3_domain_model_user ADD CONSTRAINT typo3_typo3_domain_model_user_ibfk_1 FOREIGN KEY (typo3_userpreferences) REFERENCES typo3_typo3_domain_model_userpreferences(flow3_persistence_identifier)");
         $this->addSql("CREATE UNIQUE INDEX UNIQ_5FCB1CAF3210CEC ON typo3_typo3_domain_model_user (typo3_userpreferences)");

--- a/Neos.Neos/Migrations/Mysql/Version20150309215317.php
+++ b/Neos.Neos/Migrations/Mysql/Version20150309215317.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
@@ -18,21 +19,31 @@ class Version20150309215317 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+        foreach ($this->sm->listTableForeignKeys('typo3_neos_domain_model_domain') as $foreignKey) {
+            if (in_array('site', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $indexes = $this->sm->listTableIndexes('typo3_neos_domain_model_domain');
         if (array_key_exists('idx_f227e8f6694309e4', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY typo3_neos_domain_model_domain_ibfk_1");
             $this->addSql("DROP INDEX idx_f227e8f6694309e4 ON typo3_neos_domain_model_domain");
             $this->addSql("CREATE INDEX IDX_8E49A537694309E4 ON typo3_neos_domain_model_domain (site)");
             $this->addSql("ALTER TABLE typo3_neos_domain_model_domain ADD CONSTRAINT typo3_neos_domain_model_domain_ibfk_1 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier)");
         }
+
         $indexes = $this->sm->listTableIndexes('typo3_neos_domain_model_site');
         if (array_key_exists('flow3_identity_typo3_typo3_domain_model_site', $indexes)) {
             $this->addSql("DROP INDEX flow3_identity_typo3_typo3_domain_model_site ON typo3_neos_domain_model_site");
             $this->addSql("CREATE UNIQUE INDEX flow_identity_typo3_neos_domain_model_site ON typo3_neos_domain_model_site (nodename)");
         }
+
+        foreach ($this->sm->listTableForeignKeys('typo3_neos_domain_model_user') as $foreignKey) {
+            if (in_array('preferences', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $indexes = $this->sm->listTableIndexes('typo3_neos_domain_model_user');
         if (array_key_exists('uniq_e3f98b13e931a6f5', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY typo3_neos_domain_model_user_ibfk_1");
             $this->addSql("DROP INDEX uniq_e3f98b13e931a6f5 ON typo3_neos_domain_model_user");
             $this->addSql("CREATE UNIQUE INDEX UNIQ_FC846DAAE931A6F5 ON typo3_neos_domain_model_user (preferences)");
             $this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT typo3_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");
@@ -51,11 +62,17 @@ class Version20150309215317 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("CREATE UNIQUE INDEX uid ON typo3_neos_eventlog_domain_model_event (uid)");
+        if ($this->connection->getDatabasePlatform() instanceof MariaDBPlatform) {
+            $this->addSql("CREATE UNIQUE INDEX uid ON typo3_neos_eventlog_domain_model_event (uid)");
+        }
 
+        foreach ($this->sm->listTableForeignKeys('typo3_neos_domain_model_domain') as $foreignKey) {
+            if (in_array('site', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $indexes = $this->sm->listTableIndexes('typo3_neos_domain_model_domain');
         if (array_key_exists('idx_8e49a537694309e4', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_neos_domain_model_domain DROP FOREIGN KEY typo3_neos_domain_model_domain_ibfk_1");
             $this->addSql("DROP INDEX idx_8e49a537694309e4 ON typo3_neos_domain_model_domain");
             $this->addSql("CREATE INDEX IDX_F227E8F6694309E4 ON typo3_neos_domain_model_domain (site)");
             $this->addSql("ALTER TABLE typo3_neos_domain_model_domain ADD CONSTRAINT typo3_neos_domain_model_domain_ibfk_1 FOREIGN KEY (site) REFERENCES typo3_neos_domain_model_site (persistence_object_identifier)");
@@ -65,9 +82,14 @@ class Version20150309215317 extends AbstractMigration
             $this->addSql("DROP INDEX flow_identity_typo3_neos_domain_model_site ON typo3_neos_domain_model_site");
             $this->addSql("CREATE UNIQUE INDEX flow3_identity_typo3_typo3_domain_model_site ON typo3_neos_domain_model_site (nodename)");
         }
+
+        foreach ($this->sm->listTableForeignKeys('typo3_neos_domain_model_user') as $foreignKey) {
+            if (in_array('preferences', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
         $indexes = $this->sm->listTableIndexes('typo3_neos_domain_model_user');
         if (array_key_exists('uniq_fc846daae931a6f5', $indexes)) {
-            $this->addSql("ALTER TABLE typo3_neos_domain_model_user DROP FOREIGN KEY typo3_neos_domain_model_user_ibfk_1");
             $this->addSql("DROP INDEX uniq_fc846daae931a6f5 ON typo3_neos_domain_model_user");
             $this->addSql("CREATE UNIQUE INDEX UNIQ_E3F98B13E931A6F5 ON typo3_neos_domain_model_user (preferences)");
             $this->addSql("ALTER TABLE typo3_neos_domain_model_user ADD CONSTRAINT typo3_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES typo3_neos_domain_model_userpreferences (persistence_object_identifier)");

--- a/Neos.Neos/Migrations/Mysql/Version20170110130253.php
+++ b/Neos.Neos/Migrations/Mysql/Version20170110130253.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
 use Doctrine\Migrations\AbstractMigration;
@@ -11,7 +12,7 @@ class Version20170110130253 extends AbstractMigration
     /**
      * @return string
      */
-    public function getDescription(): string 
+    public function getDescription(): string
     {
         return 'Adjust foreign key and index names to the renaming of TYPO3.Neos to Neos.Neos';
     }
@@ -20,7 +21,7 @@ class Version20170110130253 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function up(Schema $schema): void 
+    public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
@@ -35,7 +36,11 @@ class Version20170110130253 extends AbstractMigration
             $this->addSql('DROP INDEX documentnodeidentifier ON neos_neos_eventlog_domain_model_event');
             $this->addSql('ALTER TABLE neos_neos_eventlog_domain_model_event RENAME INDEX idx_30ab3a75b684c08 TO IDX_D6DBC30A5B684C08');
         } else {
-            $this->addSql('ALTER TABLE neos_neos_domain_model_domain DROP FOREIGN KEY neos_neos_domain_model_domain_ibfk_1');
+            foreach ($this->sm->listTableForeignKeys('neos_neos_domain_model_domain') as $foreignKey) {
+                if (in_array('site', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                    $this->addSql("ALTER TABLE neos_neos_domain_model_domain DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql('DROP INDEX idx_8e49a537694309e4 ON neos_neos_domain_model_domain');
             $this->addSql('CREATE INDEX IDX_51265BE9694309E4 ON neos_neos_domain_model_domain (site)');
             $this->addSql('DROP INDEX flow_identity_typo3_neos_domain_model_domain ON neos_neos_domain_model_domain');
@@ -51,7 +56,11 @@ class Version20170110130253 extends AbstractMigration
             $this->addSql('CREATE UNIQUE INDEX flow_identity_neos_neos_domain_model_site ON neos_neos_domain_model_site (nodename)');
             $this->addSql('ALTER TABLE neos_neos_domain_model_site ADD CONSTRAINT FK_1854B2075CEB2C15 FOREIGN KEY (assetcollection) REFERENCES neos_media_domain_model_assetcollection (persistence_object_identifier)');
             $this->addSql('ALTER TABLE neos_neos_domain_model_site ADD CONSTRAINT FK_1854B207B8872B4A FOREIGN KEY (primarydomain) REFERENCES neos_neos_domain_model_domain (persistence_object_identifier)');
-            $this->addSql('ALTER TABLE neos_neos_domain_model_user DROP FOREIGN KEY neos_neos_domain_model_user_ibfk_1');
+            foreach ($this->sm->listTableForeignKeys('neos_neos_domain_model_user') as $foreignKey) {
+                if (in_array('preferences', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                    $this->addSql("ALTER TABLE neos_neos_domain_model_user DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql('DROP INDEX uniq_fc846daae931a6f5 ON neos_neos_domain_model_user');
             $this->addSql('CREATE UNIQUE INDEX UNIQ_ED60F5E3E931A6F5 ON neos_neos_domain_model_user (preferences)');
             $this->addSql('ALTER TABLE neos_neos_domain_model_user ADD CONSTRAINT neos_neos_domain_model_user_ibfk_1 FOREIGN KEY (preferences) REFERENCES neos_neos_domain_model_userpreferences (persistence_object_identifier)');
@@ -67,7 +76,7 @@ class Version20170110130253 extends AbstractMigration
      * @param Schema $schema
      * @return void
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 


### PR DESCRIPTION
What I did

Some old Flow migrations dropped foreign keys by their hardcoded auto-generated names (e.g. ..._ibfk_1). These names are no longer reliable: on MariaDB 12+, renaming a table no longer renames its auto-generated foreign key/index names along with it, so the constraint names the migrations expect may not exist and the migrations fail.

Instead of relying on hardcoded constraint names, the affected migrations now look up the actual foreign keys on the table via the schema manager and drop the one defined on the relevant column. This works regardless of what the constraint is actually named, making the migrations compatible with MySQL, MariaDB < 12 and MariaDB ≥ 12 alike.

Why the CI change

Until now this breakage went unnoticed because the pipeline never executed the Doctrine migrations. The build workflow now runs ./flow doctrine:migrate before the functional tests, so the full migration chain is verified on every build.

Depends on: #5853

Also depending on: https://github.com/neos/flow-development-collection/pull/3571