### PR TITLE
FEATURE: Replay throughput profiling chart via a PerformanceTracer

### DIFF
--- a/Neos.ContentRepository.Core/Classes/ContentRepository.php
+++ b/Neos.ContentRepository.Core/Classes/ContentRepository.php
@@ -31,6 +31,7 @@ use Neos\ContentRepository\Core\Feature\Security\AuthProviderInterface;
 use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
 use Neos\ContentRepository\Core\Feature\Security\Exception\AccessDenied;
 use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\TracePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
@@ -91,25 +92,25 @@ final class ContentRepository
      */
     public function handle(CommandInterface $command): void
     {
-        $this->performanceTracer?->openSpan('ContentRepository::handle', ['c' => get_class($command)]);
+        $this->performanceTracer?->openSpan(TracePoint::ContentRepositoryHandle, ['c' => get_class($command)]);
         try {
             $command = $this->commandHook->onBeforeHandle($command);
-            $this->performanceTracer?->mark('CommandHook::onBeforeHandle');
+            $this->performanceTracer?->mark(TracePoint::CommandHookOnBeforeHandle);
 
             $privilege = $this->authProvider->canExecuteCommand($command);
-            $this->performanceTracer?->mark('AuthProvider::canExecuteCommand');
+            $this->performanceTracer?->mark(TracePoint::AuthProviderCanExecuteCommand);
             if (!$privilege->granted) {
                 throw AccessDenied::becauseCommandIsNotGranted($command, $privilege->getReason());
             }
             $toPublish = $this->commandBus->handle($command);
-            $this->performanceTracer?->mark('CommandBus::handle');
+            $this->performanceTracer?->mark(TracePoint::CommandBusHandle);
 
             $correlationId = CorrelationId::fromString(sprintf('%s_%s', substr($command::class, strrpos($command::class, '\\') + 1, 20), bin2hex(random_bytes(9))));
 
             // simple case
             if ($toPublish instanceof EventsToPublish) {
                 $this->eventStore->commit($toPublish->streamName, $this->enrichAndNormalizeEvents($toPublish->events, $correlationId), $toPublish->expectedVersion);
-                $this->performanceTracer?->mark('EventStore::commit');
+                $this->performanceTracer?->mark(TracePoint::EventStoreCommit);
                 $fullCatchUpResult = $this->subscriptionEngine->catchUpActive(); // NOTE: we don't batch here, to ensure the catchup is run completely and any errors don't stop it.
                 // SubscriptionEngine is tracing automatically; so we do not need to add this here
                 if ($fullCatchUpResult->hadErrors()) {
@@ -119,7 +120,7 @@ final class ContentRepository
                 foreach ($additionalCommands as $additionalCommand) {
                     $this->handle($additionalCommand);
                 }
-                $this->performanceTracer?->mark('CommandHook::onAfterHandle');
+                $this->performanceTracer?->mark(TracePoint::CommandHookOnAfterHandle);
                 return;
             }
 
@@ -129,7 +130,7 @@ final class ContentRepository
                 foreach ($toPublish as $eventsToPublish) {
                     try {
                         $this->eventStore->commit($eventsToPublish->streamName, $this->enrichAndNormalizeEvents($eventsToPublish->events, $correlationId), $eventsToPublish->expectedVersion);
-                        $this->performanceTracer?->mark('EventStore::commit', ['streamName' => $eventsToPublish->streamName->value, 'cnt' => $eventsToPublish->events->count()]);
+                        $this->performanceTracer?->mark(TracePoint::EventStoreCommit, ['streamName' => $eventsToPublish->streamName->value, 'cnt' => $eventsToPublish->events->count()]);
                         $publishedEvents = $publishedEvents->withAppendedEvents($eventsToPublish->events->toInnerEvents());
                     } catch (ConcurrencyException $concurrencyException) {
                         // we pass the exception into the generator (->throw), so it could be try-caught and reacted upon:
@@ -143,7 +144,7 @@ final class ContentRepository
                         $yieldedErrorStrategy = $toPublish->throw($concurrencyException);
                         if ($yieldedErrorStrategy instanceof EventsToPublish) {
                             $this->eventStore->commit($yieldedErrorStrategy->streamName, $this->enrichAndNormalizeEvents($yieldedErrorStrategy->events, $correlationId), $yieldedErrorStrategy->expectedVersion);
-                            $this->performanceTracer?->mark('EventStore::commit');
+                            $this->performanceTracer?->mark(TracePoint::EventStoreCommit);
                         }
                         throw $concurrencyException;
                     }
@@ -152,7 +153,7 @@ final class ContentRepository
                 // We always NEED to catchup even if there was an unexpected ConcurrencyException to make sure previous commits are handled.
                 // Technically it would be acceptable for the catchup to fail here (due to hook errors) because all the events are already persisted.
                 $fullCatchUpResult = $this->subscriptionEngine->catchUpActive(); // NOTE: we don't batch here, to ensure the catchup is run completely and any errors don't stop it.
-                $this->performanceTracer?->mark('SubscriptionEngine::catchUpActive');
+                $this->performanceTracer?->mark(TracePoint::SubscriptionEngineCatchUpActive);
                 if ($fullCatchUpResult->hadErrors()) {
                     throw CatchUpHadErrors::createFromErrors($fullCatchUpResult->errors);
                 }
@@ -161,7 +162,7 @@ final class ContentRepository
             foreach ($additionalCommands as $additionalCommand) {
                 $this->handle($additionalCommand);
             }
-            $this->performanceTracer?->mark('CommandHook::onAfterHandle');
+            $this->performanceTracer?->mark(TracePoint::CommandHookOnAfterHandle);
         } finally {
             $this->performanceTracer?->closeSpan();
         }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/LogFileTracer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/LogFileTracer.php
@@ -35,10 +35,11 @@ final class LogFileTracer implements PerformanceTracerInterface
     {
     }
 
-    public function openSpan(string $name, array $params = []): void
+    public function openSpan(string|TracePoint $name, array $params = []): void
     {
         $this->ensureFileOpen();
 
+        $name = TracePoint::nameOf($name);
         $startTime = microtime(true);
         $paramsStr = empty($params) ? '' : ' ' . json_encode($params);
 
@@ -79,10 +80,11 @@ final class LogFileTracer implements PerformanceTracerInterface
         ));
     }
 
-    public function mark(string $name, array $params = []): void
+    public function mark(string|TracePoint $name, array $params = []): void
     {
         $this->ensureFileOpen();
 
+        $name = TracePoint::nameOf($name);
         $currentTime = microtime(true);
         $duration = $this->lastMarkTime > 0
             ? ($currentTime - $this->lastMarkTime) * 1000

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/PerformanceTracerInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/PerformanceTracerInterface.php
@@ -32,10 +32,11 @@ interface PerformanceTracerInterface
      *          $this->performanceTracer?->closeSpan();
      *      }
      *
-     * @param string $name A descriptive name for this span (e.g., "contentRepository::handle")
+     * @param string|TracePoint $name A descriptive name for this span; a {@see TracePoint} for the points the
+     *                                 Content Repository emits itself, or a plain string for ad-hoc instrumentation
      * @param array<string, mixed> $params attributes to attach to the span (e.g., ['c' => 'CreateNode'])
      */
-    public function openSpan(string $name, array $params = []): void;
+    public function openSpan(string|TracePoint $name, array $params = []): void;
 
     /**
      * Close a span, opened by {@see self::openSpan()} before.
@@ -50,8 +51,10 @@ interface PerformanceTracerInterface
      * including the operation just completed. Place mark() calls immediately AFTER the
      * operation you want to measure.
      *
-     * @param string $name A descriptive name identifying the operation that just completed
+     * @param string|TracePoint $name A descriptive name identifying the operation that just completed; a
+     *                                 {@see TracePoint} for the points the Content Repository emits itself,
+     *                                 or a plain string for ad-hoc instrumentation
      * @param array<string, mixed> $params attributes to attach to the span (e.g., ['c' => 'CreateNode'])
      */
-    public function mark(string $name, array $params = []): void;
+    public function mark(string|TracePoint $name, array $params = []): void;
 }

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/ProbeInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/ProbeInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Infrastructure\PerformanceTracing;
+
+/**
+ * A named measurement that can be read repeatedly while a trace is running, e.g. table row counts via SQL,
+ * the current memory usage, … Sampled by {@see ReplayThroughputTracer} at its (throttled) sampling interval
+ * and drawn as its own chart over time.
+ *
+ * A probe produces one chart (titled {@see label()}); a single {@see sample()} may return several labelled
+ * values, each of which becomes one line within that chart sharing its Y axis. Return one value to draw a
+ * single line, or several (e.g. from a UNION/GROUP BY query) to group related lines into the same chart.
+ *
+ * Implementations decide what they measure; this keeps measurement-specific dependencies (a DBAL connection
+ * for SQL probes, …) out of the Content Repository core. {@see sample()} must be cheap-ish and read-only –
+ * it runs in-process while e.g. a replay/catchup is going on.
+ *
+ * @api (experimental) for custom measurements wired into {@see ReplayThroughputTracer}
+ */
+interface ProbeInterface
+{
+    /**
+     * Human-readable title of the chart this probe draws.
+     */
+    public function label(): string;
+
+    /**
+     * Reads the current values: line label => value. One entry draws a single line; several entries draw several
+     * lines in this probe's chart (shared Y axis). Called once per sampling tick; must not throw (the tracer
+     * ignores failures, but a throwing probe still costs a caught exception per tick).
+     *
+     * @return array<string, float>
+     */
+    public function sample(): array;
+}

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/ReplayThroughputTracer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/ReplayThroughputTracer.php
@@ -74,7 +74,7 @@ final class ReplayThroughputTracer implements PerformanceTracerInterface
 
     public function mark(string|TracePoint $name, array $params = []): void
     {
-        if ($name === TracePoint::ProjectionApply) {
+        if (TracePoint::ProjectionApply->equals($name)) {
             // Count events, not projection applies: the same event is applied to every subscription and thus fires
             // one mark per subscription. Those marks are consecutive and carry the same sequence number, so we only
             // count when the sequence number changes.

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/ReplayThroughputTracer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/ReplayThroughputTracer.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Infrastructure\PerformanceTracing;
+
+/**
+ * A {@see PerformanceTracerInterface} specialised for measuring replay/catchup throughput: it counts the distinct
+ * events applied while the {@see SubscriptionEngine} catches up and renders the result as a standalone SVG line
+ * chart. Intended as an ad-hoc before/after measurement tool; the typical use is `subscription:replay` with this
+ * tracer configured.
+ *
+ * It derives the event count from the {@see TracePoint::ProjectionApply} mark (and its `sequenceNumber` param)
+ *
+ * Optionally a list of {@see ProbeInterface}s (e.g. table row counts via SQL) is sampled regularily.
+ *
+ * Each probe is drawn as its own chart underneath the throughput chart (own Y axis, shared time X axis).
+ *
+ * The SVG is (re)written incrementally on each sample, so a chart can be viewed during the run already..
+ *
+ * @internal a debugging/measurement aid; build it via a {@see PerformanceTracerFactoryInterface}
+ */
+final class ReplayThroughputTracer implements PerformanceTracerInterface
+{
+    private const NANOS_PER_SECOND = 1_000_000_000;
+
+    // SVG geometry (all values are user units = px in the default viewBox)
+    private const WIDTH = 1000;
+    private const MARGIN_LEFT = 70;   // room for the Y axis labels
+    private const MARGIN_RIGHT = 20;
+    private const PANEL_HEIGHT = 240; // plot height of a single chart
+    private const PANEL_GAP = 70;     // vertical space between stacked charts (also holds a chart's legend)
+    private const TOP_MARGIN = 40;    // room for the title above the first chart
+
+    private readonly int $startedAtNanos;
+
+    private int $openSpanDepth = 0;
+
+    private int $processedEvents = 0;
+
+    /**
+     * Sequence number of the event counted last, to deduplicate the per-subscriber {@see TracePoint::ProjectionApply}
+     * marks: one event applied to N subscriptions fires N consecutive marks with the same sequence number.
+     */
+    private ?int $lastSequenceNumber = null;
+
+    private int $lastSampleNanos;
+
+    /**
+     * One entry per sampling tick. `panels` maps a probe's chart title to that probe's labelled values at the tick.
+     *
+     * @var list<array{elapsedSeconds: float, events: int, panels: array<string, array<string, float>>}>
+     */
+    private array $samples = [];
+
+    /**
+     * @param string $svgPath the file the SVG chart is (incrementally) written to
+     * @param list<ProbeInterface> $probes sampled on each (throttled) heartbeat; one chart per probe
+     * @param float $sampleIntervalSeconds minimum wall-time between samples (and incremental SVG writes)
+     */
+    public function __construct(
+        private readonly string $svgPath,
+        private readonly array $probes = [],
+        private readonly float $sampleIntervalSeconds = 2.0,
+    ) {
+        $this->startedAtNanos = hrtime(true);
+        $this->lastSampleNanos = $this->startedAtNanos;
+    }
+
+    public function openSpan(string|TracePoint $name, array $params = []): void
+    {
+        $this->openSpanDepth++;
+    }
+
+    public function mark(string|TracePoint $name, array $params = []): void
+    {
+        if ($name === TracePoint::ProjectionApply) {
+            // Count events, not projection applies: the same event is applied to every subscription and thus fires
+            // one mark per subscription. Those marks are consecutive and carry the same sequence number, so we only
+            // count when the sequence number changes.
+            $sequenceNumber = $params['sequenceNumber'] ?? null;
+            if ($sequenceNumber !== $this->lastSequenceNumber) {
+                $this->processedEvents++;
+                $this->lastSequenceNumber = $sequenceNumber;
+
+                // we need to sample every $this->sampleIntervalSeconds
+                if ((hrtime(true) - $this->lastSampleNanos) / self::NANOS_PER_SECOND >= $this->sampleIntervalSeconds) {
+                    $this->takeSample();
+                }
+            }
+        }
+    }
+
+    public function closeSpan(): void
+    {
+        $this->openSpanDepth = max(0, $this->openSpanDepth - 1);
+        if ($this->openSpanDepth === 0) {
+            // a full top-level operation finished – take a final sample and write the chart
+            $this->takeSample();
+        }
+    }
+
+    private function takeSample(): void
+    {
+        // Only record/write once we are actually replaying events. This keeps the tracer dormant during ordinary
+        // command handling (which still opens/closes spans) and avoids writing an empty chart.
+        if ($this->processedEvents === 0) {
+            return;
+        }
+        $panels = [];
+        foreach ($this->probes as $probe) {
+            try {
+                $panels[$probe->label()] = $probe->sample();
+            } catch (\Throwable) {
+                // ignore – measurement must never interfere with the traced process
+            }
+        }
+        $this->samples[] = [
+            'elapsedSeconds' => (hrtime(true) - $this->startedAtNanos) / self::NANOS_PER_SECOND,
+            'events' => $this->processedEvents,
+            'panels' => $panels,
+        ];
+        $this->lastSampleNanos = hrtime(true);
+        $this->persistSvg();
+    }
+
+    /**
+     * Atomically writes the current chart (temp file + rename) so an interrupt mid-write cannot leave a corrupt
+     * file behind. Write failures are intentionally ignored – measurement must never break the traced process.
+     */
+    private function persistSvg(): void
+    {
+        $tmpPath = $this->svgPath . '.tmp';
+        if (@file_put_contents($tmpPath, $this->renderSvg()) !== false) {
+            @rename($tmpPath, $this->svgPath);
+        }
+    }
+
+    /**
+     * Builds the whole SVG document.
+     *
+     * Layout: a bold title line, then a vertical stack of charts. Chart 0 is always the cumulative throughput
+     * (events over time); each configured probe adds one more chart below it. Every chart shares the same time
+     * (X) axis but has its own value (Y) axis, so series of very different magnitudes never get flattened into
+     * one scale.
+     *
+     * The actual drawing of a single chart lives in {@see renderPanel()}; this method only decides which charts
+     * exist, their value range and vertical position, and the overall canvas height.
+     */
+    private function renderSvg(): string
+    {
+        // Map a number of seconds to an X coordinate. The time axis spans 0 .. the last sample's elapsed time.
+        $plotWidth = self::WIDTH - self::MARGIN_LEFT - self::MARGIN_RIGHT;
+        $totalSeconds = max($this->samples === [] ? 0.0 : end($this->samples)['elapsedSeconds'], 0.000_000_001);
+        $x = static fn (float $seconds): float => self::MARGIN_LEFT + ($seconds / $totalSeconds) * $plotWidth;
+
+        // Chart 0 – cumulative throughput. A single line "events" starting at the origin; its Y axis is pinned to
+        // the total number of processed events so the curve fills the chart.
+        $eventSeries = ['events' => [[0.0, 0.0]]];
+        foreach ($this->samples as $sample) {
+            $eventSeries['events'][] = [$sample['elapsedSeconds'], (float)$sample['events']];
+        }
+        $panels = [[
+            'axisLabel' => 'events processed (cumulative)',
+            'series' => $eventSeries,
+            'max' => (float)max($this->processedEvents, 1),
+            'legend' => false,
+        ]];
+
+        // One chart per probe. All lines of a probe share that chart's Y axis, scaled to the probe's largest value
+        // seen so far.
+        foreach ($this->probePanelTitles() as $title) {
+            $series = $this->collectPanelSeries($title);
+            $max = 1.0;
+            foreach ($series as $points) {
+                foreach ($points as [, $value]) {
+                    $max = max($max, $value);
+                }
+            }
+            $panels[] = ['axisLabel' => $title, 'series' => $series, 'max' => $max, 'legend' => true];
+        }
+
+        // Canvas height grows with the number of stacked charts (+ a trailing margin for the last X axis labels).
+        $count = count($panels);
+        $height = self::TOP_MARGIN + $count * self::PANEL_HEIGHT + max(0, $count - 1) * self::PANEL_GAP + 40;
+
+        $avgThroughput = $this->processedEvents / $totalSeconds;
+        $title = sprintf(
+            '%s events in %ss — avg %s events/s',
+            number_format($this->processedEvents, 0),
+            number_format($totalSeconds, 1),
+            number_format($avgThroughput, 0)
+        );
+        $body = sprintf('<text x="%d" y="24" font-size="15" font-weight="bold" fill="#222">%s</text>', self::MARGIN_LEFT, $title);
+
+        foreach ($panels as $index => $panel) {
+            $top = self::TOP_MARGIN + $index * (self::PANEL_HEIGHT + self::PANEL_GAP);
+            $body .= self::renderPanel($panel['axisLabel'], $panel['series'], $panel['max'], $top, $top + self::PANEL_HEIGHT, $x, $totalSeconds, $panel['legend']);
+        }
+
+        $width = self::WIDTH;
+        return <<<SVG
+            <?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="{$width}" height="{$height}" viewBox="0 0 {$width} {$height}" font-family="sans-serif">
+              {$body}
+            </svg>
+            SVG;
+    }
+
+    /**
+     * Ordered, de-duplicated list of probe chart titles (one chart per probe, in configuration order).
+     *
+     * @return list<string>
+     */
+    private function probePanelTitles(): array
+    {
+        $titles = [];
+        foreach ($this->probes as $probe) {
+            $titles[$probe->label()] = true;
+        }
+        return array_keys($titles);
+    }
+
+    /**
+     * Reshapes the per-tick samples of one chart into one time series per line label. A line only has points for
+     * the ticks where the probe actually returned that label, so lines that appear/disappear over time are fine.
+     *
+     * @return array<string, list<array{0: float, 1: float}>> lineLabel => list of [elapsedSeconds, value]
+     */
+    private function collectPanelSeries(string $title): array
+    {
+        $series = [];
+        foreach ($this->samples as $sample) {
+            foreach ($sample['panels'][$title] ?? [] as $lineLabel => $value) {
+                $series[$lineLabel][] = [$sample['elapsedSeconds'], $value];
+            }
+        }
+        return $series;
+    }
+
+    /**
+     * Renders one chart between $top and $bottom: horizontal gridlines + Y labels at "nice" round values, the
+     * shared X axis, a rotated axis caption, one coloured polyline per series, and – if requested – a legend in
+     * the gap above the chart. All series share this chart's Y axis.
+     *
+     * @param array<string, list<array{0: float, 1: float}>> $series lineLabel => list of [elapsedSeconds, value]
+     */
+    private static function renderPanel(string $axisLabel, array $series, float $maxValue, float $top, float $bottom, callable $x, float $totalSeconds, bool $showLegend): string
+    {
+        // d3-style "nice" Y axis: pick a round step (1/2/5 × 10ⁿ) and round the top of the range up to a multiple
+        // of it, so labels read 0, 5,000, 10,000 … instead of 0, 8,333, 16,667 …
+        $step = self::niceStep($maxValue / 5);
+        $niceMax = max($step, ceil($maxValue / $step) * $step);
+        $decimals = $step < 1.0 ? (int)ceil(-log10($step)) : 0;
+
+        // Map a value to a Y coordinate within this chart (0 at the bottom edge, $niceMax at the top edge).
+        $y = static fn (float $value): float => $bottom - ($value / $niceMax) * ($bottom - $top);
+
+        // Y axis: a gridline/label at every nice step from 0 up to (and including) the nice maximum.
+        $out = '';
+        for ($value = 0.0; $value <= $niceMax + $step * 0.001; $value += $step) {
+            $out .= self::yTick(self::MARGIN_LEFT, self::WIDTH - self::MARGIN_RIGHT, $y($value), number_format($value, $decimals));
+        }
+        // X axis (time) + a rotated caption naming the chart.
+        $out .= self::xAxis($x, $totalSeconds, $top, $bottom);
+        $out .= sprintf('<text x="18" y="%.1f" font-size="11" fill="#555" transform="rotate(-90 18 %.1f)" text-anchor="end">%s</text>', $top + 60, $top + 60, htmlspecialchars($axisLabel, ENT_QUOTES));
+
+        // One polyline per series; colours cycle through the palette. Optional legend sits in the gap above.
+        $palette = ['#1f77b4', '#2ca02c', '#d62728', '#9467bd', '#ff7f0e', '#8c564b'];
+        $legendY = $top - 22;
+        $index = 0;
+        foreach ($series as $label => $points) {
+            $color = $palette[$index % count($palette)];
+            $linePoints = [];
+            foreach ($points as [$seconds, $value]) {
+                $linePoints[] = sprintf('%.1f,%.1f', $x($seconds), $y($value));
+            }
+            $out .= sprintf('<polyline fill="none" stroke="%s" stroke-width="1.5" points="%s"/>', $color, implode(' ', $linePoints));
+            if ($showLegend) {
+                $legendX = self::MARGIN_LEFT + $index * 200;
+                $out .= sprintf('<line x1="%d" y1="%d" x2="%d" y2="%d" stroke="%s" stroke-width="2"/>', $legendX, $legendY, $legendX + 20, $legendY, $color);
+                $out .= sprintf('<text x="%d" y="%d" font-size="11" fill="#555">%s</text>', $legendX + 26, $legendY + 4, htmlspecialchars((string)$label, ENT_QUOTES));
+            }
+            $index++;
+        }
+        return $out;
+    }
+
+    /**
+     * A single horizontal gridline across the plot with a right-aligned value label to the left of the Y axis.
+     */
+    private static function yTick(float $x1, float $x2, float $y, string $label): string
+    {
+        return sprintf(
+            '<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="#e0e0e0" stroke-width="1"/>' .
+            '<text x="%.1f" y="%.1f" font-size="11" fill="#555" text-anchor="end">%s</text>',
+            $x1,
+            $y,
+            $x2,
+            $y,
+            $x1 - 8,
+            $y + 4,
+            $label
+        );
+    }
+
+    /**
+     * X axis gridlines + labels for the chart between $top and $bottom. The tick spacing adapts to the total
+     * duration (down to sub-second), so the chart stays readable whether a run lasts milliseconds or hours.
+     */
+    private static function xAxis(callable $x, float $totalSeconds, float $top, float $bottom): string
+    {
+        // Aim for ~6 ticks, rounded to a "nice" step; pick label precision so sub-second steps aren't all "0s".
+        $step = self::niceStep($totalSeconds / 6);
+        $decimals = $step < 1.0 ? (int)ceil(-log10($step)) : 0;
+        $out = '';
+        for ($seconds = 0.0; $seconds <= $totalSeconds + $step * 0.001; $seconds += $step) {
+            $xx = $x($seconds);
+            $out .= sprintf(
+                '<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="#e0e0e0" stroke-width="1"/>' .
+                '<text x="%.1f" y="%.1f" font-size="11" fill="#555" text-anchor="middle">%ss</text>',
+                $xx,
+                $top,
+                $xx,
+                $bottom,
+                $xx,
+                $bottom + 18,
+                number_format($seconds, $decimals)
+            );
+        }
+        return $out;
+    }
+
+    /**
+     * Rounds a raw axis step up to the nearest "nice" value (1, 2 or 5 × a power of ten), scaling cleanly into
+     * the sub-second range (…, 0.1, 0.2, 0.5, 1, 2, 5, …).
+     */
+    private static function niceStep(float $raw): float
+    {
+        if ($raw <= 0.0) {
+            return 1.0;
+        }
+        $magnitude = 10 ** floor(log10($raw));
+        $normalized = $raw / $magnitude;
+        $nice = match (true) {
+            $normalized <= 1.0 => 1.0,
+            $normalized <= 2.0 => 2.0,
+            $normalized <= 5.0 => 5.0,
+            default => 10.0,
+        };
+        return $nice * $magnitude;
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/TracePoint.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/TracePoint.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Infrastructure\PerformanceTracing;
+
+/**
+ * Well-known, named instrumentation points passed to {@see PerformanceTracerInterface::openSpan()}
+ * and {@see PerformanceTracerInterface::mark()}.
+ *
+ * Using an enum (instead of a bare string) for the points the Content Repository emits itself makes them
+ * type-safe, refactor-safe and discoverable: a tracer implementation that wants to react to a specific
+ * point can compare against an enum case (e.g. `$name === TracePoint::ProjectionApply`) instead of a
+ * magic string. Ad-hoc / third-party instrumentation may still pass a plain string – hence the tracer
+ * methods accept `string|TracePoint`.
+ *
+ * NOTE: A point that consumers are expected to react to MUST always be emitted as the enum case (never as
+ * the equivalent literal string), otherwise `=== TracePoint::X` matching would silently miss those sites.
+ *
+ * @api (experimental) together with {@see PerformanceTracerInterface}
+ */
+enum TracePoint: string
+{
+    // spans
+    case ContentRepositoryHandle = 'ContentRepository::handle';
+    case SubscriptionEngineCatchUpSubscriptions = 'SubscriptionEngine::catchUpSubscriptions';
+
+    // marks
+    case CommandHookOnBeforeHandle = 'CommandHook::onBeforeHandle';
+    case AuthProviderCanExecuteCommand = 'AuthProvider::canExecuteCommand';
+    case CommandBusHandle = 'CommandBus::handle';
+    case EventStoreCommit = 'EventStore::commit';
+    case CommandHookOnAfterHandle = 'CommandHook::onAfterHandle';
+    case SubscriptionEngineCatchUpActive = 'SubscriptionEngine::catchUpActive';
+    case CatchUpHooksOnBeforeCatchUp = 'CatchUpHooks::onBeforeCatchUp';
+    case ProjectionApply = 'Projection::apply';
+
+    /**
+     * The human-readable name for display/logging; normalises the `string|TracePoint` union.
+     */
+    public static function nameOf(string|TracePoint $name): string
+    {
+        return $name instanceof TracePoint ? $name->value : $name;
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/TracePoint.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/PerformanceTracing/TracePoint.php
@@ -10,12 +10,9 @@ namespace Neos\ContentRepository\Core\Infrastructure\PerformanceTracing;
  *
  * Using an enum (instead of a bare string) for the points the Content Repository emits itself makes them
  * type-safe, refactor-safe and discoverable: a tracer implementation that wants to react to a specific
- * point can compare against an enum case (e.g. `$name === TracePoint::ProjectionApply`) instead of a
- * magic string. Ad-hoc / third-party instrumentation may still pass a plain string – hence the tracer
+ * point can compare against an enum case instead of a magic string.
+ * Ad-hoc / third-party instrumentation may still pass a plain string – hence the tracer
  * methods accept `string|TracePoint`.
- *
- * NOTE: A point that consumers are expected to react to MUST always be emitted as the enum case (never as
- * the equivalent literal string), otherwise `=== TracePoint::X` matching would silently miss those sites.
  *
  * @api (experimental) together with {@see PerformanceTracerInterface}
  */
@@ -41,5 +38,13 @@ enum TracePoint: string
     public static function nameOf(string|TracePoint $name): string
     {
         return $name instanceof TracePoint ? $name->value : $name;
+    }
+
+    public function equals(string|TracePoint $name): bool
+    {
+        if ($name instanceof TracePoint) {
+            return $name === $this;
+        }
+        return $name === $this->value;
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -7,6 +7,7 @@ namespace Neos\ContentRepository\Core\Subscription\Engine;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\EventStore\EventNormalizer;
 use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\TracePoint;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
 use Neos\ContentRepository\Core\Subscription\DetachedSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\Exception\SubscriptionEngineAlreadyProcessingException;
@@ -273,7 +274,7 @@ final class SubscriptionEngine
      */
     private function catchUpSubscriptions(SubscriptionEngineCriteria $criteria, SubscriptionStatusFilter $status, \Closure|null $progressCallback, int|null $batchSize): ProcessedResult
     {
-        $this->performanceTracer?->openSpan('SubscriptionEngine::catchUpSubscriptions', []);
+        $this->performanceTracer?->openSpan(TracePoint::SubscriptionEngineCatchUpSubscriptions);
         try {
             if ($batchSize !== null && $batchSize <= 0) {
                 throw new \InvalidArgumentException(sprintf('Invalid batchSize %d specified, must be either NULL or a positive integer.', $batchSize), 1733597950);
@@ -320,7 +321,7 @@ final class SubscriptionEngine
                     $this->logCatchupHookError($error);
                 }
             }
-            $this->performanceTracer?->mark('CatchUpHooks::onBeforeCatchUp');
+            $this->performanceTracer?->mark(TracePoint::CatchUpHooksOnBeforeCatchUp);
 
             while (true) {
                 /**
@@ -365,7 +366,7 @@ final class SubscriptionEngine
 
                         try {
                             $subscriber->projection->apply($domainEvent, $eventEnvelope);
-                            $this->performanceTracer?->mark('Projection::apply', ['subscription' => $subscription->id->value, 'event' => $eventEnvelope->event->type->value]);
+                            $this->performanceTracer?->mark(TracePoint::ProjectionApply, ['subscription' => $subscription->id->value, 'event' => $eventEnvelope->event->type->value, 'sequenceNumber' => $eventEnvelope->sequenceNumber->value]);
                         } catch (\Throwable $e) {
                             // ERROR Case:
                             $errors[] = Error::create($subscription->id, $e->getMessage(), $errors === [] ? $e : null, $eventEnvelope->sequenceNumber);

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/PerformanceTracer/ReplayThroughputTracerFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/PerformanceTracer/ReplayThroughputTracerFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Factory\PerformanceTracer;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\ReplayThroughputTracer;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepositoryRegistry\Exception\InvalidConfigurationException;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Builds a {@see ReplayThroughputTracer} from settings. Each configured `sqlProbes` entry becomes a
+ * {@see SqlProbe} over the default Flow DB connection.
+ *
+ * Example settings:
+ *
+ *   performanceTracer:
+ *     factoryObjectName: Neos\ContentRepositoryRegistry\Factory\PerformanceTracer\ReplayThroughputTracerFactory
+ *     options:
+ *       fileName: '%FLOW_PATH_DATA%Logs/ContentRepositoryThroughput.svg'
+ *       sampleIntervalSeconds: 2.0
+ *       sqlProbes:
+ *         'nodes': 'SELECT COUNT(*) FROM cr_default_p_graph_node'
+ *         'hierarchy relations': 'SELECT COUNT(*) FROM cr_default_p_graph_hierarchyrelation'
+ *
+ * @api
+ */
+final class ReplayThroughputTracerFactory implements PerformanceTracerFactoryInterface
+{
+    #[Flow\Inject]
+    protected EntityManagerInterface $entityManager;
+
+    public function build(ContentRepositoryId $contentRepositoryId, array $options): PerformanceTracerInterface
+    {
+        isset($options['fileName']) || throw InvalidConfigurationException::fromMessage('Content repository "%s" does not have performanceTracer.options.fileName configured. Recommended: %%FLOW_PATH_DATA%%Logs/ContentRepositoryThroughput.svg', $contentRepositoryId->value);
+
+        $connection = $this->entityManager->getConnection();
+        $probes = [];
+        foreach ($options['sqlProbes'] ?? [] as $label => $sql) {
+            $probes[] = new SqlProbe((string)$label, $connection, (string)$sql);
+        }
+
+        return new ReplayThroughputTracer(
+            $options['fileName'],
+            $probes,
+            (float)($options['sampleIntervalSeconds'] ?? 2.0),
+        );
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/PerformanceTracer/ReplayThroughputTracerFactory.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/PerformanceTracer/ReplayThroughputTracerFactory.php
@@ -23,6 +23,7 @@ use Neos\Flow\Annotations as Flow;
  *       fileName: '%FLOW_PATH_DATA%Logs/ContentRepositoryThroughput.svg'
  *       sampleIntervalSeconds: 2.0
  *       sqlProbes:
+ *         # or use cr_{contentRepository} _p_graph_hierarchyrelation to interpolate the cr id
  *         'nodes': 'SELECT COUNT(*) FROM cr_default_p_graph_node'
  *         'hierarchy relations': 'SELECT COUNT(*) FROM cr_default_p_graph_hierarchyrelation'
  *
@@ -40,7 +41,7 @@ final class ReplayThroughputTracerFactory implements PerformanceTracerFactoryInt
         $connection = $this->entityManager->getConnection();
         $probes = [];
         foreach ($options['sqlProbes'] ?? [] as $label => $sql) {
-            $probes[] = new SqlProbe((string)$label, $connection, (string)$sql);
+            $probes[] = new SqlProbe((string)$label, $connection, str_replace('{contentRepository}', $contentRepositoryId->value, (string)$sql));
         }
 
         return new ReplayThroughputTracer(

--- a/Neos.ContentRepositoryRegistry/Classes/Factory/PerformanceTracer/SqlProbe.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Factory/PerformanceTracer/SqlProbe.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Factory\PerformanceTracer;
+
+use Doctrine\DBAL\Connection;
+use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\ProbeInterface;
+
+/**
+ * A {@see ProbeInterface} backed by an (arbitrary, read-only) SQL query, drawn as one chart. Can be used f.e.
+ * to correlate replay throughput with table growth.
+ *
+ * The query result shape decides how many lines the chart has:
+ * - one column  → a single line named after the chart, e.g. `SELECT COUNT(*) FROM cr_default_p_graph_node`
+ * - two columns → one line per row, first column = line label, second = value. Group several measurements into
+ *   one chart (shared Y axis) via UNION or GROUP BY, e.g.
+ *       SELECT 'nodes' AS label, COUNT(*) AS value FROM cr_default_p_graph_node
+ *       UNION ALL SELECT 'hierarchy relations', COUNT(*) FROM cr_default_p_graph_hierarchyrelation
+ *
+ * It runs on the same connection while a replay/catchup is in progress, so keep it cheap (it is sampled once
+ * per sampling interval by {@see ReplayThroughputTracer} – every 2 seconds by default).
+ *
+ * @internal
+ */
+final class SqlProbe implements ProbeInterface
+{
+    public function __construct(
+        private readonly string $label,
+        private readonly Connection $connection,
+        private readonly string $sql,
+    ) {
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+
+    public function sample(): array
+    {
+        $values = [];
+        foreach ($this->connection->fetchAllNumeric($this->sql) as $row) {
+            if (count($row) >= 2) {
+                // (label, value) rows → one line per row
+                $values[(string)$row[0]] = (float)$row[1];
+            } else {
+                // single scalar → one line named after the chart
+                $values[$this->label] = (float)$row[0];
+            }
+        }
+        return $values;
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
+++ b/Neos.ContentRepositoryRegistry/Configuration/Settings.yaml
@@ -113,6 +113,26 @@ Neos:
         #     fileName: '%FLOW_PATH_DATA%Logs/ContentRepositoryProfile.log'
         #     # how long should a mark be at least, to be logged? if 0, everything is shown.
         #     minimumMarkDurationMs: 1
+        #
+        # Alternatively, to chart replay/catchup throughput (events/second over time) as an SVG – useful as a
+        # before/after measurement for "./flow subscription:replay" – use the ReplayThroughputTracer. The
+        # optional "sqlProbes" run arbitrary scalar SQL at the sampling interval and are drawn in a second panel
+        # (e.g. to correlate throughput with table growth):
+        # performanceTracer:
+        #   factoryObjectName: Neos\ContentRepositoryRegistry\Factory\PerformanceTracer\ReplayThroughputTracerFactory
+        #   options:
+        #     fileName: '%FLOW_PATH_DATA%Logs/ContentRepositoryThroughput.svg'
+        #     # minimum wall-time between samples; sub-second values (e.g. 0.1) are allowed
+        #     sampleIntervalSeconds: 2.0
+        #     sqlProbes:
+        #       'nodes-and-relations': |
+        #         SELECT 'nodes', COUNT(*) FROM cr_default_p_graph_node
+        #         UNION
+        #         SELECT 'hierarchy relations', COUNT(*) FROM cr_default_p_graph_hierarchyrelation
+        #       'contentstream-count': |
+        #         SELECT COUNT(*) FROM cr_default_p_graph_contentstream
+        #       'referencerelation-count': |
+        #         SELECT COUNT(*) FROM cr_default_p_graph_referencerelation
 
     nodeMigration:
       filterFactories:


### PR DESCRIPTION
Opt-in PerformanceTracer that charts replay/catchup throughput (events/s over time) to an SVG — a before/after aid for CR adjustments and then measuring `./flow subscription:replay`.
Wired through the existing tracer factory/settings.

- introduced `TracePoint` enum for (optional) type-safe span/mark names
  - !!! BREAKING for existing Tracer implementations (i.e. Plumber)
- Pluggable SQL probes drawn as their own charts (one probe = one chart; UNION/GROUP BY = multiple lines) to correlate throughput with e.g. table growth
- incremental SVG writing so one can already inspect the chart during replay

**This was developed for finding the performance issues in https://github.com/neos/neos-development-collection/pull/5776**

## Configuration

```yaml
Neos:
  ContentRepositoryRegistry:
    presets:
      'default':
        performanceTracer:
          factoryObjectName: Neos\ContentRepositoryRegistry\Factory\PerformanceTracer\ReplayThroughputTracerFactory
          options:
            fileName: '%FLOW_PATH_DATA%Logs/ContentRepositoryThroughput.svg'
            # minimum wall-time between samples; sub-second values (e.g. 0.1) are allowed
            sampleIntervalSeconds: 2.0
            sqlProbes:
              'nodes-and-relations': |
                SELECT 'nodes', COUNT(*) FROM cr_default_p_graph_node
                UNION
                SELECT 'hierarchy relations', COUNT(*) FROM cr_default_p_graph_hierarchyrelation
              'contentstream-count': |
                SELECT COUNT(*) FROM cr_default_p_graph_contentstream
              'referencerelation-count': |
                SELECT COUNT(*) FROM cr_default_p_graph_referencerelation

```

## Example chart

<img width="1000" height="1250" alt="ContentRepositoryThroughput" src="https://github.com/user-attachments/assets/f6fc3f4d-7408-4f0e-aa02-94305875a7f7" />
