### PR TITLE
TAKS: Use new workspaces icon in backend module

### DIFF
--- a/Neos.Workspace.Ui/Configuration/Settings.Neos.yaml
+++ b/Neos.Workspace.Ui/Configuration/Settings.Neos.yaml
@@ -7,7 +7,7 @@ Neos:
             label: 'Neos.Workspace.Ui:Main:workspaces.label'
             controller: 'Neos\Workspace\Ui\Controller\WorkspaceController'
             description: 'Neos.Workspace.Ui:Main:workspaces.description'
-            icon: fas fa-th-large
+            icon: 'fas fa-layer-group'
             mainStylesheet: 'Lite'
             additionalResources:
               javaScripts:


### PR DESCRIPTION
We have then the same icon in the modules, workspace dropdown and publish dropdown. See https://github.com/neos/neos-ui/pull/4113

<img width="664" height="486" alt="CleanShot 2026-06-11 at 13 37 20@2x" src="https://github.com/user-attachments/assets/225da30a-e6ca-4452-bc11-0945fdd5d592" />

<img width="3186" height="1324" alt="CleanShot 2026-06-11 at 13 37 15@2x" src="https://github.com/user-attachments/assets/40a61097-3668-489e-b88f-4e5abd0f5ece" />
