### PR TITLE
BUGFIX: Add migration to fix json column types in neos_contentrepository_domain_model_nodedata

### DIFF
--- a/Neos.ContentRepository/Migrations/Postgresql/Version20200101000000.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20200101000000.php
@@ -4,9 +4,6 @@ namespace Neos\Flow\Persistence\Doctrine\Migrations;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
-/**
- * Migrates TYPO3CR NodeData entries from using serialized data to json encoded data and changes the field type to JSONB afterwards.
- */
 class Version20200101000000 extends AbstractMigration
 {
     /**

--- a/Neos.ContentRepository/Migrations/Postgresql/Version20200101000000.php
+++ b/Neos.ContentRepository/Migrations/Postgresql/Version20200101000000.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Migrates TYPO3CR NodeData entries from using serialized data to json encoded data and changes the field type to JSONB afterwards.
+ */
+class Version20200101000000 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema): void 
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $this->connection->exec("COMMENT ON COLUMN neos_contentrepository_domain_model_nodedata.dimensionvalues IS '(DC2Type:flow_json_array)';");
+        $this->connection->exec("COMMENT ON COLUMN neos_contentrepository_domain_model_nodedata.accessroles IS '(DC2Type:flow_json_array)';");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema): void 
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        $this->connection->exec("COMMENT ON COLUMN neos_contentrepository_domain_model_nodedata.dimensionvalues IS '(DC2Type:json_array)';");
+        $this->connection->exec("COMMENT ON COLUMN neos_contentrepository_domain_model_nodedata.accessroles IS '(DC2Type:json_array)';");
+    }
+}


### PR DESCRIPTION
Adds a missing migration for Neos 8.4 with PGSQL.

Renames the doctrine type comments to `flow_json_array`. I've choosen a random version number after latest migration in 8.4 but before any possible migration version of newer versions. This shall ensure the right order.

We can discuss if we need this in 8.3 already. But I think 8.4 shoud be fine.

Test will be provided via #5611 