### PR TITLE
BUGFIX: Do not disable visible node variants when migrating hidden nodes

### DIFF
--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/HiddenNodeVariant.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/HiddenNodeVariant.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+namespace Neos\ContentRepository\LegacyNodeMigration\Helpers;
+
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A node variant that was hidden in the legacy data and is disabled via a deferred SubtreeWasTagged
+ * event at the end of the migration, once all variants of its node aggregate are known.
+ *
+ * @Flow\Proxy(false)
+ */
+final readonly class HiddenNodeVariant
+{
+    public function __construct(
+        public NodeAggregateId $nodeAggregateId,
+        public OriginDimensionSpacePoint $originDimensionSpacePoint,
+    ) {
+    }
+}

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
@@ -62,8 +62,9 @@ final class VisitedNodeAggregate
      *
      * On the other hand, these are the dimension space points that resolved to the occupant in the legacy content
      * repository: a dimension without an own node data row inherited the nearest variant in its fallback chain,
-     * including its hidden state, no matter in which order the rows were processed. Such points must stay disabled
-     * even if a variant visited after the occupant claimed them for the exported structure.
+     * including its hidden state. With the coverage claims following the fallback order this is normally already
+     * part of the coverage above; it remains as a safety net for constellations where claims stay order-dependent
+     * (incomparable origins in multi-dimensional setups), so previously hidden content can never become visible.
      */
     public function resolveAffectedDimensionSpacePoints(OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): DimensionSpacePointSet
     {

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
@@ -30,12 +30,12 @@ final class VisitedNodeAggregate
 
     ) {}
 
-    public function addVariant(OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, PropertyNames $propertyNames): void
+    public function addVariant(OriginDimensionSpacePoint $originDimensionSpacePoint, NodeAggregateId $parentNodeAggregateId, PropertyNames $propertyNames, DimensionSpacePointSet $claimedDimensionSpacePoints): void
     {
         if (isset($this->variants[$originDimensionSpacePoint->hash])) {
             throw new MigrationException(sprintf('Node "%s" with dimension space point "%s" was already visited before', $this->nodeAggregateId->value, $originDimensionSpacePoint->toJson()), 1653050442);
         }
-        $this->variants[$originDimensionSpacePoint->hash] = new VisitedNodeVariant($originDimensionSpacePoint, $parentNodeAggregateId, $propertyNames);
+        $this->variants[$originDimensionSpacePoint->hash] = new VisitedNodeVariant($originDimensionSpacePoint, $parentNodeAggregateId, $propertyNames, $claimedDimensionSpacePoints);
     }
 
     public function getOriginDimensionSpacePoints(): OriginDimensionSpacePointSet
@@ -56,9 +56,9 @@ final class VisitedNodeAggregate
      * disable tag for the occupant must affect after all variants of its node aggregate have been processed.
      *
      * These are, on the one hand, the dimension space points the occupant still covers in the exported structure:
-     * each creation/variation event claims coverage of the specialization set of its origin, excluding the origins
-     * visited before it, and later events take over the dimension space points they claim. The occupant keeps its
-     * own claim minus everything that variants visited after it claimed for themselves.
+     * each creation/variation event claims coverage (recorded on the visited variant), and later events take over
+     * the dimension space points they claim. The occupant keeps its own claim minus everything that variants
+     * visited after it claimed for themselves.
      *
      * On the other hand, these are the dimension space points that resolved to the occupant in the legacy content
      * repository: a dimension without an own node data row inherited the nearest variant in its fallback chain,
@@ -67,19 +67,18 @@ final class VisitedNodeAggregate
      */
     public function resolveAffectedDimensionSpacePoints(OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): DimensionSpacePointSet
     {
-        $affectedDimensionSpacePoints = new DimensionSpacePointSet([]);
-        $previouslyVisitedDimensionSpacePoints = new DimensionSpacePointSet([]);
+        $affectedDimensionSpacePoints = $this->getVariant($occupant)->claimedDimensionSpacePoints;
+        $occupantWasVisited = false;
         foreach ($this->variants as $variant) {
-            $claimedDimensionSpacePoints = $interDimensionalVariationGraph->getSpecializationSet($variant->originDimensionSpacePoint->toDimensionSpacePoint(), true, $previouslyVisitedDimensionSpacePoints);
             if ($variant->originDimensionSpacePoint->equals($occupant)) {
-                $affectedDimensionSpacePoints = $claimedDimensionSpacePoints;
-            } else {
-                $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getDifference($claimedDimensionSpacePoints);
+                $occupantWasVisited = true;
+            } elseif ($occupantWasVisited) {
+                $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getDifference($variant->claimedDimensionSpacePoints);
             }
-            $previouslyVisitedDimensionSpacePoints = $previouslyVisitedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$variant->originDimensionSpacePoint->toDimensionSpacePoint()]));
         }
+        $visitedOrigins = $this->getOriginDimensionSpacePoints()->toDimensionSpacePointSet();
         foreach ($interDimensionalVariationGraph->getSpecializationSet($occupant->toDimensionSpacePoint(), true) as $specialization) {
-            if ($this->fallbackResolvesToOccupant($specialization, $occupant, $interDimensionalVariationGraph)) {
+            if ($this->fallbackResolvesToOccupant($specialization, $occupant, $visitedOrigins, $interDimensionalVariationGraph)) {
                 $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$specialization]));
             }
         }
@@ -91,9 +90,8 @@ final class VisitedNodeAggregate
      * is the nearest visited origin in its fallback chain, so the legacy content repository presented the occupant's
      * variant (and visibility) in this dimension space point.
      */
-    private function fallbackResolvesToOccupant(DimensionSpacePoint $dimensionSpacePoint, OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): bool
+    private function fallbackResolvesToOccupant(DimensionSpacePoint $dimensionSpacePoint, OriginDimensionSpacePoint $occupant, DimensionSpacePointSet $visitedOrigins, InterDimensionalVariationGraph $interDimensionalVariationGraph): bool
     {
-        $visitedOrigins = $this->getOriginDimensionSpacePoints()->toDimensionSpacePointSet();
         foreach ([$dimensionSpacePoint, ...$interDimensionalVariationGraph->getWeightedGeneralizations($dimensionSpacePoint)] as $fallback) {
             if ($visitedOrigins->contains($fallback)) {
                 return $fallback->equals($occupant->toDimensionSpacePoint());

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace Neos\ContentRepository\LegacyNodeMigration\Helpers;
 
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
+use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -46,5 +48,29 @@ final class VisitedNodeAggregate
             throw new \InvalidArgumentException(sprintf('Variant %s of node "%s" has not been visited before', $originDimensionSpacePoint->toJson(), $this->nodeAggregateId->value), 1656058159);
         }
         return $this->variants[$originDimensionSpacePoint->hash];
+    }
+
+    /**
+     * Resolves the dimension space points the given occupant still covers after all variants of its node aggregate
+     * have been processed.
+     *
+     * Each creation/variation event claims coverage of the specialization set of its origin, excluding the origins
+     * visited before it, and later events take over the dimension space points they claim. The final coverage of the
+     * given occupant is therefore its own claim minus everything that variants visited after it claimed for themselves.
+     */
+    public function getCoverageByOccupant(OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): DimensionSpacePointSet
+    {
+        $coverage = new DimensionSpacePointSet([]);
+        $previouslyVisitedDimensionSpacePoints = new DimensionSpacePointSet([]);
+        foreach ($this->variants as $variant) {
+            $claimedDimensionSpacePoints = $interDimensionalVariationGraph->getSpecializationSet($variant->originDimensionSpacePoint->toDimensionSpacePoint(), true, $previouslyVisitedDimensionSpacePoints);
+            if ($variant->originDimensionSpacePoint->equals($occupant)) {
+                $coverage = $claimedDimensionSpacePoints;
+            } else {
+                $coverage = $coverage->getDifference($claimedDimensionSpacePoints);
+            }
+            $previouslyVisitedDimensionSpacePoints = $previouslyVisitedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$variant->originDimensionSpacePoint->toDimensionSpacePoint()]));
+        }
+        return $coverage;
     }
 }

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregate.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Neos\ContentRepository\LegacyNodeMigration\Helpers;
 
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\InterDimensionalVariationGraph;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
@@ -51,26 +52,53 @@ final class VisitedNodeAggregate
     }
 
     /**
-     * Resolves the dimension space points the given occupant still covers after all variants of its node aggregate
-     * have been processed.
+     * Resolves the dimension space points whose visibility follows the given (hidden) occupant, i.e. the points a
+     * disable tag for the occupant must affect after all variants of its node aggregate have been processed.
      *
-     * Each creation/variation event claims coverage of the specialization set of its origin, excluding the origins
-     * visited before it, and later events take over the dimension space points they claim. The final coverage of the
-     * given occupant is therefore its own claim minus everything that variants visited after it claimed for themselves.
+     * These are, on the one hand, the dimension space points the occupant still covers in the exported structure:
+     * each creation/variation event claims coverage of the specialization set of its origin, excluding the origins
+     * visited before it, and later events take over the dimension space points they claim. The occupant keeps its
+     * own claim minus everything that variants visited after it claimed for themselves.
+     *
+     * On the other hand, these are the dimension space points that resolved to the occupant in the legacy content
+     * repository: a dimension without an own node data row inherited the nearest variant in its fallback chain,
+     * including its hidden state, no matter in which order the rows were processed. Such points must stay disabled
+     * even if a variant visited after the occupant claimed them for the exported structure.
      */
-    public function getCoverageByOccupant(OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): DimensionSpacePointSet
+    public function resolveAffectedDimensionSpacePoints(OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): DimensionSpacePointSet
     {
-        $coverage = new DimensionSpacePointSet([]);
+        $affectedDimensionSpacePoints = new DimensionSpacePointSet([]);
         $previouslyVisitedDimensionSpacePoints = new DimensionSpacePointSet([]);
         foreach ($this->variants as $variant) {
             $claimedDimensionSpacePoints = $interDimensionalVariationGraph->getSpecializationSet($variant->originDimensionSpacePoint->toDimensionSpacePoint(), true, $previouslyVisitedDimensionSpacePoints);
             if ($variant->originDimensionSpacePoint->equals($occupant)) {
-                $coverage = $claimedDimensionSpacePoints;
+                $affectedDimensionSpacePoints = $claimedDimensionSpacePoints;
             } else {
-                $coverage = $coverage->getDifference($claimedDimensionSpacePoints);
+                $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getDifference($claimedDimensionSpacePoints);
             }
             $previouslyVisitedDimensionSpacePoints = $previouslyVisitedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$variant->originDimensionSpacePoint->toDimensionSpacePoint()]));
         }
-        return $coverage;
+        foreach ($interDimensionalVariationGraph->getSpecializationSet($occupant->toDimensionSpacePoint(), true) as $specialization) {
+            if ($this->fallbackResolvesToOccupant($specialization, $occupant, $interDimensionalVariationGraph)) {
+                $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$specialization]));
+            }
+        }
+        return $affectedDimensionSpacePoints;
+    }
+
+    /**
+     * Whether the given dimension space point resolves to the occupant via the fallback mechanism, i.e. the occupant
+     * is the nearest visited origin in its fallback chain, so the legacy content repository presented the occupant's
+     * variant (and visibility) in this dimension space point.
+     */
+    private function fallbackResolvesToOccupant(DimensionSpacePoint $dimensionSpacePoint, OriginDimensionSpacePoint $occupant, InterDimensionalVariationGraph $interDimensionalVariationGraph): bool
+    {
+        $visitedOrigins = $this->getOriginDimensionSpacePoints()->toDimensionSpacePointSet();
+        foreach ([$dimensionSpacePoint, ...$interDimensionalVariationGraph->getWeightedGeneralizations($dimensionSpacePoint)] as $fallback) {
+            if ($visitedOrigins->contains($fallback)) {
+                return $fallback->equals($occupant->toDimensionSpacePoint());
+            }
+        }
+        return false;
     }
 }

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregates.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeAggregates.php
@@ -34,6 +34,9 @@ final class VisitedNodeAggregates
         $this->add($nodeAggregateId, $allowedDimensionSubspace, $nodeTypeName, $nodePath, NodeAggregateId::fromString('00000000-0000-0000-0000-000000000000'), PropertyNames::createEmpty());
     }
 
+    /**
+     * @param DimensionSpacePointSet|null $claimedDimensionSpacePoints The coverage the exported creation/variation event of the added variant claims, or null to default to the visited dimension space point itself (used for root nodes, whose variants are only registered for parent resolution)
+     */
     public function add(
         NodeAggregateId $nodeAggregateId,
         DimensionSpacePointSet $coveredDimensionSpacePoints,
@@ -41,13 +44,14 @@ final class VisitedNodeAggregates
         NodePath $nodePath,
         NodeAggregateId $parentNodeAggregateId,
         PropertyNames $propertyNames,
+        ?DimensionSpacePointSet $claimedDimensionSpacePoints = null,
     ): void {
         $visitedNodeAggregate = $this->byNodeAggregateId[$nodeAggregateId->value] ?? new VisitedNodeAggregate($nodeAggregateId, $nodeTypeName);
         if (!$nodeTypeName->equals($visitedNodeAggregate->nodeTypeName)) {
             throw new MigrationException(sprintf('Node aggregate with id "%s" has a type of "%s" in content dimension %s. I was visited previously for content dimension %s with the type "%s". Node variants must not have different types', $nodeAggregateId->value, $nodeTypeName->value, $coveredDimensionSpacePoints->toJson(), $visitedNodeAggregate->getOriginDimensionSpacePoints()->toJson(), $visitedNodeAggregate->nodeTypeName->value), 1655913685);
         }
         foreach ($coveredDimensionSpacePoints as $dimensionSpacePoint) {
-            $visitedNodeAggregate->addVariant(OriginDimensionSpacePoint::fromDimensionSpacePoint($dimensionSpacePoint), $parentNodeAggregateId, $propertyNames);
+            $visitedNodeAggregate->addVariant(OriginDimensionSpacePoint::fromDimensionSpacePoint($dimensionSpacePoint), $parentNodeAggregateId, $propertyNames, $claimedDimensionSpacePoints ?? new DimensionSpacePointSet([$dimensionSpacePoint]));
             $pathAndDimensionSpacePointHash = $nodePath->serializeToString() . '__' . $dimensionSpacePoint->hash;
             if (isset($this->byPathAndDimensionSpacePoint[$pathAndDimensionSpacePointHash])) {
                 throw new MigrationException(sprintf('Node "%s" with path "%s" and dimension space point "%s" was already visited before', $nodeAggregateId->value, $nodePath->serializeToString(), $dimensionSpacePoint->toJson()), 1655900356);

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeVariant.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Helpers/VisitedNodeVariant.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Neos\ContentRepository\LegacyNodeMigration\Helpers;
 
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
@@ -13,10 +14,14 @@ use Neos\Flow\Annotations as Flow;
 final readonly class VisitedNodeVariant
 {
 
+    /**
+     * @param DimensionSpacePointSet $claimedDimensionSpacePoints The dimension space points the exported creation/variation event of this variant covers
+     */
     public function __construct(
         public OriginDimensionSpacePoint $originDimensionSpacePoint,
         public NodeAggregateId $parentNodeAggregateId,
         // the property names this variant holds; a variant created from it copies exactly these
         public PropertyNames $propertyNames,
+        public DimensionSpacePointSet $claimedDimensionSpacePoints
     ) {}
 }

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -484,15 +484,27 @@ final class EventExportProcessor implements ProcessorInterface
 
     /**
      * Resolves the dimension space points a new variant of the node aggregate in the given origin claims for
-     * itself, i.e. the coverage of the exported creation/variation event: the specialization set of the origin,
-     * excluding the origins of previously visited variants.
+     * itself, i.e. the coverage of the exported creation/variation event.
+     *
+     * This replicates {@see \Neos\ContentRepository\Core\Feature\Common\NodeVariationInternals::calculateEffectiveVisibility()}: the variant covers the
+     * specialization set of its origin, except dimension space points already covered by a nearer variant, i.e.
+     * by a previously visited origin that is itself a specialization of the new origin (including that origin's
+     * own specializations). Dimension space points that fall back to a nearer origin therefore stay with it, no
+     * matter in which order the node data rows are processed.
      */
     private function resolveCoverageClaim(NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint): DimensionSpacePointSet
     {
+        $specializations = $this->interDimensionalVariationGraph->getIndexedSpecializations($originDimensionSpacePoint->toDimensionSpacePoint());
+        $excludedSet = new DimensionSpacePointSet([]);
+        foreach ($this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId) as $alreadyVisitedOrigin) {
+            if ($specializations->contains($alreadyVisitedOrigin->toDimensionSpacePoint())) {
+                $excludedSet = $excludedSet->getUnion($this->interDimensionalVariationGraph->getSpecializationSet($alreadyVisitedOrigin->toDimensionSpacePoint()));
+            }
+        }
         return $this->interDimensionalVariationGraph->getSpecializationSet(
             $originDimensionSpacePoint->toDimensionSpacePoint(),
             true,
-            $this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId)->toDimensionSpacePointSet()
+            $excludedSet
         );
     }
 

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -68,9 +68,9 @@ final class EventExportProcessor implements ProcessorInterface
     private array $nodeReferencesWereSetEvents = [];
 
     /**
-     * @var SubtreeWasTagged[]
+     * @var array<int, array{nodeAggregateId: NodeAggregateId, originDimensionSpacePoint: OriginDimensionSpacePoint}>
      */
-    private array $subtreeWasTaggedEvents = [];
+    private array $pendingSubtreeWasTaggedEvents = [];
 
     private int $numberOfExportedEvents = 0;
 
@@ -113,8 +113,16 @@ final class EventExportProcessor implements ProcessorInterface
             $this->processNodeData($context, $nodeDataRow);
         }
         // Disable nodes, when the full import is done.
-        foreach ($this->subtreeWasTaggedEvents as $subtreeWasTaggedEvent) {
-            $this->exportEvent($subtreeWasTaggedEvent);
+        // The affected dimension space points are resolved only now, when all variants of each node aggregate
+        // are known, so a hidden variant does not disable variants of other dimensions created after it.
+        foreach ($this->pendingSubtreeWasTaggedEvents as $pendingSubtreeWasTaggedEvent) {
+            $this->exportEvent(new SubtreeWasTagged(
+                $this->workspaceName,
+                $this->contentStreamId,
+                $pendingSubtreeWasTaggedEvent['nodeAggregateId'],
+                $this->resolveAffectedDimensionSpacePoints($pendingSubtreeWasTaggedEvent['nodeAggregateId'], $pendingSubtreeWasTaggedEvent['originDimensionSpacePoint']),
+                NeosSubtreeTag::disabled()
+            ));
         }
         // Set References, now when the full import is done.
         foreach ($this->nodeReferencesWereSetEvents as $nodeReferencesWereSetEvent) {
@@ -134,6 +142,7 @@ final class EventExportProcessor implements ProcessorInterface
     {
         $this->visitedNodes = new VisitedNodeAggregates();
         $this->nodeReferencesWereSetEvents = [];
+        $this->pendingSubtreeWasTaggedEvents = [];
         $this->numberOfExportedEvents = 0;
         $this->eventFileResource = fopen('php://temp/maxmemory:5242880', 'rb+') ?: null;
         Assert::resource($this->eventFileResource, null, 'Failed to create temporary event file resource');
@@ -283,8 +292,9 @@ final class EventExportProcessor implements ProcessorInterface
         }
         // nodes are hidden via SubtreeWasTagged event
         if ($this->isNodeHidden($nodeDataRow)) {
-            // Put event at the end of the export, so variants created after this node are not disabled on variation
-            $this->subtreeWasTaggedEvents[] = new SubtreeWasTagged($this->workspaceName, $this->contentStreamId, $nodeAggregateId, $this->interDimensionalVariationGraph->getSpecializationSet($originDimensionSpacePoint->toDimensionSpacePoint(), true, $this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId)->toDimensionSpacePointSet()), NeosSubtreeTag::disabled());
+            // The event is built and exported at the end of the export (see run()), when all variants of the node
+            // aggregate are known, so the tag only affects the dimension space points this variant still covers then
+            $this->pendingSubtreeWasTaggedEvents[] = ['nodeAggregateId' => $nodeAggregateId, 'originDimensionSpacePoint' => $originDimensionSpacePoint];
         }
 
         if (!$serializedPropertyValuesAndReferences->references->isEmpty()) {
@@ -527,6 +537,30 @@ final class EventExportProcessor implements ProcessorInterface
 
         return false;
 
+    }
+
+    /**
+     * Resolves the dimension space points a (hidden) node variant still covers after all variants of its node
+     * aggregate have been processed.
+     *
+     * Each creation/variation event claims coverage of the specialization set of its origin, excluding the origins
+     * visited before it, and later events take over the dimension space points they claim. The final coverage of the
+     * tagged origin is therefore its own claim minus everything that variants visited after it claimed for themselves.
+     */
+    private function resolveAffectedDimensionSpacePoints(NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $taggedOriginDimensionSpacePoint): DimensionSpacePointSet
+    {
+        $affectedDimensionSpacePoints = new DimensionSpacePointSet([]);
+        $previouslyVisitedDimensionSpacePoints = new DimensionSpacePointSet([]);
+        foreach ($this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId) as $visitedOriginDimensionSpacePoint) {
+            $claimedDimensionSpacePoints = $this->interDimensionalVariationGraph->getSpecializationSet($visitedOriginDimensionSpacePoint->toDimensionSpacePoint(), true, $previouslyVisitedDimensionSpacePoints);
+            if ($visitedOriginDimensionSpacePoint->equals($taggedOriginDimensionSpacePoint)) {
+                $affectedDimensionSpacePoints = $claimedDimensionSpacePoints;
+            } else {
+                $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getDifference($claimedDimensionSpacePoints);
+            }
+            $previouslyVisitedDimensionSpacePoints = $previouslyVisitedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$visitedOriginDimensionSpacePoint->toDimensionSpacePoint()]));
+        }
+        return $affectedDimensionSpacePoints;
     }
 
     private function isRootNodePath(string $path): bool

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -121,7 +121,7 @@ final class EventExportProcessor implements ProcessorInterface
                 $this->workspaceName,
                 $this->contentStreamId,
                 $hiddenNodeVariant->nodeAggregateId,
-                $this->visitedNodes->getByNodeAggregateId($hiddenNodeVariant->nodeAggregateId)->getCoverageByOccupant($hiddenNodeVariant->originDimensionSpacePoint, $this->interDimensionalVariationGraph),
+                $this->visitedNodes->getByNodeAggregateId($hiddenNodeVariant->nodeAggregateId)->resolveAffectedDimensionSpacePoints($hiddenNodeVariant->originDimensionSpacePoint, $this->interDimensionalVariationGraph),
                 NeosSubtreeTag::disabled()
             ));
         }

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -121,7 +121,7 @@ final class EventExportProcessor implements ProcessorInterface
                 $this->workspaceName,
                 $this->contentStreamId,
                 $hiddenNodeVariant->nodeAggregateId,
-                $this->resolveAffectedDimensionSpacePoints($hiddenNodeVariant->nodeAggregateId, $hiddenNodeVariant->originDimensionSpacePoint),
+                $this->visitedNodes->getByNodeAggregateId($hiddenNodeVariant->nodeAggregateId)->getCoverageByOccupant($hiddenNodeVariant->originDimensionSpacePoint, $this->interDimensionalVariationGraph),
                 NeosSubtreeTag::disabled()
             ));
         }
@@ -538,30 +538,6 @@ final class EventExportProcessor implements ProcessorInterface
 
         return false;
 
-    }
-
-    /**
-     * Resolves the dimension space points a (hidden) node variant still covers after all variants of its node
-     * aggregate have been processed.
-     *
-     * Each creation/variation event claims coverage of the specialization set of its origin, excluding the origins
-     * visited before it, and later events take over the dimension space points they claim. The final coverage of the
-     * tagged origin is therefore its own claim minus everything that variants visited after it claimed for themselves.
-     */
-    private function resolveAffectedDimensionSpacePoints(NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $taggedOriginDimensionSpacePoint): DimensionSpacePointSet
-    {
-        $affectedDimensionSpacePoints = new DimensionSpacePointSet([]);
-        $previouslyVisitedDimensionSpacePoints = new DimensionSpacePointSet([]);
-        foreach ($this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId) as $visitedOriginDimensionSpacePoint) {
-            $claimedDimensionSpacePoints = $this->interDimensionalVariationGraph->getSpecializationSet($visitedOriginDimensionSpacePoint->toDimensionSpacePoint(), true, $previouslyVisitedDimensionSpacePoints);
-            if ($visitedOriginDimensionSpacePoint->equals($taggedOriginDimensionSpacePoint)) {
-                $affectedDimensionSpacePoints = $claimedDimensionSpacePoints;
-            } else {
-                $affectedDimensionSpacePoints = $affectedDimensionSpacePoints->getDifference($claimedDimensionSpacePoints);
-            }
-            $previouslyVisitedDimensionSpacePoints = $previouslyVisitedDimensionSpacePoints->getUnion(new DimensionSpacePointSet([$visitedOriginDimensionSpacePoint->toDimensionSpacePoint()]));
-        }
-        return $affectedDimensionSpacePoints;
     }
 
     private function isRootNodePath(string $path): bool

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -46,6 +46,7 @@ use Neos\ContentRepository\Export\ProcessingContext;
 use Neos\ContentRepository\Export\ProcessorInterface;
 use Neos\ContentRepository\Export\Severity;
 use Neos\ContentRepository\LegacyNodeMigration\Exception\MigrationException;
+use Neos\ContentRepository\LegacyNodeMigration\Helpers\HiddenNodeVariant;
 use Neos\ContentRepository\LegacyNodeMigration\Helpers\SerializedPropertyValuesAndReferences;
 use Neos\ContentRepository\LegacyNodeMigration\Helpers\VisitedNodeAggregate;
 use Neos\ContentRepository\LegacyNodeMigration\Helpers\VisitedNodeAggregates;
@@ -68,9 +69,9 @@ final class EventExportProcessor implements ProcessorInterface
     private array $nodeReferencesWereSetEvents = [];
 
     /**
-     * @var array<int, array{nodeAggregateId: NodeAggregateId, originDimensionSpacePoint: OriginDimensionSpacePoint}>
+     * @var array<int, HiddenNodeVariant>
      */
-    private array $pendingSubtreeWasTaggedEvents = [];
+    private array $hiddenNodeVariants = [];
 
     private int $numberOfExportedEvents = 0;
 
@@ -115,12 +116,12 @@ final class EventExportProcessor implements ProcessorInterface
         // Disable nodes, when the full import is done.
         // The affected dimension space points are resolved only now, when all variants of each node aggregate
         // are known, so a hidden variant does not disable variants of other dimensions created after it.
-        foreach ($this->pendingSubtreeWasTaggedEvents as $pendingSubtreeWasTaggedEvent) {
+        foreach ($this->hiddenNodeVariants as $hiddenNodeVariant) {
             $this->exportEvent(new SubtreeWasTagged(
                 $this->workspaceName,
                 $this->contentStreamId,
-                $pendingSubtreeWasTaggedEvent['nodeAggregateId'],
-                $this->resolveAffectedDimensionSpacePoints($pendingSubtreeWasTaggedEvent['nodeAggregateId'], $pendingSubtreeWasTaggedEvent['originDimensionSpacePoint']),
+                $hiddenNodeVariant->nodeAggregateId,
+                $this->resolveAffectedDimensionSpacePoints($hiddenNodeVariant->nodeAggregateId, $hiddenNodeVariant->originDimensionSpacePoint),
                 NeosSubtreeTag::disabled()
             ));
         }
@@ -142,7 +143,7 @@ final class EventExportProcessor implements ProcessorInterface
     {
         $this->visitedNodes = new VisitedNodeAggregates();
         $this->nodeReferencesWereSetEvents = [];
-        $this->pendingSubtreeWasTaggedEvents = [];
+        $this->hiddenNodeVariants = [];
         $this->numberOfExportedEvents = 0;
         $this->eventFileResource = fopen('php://temp/maxmemory:5242880', 'rb+') ?: null;
         Assert::resource($this->eventFileResource, null, 'Failed to create temporary event file resource');
@@ -294,7 +295,7 @@ final class EventExportProcessor implements ProcessorInterface
         if ($this->isNodeHidden($nodeDataRow)) {
             // The event is built and exported at the end of the export (see run()), when all variants of the node
             // aggregate are known, so the tag only affects the dimension space points this variant still covers then
-            $this->pendingSubtreeWasTaggedEvents[] = ['nodeAggregateId' => $nodeAggregateId, 'originDimensionSpacePoint' => $originDimensionSpacePoint];
+            $this->hiddenNodeVariants[] = new HiddenNodeVariant($nodeAggregateId, $originDimensionSpacePoint);
         }
 
         if (!$serializedPropertyValuesAndReferences->references->isEmpty()) {

--- a/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
+++ b/Neos.ContentRepository.LegacyNodeMigration/Classes/Processors/EventExportProcessor.php
@@ -247,10 +247,11 @@ final class EventExportProcessor implements ProcessorInterface
 
         $serializedPropertyValuesAndReferences = $this->extractPropertyValuesAndReferences($context, $nodeDataRow, $nodeType);
 
+        $claimedDimensionSpacePoints = $this->resolveCoverageClaim($nodeAggregateId, $originDimensionSpacePoint);
+
         if ($this->isAutoCreatedChildNode($parentNodeAggregate->nodeTypeName, $nodeName) && !$this->visitedNodes->containsNodeAggregate($nodeAggregateId)) {
             // Create tethered node if the node was not found before.
             // If the node was already visited, we want to create a node variant (and keep the tethering status)
-            $specializations = $this->interDimensionalVariationGraph->getSpecializationSet($originDimensionSpacePoint->toDimensionSpacePoint(), true, $this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId)->toDimensionSpacePointSet());
             $this->exportEvent(
                 new NodeAggregateWithNodeWasCreated(
                     $this->workspaceName,
@@ -258,7 +259,7 @@ final class EventExportProcessor implements ProcessorInterface
                     $nodeAggregateId,
                     $nodeTypeName,
                     $originDimensionSpacePoint,
-                    InterdimensionalSiblings::fromDimensionSpacePointSetWithoutSucceedingSiblings($specializations),
+                    InterdimensionalSiblings::fromDimensionSpacePointSetWithoutSucceedingSiblings($claimedDimensionSpacePoints),
                     $parentNodeAggregate->nodeAggregateId,
                     $nodeName,
                     $serializedPropertyValuesAndReferences->serializedPropertyValues,
@@ -268,7 +269,7 @@ final class EventExportProcessor implements ProcessorInterface
             );
         } elseif ($this->visitedNodes->containsNodeAggregate($nodeAggregateId)) {
             // Create node variant, BOTH for tethered and regular nodes
-            $this->createNodeVariant($nodeAggregateId, $originDimensionSpacePoint, $serializedPropertyValuesAndReferences, $parentNodeAggregate);
+            $this->createNodeVariant($nodeAggregateId, $originDimensionSpacePoint, $claimedDimensionSpacePoints, $serializedPropertyValuesAndReferences, $parentNodeAggregate);
         } else {
             // create node aggregate
             $this->exportEvent(
@@ -278,11 +279,7 @@ final class EventExportProcessor implements ProcessorInterface
                     $nodeAggregateId,
                     $nodeTypeName,
                     $originDimensionSpacePoint,
-                    InterdimensionalSiblings::fromDimensionSpacePointSetWithoutSucceedingSiblings(
-                        $this->interDimensionalVariationGraph->getSpecializationSet(
-                            $originDimensionSpacePoint->toDimensionSpacePoint()
-                        )
-                    ),
+                    InterdimensionalSiblings::fromDimensionSpacePointSetWithoutSucceedingSiblings($claimedDimensionSpacePoints),
                     $parentNodeAggregate->nodeAggregateId,
                     $nodeName,
                     $serializedPropertyValuesAndReferences->serializedPropertyValues,
@@ -302,7 +299,7 @@ final class EventExportProcessor implements ProcessorInterface
             $this->nodeReferencesWereSetEvents[] = new NodeReferencesWereSet($this->workspaceName, $this->contentStreamId, $nodeAggregateId, new OriginDimensionSpacePointSet([$originDimensionSpacePoint]), $serializedPropertyValuesAndReferences->references);
         }
 
-        $this->visitedNodes->add($nodeAggregateId, new DimensionSpacePointSet([$originDimensionSpacePoint->toDimensionSpacePoint()]), $nodeTypeName, $nodePath, $parentNodeAggregate->nodeAggregateId, $serializedPropertyValuesAndReferences->serializedPropertyValues->getPropertyNames());
+        $this->visitedNodes->add($nodeAggregateId, new DimensionSpacePointSet([$originDimensionSpacePoint->toDimensionSpacePoint()]), $nodeTypeName, $nodePath, $parentNodeAggregate->nodeAggregateId, $serializedPropertyValuesAndReferences->serializedPropertyValues->getPropertyNames(), $claimedDimensionSpacePoints);
     }
 
     /**
@@ -386,10 +383,9 @@ final class EventExportProcessor implements ProcessorInterface
      * NOTE: We prioritize specializations/generalizations over peer variants ("ch" creates a specialization variant of "de" rather than a peer of "en" if both has been seen before).
      * For that reason we loop over all previously visited dimension space points until we encounter a specialization/generalization. Otherwise, the last NodePeerVariantWasCreated will be used
      */
-    private function createNodeVariant(NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, SerializedPropertyValuesAndReferences $serializedPropertyValuesAndReferences, VisitedNodeAggregate $parentNodeAggregate): void
+    private function createNodeVariant(NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint, DimensionSpacePointSet $coveredDimensionSpacePoints, SerializedPropertyValuesAndReferences $serializedPropertyValuesAndReferences, VisitedNodeAggregate $parentNodeAggregate): void
     {
         $alreadyVisitedOriginDimensionSpacePoints = $this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId);
-        $coveredDimensionSpacePoints = $this->interDimensionalVariationGraph->getSpecializationSet($originDimensionSpacePoint->toDimensionSpacePoint(), true, $alreadyVisitedOriginDimensionSpacePoints->toDimensionSpacePointSet());
         $variantCreatedEvent = null;
         $variantSourceOriginDimensionSpacePoint = null;
         foreach ($alreadyVisitedOriginDimensionSpacePoints as $alreadyVisitedOriginDimensionSpacePoint) {
@@ -484,6 +480,20 @@ final class EventExportProcessor implements ProcessorInterface
                 )
             ));
         }
+    }
+
+    /**
+     * Resolves the dimension space points a new variant of the node aggregate in the given origin claims for
+     * itself, i.e. the coverage of the exported creation/variation event: the specialization set of the origin,
+     * excluding the origins of previously visited variants.
+     */
+    private function resolveCoverageClaim(NodeAggregateId $nodeAggregateId, OriginDimensionSpacePoint $originDimensionSpacePoint): DimensionSpacePointSet
+    {
+        return $this->interDimensionalVariationGraph->getSpecializationSet(
+            $originDimensionSpacePoint->toDimensionSpacePoint(),
+            true,
+            $this->visitedNodes->alreadyVisitedOriginDimensionSpacePoints($nodeAggregateId)->toDimensionSpacePointSet()
+        );
     }
 
     private function isAutoCreatedChildNode(NodeTypeName $parentNodeTypeName, NodeName $nodeName): bool

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenInDimensions.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenInDimensions.feature
@@ -69,6 +69,34 @@ Feature: Migrating hidden nodes with content dimensions
       | NodeGeneralizationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "generalizationOrigin": {"language": "en"}}             |
       | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"},{"language": "ch"}], "tag": "disabled"} |
 
+  Scenario: A hidden node variant processed before a visible generalization variant must stay hidden in the dimensions it shines through to
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden |
+      | sites-node-id | /sites           | unstructured          |                      | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | 1      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 0      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                         |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                            |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}}                                            |
+      | NodeGeneralizationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "generalizationOrigin": {"language": "en"}}             |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "de"},{"language": "ch"}], "tag": "disabled"} |
+
+  Scenario: A hidden node variant processed after a visible generalization variant must stay hidden in the dimensions it shines through to
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden |
+      | sites-node-id | /sites           | unstructured          |                      | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | 1      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                         |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                            |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}}                                            |
+      | NodeSpecializationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "en"}, "specializationOrigin": {"language": "de"}}             |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "de"},{"language": "ch"}], "tag": "disabled"} |
+
   Scenario: A hidden node without dimension values must be disabled in every dimension it was created in
     When I have the following node data rows:
       | Identifier    | Path             | Node Type             | Dimension Values | Hidden |

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenInDimensions.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenInDimensions.feature
@@ -67,7 +67,7 @@ Feature: Migrating hidden nodes with content dimensions
       | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                            |
       | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}}                                            |
       | NodeGeneralizationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "generalizationOrigin": {"language": "en"}}             |
-      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"},{"language": "ch"}], "tag": "disabled"} |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"}], "tag": "disabled"}                    |
 
   Scenario: A hidden node variant processed before a visible generalization variant must stay hidden in the dimensions it shines through to
     When I have the following node data rows:

--- a/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenInDimensions.feature
+++ b/Neos.ContentRepository.LegacyNodeMigration/Tests/Behavior/Features/HiddenInDimensions.feature
@@ -1,0 +1,86 @@
+Feature: Migrating hidden nodes with content dimensions
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Default | Values     | Generalizations |
+      | language   | en      | en, de, ch | ch->de->en      |
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Site': {}
+    'Some.Package:Homepage':
+      superTypes:
+        'Neos.Neos:Site': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+
+  Scenario: A hidden node variant processed before a visible variant of the same node must not disable the visible variant
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden |
+      | sites-node-id | /sites           | unstructured          |                      | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 1      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | 0      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                      |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                         |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}}                         |
+      | NodeSpecializationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "en"}, "specializationOrigin": {"language": "de"}} |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"}], "tag": "disabled"} |
+
+  Scenario: A hidden node without variants in fallback dimensions must stay hidden in all dimensions it shines through to
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden |
+      | sites-node-id | /sites           | unstructured          |                      | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 1      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                                            |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                                               |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}}                                                               |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"},{"language": "de"},{"language": "ch"}], "tag": "disabled"} |
+
+  Scenario: Two hidden variants of the same node must each be disabled with their own coverage
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden |
+      | sites-node-id | /sites           | unstructured          |                      | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 1      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | 1      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                         |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                            |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}}                                            |
+      | NodeSpecializationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "en"}, "specializationOrigin": {"language": "de"}}             |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"}], "tag": "disabled"}                    |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "de"},{"language": "ch"}], "tag": "disabled"} |
+
+  Scenario: A hidden node variant processed after a visible variant of the same node must not disable the visible variant
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values     | Hidden |
+      | sites-node-id | /sites           | unstructured          |                      | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["de"]} | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage | {"language": ["en"]} | 1      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                                         |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                            |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "de"}}                                            |
+      | NodeGeneralizationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "de"}, "generalizationOrigin": {"language": "en"}}             |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"},{"language": "ch"}], "tag": "disabled"} |
+
+  Scenario: A hidden node without dimension values must be disabled in every dimension it was created in
+    When I have the following node data rows:
+      | Identifier    | Path             | Node Type             | Dimension Values | Hidden |
+      | sites-node-id | /sites           | unstructured          |                  | 0      |
+      | site-node-id  | /sites/test-site | Some.Package:Homepage |                  | 1      |
+    And I run the event migration
+    Then I expect the following events to be exported
+      | Type                                | Payload                                                                                                             |
+      | RootNodeAggregateWithNodeWasCreated | {"nodeAggregateId": "sites-node-id"}                                                                                |
+      | NodeAggregateWithNodeWasCreated     | {"nodeAggregateId": "site-node-id", "originDimensionSpacePoint": {"language": "en"}}                                |
+      | NodeSpecializationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "en"}, "specializationOrigin": {"language": "de"}} |
+      | NodeSpecializationVariantWasCreated | {"nodeAggregateId": "site-node-id", "sourceOrigin": {"language": "en"}, "specializationOrigin": {"language": "ch"}} |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "en"}], "tag": "disabled"}        |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "de"}], "tag": "disabled"}        |
+      | SubtreeWasTagged                    | {"nodeAggregateId": "site-node-id", "affectedDimensionSpacePoints": [{"language": "ch"}], "tag": "disabled"}        |


### PR DESCRIPTION
### What I did
This fixes a bug in the legacy node migration where a node that is hidden in one dimension could end up disabled in other dimensions as well, even though it has its own visible variant there. For example, a page with a hidden en row and a visible de row was disabled in both languages after the migration, although it was visible in de in the old content repository.

###  How I did it
Hidden nodes are migrated as SubtreeWasTagged (disabled) events. These events were already exported at the very end of the migration, but their affected dimension space points were computed while the row was being processed, at a point where variants of the same node in other dimensions may not have been seen yet. The exported tag could therefore still cover dimensions whose own row said the node is visible.

The affected dimension space points are now resolved when the events are exported, after all rows have been processed. The tag is limited to the dimension space points the hidden variant still covers in the final structure, so visible variants keep their state.