### PR TITLE
BUGFIX: Provide `./flow subscription:catchUpActive` to invoke a manual catchup

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/ContentRepositoryMaintenanceCommandControllerTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/ContentRepositoryMaintenanceCommandControllerTest.php
@@ -139,4 +139,27 @@ final class ContentRepositoryMaintenanceCommandControllerTest extends AbstractSu
 
         $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(2));
     }
+
+    /** @test */
+    public function catchupOnAdvancedModifiedEventStore(): void
+    {
+        $this->fakeProjection->expects(self::once())->method('setUp');
+        $this->fakeProjection->expects(self::once())->method('apply');
+        $this->fakeProjection->expects(self::never())->method('resetState');
+        $this->fakeProjection->expects(self::any())->method('status')->willReturn(ProjectionStatus::ok());
+
+        $this->crController->setupCommand(contentRepository: $this->contentRepository->id->value, quiet: true);
+        self::assertEmpty($this->bufferedOutput->fetch());
+        $this->expectOkayStatus('contentGraph', SubscriptionStatus::ACTIVE, SequenceNumber::none());
+        $this->expectOkayStatus('Vendor.Package:FakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::none());
+        $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::none());
+
+        $this->commitExampleContentStreamEvent();
+
+        $this->subscriptionController->catchUpActiveCommand(contentRepository: $this->contentRepository->id->value, quiet: true);
+        self::assertEmpty($this->bufferedOutput->fetch());
+        $this->expectOkayStatus('contentGraph', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
+        $this->expectOkayStatus('Vendor.Package:FakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
+        $this->expectOkayStatus('Vendor.Package:SecondFakeProjection', SubscriptionStatus::ACTIVE, SequenceNumber::fromInteger(1));
+    }
 }

--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
@@ -149,6 +149,23 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
     }
 
     /**
+     * Catchup all active subscriptions
+     *
+     * Allows explicit manual invocation for recovery
+     * All modifications via {@see ContentRepository::handle()} already trigger a catchup internally
+     * It cannot be 100% guaranteed that the commited events are catchup as they are two transactions by design
+     * A lost database connection or killed PHP process can result in the event-store being ahead.
+     */
+    public function catchupAllSubscriptions(\Closure|null $progressCallback = null): Error|null
+    {
+        $catchupResult = $this->subscriptionEngine->catchUpActive(progressCallback: $progressCallback, batchSize: self::REPLAY_BATCH_SIZE);
+        if ($catchupResult->errors !== null) {
+            return self::createErrorForReason('Catchup failed:', $catchupResult->errors);
+        }
+        return null;
+    }
+
+    /**
      * Reactivate a subscription
      *
      * The explicit catchup is only needed for subscriptions in the error or detached status with an advanced position.

--- a/Neos.ContentRepositoryRegistry/Classes/Command/SubscriptionCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/SubscriptionCommandController.php
@@ -89,6 +89,52 @@ final class SubscriptionCommandController extends CommandController
     }
 
     /**
+     * Catchup all active subscriptions
+     *
+     * Allows explicit manual invocation for recovery
+     * All modifications via {@see ContentRepository::handle()} already trigger a catchup internally
+     * It cannot be 100% guaranteed that the commited events are catchup as they are two transactions by design
+     * A lost database connection or killed PHP process can result in the event-store being ahead.
+     *
+     * @param string $contentRepository Identifier of the Content Repository instance to operate on
+     * @param bool $quiet If set only fatal errors are rendered to the output
+     */
+    public function catchUpActiveCommand(string $contentRepository = 'default', bool $quiet = false): void
+    {
+        if ($quiet) {
+            $this->output->getOutput()->setVerbosity(Output::VERBOSITY_QUIET);
+        }
+
+        $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
+        $contentRepositoryMaintainer = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new ContentRepositoryMaintainerFactory());
+
+        $progressCallback = null;
+        if (!$quiet) {
+            $this->outputLine('Catchup new events for all subscriptions of content repository "%s" ...', [$contentRepositoryId->value]);
+            $this->output->getProgressBar()->setFormat('debug');
+            $this->output->progressStart();
+            $progressCallback = fn () => $this->output->progressAdvance();
+        }
+
+        $result = $contentRepositoryMaintainer->catchupAllSubscriptions(progressCallback: $progressCallback);
+
+        if (!$quiet) {
+            $this->output->progressFinish();
+            $this->outputLine();
+        }
+        if ($result !== null) {
+            $this->outputLine('<error>%s</error>', [$result->getMessage()]);
+            $this->quit(1);
+        } elseif (!$quiet) {
+            if ($this->output->getProgressBar()->getProgress() === 0) {
+                $this->outputLine('<success>Already fully caught up.</success>');
+            } else {
+                $this->outputLine('<success>Done.</success>');
+            }
+        }
+    }
+
+    /**
      * Replays all projections of the specified Content Repository by resetting their states and performing a full catchup
      *
      * @param string $contentRepository Identifier of the Content Repository instance to operate on


### PR DESCRIPTION
In the past year i shared a snippet on slack a few times which allowed to trigger a manual catchup. This is not intended to be required to use but we cannot rule out the possibility:

> Allows explicit manual invocation for recovery
> All modifications via `ContentRepository::handle()` already trigger a catchup internally
> It cannot be 100% guaranteed that the commited events are catchup as they are two transactions by design
> A lost database connection or killed PHP process can result in the event-store being ahead.

Now the introduction of the subscription engine #5321 christian and me agreed on a simpler easier to use api instead of the technical _correct_ api. That turns out not to help though. So here it is. 

Also with the new locking #5852 we can run into the theoretical problem that a process wants to do an catchup but a simulated publishing might be blocking it for too long which means no catchup is done.

The code people previously had to use ^^

```php
public function catchUpActiveCommand(string $contentRepository = 'default'): void
{
    $subscriptionEngineAccessor = new class implements ContentRepositoryServiceFactoryInterface {
        public SubscriptionEngine|null $subscriptionEngine;
        public function build(ContentRepositoryServiceFactoryDependencies $serviceFactoryDependencies): ContentRepositoryServiceInterface
        {
            $this->subscriptionEngine = $serviceFactoryDependencies->subscriptionEngine;
            return new class implements ContentRepositoryServiceInterface
            {
            };
        }
    };
    $this-contentRepositoryRegistry->buildService(ContentRepositoryId::fromString($contentRepository), $subscriptionEngineAccessor);
    $subscriptionEngine = $subscriptionEngineAccessor->subscriptionEngine;
    $subscriptionEngine->catchUpActive();
}
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
