### PR TITLE
TASK: Disable new global cr advisory lock by default

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/PublishingDuringPublishing/PublishingDuringPublishingTest.php
@@ -99,6 +99,9 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
             ]
         ]);
 
+        /** Hack until https://github.com/neos/neos-development-collection/issues/5869 is fixed */
+        \Neos\ContentRepository\Dbal\MysqlPlatformContentRepositoryLocker::enableForContentRepository(ContentRepositoryId::fromString('test_parallel'));
+
         $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
 
         $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);

--- a/Neos.ContentRepository.Dbal/Classes/MysqlPlatformContentRepositoryLocker.php
+++ b/Neos.ContentRepository.Dbal/Classes/MysqlPlatformContentRepositoryLocker.php
@@ -14,10 +14,24 @@ use Doctrine\DBAL\Exception as DBALException;
  */
 final class MysqlPlatformContentRepositoryLocker
 {
+    /**
+     * @var array<string,true>
+     */
+    private static array $enabledForContentRepositories = [];
+
     private function __construct(
+        private ContentRepositoryId $contentRepositoryId,
         private string $crLockName,
         private Connection $dbal,
     ) {
+    }
+
+    /**
+     * @internal
+     */
+    public static function enableForContentRepository(ContentRepositoryId $contentRepositoryId): void
+    {
+        self::$enabledForContentRepositories[$contentRepositoryId->value] = true;
     }
 
     public static function forContentRepositoryAndConnection(
@@ -25,6 +39,7 @@ final class MysqlPlatformContentRepositoryLocker
         Connection $connection,
     ): self {
         return new self(
+            contentRepositoryId: $contentRepositoryId,
             crLockName: sprintf('CR_%s', strtoupper($contentRepositoryId->value)),
             dbal: $connection,
         );
@@ -38,6 +53,9 @@ final class MysqlPlatformContentRepositoryLocker
      */
     public function acquireLock(int $timeoutInSeconds): void
     {
+        if (!isset(self::$enabledForContentRepositories[$this->contentRepositoryId->value])) {
+            return;
+        }
         try {
             $result = $this->dbal->executeQuery('SELECT GET_LOCK(:name, :timeoutInSeconds)', ['name' => $this->crLockName, 'timeoutInSeconds' => $timeoutInSeconds]);
         } catch (DBALException $exception) {
@@ -55,6 +73,9 @@ final class MysqlPlatformContentRepositoryLocker
      */
     public function releaseLock(): void
     {
+        if (!isset(self::$enabledForContentRepositories[$this->contentRepositoryId->value])) {
+            return;
+        }
         try {
             $this->dbal->executeStatement('SELECT RELEASE_LOCK(:name)', ['name' => $this->crLockName]);
         } catch (DBALException $exception) {

--- a/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
+++ b/Neos.ContentRepositoryRegistry/Classes/ContentRepositoryRegistry.php
@@ -187,6 +187,12 @@ final class ContentRepositoryRegistry
             $contentRepositorySettings = Arrays::arrayMergeRecursiveOverrule($this->settings['presets'][$contentRepositorySettings['preset']], $contentRepositorySettings);
             unset($contentRepositorySettings['preset']);
         }
+
+        /** Hack until https://github.com/neos/neos-development-collection/issues/5869 is fixed */
+        if (($contentRepositorySettings['experimentalContentRepositoryLock'] ?? false) === true) {
+            \Neos\ContentRepository\Dbal\MysqlPlatformContentRepositoryLocker::enableForContentRepository($contentRepositoryId);
+        }
+
         try {
             /** @var CatchUpHookFactoryInterface<ContentGraphReadModelInterface>|null $contentGraphCatchUpHookFactory */
             $contentGraphCatchUpHookFactory = $this->buildCatchUpHookFactory($contentRepositoryId, 'contentGraph', $contentRepositorySettings['contentGraphProjection']);


### PR DESCRIPTION
Followup to https://github.com/neos/neos-development-collection/pull/5852

Adds `experimentalContentRepositoryLock` as configuration option - for us - it does not work fully yet.

See

https://github.com/neos/neos-development-collection/issues/5869

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
