### PR TITLE
BUGFIX: Migrated node variants leak properties from a different dimen…

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -146,6 +146,11 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
         return $this->values[$propertyName] ?? null;
     }
 
+    public function getPropertyNames(): PropertyNames
+    {
+        return PropertyNames::fromArray(array_keys($this->values));
+    }
+
     public function getIterator(): \Traversable
     {
         yield from $this->values;

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Node/PropertyNames.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Node/PropertyNames.php
@@ -46,6 +46,21 @@ final readonly class PropertyNames implements \IteratorAggregate, \Countable, \J
         return new self(...$this->values, ...$other->values);
     }
 
+    public function getDifference(self $other): self
+    {
+        $otherPropertyNames = [];
+        foreach ($other->values as $propertyName) {
+            $otherPropertyNames[$propertyName->value] = true;
+        }
+        $difference = [];
+        foreach ($this->values as $propertyName) {
+            if (!isset($otherPropertyNames[$propertyName->value])) {
+                $difference[] = $propertyName;
+            }
+        }
+        return new self(...$difference);
+    }
+
     public function jsonSerialize(): mixed
     {
         return $this->values;

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/PropertyNamesTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Node/PropertyNamesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\SharedModel\Node;
+
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
+use PHPUnit\Framework\TestCase;
+
+class PropertyNamesTest extends TestCase
+{
+    public static function differenceDataProvider(): iterable
+    {
+        yield 'empty' => ['names1' => [], 'names2' => [], 'expectedResult' => []];
+        yield 'one empty' => ['names1' => [], 'names2' => ['foo'], 'expectedResult' => []];
+        yield 'two empty' => ['names1' => ['foo'], 'names2' => [], 'expectedResult' => ['foo']];
+        yield 'no intersection' => ['names1' => ['foo', 'bar'], 'names2' => ['baz', 'foos'], 'expectedResult' => ['foo', 'bar']];
+        yield 'with intersection' => ['names1' => ['foo', 'bar', 'baz'], 'names2' => ['baz', 'bars', 'foo'], 'expectedResult' => ['bar']];
+        yield 'with intersection reversed' => ['names1' => ['baz', 'bars', 'foo'], 'names2' => ['foo', 'bar', 'baz'], 'expectedResult' => ['bars']];
+    }
+
+    /**
+     * @test
+     * @dataProvider differenceDataProvider
+     */
+    public function getDifference(array $names1, array $names2, array $expectedResult): void
+    {
+        self::assertSame($expectedResult, array_column(iterator_to_array(PropertyNames::fromArray($names1)->getDifference(PropertyNames::fromArray($names2))), 'value'));
+    }
+}

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
@@ -6,6 +6,7 @@ use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
 use Neos\ContentRepository\LegacyNodeMigration\Exception\MigrationException;
 use Neos\Flow\Annotations as Flow;
 
@@ -26,12 +27,12 @@ final class VisitedNodeAggregate
 
     ) {}
 
-    public function addVariant(OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId): void
+    public function addVariant(OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, PropertyNames $propertyNames): void
     {
         if (isset($this->variants[$originDimensionSpacePoint->hash])) {
             throw new MigrationException(sprintf('Node "%s" with dimension space point "%s" was already visited before', $this->nodeAggregateId->value, $originDimensionSpacePoint->toJson()), 1653050442);
         }
-        $this->variants[$originDimensionSpacePoint->hash] = new VisitedNodeVariant($originDimensionSpacePoint, $parentNodeAggregateId);
+        $this->variants[$originDimensionSpacePoint->hash] = new VisitedNodeVariant($originDimensionSpacePoint, $parentNodeAggregateId, $propertyNames);
     }
 
     public function getOriginDimensionSpacePoints(): OriginDimensionSpacePointSet

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregates.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregates.php
@@ -9,6 +9,7 @@ use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodePath;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
 use Neos\ContentRepository\LegacyNodeMigration\Exception\MigrationException;
 use Neos\Flow\Annotations as Flow;
 
@@ -30,17 +31,23 @@ final class VisitedNodeAggregates
 
     public function addRootNode(NodeAggregateId $nodeAggregateId, NodeTypeName $nodeTypeName, NodePath $nodePath, DimensionSpacePointSet $allowedDimensionSubspace): void
     {
-        $this->add($nodeAggregateId, $allowedDimensionSubspace, $nodeTypeName, $nodePath, NodeAggregateId::fromString('00000000-0000-0000-0000-000000000000'));
+        $this->add($nodeAggregateId, $allowedDimensionSubspace, $nodeTypeName, $nodePath, NodeAggregateId::fromString('00000000-0000-0000-0000-000000000000'), PropertyNames::createEmpty());
     }
 
-    public function add(NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $coveredDimensionSpacePoints, NodeTypeName $nodeTypeName, NodePath $nodePath, NodeAggregateId $parentNodeAggregateId): void
-    {
+    public function add(
+        NodeAggregateId $nodeAggregateId,
+        DimensionSpacePointSet $coveredDimensionSpacePoints,
+        NodeTypeName $nodeTypeName,
+        NodePath $nodePath,
+        NodeAggregateId $parentNodeAggregateId,
+        PropertyNames $propertyNames,
+    ): void {
         $visitedNodeAggregate = $this->byNodeAggregateId[$nodeAggregateId->value] ?? new VisitedNodeAggregate($nodeAggregateId, $nodeTypeName);
         if (!$nodeTypeName->equals($visitedNodeAggregate->nodeTypeName)) {
             throw new MigrationException(sprintf('Node aggregate with id "%s" has a type of "%s" in content dimension %s. I was visited previously for content dimension %s with the type "%s". Node variants must not have different types', $nodeAggregateId->value, $nodeTypeName->value, $coveredDimensionSpacePoints->toJson(), $visitedNodeAggregate->getOriginDimensionSpacePoints()->toJson(), $visitedNodeAggregate->nodeTypeName->value), 1655913685);
         }
         foreach ($coveredDimensionSpacePoints as $dimensionSpacePoint) {
-            $visitedNodeAggregate->addVariant(OriginDimensionSpacePoint::fromDimensionSpacePoint($dimensionSpacePoint), $parentNodeAggregateId);
+            $visitedNodeAggregate->addVariant(OriginDimensionSpacePoint::fromDimensionSpacePoint($dimensionSpacePoint), $parentNodeAggregateId, $propertyNames);
             $pathAndDimensionSpacePointHash = $nodePath->serializeToString() . '__' . $dimensionSpacePoint->hash;
             if (isset($this->byPathAndDimensionSpacePoint[$pathAndDimensionSpacePointHash])) {
                 throw new MigrationException(sprintf('Node "%s" with path "%s" and dimension space point "%s" was already visited before', $nodeAggregateId->value, $nodePath->serializeToString(), $dimensionSpacePoint->toJson()), 1655900356);

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeVariant.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeVariant.php
@@ -4,6 +4,7 @@ namespace Neos\ContentRepository\LegacyNodeMigration\Helpers;
 
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -14,6 +15,8 @@ final readonly class VisitedNodeVariant
 
     public function __construct(
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
-        public NodeAggregateId $parentNodeAggregateId
+        public NodeAggregateId $parentNodeAggregateId,
+        // the property names this variant holds; a variant created from it copies exactly these
+        public PropertyNames $propertyNames,
     ) {}
 }

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSibling;
 use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNodeWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
 use Neos\ContentRepository\Core\Feature\NodeMove\Event\NodeAggregateWasMoved;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
@@ -292,12 +291,7 @@ final class EventExportProcessor implements ProcessorInterface
             $this->nodeReferencesWereSetEvents[] = new NodeReferencesWereSet($this->workspaceName, $this->contentStreamId, $nodeAggregateId, new OriginDimensionSpacePointSet([$originDimensionSpacePoint]), $serializedPropertyValuesAndReferences->references);
         }
 
-        $this->visitedNodes->add($nodeAggregateId, new DimensionSpacePointSet([$originDimensionSpacePoint->toDimensionSpacePoint()]), $nodeTypeName, $nodePath, $parentNodeAggregate->nodeAggregateId, self::propertyNamesOf($serializedPropertyValuesAndReferences->serializedPropertyValues));
-    }
-
-    private static function propertyNamesOf(SerializedPropertyValues $serializedPropertyValues): PropertyNames
-    {
-        return PropertyNames::fromArray(array_keys($serializedPropertyValues->getPlainValues()));
+        $this->visitedNodes->add($nodeAggregateId, new DimensionSpacePointSet([$originDimensionSpacePoint->toDimensionSpacePoint()]), $nodeTypeName, $nodePath, $parentNodeAggregate->nodeAggregateId, $serializedPropertyValuesAndReferences->serializedPropertyValues->getPropertyNames());
     }
 
     /**

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -18,6 +18,7 @@ use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSibling;
 use Neos\ContentRepository\Core\Feature\Common\InterdimensionalSiblings;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Event\NodeAggregateWithNodeWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
 use Neos\ContentRepository\Core\Feature\NodeMove\Event\NodeAggregateWasMoved;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
@@ -291,7 +292,12 @@ final class EventExportProcessor implements ProcessorInterface
             $this->nodeReferencesWereSetEvents[] = new NodeReferencesWereSet($this->workspaceName, $this->contentStreamId, $nodeAggregateId, new OriginDimensionSpacePointSet([$originDimensionSpacePoint]), $serializedPropertyValuesAndReferences->references);
         }
 
-        $this->visitedNodes->add($nodeAggregateId, new DimensionSpacePointSet([$originDimensionSpacePoint->toDimensionSpacePoint()]), $nodeTypeName, $nodePath, $parentNodeAggregate->nodeAggregateId);
+        $this->visitedNodes->add($nodeAggregateId, new DimensionSpacePointSet([$originDimensionSpacePoint->toDimensionSpacePoint()]), $nodeTypeName, $nodePath, $parentNodeAggregate->nodeAggregateId, self::propertyNamesOf($serializedPropertyValuesAndReferences->serializedPropertyValues));
+    }
+
+    private static function propertyNamesOf(SerializedPropertyValues $serializedPropertyValues): PropertyNames
+    {
+        return PropertyNames::fromArray(array_keys($serializedPropertyValues->getPlainValues()));
     }
 
     /**
@@ -425,7 +431,26 @@ final class EventExportProcessor implements ProcessorInterface
             throw new MigrationException(sprintf('Node "%s" for dimension %s was already created previously', $nodeAggregateId->value, $originDimensionSpacePoint->toJson()), 1656057201);
         }
         $this->exportEvent($variantCreatedEvent);
-        if ($serializedPropertyValuesAndReferences->serializedPropertyValues->count() > 0) {
+
+        $sourceVariant = $variantSourceOriginDimensionSpacePoint !== null
+            ? $this->visitedNodes->getByNodeAggregateId($nodeAggregateId)->getVariant($variantSourceOriginDimensionSpacePoint)
+            : null;
+
+        // the variant event copied the full property set of its source dimension. unset every property this
+        // dimension's node data row does not set, so a copied-over value does not surface where the row left
+        // the property empty or did not carry it at all.
+        $ownPropertyNames = array_keys($serializedPropertyValuesAndReferences->serializedPropertyValues->getPlainValues());
+        $copiedPropertyNames = $sourceVariant?->propertyNames ?? PropertyNames::createEmpty();
+        $propertyNamesToUnset = [];
+        foreach ($copiedPropertyNames as $copiedPropertyName) {
+            if (!in_array($copiedPropertyName->value, $ownPropertyNames, true)) {
+                $propertyNamesToUnset[] = $copiedPropertyName;
+            }
+        }
+        $propertiesToUnset = PropertyNames::fromArray($propertyNamesToUnset);
+        if ($serializedPropertyValuesAndReferences->serializedPropertyValues->count() > 0
+            || !$propertiesToUnset->isEmpty()
+        ) {
             $this->exportEvent(
                 new NodePropertiesWereSet(
                     $this->workspaceName,
@@ -434,7 +459,7 @@ final class EventExportProcessor implements ProcessorInterface
                     $originDimensionSpacePoint,
                     $coveredDimensionSpacePoints,
                     $serializedPropertyValuesAndReferences->serializedPropertyValues,
-                    PropertyNames::createEmpty()
+                    $propertiesToUnset
                 )
             );
         }
@@ -443,10 +468,9 @@ final class EventExportProcessor implements ProcessorInterface
 
         // When we specialize/generalize, we create a node variant at exactly the same tree location as the source node
         // If the parent node aggregate id differs, we need to move the just created variant to the new location
-        $nodeAggregate = $this->visitedNodes->getByNodeAggregateId($nodeAggregateId);
         if (
-            $variantSourceOriginDimensionSpacePoint &&
-            !$parentNodeAggregate->nodeAggregateId->equals($nodeAggregate->getVariant($variantSourceOriginDimensionSpacePoint)->parentNodeAggregateId)
+            $sourceVariant !== null &&
+            !$parentNodeAggregate->nodeAggregateId->equals($sourceVariant->parentNodeAggregateId)
         ) {
             $this->exportEvent(new NodeAggregateWasMoved(
                 $this->workspaceName,

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -433,15 +433,9 @@ final class EventExportProcessor implements ProcessorInterface
         // the variant event copied the full property set of its source dimension. unset every property this
         // dimension's node data row does not set, so a copied-over value does not surface where the row left
         // the property empty or did not carry it at all.
-        $ownPropertyNames = array_keys($serializedPropertyValuesAndReferences->serializedPropertyValues->getPlainValues());
+        $ownPropertyNames = $serializedPropertyValuesAndReferences->serializedPropertyValues->getPropertyNames();
         $copiedPropertyNames = $sourceVariant?->propertyNames ?? PropertyNames::createEmpty();
-        $propertyNamesToUnset = [];
-        foreach ($copiedPropertyNames as $copiedPropertyName) {
-            if (!in_array($copiedPropertyName->value, $ownPropertyNames, true)) {
-                $propertyNamesToUnset[] = $copiedPropertyName;
-            }
-        }
-        $propertiesToUnset = PropertyNames::fromArray($propertyNamesToUnset);
+        $propertiesToUnset = $copiedPropertyNames->getDifference($ownPropertyNames);
         if ($serializedPropertyValuesAndReferences->serializedPropertyValues->count() > 0
             || !$propertiesToUnset->isEmpty()
         ) {

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
@@ -15,6 +15,8 @@ Feature: Migrating nodes with content dimensions
           type: string
         'title':
           type: string
+        'hiddenInMenu':
+          type: boolean
     'Some.Package:Thing': {}
     """
     And using identifier "default", I define a content repository
@@ -141,3 +143,20 @@ Feature: Migrating nodes with content dimensions
       | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}, "initialPropertyValues": {"text": {"value": "hallo", "type": "string"}, "title": {"value": "Startseite", "type": "string"}}}   |
       | NodePeerVariantWasCreated           | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "peerOrigin": {"language": "en"}}                                                                                                           |
       | NodePropertiesWereSet               | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}, "propertyValues": {"text": {"value": "hello", "type": "string"}}, "propertiesToUnset": ["title"]}                              |
+
+  Scenario: A "hidden in menu" flag not set on a variant's row is unset instead of keeping the copied source value
+    # "hiddeninindex" is a per-row column in the legacy content repository, migrated to the "hiddenInMenu" property.
+    # the "en" peer variant copies hiddenInMenu=true from its "de" source, but its own row is not hidden in menus,
+    # so the copied property must be unset to match what the legacy site rendered in "en".
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden in index |
+      | sites-node-id | /sites           | unstructured          |                      |                 |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | 1               |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 0               |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                             |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}, "initialPropertyValues": {"hiddenInMenu": {"value": true, "type": "boolean"}}} |
+      | NodePeerVariantWasCreated           | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "peerOrigin": {"language": "en"}}                                                           |
+      | NodePropertiesWereSet               | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}, "propertiesToUnset": ["hiddenInMenu"]}                                         |

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/Variants.feature
@@ -10,6 +10,11 @@ Feature: Migrating nodes with content dimensions
     'Some.Package:Homepage':
       superTypes:
         'Neos.Neos:Site': true
+      properties:
+        'text':
+          type: string
+        'title':
+          type: string
     'Some.Package:Thing': {}
     """
     And using identifier "default", I define a content repository
@@ -104,3 +109,35 @@ Feature: Migrating nodes with content dimensions
       | NodeAggregateWasMoved               | {"nodeAggregateId": "a", "newParentNodeAggregateId": "b", "succeedingSiblingsForCoverage": [{"dimensionSpacePoint":{"language":"ch"},"nodeAggregateId":null}]}                                                                                                                    |
       | NodeSpecializationVariantWasCreated | {"nodeAggregateId": "a1", "sourceOrigin": {"language": "de"}, "specializationOrigin": {"language": "ch"}, "specializationSiblings": [{"dimensionSpacePoint":{"language": "ch"},"nodeAggregateId":null}]}                                                                          |
 
+
+  Scenario: A property emptied in a variant is unset instead of keeping the copied source value
+    # the "en" peer variant is created as a copy of its "de" source, so it starts with text="hallo".
+    # an emptied "en" value must be exported as a property to unset, otherwise the copied value survives.
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Properties        |
+      | sites-node-id | /sites           | unstructured          |                      |                   |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | {"text": "hallo"} |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | {"text": ""}      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                          |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                             |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}, "initialPropertyValues": {"text": {"value": "hallo", "type": "string"}}} |
+      | NodePeerVariantWasCreated           | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "peerOrigin": {"language": "en"}}                         |
+      | NodePropertiesWereSet               | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}, "propertiesToUnset": ["text"]}               |
+
+  Scenario: A property absent from a variant's row is unset instead of keeping the copied source value
+    # the "en" peer variant copies "text" and "title" from its "de" source. its row overrides "text" but does not
+    # carry "title" at all, so the copied "title" must be unset rather than left to surface in "en".
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Properties                               |
+      | sites-node-id | /sites           | unstructured          |                      |                                          |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | {"text": "hallo", "title": "Startseite"} |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | {"text": "hello"}                        |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                                                                                            |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                                                                                                               |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}, "initialPropertyValues": {"text": {"value": "hallo", "type": "string"}, "title": {"value": "Startseite", "type": "string"}}}   |
+      | NodePeerVariantWasCreated           | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "peerOrigin": {"language": "en"}}                                                                                                           |
+      | NodePropertiesWereSet               | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}, "propertyValues": {"text": {"value": "hello", "type": "string"}}, "propertiesToUnset": ["title"]}                              |


### PR DESCRIPTION
After migrating a legacy site with content dimensions, a dimension variant shows values from the dimension it was created from, even for properties left empty or never set in that variant. (e.g. an empty or non-existent property in the "en" variant still shows the "de" node after migration.

This happens because creating a node variant copies the **whole** property set of the other node as source dimension (`copyNodeToDimensionSpacePoint`); the variant-created events carry no properties of their own. The migration wrote the variant's own values but never unset the copied-over ones it doesn't override, so they survive.

It's not fixed since `EventExportProcessor::createNodeVariant()` now follows the variant creation with a `NodePropertiesWereSet` that unsets every property copied from the source which the variant's own node-data row does not set. 