### PR TITLE
BUGFIX: Instantiate datasources via object manager

### DIFF
--- a/Neos.Neos/Classes/Service/Controller/DataSourceController.php
+++ b/Neos.Neos/Classes/Service/Controller/DataSourceController.php
@@ -58,7 +58,7 @@ class DataSourceController extends AbstractServiceController
         }
 
         /** @var DataSourceInterface $dataSource */
-        $dataSource = new $dataSources[$dataSourceIdentifier]();
+        $dataSource = $this->objectManager->get($dataSources[$dataSourceIdentifier]);
         if (ObjectAccess::isPropertySettable($dataSource, 'controllerContext')) {
             ObjectAccess::setProperty($dataSource, 'controllerContext', $this->controllerContext);
         }


### PR DESCRIPTION
This is necessary to make them fully compatible with the DI changes in 9.2.