### PR TITLE
BUGFIX: Parallel workspace creation corrupts content graph

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
@@ -1,0 +1,217 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository.BehavioralTests package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\ParallelWorkspaceCreation;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
+use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
+use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlreadyExists;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
+use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use PHPUnit\Framework\Assert;
+
+class ParallelWorkspaceCreationTest extends AbstractParallelTestCase
+{
+    private const SETUP_LOCK_PATH = __DIR__ . '/setup-lock';
+    private const WRITING_IS_RUNNING_FLAG_PATH = __DIR__ . '/write-is-running-flag';
+
+    private ContentRepository $contentRepository;
+
+    protected ObjectManagerInterface $objectManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->log('------ process started ------');
+
+        $debugProjection = new DebugEventProjection(
+            'cr_test_parallel_debug_projection',
+            $this->objectManager->get(Connection::class)
+        );
+        FakeProjectionFactory::setProjection(
+            'debug',
+            $debugProjection
+        );
+
+        FakeContentDimensionSourceFactory::setWithoutDimensions();
+        FakeNodeTypeManagerFactory::setConfiguration([
+            'Neos.ContentRepository:Root' => [],
+            'Neos.ContentRepository.Testing:Document' => [
+                'properties' => [
+                    'title' => [
+                        'type' => 'string'
+                    ]
+                ]
+            ]
+        ]);
+
+        $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
+
+        $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);
+        if ($exclusiveNonBlockingLockResult === false) {
+            $this->log('waiting for setup');
+            if (!flock($setupLockResource, LOCK_SH)) {
+                throw new \RuntimeException('failed to acquire blocking shared lock');
+            }
+            $this->contentRepository = $this->contentRepositoryRegistry
+                ->get(ContentRepositoryId::fromString('test_parallel'));
+            $this->log('wait for setup finished');
+            return;
+        }
+
+        $this->log('setup started');
+        $contentRepository = $this->setUpContentRepository(ContentRepositoryId::fromString('test_parallel'));
+
+        $origin = OriginDimensionSpacePoint::createWithoutDimensions();
+        $contentRepository->handle(CreateRootWorkspace::create(
+            WorkspaceName::forLive(),
+            ContentStreamId::fromString('live-cs-id')
+        ));
+        $contentRepository->handle(CreateRootNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)
+        ));
+        $contentRepository->handle(CreateNodeAggregateWithNode::create(
+            WorkspaceName::forLive(),
+            NodeAggregateId::fromString('nody-mc-nodeface'),
+            NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+            $origin,
+            NodeAggregateId::fromString('lady-eleonode-rootford'),
+            initialPropertyValues: PropertyValuesToWrite::fromArray([
+                'title' => 'title-original'
+            ])
+        ));
+        for ($i = 0; $i <= 5000; $i++) {
+            $contentRepository->handle(CreateNodeAggregateWithNode::create(
+                WorkspaceName::forLive(),
+                NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
+                NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
+                $origin,
+                NodeAggregateId::fromString('lady-eleonode-rootford'),
+                initialPropertyValues: PropertyValuesToWrite::fromArray([
+                    'title' => 'title'
+                ])
+            ));
+        }
+        $this->contentRepository = $contentRepository;
+
+        if (!flock($setupLockResource, LOCK_UN)) {
+            throw new \RuntimeException('failed to release setup lock');
+        }
+
+        $this->log('setup finished');
+    }
+
+    /**
+     * @test
+     */
+    public function whileANodesArWrittenOnLive(): void
+    {
+        $this->log('1. workspace creation');
+        touch(self::WRITING_IS_RUNNING_FLAG_PATH);
+
+        $actualException = null;
+        try {
+            for ($i = 0; $i <= 200; $i++) {
+                $lastWorkspaceName = WorkspaceName::fromString('w-' . time());
+                try {
+                    $this->contentRepository->handle(CreateWorkspace::create(
+                        $lastWorkspaceName,
+                        WorkspaceName::forLive(),
+                        ContentStreamId::create(), // content stream id is not time based and random as we want to test workspace constraint and not the NO_STREAM check for content streams.
+                    ));
+                } catch (\Throwable $thrownException) {
+                    $actualException = $thrownException;
+                    $this->log(sprintf('Got exception %s: %s', self::shortClassName($actualException::class), $actualException->getMessage()));
+
+                    Assert::assertThat($actualException, self::logicalOr(
+                        self::isInstanceOf(WorkspaceAlreadyExists::class),
+                    ));
+                }
+            }
+        } finally {
+            unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
+        }
+
+        Assert::assertNotNull($actualException, 'Expected race condition during workspace creation');
+
+        $this->log('1. workspace creation finished');
+
+        $workspace = $this->contentRepository->findWorkspaceByName($lastWorkspaceName);
+        Assert::assertNotNull($workspace);
+    }
+
+    /**
+     * @test
+     */
+    public function thenConcurrentPublishLeadsToException(): void
+    {
+        if (!is_file(self::WRITING_IS_RUNNING_FLAG_PATH)) {
+            $this->log('waiting for 2. create workspaces');
+
+            $this->awaitFile(self::WRITING_IS_RUNNING_FLAG_PATH);
+            // If write is the process that does the (slowish) setup, and then waits for the rebase to start,
+            // We give the CR some time to close the content stream
+            // TODO find another way than to randomly wait!!!
+            // The problem is, if we dont sleep it happens often that the modification works only then the rebase is startet _really_
+            // Doing the modification several times in hope that the second one fails will likely just stop the rebase thread as it cannot close
+            usleep(10000);
+        }
+
+        $this->log('2. workspace creation');
+
+        $actualException = null;
+
+        for ($i = 0; $i <= 200; $i++) {
+            $lastWorkspaceName = WorkspaceName::fromString('w-' . time());
+            try {
+                $this->contentRepository->handle(CreateWorkspace::create(
+                    $lastWorkspaceName,
+                    WorkspaceName::forLive(),
+                    ContentStreamId::create(), // content stream id is not time based and random as we want to test workspace constraint and not the NO_STREAM check for content streams.
+                ));
+            } catch (\Throwable $thrownException) {
+                $actualException = $thrownException;
+                $this->log(sprintf('Got exception %s: %s', self::shortClassName($actualException::class), $actualException->getMessage()));
+
+                Assert::assertThat($actualException, self::logicalOr(
+                    Assert::isInstanceOf(WorkspaceAlreadyExists::class),
+                ));
+            }
+        }
+
+        Assert::assertNotNull($actualException, 'Expected race condition during workspace creation');
+
+        $this->log('2. workspace creation finished');
+
+        $workspace = $this->contentRepository->findWorkspaceByName($lastWorkspaceName);
+        Assert::assertNotNull($workspace);
+    }
+}

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
@@ -33,6 +33,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
 use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
 use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use PHPUnit\Framework\Assert;
 
@@ -151,8 +152,9 @@ class ParallelWorkspaceCreationTest extends AbstractParallelTestCase
                     $actualException = $thrownException;
                     $this->log(sprintf('Got exception %s: %s', self::shortClassName($actualException::class), $actualException->getMessage()));
 
-                    Assert::assertThat($actualException, self::logicalOr(
-                        self::isInstanceOf(WorkspaceAlreadyExists::class),
+                    Assert::assertThat($actualException, Assert::logicalOr(
+                        Assert::isInstanceOf(WorkspaceAlreadyExists::class),
+                        Assert::isInstanceOf(ConcurrencyException::class),
                     ));
                 }
             }
@@ -201,8 +203,9 @@ class ParallelWorkspaceCreationTest extends AbstractParallelTestCase
                 $actualException = $thrownException;
                 $this->log(sprintf('Got exception %s: %s', self::shortClassName($actualException::class), $actualException->getMessage()));
 
-                Assert::assertThat($actualException, self::logicalOr(
+                Assert::assertThat($actualException, Assert::logicalOr(
                     Assert::isInstanceOf(WorkspaceAlreadyExists::class),
+                    Assert::isInstanceOf(ConcurrencyException::class),
                 ));
             }
         }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWork
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Exception\WorkspaceAlreadyExists;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Service\ContentStreamPrunerFactory;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
@@ -162,6 +163,8 @@ class ParallelWorkspaceCreationTest extends AbstractParallelTestCase
             unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
         }
 
+        $this->assertNoDanglingContentStreams();
+
         Assert::assertNotNull($actualException, 'Expected race condition during workspace creation');
 
         $this->log('1. workspace creation finished');
@@ -210,11 +213,27 @@ class ParallelWorkspaceCreationTest extends AbstractParallelTestCase
             }
         }
 
+        $this->assertNoDanglingContentStreams();
+
         Assert::assertNotNull($actualException, 'Expected race condition during workspace creation');
 
         $this->log('2. workspace creation finished');
 
         $workspace = $this->contentRepository->findWorkspaceByName($lastWorkspaceName);
         Assert::assertNotNull($workspace);
+    }
+
+    private function assertNoDanglingContentStreams(): void
+    {
+        $contentStreamPruner = $this->contentRepositoryRegistry->buildService($this->contentRepository->id, new ContentStreamPrunerFactory());
+        $lines = [];
+        $contentStreamPruner->outputStatus(function ($line = '') use (&$lines) {
+            $lines[] = $line;
+        });
+        Assert::assertSame(<<<MESSAGE
+        Okay. No dangling streams found
+        
+        Okay. No pruneable streams in the event stream
+        MESSAGE, join("\n", $lines));
     }
 }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelWorkspaceCreation/ParallelWorkspaceCreationTest.php
@@ -230,10 +230,18 @@ class ParallelWorkspaceCreationTest extends AbstractParallelTestCase
         $contentStreamPruner->outputStatus(function ($line = '') use (&$lines) {
             $lines[] = $line;
         });
-        Assert::assertSame(<<<MESSAGE
-        Okay. No dangling streams found
-        
-        Okay. No pruneable streams in the event stream
-        MESSAGE, join("\n", $lines));
+
+        // FIXME Machine readable output
+        Assert::assertStringNotContainsString(
+            'Dangling content streams that are not removed (ContentStreamWasRemoved) and not in use by workspace:',
+            join("\n", $lines)
+        );
+
+        // FIXME requires https://github.com/neos/neos-development-collection/issues/5827
+        // Assert::assertSame(<<<MESSAGE
+        // Okay. No dangling streams found
+        //
+        // Okay. No pruneable streams in the event stream
+        // MESSAGE, join("\n", $lines));
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -66,8 +66,11 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Exception\ConcurrencyException;
+use Neos\EventStore\Model\Event\EventType;
+use Neos\EventStore\Model\Event\EventTypes;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\Event\Version;
+use Neos\EventStore\Model\EventStream\EventStreamFilter;
 use Neos\EventStore\Model\EventStream\EventStreamInterface;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
 
@@ -141,8 +144,18 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             sprintf('Create workspace %s with base %s', $command->workspaceName->value, $baseWorkspace->workspaceName->value)
         );
 
+        $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
+        $workspaceStream = $this->eventStore->load(
+            $workspaceStreamName,
+            EventStreamFilter::create(eventTypes:EventTypes::create(EventType::fromString('WorkspaceWasRemoved')))
+        );
+        $expectedWorkspaceStreamVersion = ExpectedVersion::NO_STREAM();
+        foreach ($workspaceStream->backwards()->limit(1) as $eventEnvelope) {
+            $expectedWorkspaceStreamVersion = ExpectedVersion::fromVersion($eventEnvelope->version);
+            break;
+        }
         yield new EventsToPublish(
-            WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName(),
+            $workspaceStreamName,
             Events::with(
                 new WorkspaceWasCreated(
                     $command->workspaceName,
@@ -150,7 +163,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $command->newContentStreamId,
                 )
             ),
-            ExpectedVersion::ANY(),
+            $expectedWorkspaceStreamVersion,
         );
     }
 
@@ -176,15 +189,26 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             ExpectedVersion::NO_STREAM()
         );
 
+        $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
+        $workspaceStream = $this->eventStore->load(
+            $workspaceStreamName,
+            EventStreamFilter::create(eventTypes:EventTypes::create(EventType::fromString('WorkspaceWasRemoved')))
+        );
+        $expectedWorkspaceStreamVersion = ExpectedVersion::NO_STREAM();
+        foreach ($workspaceStream->backwards()->limit(1) as $eventEnvelope) {
+            $expectedWorkspaceStreamVersion = ExpectedVersion::fromVersion($eventEnvelope->version);
+            break;
+        }
+
         yield new EventsToPublish(
-            WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName(),
+            $workspaceStreamName,
             Events::with(
                 new RootWorkspaceWasCreated(
                     $command->workspaceName,
                     $command->newContentStreamId
                 )
             ),
-            ExpectedVersion::ANY()
+            $expectedWorkspaceStreamVersion,
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -144,18 +144,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             sprintf('Create workspace %s with base %s', $command->workspaceName->value, $baseWorkspace->workspaceName->value)
         );
 
-        $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
-        $workspaceStream = $this->eventStore->load(
-            $workspaceStreamName,
-            EventStreamFilter::create(eventTypes:EventTypes::create(EventType::fromString('WorkspaceWasRemoved')))
-        );
-        $expectedWorkspaceStreamVersion = ExpectedVersion::NO_STREAM();
-        foreach ($workspaceStream->backwards()->limit(1) as $eventEnvelope) {
-            $expectedWorkspaceStreamVersion = ExpectedVersion::fromVersion($eventEnvelope->version);
-            break;
-        }
+        $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName);
+        $expectedWorkspaceStreamVersion = $this->requireWorkspaceStreamVersionForCreation($workspaceStreamName);
         yield new EventsToPublish(
-            $workspaceStreamName,
+            $workspaceStreamName->getEventStreamName(),
             Events::with(
                 new WorkspaceWasCreated(
                     $command->workspaceName,
@@ -189,19 +181,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             ExpectedVersion::NO_STREAM()
         );
 
-        $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName)->getEventStreamName();
-        $workspaceStream = $this->eventStore->load(
-            $workspaceStreamName,
-            EventStreamFilter::create(eventTypes:EventTypes::create(EventType::fromString('WorkspaceWasRemoved')))
-        );
-        $expectedWorkspaceStreamVersion = ExpectedVersion::NO_STREAM();
-        foreach ($workspaceStream->backwards()->limit(1) as $eventEnvelope) {
-            $expectedWorkspaceStreamVersion = ExpectedVersion::fromVersion($eventEnvelope->version);
-            break;
-        }
-
+        $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName);
+        $expectedWorkspaceStreamVersion = $this->requireWorkspaceStreamVersionForCreation($workspaceStreamName);
         yield new EventsToPublish(
-            $workspaceStreamName,
+            $workspaceStreamName->getEventStreamName(),
             Events::with(
                 new RootWorkspaceWasCreated(
                     $command->workspaceName,
@@ -931,5 +914,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             }
             $nextBaseWorkspace = $this->requireBaseWorkspace($nextBaseWorkspace, $commandHandlingDependencies);
         }
+    }
+
+    /**
+     * The workspace stream version from the even-store. We cannot use the constant NO_STREAM() as we allow recreation of workspaces.
+     */
+    private function requireWorkspaceStreamVersionForCreation(WorkspaceEventStreamName $workspaceStreamName): ExpectedVersion
+    {
+        // If an event exists, the only valid last event is a removal, otherwise we are not allowed to recreate the workspace.
+        $workspaceStream = $this->eventStore->load(
+            $workspaceStreamName->getEventStreamName(),
+            EventStreamFilter::create(eventTypes:EventTypes::create(EventType::fromString('WorkspaceWasRemoved')))
+        );
+        foreach ($workspaceStream->backwards()->limit(1) as $eventEnvelope) {
+            return ExpectedVersion::fromVersion($eventEnvelope->version);
+        }
+        return ExpectedVersion::NO_STREAM();
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -146,17 +146,21 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName);
         $expectedWorkspaceStreamVersion = $this->requireWorkspaceStreamVersionForCreation($workspaceStreamName);
-        yield new EventsToPublish(
-            $workspaceStreamName->getEventStreamName(),
-            Events::with(
-                new WorkspaceWasCreated(
-                    $command->workspaceName,
-                    $command->baseWorkspaceName,
-                    $command->newContentStreamId,
-                )
-            ),
-            $expectedWorkspaceStreamVersion,
-        );
+        try {
+            yield new EventsToPublish(
+                $workspaceStreamName->getEventStreamName(),
+                Events::with(
+                    new WorkspaceWasCreated(
+                        $command->workspaceName,
+                        $command->baseWorkspaceName,
+                        $command->newContentStreamId,
+                    )
+                ),
+                $expectedWorkspaceStreamVersion,
+            );
+        } catch (ConcurrencyException) {
+            yield $this->removeContentStreamWithoutConstraintChecks($command->newContentStreamId);
+        }
     }
 
     /**
@@ -183,16 +187,20 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
         $workspaceStreamName = WorkspaceEventStreamName::fromWorkspaceName($command->workspaceName);
         $expectedWorkspaceStreamVersion = $this->requireWorkspaceStreamVersionForCreation($workspaceStreamName);
-        yield new EventsToPublish(
-            $workspaceStreamName->getEventStreamName(),
-            Events::with(
-                new RootWorkspaceWasCreated(
-                    $command->workspaceName,
-                    $command->newContentStreamId
-                )
-            ),
-            $expectedWorkspaceStreamVersion,
-        );
+        try {
+            yield new EventsToPublish(
+                $workspaceStreamName->getEventStreamName(),
+                Events::with(
+                    new RootWorkspaceWasCreated(
+                        $command->workspaceName,
+                        $command->newContentStreamId
+                    )
+                ),
+                $expectedWorkspaceStreamVersion,
+            );
+        } catch (ConcurrencyException) {
+            yield $this->removeContentStreamWithoutConstraintChecks($command->newContentStreamId);
+        }
     }
 
     private function handlePublishWorkspace(


### PR DESCRIPTION
Fixes: https://github.com/neos/neos-development-collection/issues/5591

Introduce failing test for parallel workspace creation
    
> Integrity constraint violation: 1062 Duplicate entry 'w-1780989485' for key 'PRIMARY''

related https://github.com/neos/neos-development-collection/issues/5058

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
