### PR TITLE
Performance Improvements for Hierarchy Relations

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -944,8 +944,8 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                   h.dimensionspacepointhash,
                   :targetContentStreamLayer as contentstreamlayer
                 FROM
-                  {$this->hierarchyRelationStatement->toSql()} h
-                WHERE 
+                  {$this->hierarchyRelationStatement->andInnerWhereRelationIdMatches('childnodeanchor = :originalNodeAnchor OR parentnodeanchor = :originalNodeAnchor')->toSql()} h
+                WHERE
                   :originalNodeAnchor IN (h.childnodeanchor, h.parentnodeanchor)
                   AND h.contentstreamlayer IN (:contentStreamLayers)
                 ON DUPLICATE KEY UPDATE parentnodeanchor = VALUES(parentnodeanchor), childnodeanchor = VALUES(childnodeanchor)

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -25,100 +25,30 @@ trait SubtreeTagging
 {
     private function addSubtreeTag(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
     {
-        // Performance: resolve the "winning layer per relation id" PER CANDIDATE ROW via a correlated NOT EXISTS,
-        // scoped by the recursion frontier (parentnodeanchor), instead of materialising the layer-resolved hierarchy
-        // for the whole affected dimension up front. {@see HierarchyRelationStatement::toSql()}'s inner
-        // MAX(contentstreamlayer) GROUP BY id is a full-table aggregation; reading it for every tag event (and, in the
-        // recursive walk, re-reading the materialised result once per tree level) costs O(table) regardless of how
-        // small the tagged subtree is.
+        // Performance: walk the subtree ONE LEVEL AT A TIME, driven from PHP, instead of in a single recursive CTE.
+        // A recursive CTE cannot scope its per-level layer resolution to the current frontier (the recursive relation
+        // may not appear inside the derived MAX(contentstreamlayer) subquery), so it ends up resolving the whole
+        // content stream per level — O(table) regardless of how small the tagged subtree is. By holding the frontier
+        // in PHP, each level runs the proven, index-scoped resolution (`parentnodeanchor IN (frontier)` pushed into the
+        // {@see HierarchyRelationStatement} subquery), so the operation scales with the SUBTREE size, not the table.
         //
-        // The recursive member is allowed to reference the base hierarchyrelation table inside a subquery (only the
-        // recursive CTE relation itself may not appear in a subquery), so each candidate row resolves its own winning
-        // layer with `NOT EXISTS (a higher visible layer for the same id)`. With UNIQ(id, contentstreamlayer) the max
-        // visible layer is the unique row with nothing above it, so this is exactly equivalent to the MAX(layer) join —
-        // but the candidate rows are first cut down to the frontier's children via the (parentnodeanchor, ...) index,
-        // so the whole statement scales with the SUBTREE size, not the table size. No GROUP BY, no materialised view.
+        // We walk per dimension space point to keep the parent<->child dsp pairing exact (a single parent anchor may
+        // have children in several covered dimensions). Each level: resolve the untagged winning child relations of the
+        // current frontier (one query), write the inherited tag onto them (one query), then descend.
         //
-        // Tombstones (removal writes a row with the highest layer and NULL anchors) stay correct for free: a removed
-        // relation's winning row is the NULL-parent tombstone which never matches `parentnodeanchor = frontier`, and a
-        // still-pointing pre-removal row fails NOT EXISTS because the tombstone sits above it.
-        $isWinningLayer = fn (string $alias): string => <<<SQL
-            $alias.contentstreamlayer IN (:contentStreamLayers)
-              AND NOT EXISTS (
-                SELECT 1 FROM {$this->tableNames->hierarchyRelation()} w
-                WHERE w.id = $alias.id
-                  AND w.contentstreamlayer IN (:contentStreamLayers)
-                  AND w.contentstreamlayer > $alias.contentstreamlayer
-              )
-            SQL;
-        $chIsWinningLayer = $isWinningLayer('ch');
-        $dhIsWinningLayer = $isWinningLayer('dh');
-        // The recursion already resolves each row's winning layer, so it carries (id, contentstreamlayer) forward
-        // (both ints — no JSON travels through the recursive CTE). The outer SELECT then fetches the rows to rewrite
-        // with a plain UNIQ(id, contentstreamlayer) lookup instead of resolving the winning layer a second time.
-        $addTagToDescendantsStatement = <<<SQL
-            INSERT INTO {$this->tableNames->hierarchyRelation()} (
-              id,
-              parentnodeanchor,
-              childnodeanchor,
-              position,
-              subtreetags,
-              dimensionspacepointhash,
-              contentstreamlayer
-            )
-            WITH RECURSIVE cte (id, contentstreamlayer, childnodeanchor, dsp) AS (
-                SELECT
-                  ch.id,
-                  ch.contentstreamlayer,
-                  ch.childnodeanchor,
-                  ch.dimensionspacepointhash
-                FROM
-                  {$this->tableNames->hierarchyRelation()} ch
-                  INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ch.parentnodeanchor
-                WHERE
-                  n.nodeaggregateid = :nodeAggregateId
-                  AND ch.dimensionspacepointhash IN (:dimensionSpacePointHashes)
-                  AND {$chIsWinningLayer}
-                  AND NOT JSON_CONTAINS_PATH(ch.subtreetags, 'one', :tagPath)
-                UNION ALL
-                SELECT
-                  dh.id,
-                  dh.contentstreamlayer,
-                  dh.childnodeanchor,
-                  dh.dimensionspacepointhash
-                FROM
-                  cte
-                  JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.childnodeanchor
-                  AND dh.dimensionspacepointhash = cte.dsp
-                WHERE
-                  {$dhIsWinningLayer}
-                  AND NOT JSON_CONTAINS_PATH(dh.subtreetags, 'one', :tagPath)
-              )
-            SELECT
-              h.id,
-              h.parentnodeanchor,
-              h.childnodeanchor,
-              h.position,
-              JSON_INSERT(h.subtreetags, :tagPath, null) as subtreetags,
-              h.dimensionspacepointhash,
-              :targetContentStreamLayer as contentstreamlayer
-            FROM
-              {$this->tableNames->hierarchyRelation()} h
-              JOIN cte ON h.id = cte.id AND h.contentstreamlayer = cte.contentstreamlayer
-            ON DUPLICATE KEY UPDATE subtreetags = VALUES(subtreetags)
-            SQL;
-
+        // Tombstones stay correct for free: a removed relation's winning row is the NULL-parent tombstone, which never
+        // matches the outer `parentnodeanchor IN (frontier)`, so removed subtrees drop out (the id-based inner pushdown
+        // keeps every layer, including the tombstone, in the resolution).
+        $tagPath = '$."' . $tag->value . '"';
         try {
-            $this->dbal->executeStatement($addTagToDescendantsStatement, [
-                'contentStreamLayers' => $contentStreamLayers->toIntArray(),
-                'nodeAggregateId' => $nodeAggregateId->value,
-                'dimensionSpacePointHashes' => $affectedDimensionSpacePoints->getPointHashes(),
-                'tagPath' => '$."' . $tag->value . '"',
-                'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
-            ], [
-                'dimensionSpacePointHashes' => ArrayParameterType::STRING,
-                'contentStreamLayers' => ArrayParameterType::INTEGER,
-            ]);
+            foreach ($affectedDimensionSpacePoints as $dimensionSpacePoint) {
+                $level = $this->findUntaggedWinningChildRelationsOfNodeAggregate($contentStreamLayers, $nodeAggregateId, $dimensionSpacePoint, $tagPath);
+                while ($level !== []) {
+                    $this->writeInheritedSubtreeTag($contentStreamLayers, $level, $tagPath);
+                    $childNodeAnchors = array_map(static fn (array $row) => (int)$row['childnodeanchor'], $level);
+                    $level = $this->findUntaggedWinningChildRelationsOfAnchors($contentStreamLayers, $childNodeAnchors, $dimensionSpacePoint, $tagPath);
+                }
+            }
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('1: Failed to add subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamLayers->toDebugString(), $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716479749, $e);
         }
@@ -164,196 +94,464 @@ trait SubtreeTagging
         }
     }
 
-    private function removeSubtreeTag(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
+    /**
+     * Resolve the untagged winning child hierarchy relations directly beneath the given node aggregate (the seed level
+     * of the subtree walk), scoped to a single dimension space point. Index-driven via the new-parent aggregate's
+     * relation anchors; tombstone-safe via the id-based inner pushdown.
+     *
+     * @return list<array{id:int, contentstreamlayer:int, childnodeanchor:int}>
+     */
+    private function findUntaggedWinningChildRelationsOfNodeAggregate(ContentStreamLayers $contentStreamLayers, NodeAggregateId $parentNodeAggregateId, DimensionSpacePoint $dimensionSpacePoint, string $tagPath): array
     {
-        $removeTagStatement = <<<SQL
+        $statement = <<<SQL
+            SELECT h.id, h.contentstreamlayer, h.childnodeanchor
+            FROM {$this->hierarchyRelationStatement
+                ->where('h.dimensionspacepointhash = :dimensionSpacePointHash')
+                ->andWhere("NOT JSON_CONTAINS_PATH(h.subtreetags, 'one', :tagPath)")
+                ->andInnerWhereRelationIdMatches('parentnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :parentNodeAggregateId)')
+                ->toSql()} h
+              INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = h.parentnodeanchor
+            WHERE n.nodeaggregateid = :parentNodeAggregateId
+            SQL;
+        /** @var list<array{id:int, contentstreamlayer:int, childnodeanchor:int}> $rows */
+        $rows = $this->dbal->fetchAllAssociative($statement, [
+            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
+            'parentNodeAggregateId' => $parentNodeAggregateId->value,
+            'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
+            'tagPath' => $tagPath,
+        ], [
+            'contentStreamLayers' => ArrayParameterType::INTEGER,
+        ]);
+        return $rows;
+    }
+
+    /**
+     * Resolve the untagged winning child hierarchy relations of a whole frontier of parent node anchors in one query,
+     * scoped to a single dimension space point. This is the per-level batch step of the subtree walk.
+     *
+     * @param list<int> $parentNodeAnchors
+     * @return list<array{id:int, contentstreamlayer:int, childnodeanchor:int}>
+     */
+    private function findUntaggedWinningChildRelationsOfAnchors(ContentStreamLayers $contentStreamLayers, array $parentNodeAnchors, DimensionSpacePoint $dimensionSpacePoint, string $tagPath): array
+    {
+        if ($parentNodeAnchors === []) {
+            return [];
+        }
+        $statement = <<<SQL
+            SELECT h.id, h.contentstreamlayer, h.childnodeanchor
+            FROM {$this->hierarchyRelationStatement
+                ->where('h.dimensionspacepointhash = :dimensionSpacePointHash')
+                ->andWhere('h.parentnodeanchor IN (:parentNodeAnchors)')
+                ->andWhere("NOT JSON_CONTAINS_PATH(h.subtreetags, 'one', :tagPath)")
+                ->andInnerWhereRelationIdMatches('parentnodeanchor IN (:parentNodeAnchors)')
+                ->toSql()} h
+            SQL;
+        /** @var list<array{id:int, contentstreamlayer:int, childnodeanchor:int}> $rows */
+        $rows = $this->dbal->fetchAllAssociative($statement, [
+            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
+            'parentNodeAnchors' => $parentNodeAnchors,
+            'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
+            'tagPath' => $tagPath,
+        ], [
+            'contentStreamLayers' => ArrayParameterType::INTEGER,
+            'parentNodeAnchors' => ArrayParameterType::INTEGER,
+        ]);
+        return $rows;
+    }
+
+    /**
+     * Write the inherited subtree tag (null marker) onto the given winning relations, copying each into the write layer.
+     * The relations are addressed by their unique (id, contentstreamlayer) so no layer re-resolution is needed.
+     *
+     * @param list<array{id:int, contentstreamlayer:int, childnodeanchor:int}> $relations
+     */
+    private function writeInheritedSubtreeTag(ContentStreamLayers $contentStreamLayers, array $relations, string $tagPath): void
+    {
+        if ($relations === []) {
+            return;
+        }
+        $idLayerPairs = implode(',', array_map(
+            static fn (array $row) => '(' . (int)$row['id'] . ',' . (int)$row['contentstreamlayer'] . ')',
+            $relations
+        ));
+        $statement = <<<SQL
             INSERT INTO {$this->tableNames->hierarchyRelation()} (
-              id,
-              parentnodeanchor,
-              childnodeanchor,
-              position,
-              subtreetags,
-              dimensionspacepointhash,
-              contentstreamlayer
+              id, parentnodeanchor, childnodeanchor, position, subtreetags, dimensionspacepointhash, contentstreamlayer
             )
             SELECT
-              h2.id,
-              h2.parentnodeanchor,
-              h2.childnodeanchor,
-              h2.position,
-              h2.subtreetags,
-              h2.dimensionspacepointhash,
-              h2.contentstreamlayer
-            FROM
-              (
-                SELECT
-                  h.id,
-                  h.parentnodeanchor,
-                  h.childnodeanchor,
-                  h.position,
-                  IF(
-                    (
-                      SELECT
-                        containsTag
-                      FROM
-                        (
-                          SELECT
-                            JSON_CONTAINS_PATH(gph.subtreetags, 'one', :tagPath) as containsTag
-                          FROM
-                            {$this->hierarchyRelationStatement->toSql()} gph
-                            INNER JOIN {$this->hierarchyRelationStatement->toSql()} ph ON ph.parentnodeanchor = gph.childnodeanchor
-                            INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
-                          WHERE
-                            ph.parentnodeanchor = gph.childnodeanchor
-                            AND n.nodeaggregateid = :nodeAggregateId
-                          LIMIT
-                            1
-                        ) as containsTagSubQuery
-                    ),
-                    JSON_SET(subtreetags, :tagPath, null),
-                    JSON_REMOVE(subtreetags, :tagPath)
-                  ) as subtreetags,
-                  h.subtreetags as currentsubtreetags,
-                  h.dimensionspacepointhash,
-                  :targetContentStreamLayer as contentstreamlayer
-                FROM
-                  {$this->hierarchyRelationStatement->toSql()} h
-                  JOIN (
-                    WITH
-                      RECURSIVE cte (childnodeanchor, dsp) AS (
-                        SELECT
-                          ph.childnodeanchor,
-                          ph.dimensionspacepointhash
-                        FROM
-                          {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash in (:dimensionSpacePointHashes)')->toSql()} ph
-                          INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
-                        WHERE
-                          n.nodeaggregateid = :nodeAggregateId
-                        UNION ALL
-                        SELECT
-                          dh.childnodeanchor,
-                          dh.dimensionspacepointhash
-                        FROM
-                          cte
-                          JOIN {$this->hierarchyRelationStatement->toSql()} dh ON dh.parentnodeanchor = cte.childnodeanchor
-                          AND dh.dimensionspacepointhash = cte.dsp
-                        WHERE
-                          JSON_EXTRACT(dh.subtreetags, :tagPath) != TRUE
-                      )
-                    SELECT
-                      *
-                    FROM
-                      cte
-                  ) subquery ON h.dimensionspacepointhash = subquery.dsp
-                  AND h.childnodeanchor = subquery.childnodeanchor
-              ) AS h2
-            WHERE
-              NOT {$this->jsonEqualsSql('h2.subtreetags', 'h2.currentsubtreetags')}
-            ON DUPLICATE KEY UPDATE subtreetags = VALUES (subtreetags)
+              h.id,
+              h.parentnodeanchor,
+              h.childnodeanchor,
+              h.position,
+              JSON_INSERT(h.subtreetags, :tagPath, null) as subtreetags,
+              h.dimensionspacepointhash,
+              :targetContentStreamLayer as contentstreamlayer
+            FROM {$this->tableNames->hierarchyRelation()} h
+            WHERE (h.id, h.contentstreamlayer) IN ($idLayerPairs)
+            ON DUPLICATE KEY UPDATE subtreetags = VALUES(subtreetags)
             SQL;
+        $this->dbal->executeStatement($statement, [
+            'tagPath' => $tagPath,
+            'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
+        ]);
+    }
+
+    /**
+     * Remove an explicit subtree tag from a node aggregate, ONE LEVEL AT A TIME driven from PHP - the same scoped
+     * per-level walk as {@see addSubtreeTag()}, run in reverse.
+     *
+     * Untagging the node has one of two global effects, decided once up front by whether the node still inherits the tag
+     * from an ancestor (i.e. its parent relation still carries the tag):
+     *  - still inherited -> the explicit `true` becomes an inherited `null` marker on the node; its descendants already
+     *    carry the inherited `null` and stay unchanged.
+     *  - no longer inherited -> the tag key is removed entirely from the node AND from every descendant that only
+     *    inherited it.
+     *
+     * The walk starts at the node itself and descends only into children that carry the tag as INHERITED (`null`): a
+     * child that has the tag set explicitly (`true`) keeps its own tag and its independently-tagged subtree, so we stop
+     * there; a child without the tag at all is unaffected, so we stop there too. (This mirrors the recursive CTE's
+     * `JSON_EXTRACT(subtreetags, :tagPath) != TRUE` frontier filter exactly.)
+     *
+     * Walked per dimension to keep the parent<->child dsp pairing exact. Tombstone-safe via the id-based inner pushdown.
+     */
+    private function removeSubtreeTag(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
+    {
+        $tagKey = $tag->value;
+        $tagPath = '$."' . $tag->value . '"';
         try {
-            $this->dbal->executeStatement($removeTagStatement, [
-                'contentStreamLayers' => $contentStreamLayers->toIntArray(),
-                'nodeAggregateId' => $nodeAggregateId->value,
-                'dimensionSpacePointHashes' => $affectedDimensionSpacePoints->getPointHashes(),
-                'tagPath' => '$."' . $tag->value . '"',
-                'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
-            ], [
-                'dimensionSpacePointHashes' => ArrayParameterType::STRING,
-                'contentStreamLayers' => ArrayParameterType::INTEGER,
-            ]);
+            // Decide once (as the original correlated subquery did): does the node still inherit the tag from a parent?
+            $parentNodeAnchors = $this->findParentNodeAnchorsOfNodeAggregate($contentStreamLayers, $nodeAggregateId);
+            $stillInherited = $this->anyRelationContainsTag($contentStreamLayers, $parentNodeAnchors, $tagPath);
+
+            foreach ($affectedDimensionSpacePoints as $dimensionSpacePoint) {
+                $seed = $this->findWinningRelationOfNodeAggregate($contentStreamLayers, $nodeAggregateId, $dimensionSpacePoint);
+                if ($seed === null) {
+                    continue;
+                }
+                $toProcess = [$seed];
+                $visited = [(int)$seed['childnodeanchor'] => true];
+                while ($toProcess !== []) {
+                    $writeBatch = [];
+                    $frontierAnchors = [];
+                    foreach ($toProcess as $relation) {
+                        $currentTags = $this->decodeSubtreeTags($relation['subtreetags']);
+                        $newTags = $currentTags;
+                        if ($stillInherited) {
+                            // JSON_SET(subtreetags, :tagPath, null): explicit `true` becomes inherited `null`
+                            $newTags[$tagKey] = null;
+                        } else {
+                            // JSON_REMOVE(subtreetags, :tagPath): drop the tag entirely
+                            unset($newTags[$tagKey]);
+                        }
+                        if (!$this->subtreeTagsEqual($newTags, $currentTags)) {
+                            $writeBatch[] = [
+                                'id' => (int)$relation['id'],
+                                'parentnodeanchor' => (int)$relation['parentnodeanchor'],
+                                'childnodeanchor' => (int)$relation['childnodeanchor'],
+                                'position' => (int)$relation['position'],
+                                'dimensionspacepointhash' => $relation['dimensionspacepointhash'],
+                                'subtreetags' => $this->encodeSubtreeTags($newTags),
+                            ];
+                        }
+                        $frontierAnchors[] = (int)$relation['childnodeanchor'];
+                    }
+                    $this->writeRecomputedSubtreeTags($contentStreamLayers, $writeBatch);
+
+                    // descend only into children that carry the tag as INHERITED (null); stop at explicit (true) or absent
+                    $children = $this->findWinningChildRelationsOfAnchors($contentStreamLayers, $frontierAnchors, $dimensionSpacePoint);
+                    $toProcess = [];
+                    foreach ($children as $child) {
+                        $childAnchor = (int)$child['childnodeanchor'];
+                        if (isset($visited[$childAnchor])) {
+                            continue;
+                        }
+                        $childTags = $this->decodeSubtreeTags($child['subtreetags']);
+                        if (!array_key_exists($tagKey, $childTags) || $childTags[$tagKey] !== null) {
+                            continue;
+                        }
+                        $visited[$childAnchor] = true;
+                        $toProcess[] = $child;
+                    }
+                }
+            }
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to remove subtree tag %s for content stream %s, node aggregate id %s and dimension space points %s: %s', $tag->value, $contentStreamLayers->toDebugString(), $nodeAggregateId->value, $affectedDimensionSpacePoints->toJson(), $e->getMessage()), 1716482293, $e);
         }
     }
 
+    /**
+     * Resolve the distinct winning parent node anchors of a node aggregate across all dimensions - used by
+     * {@see removeSubtreeTag()} to find the relations that determine whether the node still inherits a tag.
+     *
+     * @return list<int>
+     */
+    private function findParentNodeAnchorsOfNodeAggregate(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId): array
+    {
+        $statement = <<<SQL
+            SELECT DISTINCT h.parentnodeanchor
+            FROM {$this->hierarchyRelationStatement
+                ->where('')
+                ->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')
+                ->toSql()} h
+              INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = h.childnodeanchor
+            WHERE n.nodeaggregateid = :nodeAggregateId
+            SQL;
+        /** @var list<int> $anchors */
+        $anchors = array_map('intval', $this->dbal->fetchFirstColumn($statement, [
+            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
+            'nodeAggregateId' => $nodeAggregateId->value,
+        ], [
+            'contentStreamLayers' => ArrayParameterType::INTEGER,
+        ]));
+        return $anchors;
+    }
+
+    /**
+     * Whether any winning relation among the given node anchors carries the tag (explicit or inherited) - i.e. whether a
+     * descendant of those nodes still inherits the tag.
+     *
+     * @param list<int> $childNodeAnchors
+     */
+    private function anyRelationContainsTag(ContentStreamLayers $contentStreamLayers, array $childNodeAnchors, string $tagPath): bool
+    {
+        if ($childNodeAnchors === []) {
+            return false;
+        }
+        $statement = <<<SQL
+            SELECT 1
+            FROM {$this->hierarchyRelationStatement
+                ->where('h.childnodeanchor IN (:childNodeAnchors)')
+                ->andWhere("JSON_CONTAINS_PATH(h.subtreetags, 'one', :tagPath)")
+                ->andInnerWhereRelationIdMatches('childnodeanchor IN (:childNodeAnchors)')
+                ->toSql()} h
+            LIMIT 1
+            SQL;
+        $result = $this->dbal->fetchOne($statement, [
+            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
+            'childNodeAnchors' => $childNodeAnchors,
+            'tagPath' => $tagPath,
+        ], [
+            'contentStreamLayers' => ArrayParameterType::INTEGER,
+            'childNodeAnchors' => ArrayParameterType::INTEGER,
+        ]);
+        return $result !== false;
+    }
+
+    /**
+     * Recompute the full inherited-tag closure of the subtree rooted at the (just moved) new parent, ONE LEVEL AT A TIME
+     * driven from PHP - the same scoped per-level walk as {@see addSubtreeTag()}, but a *set* recompute rather than an
+     * additive one: a moved subtree must gain the tags inherited from its new ancestors AND drop the tags inherited from
+     * its old ones.
+     *
+     * Per node we carry an accumulated set of tag keys from the new parent down to that node. The seed set is ALL keys of
+     * the new parent's own subtree tags (its explicit tags plus the tags it itself inherits - its complete effective set
+     * cascades down). Each descendant contributes only its OWN EXPLICIT (`true`) keys to the accumulator. A node's new
+     * subtree tags are then {accumulated set => null} overlaid with {own explicit keys => true} - replicating the SQL's
+     * `JSON_MERGE_PATCH(JSON_OBJECTAGG(inherited, null), JSON_MERGE_PATCH('{}', own))` exactly (own explicit overrides the
+     * inherited null marker; stale inherited nulls not in the new accumulated set are dropped).
+     *
+     * Called once per covered dimension (see {@see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeMove}),
+     * so there is no dimension loop here. Tombstones stay correct for free via the id-based inner pushdown: a removed
+     * relation's winning row is the NULL-parent tombstone, which never matches the outer `parentnodeanchor IN (frontier)`.
+     */
     private function moveSubtreeTags(ContentStreamLayers $contentStreamLayers, NodeAggregateId $newParentNodeAggregateId, DimensionSpacePoint $coveredDimensionSpacePoint): void
     {
-        $moveSubtreeTagsStatement = <<<SQL
-            INSERT INTO {$this->tableNames->hierarchyRelation()} (
-              id, parentnodeanchor, childnodeanchor,
-              position, subtreetags, dimensionspacepointhash,
-              contentstreamlayer
-            )
-            SELECT
-              h2.id,
-              h2.parentnodeanchor,
-              h2.childnodeanchor,
-              h2.position,
-              h2.subtreetags,
-              h2.dimensionspacepointhash,
-              h2.contentstreamlayer
-            FROM
-              (
-                SELECT
-                  h.id,
-                  h.parentnodeanchor,
-                  h.childnodeanchor,
-                  h.position,
-                  h.dimensionspacepointhash,
-                  (
-                    SELECT
-                      JSON_MERGE_PATCH(
-                        IFNULL(JSON_OBJECTAGG(htk.k, null), '{}'),
-                        JSON_MERGE_PATCH('{}', h.subtreetags)
-                      )
-                    FROM
-                      JSON_TABLE(r.subtreeTagsToInherit, '\$[*]' COLUMNS (k VARCHAR(36) PATH '\$')) htk
-                  ) as subtreetags,
-                  h.subtreetags as currentsubtreetags,
-                  :targetContentStreamLayer as contentstreamlayer
-                FROM
-                  {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
-                  JOIN (
-                    WITH
-                      RECURSIVE cte AS (
-                        SELECT
-                          JSON_KEYS(th.subtreetags) subtreeTagsToInherit,
-                          th.childnodeanchor
-                        FROM
-                          {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} th
-                          INNER JOIN {$this->tableNames->node()} tn ON tn.relationanchorpoint = th.childnodeanchor
-                        WHERE
-                          tn.nodeaggregateid = :newParentNodeAggregateId
-                        UNION
-                        SELECT
-                          JSON_MERGE_PRESERVE(
-                            cte.subtreeTagsToInherit,
-                            JSON_KEYS(
-                              JSON_MERGE_PATCH('{}', dh.subtreetags)
-                            )
-                          ) AS subtreeTagsToInherit,
-                          dh.childnodeanchor
-                        FROM
-                          cte
-                          JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} dh ON dh.parentnodeanchor = cte.childnodeanchor
-                      )
-                    SELECT
-                      *
-                    FROM
-                      cte
-                  ) AS r
-                WHERE
-                  h.childnodeanchor = r.childnodeanchor
-              ) AS h2
-            WHERE
-              NOT {$this->jsonEqualsSql('h2.subtreetags', 'h2.currentsubtreetags')}
-            ON DUPLICATE KEY UPDATE subtreetags = VALUES(subtreetags)
-            SQL;
         try {
-            // Mysql hack, too eager to optimize https://dev.mysql.com/doc/refman/8.4/en/derived-table-optimization.html
-            $this->dbal->executeQuery('set optimizer_switch="derived_merge=off"');
-            $this->dbal->executeStatement($moveSubtreeTagsStatement, [
-                'contentStreamLayers' => $contentStreamLayers->toIntArray(),
-                'newParentNodeAggregateId' => $newParentNodeAggregateId->value,
-                'dimensionSpacePointHash' => $coveredDimensionSpacePoint->hash,
-                'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
-            ], [
-                'contentStreamLayers' => ArrayParameterType::INTEGER,
-            ]);
+            $seed = $this->findWinningRelationOfNodeAggregate($contentStreamLayers, $newParentNodeAggregateId, $coveredDimensionSpacePoint);
+            if ($seed === null) {
+                // the new parent is not present in this dimension - nothing to recompute
+                return;
+            }
+            // accumulated inherited tag-key set per (child)node anchor; seeded with ALL of the new parent's keys
+            $accumulatedSetByAnchor = [
+                (int)$seed['childnodeanchor'] => array_keys($this->decodeSubtreeTags($seed['subtreetags'])),
+            ];
+            $visited = [(int)$seed['childnodeanchor'] => true];
+            $frontier = [(int)$seed['childnodeanchor']];
+
+            while ($frontier !== []) {
+                $children = $this->findWinningChildRelationsOfAnchors($contentStreamLayers, $frontier, $coveredDimensionSpacePoint);
+                $writeBatch = [];
+                $nextFrontier = [];
+                foreach ($children as $child) {
+                    $childAnchor = (int)$child['childnodeanchor'];
+                    if (isset($visited[$childAnchor])) {
+                        // cycle guard (a content tree must not contain cycles, but never loop forever on malformed data)
+                        continue;
+                    }
+                    $parentAccumulatedSet = $accumulatedSetByAnchor[(int)$child['parentnodeanchor']] ?? [];
+                    $currentTags = $this->decodeSubtreeTags($child['subtreetags']);
+
+                    // {accumulated set => null} overlaid with {own explicit keys => true}
+                    $newTags = array_fill_keys($parentAccumulatedSet, null);
+                    foreach ($currentTags as $key => $value) {
+                        if ($value === true) {
+                            $newTags[$key] = true;
+                        }
+                    }
+                    $accumulatedSetByAnchor[$childAnchor] = array_keys($newTags);
+
+                    if (!$this->subtreeTagsEqual($newTags, $currentTags)) {
+                        $writeBatch[] = [
+                            'id' => (int)$child['id'],
+                            'parentnodeanchor' => (int)$child['parentnodeanchor'],
+                            'childnodeanchor' => $childAnchor,
+                            'position' => (int)$child['position'],
+                            'dimensionspacepointhash' => $child['dimensionspacepointhash'],
+                            'subtreetags' => $this->encodeSubtreeTags($newTags),
+                        ];
+                    }
+                    $visited[$childAnchor] = true;
+                    $nextFrontier[] = $childAnchor;
+                }
+                $this->writeRecomputedSubtreeTags($contentStreamLayers, $writeBatch);
+                $frontier = $nextFrontier;
+            }
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf('Failed to move subtree tags for content stream %s, new parent node aggregate id %s and dimension space point %s: %s', $contentStreamLayers->toDebugString(), $newParentNodeAggregateId->value, $coveredDimensionSpacePoint->toJson(), $e->getMessage()), 1716482574, $e);
         }
+    }
+
+    /**
+     * Resolve the winning incoming hierarchy relation of a single node aggregate in one dimension - the seed of the
+     * {@see moveSubtreeTags()} and {@see removeSubtreeTag()} walks. Returns every column needed to rebuild a write-layer
+     * row. Index-driven and tombstone-safe via the id-based inner pushdown.
+     *
+     * @return array{id:int, contentstreamlayer:int, parentnodeanchor:int, childnodeanchor:int, position:int, dimensionspacepointhash:string, subtreetags:?string}|null
+     */
+    private function findWinningRelationOfNodeAggregate(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId, DimensionSpacePoint $dimensionSpacePoint): ?array
+    {
+        $statement = <<<SQL
+            SELECT h.id, h.contentstreamlayer, h.parentnodeanchor, h.childnodeanchor, h.position, h.dimensionspacepointhash, h.subtreetags
+            FROM {$this->hierarchyRelationStatement
+                ->where('h.dimensionspacepointhash = :dimensionSpacePointHash')
+                ->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')
+                ->toSql()} h
+              INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = h.childnodeanchor
+            WHERE n.nodeaggregateid = :nodeAggregateId
+            SQL;
+        /** @var array{id:int, contentstreamlayer:int, parentnodeanchor:int, childnodeanchor:int, position:int, dimensionspacepointhash:string, subtreetags:?string}|false $row */
+        $row = $this->dbal->fetchAssociative($statement, [
+            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
+            'nodeAggregateId' => $nodeAggregateId->value,
+            'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
+        ], [
+            'contentStreamLayers' => ArrayParameterType::INTEGER,
+        ]);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Resolve the winning child hierarchy relations of a whole frontier of parent node anchors in one query, scoped to a
+     * single dimension - the per-level batch step of the {@see moveSubtreeTags()} walk. Unlike the addSubtreeTag variant
+     * this has no "untagged" filter (a move recomputes the WHOLE subtree) and returns every column needed to rebuild a
+     * write-layer row.
+     *
+     * @param list<int> $parentNodeAnchors
+     * @return list<array{id:int, contentstreamlayer:int, parentnodeanchor:int, childnodeanchor:int, position:int, dimensionspacepointhash:string, subtreetags:?string}>
+     */
+    private function findWinningChildRelationsOfAnchors(ContentStreamLayers $contentStreamLayers, array $parentNodeAnchors, DimensionSpacePoint $dimensionSpacePoint): array
+    {
+        if ($parentNodeAnchors === []) {
+            return [];
+        }
+        $statement = <<<SQL
+            SELECT h.id, h.contentstreamlayer, h.parentnodeanchor, h.childnodeanchor, h.position, h.dimensionspacepointhash, h.subtreetags
+            FROM {$this->hierarchyRelationStatement
+                ->where('h.dimensionspacepointhash = :dimensionSpacePointHash')
+                ->andWhere('h.parentnodeanchor IN (:parentNodeAnchors)')
+                ->andInnerWhereRelationIdMatches('parentnodeanchor IN (:parentNodeAnchors)')
+                ->toSql()} h
+            SQL;
+        /** @var list<array{id:int, contentstreamlayer:int, parentnodeanchor:int, childnodeanchor:int, position:int, dimensionspacepointhash:string, subtreetags:?string}> $rows */
+        $rows = $this->dbal->fetchAllAssociative($statement, [
+            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
+            'parentNodeAnchors' => $parentNodeAnchors,
+            'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
+        ], [
+            'contentStreamLayers' => ArrayParameterType::INTEGER,
+            'parentNodeAnchors' => ArrayParameterType::INTEGER,
+        ]);
+        return $rows;
+    }
+
+    /**
+     * Write the PHP-recomputed subtree tags onto the given relations, copying each into the write layer. Every column is
+     * supplied from the already-fetched winning row, so no layer re-resolution is needed.
+     *
+     * @param list<array{id:int, parentnodeanchor:int, childnodeanchor:int, position:int, dimensionspacepointhash:string, subtreetags:string}> $relations
+     */
+    private function writeRecomputedSubtreeTags(ContentStreamLayers $contentStreamLayers, array $relations): void
+    {
+        if ($relations === []) {
+            return;
+        }
+        $rowPlaceholders = [];
+        $parameters = ['targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value];
+        foreach ($relations as $i => $relation) {
+            $rowPlaceholders[] = "(:id$i, :parentnodeanchor$i, :childnodeanchor$i, :position$i, :subtreetags$i, :dimensionspacepointhash$i, :targetContentStreamLayer)";
+            $parameters["id$i"] = $relation['id'];
+            $parameters["parentnodeanchor$i"] = $relation['parentnodeanchor'];
+            $parameters["childnodeanchor$i"] = $relation['childnodeanchor'];
+            $parameters["position$i"] = $relation['position'];
+            $parameters["subtreetags$i"] = $relation['subtreetags'];
+            $parameters["dimensionspacepointhash$i"] = $relation['dimensionspacepointhash'];
+        }
+        $values = implode(",\n", $rowPlaceholders);
+        $statement = <<<SQL
+            INSERT INTO {$this->tableNames->hierarchyRelation()} (
+              id, parentnodeanchor, childnodeanchor, position, subtreetags, dimensionspacepointhash, contentstreamlayer
+            )
+            VALUES $values
+            ON DUPLICATE KEY UPDATE subtreetags = VALUES(subtreetags)
+            SQL;
+        $this->dbal->executeStatement($statement, $parameters);
+    }
+
+    /**
+     * Decode a subtree tags JSON column into an associative array of tag key => (true for explicit, null for inherited).
+     *
+     * @return array<string, true|null>
+     */
+    private function decodeSubtreeTags(?string $json): array
+    {
+        if ($json === null || $json === '' || $json === '{}' || $json === '[]') {
+            return [];
+        }
+        /** @var array<string, true|null> $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
+    }
+
+    /**
+     * Encode a recomputed tag set back to its JSON column representation, forcing an object so an emptied set becomes
+     * `{}` rather than `[]`.
+     *
+     * @param array<string, true|null> $tags
+     */
+    private function encodeSubtreeTags(array $tags): string
+    {
+        if ($tags === []) {
+            return '{}';
+        }
+        return json_encode($tags, JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT);
+    }
+
+    /**
+     * Order-independent comparison of two decoded subtree tag sets (so an unchanged relation is skipped regardless of
+     * key order in the stored JSON).
+     *
+     * @param array<string, true|null> $a
+     * @param array<string, true|null> $b
+     */
+    private function subtreeTagsEqual(array $a, array $b): bool
+    {
+        if (count($a) !== count($b)) {
+            return false;
+        }
+        ksort($a);
+        ksort($b);
+        return $a === $b;
     }
 
     private function subtreeTagsForHierarchyRelation(ContentStreamLayers $contentStreamLayers, NodeRelationAnchorPoint $parentNodeAnchorPoint, DimensionSpacePoint $dimensionSpacePoint): NodeTags

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -25,6 +25,37 @@ trait SubtreeTagging
 {
     private function addSubtreeTag(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId, DimensionSpacePointSet $affectedDimensionSpacePoints, SubtreeTag $tag): void
     {
+        // Performance: resolve the "winning layer per relation id" PER CANDIDATE ROW via a correlated NOT EXISTS,
+        // scoped by the recursion frontier (parentnodeanchor), instead of materialising the layer-resolved hierarchy
+        // for the whole affected dimension up front. {@see HierarchyRelationStatement::toSql()}'s inner
+        // MAX(contentstreamlayer) GROUP BY id is a full-table aggregation; reading it for every tag event (and, in the
+        // recursive walk, re-reading the materialised result once per tree level) costs O(table) regardless of how
+        // small the tagged subtree is.
+        //
+        // The recursive member is allowed to reference the base hierarchyrelation table inside a subquery (only the
+        // recursive CTE relation itself may not appear in a subquery), so each candidate row resolves its own winning
+        // layer with `NOT EXISTS (a higher visible layer for the same id)`. With UNIQ(id, contentstreamlayer) the max
+        // visible layer is the unique row with nothing above it, so this is exactly equivalent to the MAX(layer) join —
+        // but the candidate rows are first cut down to the frontier's children via the (parentnodeanchor, ...) index,
+        // so the whole statement scales with the SUBTREE size, not the table size. No GROUP BY, no materialised view.
+        //
+        // Tombstones (removal writes a row with the highest layer and NULL anchors) stay correct for free: a removed
+        // relation's winning row is the NULL-parent tombstone which never matches `parentnodeanchor = frontier`, and a
+        // still-pointing pre-removal row fails NOT EXISTS because the tombstone sits above it.
+        $isWinningLayer = fn (string $alias): string => <<<SQL
+            $alias.contentstreamlayer IN (:contentStreamLayers)
+              AND NOT EXISTS (
+                SELECT 1 FROM {$this->tableNames->hierarchyRelation()} w
+                WHERE w.id = $alias.id
+                  AND w.contentstreamlayer IN (:contentStreamLayers)
+                  AND w.contentstreamlayer > $alias.contentstreamlayer
+              )
+            SQL;
+        $chIsWinningLayer = $isWinningLayer('ch');
+        $dhIsWinningLayer = $isWinningLayer('dh');
+        // The recursion already resolves each row's winning layer, so it carries (id, contentstreamlayer) forward
+        // (both ints — no JSON travels through the recursive CTE). The outer SELECT then fetches the rows to rewrite
+        // with a plain UNIQ(id, contentstreamlayer) lookup instead of resolving the winning layer a second time.
         $addTagToDescendantsStatement = <<<SQL
             INSERT INTO {$this->tableNames->hierarchyRelation()} (
               id,
@@ -35,6 +66,34 @@ trait SubtreeTagging
               dimensionspacepointhash,
               contentstreamlayer
             )
+            WITH RECURSIVE cte (id, contentstreamlayer, childnodeanchor, dsp) AS (
+                SELECT
+                  ch.id,
+                  ch.contentstreamlayer,
+                  ch.childnodeanchor,
+                  ch.dimensionspacepointhash
+                FROM
+                  {$this->tableNames->hierarchyRelation()} ch
+                  INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ch.parentnodeanchor
+                WHERE
+                  n.nodeaggregateid = :nodeAggregateId
+                  AND ch.dimensionspacepointhash IN (:dimensionSpacePointHashes)
+                  AND {$chIsWinningLayer}
+                  AND NOT JSON_CONTAINS_PATH(ch.subtreetags, 'one', :tagPath)
+                UNION ALL
+                SELECT
+                  dh.id,
+                  dh.contentstreamlayer,
+                  dh.childnodeanchor,
+                  dh.dimensionspacepointhash
+                FROM
+                  cte
+                  JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.childnodeanchor
+                  AND dh.dimensionspacepointhash = cte.dsp
+                WHERE
+                  {$dhIsWinningLayer}
+                  AND NOT JSON_CONTAINS_PATH(dh.subtreetags, 'one', :tagPath)
+              )
             SELECT
               h.id,
               h.parentnodeanchor,
@@ -44,38 +103,8 @@ trait SubtreeTagging
               h.dimensionspacepointhash,
               :targetContentStreamLayer as contentstreamlayer
             FROM
-              {$this->hierarchyRelationStatement->toSql()} h
-              JOIN (
-                WITH
-                  RECURSIVE cte (childnodeanchor, dsp) AS (
-                    SELECT
-                      ch.childnodeanchor,
-                      ch.dimensionspacepointhash
-                    FROM
-                      {$this->hierarchyRelationStatement
-                        ->where('h.dimensionspacepointhash in (:dimensionSpacePointHashes)')
-                        ->andWhere("NOT JSON_CONTAINS_PATH(h.subtreetags, 'one', :tagPath)")
-                        ->toSql()} ch
-                      INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ch.parentnodeanchor
-                    WHERE
-                      n.nodeaggregateid = :nodeAggregateId
-                    UNION ALL
-                    SELECT
-                      dh.childnodeanchor,
-                      dh.dimensionspacepointhash
-                    FROM
-                      cte
-                      JOIN {$this->hierarchyRelationStatement->toSql()} dh ON dh.parentnodeanchor = cte.childnodeanchor
-                      AND dh.dimensionspacepointhash = cte.dsp
-                    WHERE
-                      NOT JSON_CONTAINS_PATH(dh.subtreetags, 'one', :tagPath)
-                  )
-                SELECT
-                  *
-                FROM
-                  cte
-              ) subquery ON h.dimensionspacepointhash = subquery.dsp
-              AND h.childnodeanchor = subquery.childnodeanchor
+              {$this->tableNames->hierarchyRelation()} h
+              JOIN cte ON h.id = cte.id AND h.contentstreamlayer = cte.contentstreamlayer
             ON DUPLICATE KEY UPDATE subtreetags = VALUES(subtreetags)
             SQL;
 
@@ -113,7 +142,7 @@ trait SubtreeTagging
               h.dimensionspacepointhash,
               :targetContentStreamLayer as contentstreamlayer
             FROM
-              {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash in (:dimensionSpacePointHashes)')->toSql()} h
+              {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash in (:dimensionSpacePointHashes)')->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h
               INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = h.childnodeanchor
             WHERE
               n.nodeaggregateid = :nodeAggregateId

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -6,7 +6,6 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamLayers;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
@@ -83,7 +82,7 @@ trait SubtreeTagging
                 'contentStreamLayers' => $contentStreamLayers->toIntArray(),
                 'nodeAggregateId' => $nodeAggregateId->value,
                 'dimensionSpacePointHashes' => $affectedDimensionSpacePoints->getPointHashes(),
-                'tagPath' => '$."' . $tag->value . '"',
+                'tagPath' => $tagPath,
                 'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
             ], [
                 'dimensionSpacePointHashes' => ArrayParameterType::STRING,
@@ -200,8 +199,9 @@ trait SubtreeTagging
      * Remove an explicit subtree tag from a node aggregate, ONE LEVEL AT A TIME driven from PHP - the same scoped
      * per-level walk as {@see addSubtreeTag()}, run in reverse.
      *
-     * Untagging the node has one of two global effects, decided once up front by whether the node still inherits the tag
-     * from an ancestor (i.e. its parent relation still carries the tag):
+     * Untagging the node has one of two effects, decided PER DIMENSION by whether the node still inherits the tag from
+     * an ancestor (i.e. its parent relation in that dimension still carries the tag) - a node's parent, and thus its
+     * inheritance, can differ per dimension:
      *  - still inherited -> the explicit `true` becomes an inherited `null` marker on the node; its descendants already
      *    carry the inherited `null` and stay unchanged.
      *  - no longer inherited -> the tag key is removed entirely from the node AND from every descendant that only
@@ -219,15 +219,17 @@ trait SubtreeTagging
         $tagKey = $tag->value;
         $tagPath = '$."' . $tag->value . '"';
         try {
-            // Decide once (as the original correlated subquery did): does the node still inherit the tag from a parent?
-            $parentNodeAnchors = $this->findParentNodeAnchorsOfNodeAggregate($contentStreamLayers, $nodeAggregateId);
-            $stillInherited = $this->anyRelationContainsTag($contentStreamLayers, $parentNodeAnchors, $tagPath);
-
             foreach ($affectedDimensionSpacePoints as $dimensionSpacePoint) {
                 $seed = $this->findWinningRelationOfNodeAggregate($contentStreamLayers, $nodeAggregateId, $dimensionSpacePoint);
                 if ($seed === null) {
                     continue;
                 }
+                // Decide PER DIMENSION whether the node still inherits the tag from an ancestor: a node's parent -
+                // and therefore whether it keeps the tag as an inherited `null` or loses it entirely - can differ per
+                // dimension. We check the node's parent relation IN THIS DIMENSION (the seed's parentnodeanchor is the
+                // parent's anchor in this dimension; the parent's incoming relation has childnodeanchor = that anchor).
+                $stillInherited = $this->anyRelationContainsTag($contentStreamLayers, [(int)$seed['parentnodeanchor']], $dimensionSpacePoint, $tagPath);
+
                 $toProcess = [$seed];
                 $visited = [(int)$seed['childnodeanchor'] => true];
                 while ($toProcess !== []) {
@@ -280,39 +282,13 @@ trait SubtreeTagging
     }
 
     /**
-     * Resolve the distinct winning parent node anchors of a node aggregate across all dimensions - used by
-     * {@see removeSubtreeTag()} to find the relations that determine whether the node still inherits a tag.
-     *
-     * @return list<int>
-     */
-    private function findParentNodeAnchorsOfNodeAggregate(ContentStreamLayers $contentStreamLayers, NodeAggregateId $nodeAggregateId): array
-    {
-        $statement = <<<SQL
-            SELECT DISTINCT h.parentnodeanchor
-            FROM {$this->hierarchyRelationStatement
-                ->where('')
-                ->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')
-                ->toSql()} h
-              INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = h.childnodeanchor
-            WHERE n.nodeaggregateid = :nodeAggregateId
-            SQL;
-        /** @var list<int> $anchors */
-        $anchors = array_map('intval', $this->dbal->fetchFirstColumn($statement, [
-            'contentStreamLayers' => $contentStreamLayers->toIntArray(),
-            'nodeAggregateId' => $nodeAggregateId->value,
-        ], [
-            'contentStreamLayers' => ArrayParameterType::INTEGER,
-        ]));
-        return $anchors;
-    }
-
-    /**
-     * Whether any winning relation among the given node anchors carries the tag (explicit or inherited) - i.e. whether a
-     * descendant of those nodes still inherits the tag.
+     * Whether any winning relation among the given node anchors carries the tag (explicit or inherited) in the given
+     * dimension - used by {@see removeSubtreeTag()} to decide, per dimension, whether the node still inherits the tag
+     * from its parent.
      *
      * @param list<int> $childNodeAnchors
      */
-    private function anyRelationContainsTag(ContentStreamLayers $contentStreamLayers, array $childNodeAnchors, string $tagPath): bool
+    private function anyRelationContainsTag(ContentStreamLayers $contentStreamLayers, array $childNodeAnchors, DimensionSpacePoint $dimensionSpacePoint, string $tagPath): bool
     {
         if ($childNodeAnchors === []) {
             return false;
@@ -321,6 +297,7 @@ trait SubtreeTagging
             SELECT 1
             FROM {$this->hierarchyRelationStatement
                 ->where('h.childnodeanchor IN (:childNodeAnchors)')
+                ->andWhere('h.dimensionspacepointhash = :dimensionSpacePointHash')
                 ->andWhere("JSON_CONTAINS_PATH(h.subtreetags, 'one', :tagPath)")
                 ->andInnerWhereRelationIdMatches('childnodeanchor IN (:childNodeAnchors)')
                 ->toSql()} h
@@ -329,6 +306,7 @@ trait SubtreeTagging
         $result = $this->dbal->fetchOne($statement, [
             'contentStreamLayers' => $contentStreamLayers->toIntArray(),
             'childNodeAnchors' => $childNodeAnchors,
+            'dimensionSpacePointHash' => $dimensionSpacePoint->hash,
             'tagPath' => $tagPath,
         ], [
             'contentStreamLayers' => ArrayParameterType::INTEGER,
@@ -580,14 +558,5 @@ trait SubtreeTagging
             throw new \RuntimeException(sprintf('Failed to fetch subtree tags for hierarchy parent anchor point "%s" in content subgraph "%s@%s"', $parentNodeAnchorPoint->value, $dimensionSpacePoint->toJson(), $contentStreamLayers->toDebugString()), 1704199847);
         }
         return NodeFactory::extractNodeTagsFromJson($subtreeTagsJson);
-    }
-
-    private function jsonEqualsSql(string $sqlExpressionA, string $sqlExpressionB): string
-    {
-        if ($this->dbal->getDatabasePlatform() instanceof MariaDBPlatform) {
-            return sprintf('JSON_EQUALS(%s, %s)', $sqlExpressionA, $sqlExpressionB);
-        } else {
-            return sprintf('(CAST(%s AS JSON) = CAST(%s AS JSON))', $sqlExpressionA, $sqlExpressionB);
-        }
     }
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -334,7 +334,7 @@ trait SubtreeTagging
         }
 
         $subtreeTagsStatement = <<<SQL
-            SELECT h.subtreetags FROM {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+            SELECT h.subtreetags FROM {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('childnodeanchor = :parentNodeAnchorPoint')->toSql()} h
               WHERE h.childnodeanchor = :parentNodeAnchorPoint
             SQL;
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentGraph.php
@@ -163,7 +163,7 @@ final class ContentGraph implements ContentGraphInterface
     public function findNodeAggregateById(
         NodeAggregateId $nodeAggregateId
     ): ?NodeAggregate {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery('nodeaggregateid = :nodeAggregateId')
             ->andWhere('n.nodeaggregateid = :nodeAggregateId')
             ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([
@@ -183,7 +183,7 @@ final class ContentGraph implements ContentGraphInterface
     public function findNodeAggregatesByIds(
         NodeAggregateIds $nodeAggregateIds
     ): NodeAggregates {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery()
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeAggregateQuery('nodeaggregateid IN (:nodeAggregateIds)')
             ->andWhere('n.nodeaggregateid in (:nodeAggregateIds)')
             ->orderBy('n.relationanchorpoint', 'DESC')
             ->setParameters([

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -173,7 +173,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findNodeById(NodeAggregateId $nodeAggregateId): ?Node
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamLayers, $this->dimensionSpacePoint)
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamLayers, $this->dimensionSpacePoint, 'n', 'n.*, h.subtreetags', 'nodeaggregateid = :nodeAggregateId')
             ->andWhere('n.nodeaggregateid = :nodeAggregateId')
             ->setParameter('nodeAggregateId', $nodeAggregateId->value);
         $this->addSubtreeTagConstraints($queryBuilder);
@@ -182,7 +182,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findNodesByIds(NodeAggregateIds $nodeAggregateIds): Nodes
     {
-        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamLayers, $this->dimensionSpacePoint)
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery($this->contentStreamLayers, $this->dimensionSpacePoint, 'n', 'n.*, h.subtreetags', 'nodeaggregateid IN (:nodeAggregateIds)')
             ->andWhere('n.nodeaggregateid in (:nodeAggregateIds)')
             ->setParameter('nodeAggregateIds', $nodeAggregateIds->toStringArray(), ArrayParameterType::STRING);
         $this->addSubtreeTagConstraints($queryBuilder);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -275,18 +275,28 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
     public function findSubtree(NodeAggregateId $entryNodeAggregateId, FindSubtreeFilter $filter): ?Subtree
     {
+        // Resolve each candidate relation's winning layer PER ROW via a correlated NOT EXISTS (a higher visible layer
+        // for the same id) instead of {@see HierarchyRelationStatement::toSql()}'s full-table MAX(contentstreamlayer)
+        // GROUP BY id, which the recursive CTE would otherwise re-run for every tree level. The anchor join scopes the
+        // candidate rows to the current frontier (childnodeanchor = entry node for the seed, parentnodeanchor = p for
+        // the recursion) via the (child|parent)nodeanchor index, so the walk scales with the SUBTREE size, not the
+        // table size. With UNIQ(id, contentstreamlayer) the NOT EXISTS is exactly equivalent to the MAX(layer) join;
+        // removed relations (tombstone wins with NULL anchors) simply fail the anchor join and drop out, as before.
+        $hierarchyRelation = $this->nodeQueryBuilder->tableNames->hierarchyRelation();
+        $winningLayer = "h.contentstreamlayer IN (:contentStreamLayers) AND NOT EXISTS (SELECT 1 FROM $hierarchyRelation w WHERE w.id = h.id AND w.contentstreamlayer IN (:contentStreamLayers) AND w.contentstreamlayer > h.contentstreamlayer)";
+
         $queryBuilderInitial = $this->createQueryBuilder()
             // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
             ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, 0 AS position')
             ->from($this->nodeQueryBuilder->tableNames->node(), 'n')
-            ->innerJoin('n', $this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
+            ->innerJoin('n', $hierarchyRelation, 'h', "h.childnodeanchor = n.relationanchorpoint AND h.dimensionspacepointhash = :dimensionSpacePointHash AND $winningLayer")
             ->where('n.nodeaggregateid = :entryNodeAggregateId');
         $this->addSubtreeTagConstraints($queryBuilderInitial);
 
         $queryBuilderRecursive = $this->createQueryBuilder()
             ->select('c.*, h.subtreetags, p.nodeaggregateid AS parentNodeAggregateId, p.level + 1 AS level, h.position')
             ->from('tree', 'p')
-            ->innerJoin('p', $this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql(), 'h', 'h.parentnodeanchor = p.relationanchorpoint')
+            ->innerJoin('p', $hierarchyRelation, 'h', "h.parentnodeanchor = p.relationanchorpoint AND h.dimensionspacepointhash = :dimensionSpacePointHash AND $winningLayer")
             ->innerJoin('p', $this->nodeQueryBuilder->tableNames->node(), 'c', 'c.relationanchorpoint = h.childnodeanchor');
         if ($filter->maximumLevels !== null) {
             $queryBuilderRecursive->andWhere('p.level < :maximumLevels')->setParameter('maximumLevels', $filter->maximumLevels);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -224,7 +224,7 @@ class ProjectionContentGraph
                 SELECT
                     h.*
                 FROM
-                    {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+                    {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('childnodeanchor = :succeedingSiblingAnchorPoint')->toSql()} h
                 WHERE
                     h.childnodeanchor = :succeedingSiblingAnchorPoint
                 LIMIT 1
@@ -256,7 +256,7 @@ class ProjectionContentGraph
                 SELECT
                     h.position
                 FROM
-                    {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+                    {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('parentnodeanchor = :anchorPoint')->toSql()} h
                 WHERE
                     h.parentnodeanchor = :anchorPoint
                     AND h.position < :position
@@ -292,7 +292,7 @@ class ProjectionContentGraph
                     SELECT
                         h.parentnodeanchor
                     FROM
-                        {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+                        {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('childnodeanchor = :childAnchorPoint')->toSql()} h
                     WHERE
                         h.childnodeanchor = :childAnchorPoint
                     LIMIT 1
@@ -317,7 +317,7 @@ class ProjectionContentGraph
                 SELECT
                     h.position
                 FROM
-                    {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+                    {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('parentnodeanchor = :parentAnchorPoint')->toSql()} h
                 WHERE
                     h.parentnodeanchor = :parentAnchorPoint
                 -- select the MAX position
@@ -359,7 +359,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+                {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('parentnodeanchor = :parentAnchorPoint')->toSql()} h
             WHERE
                 h.parentnodeanchor = :parentAnchorPoint
         SQL;
@@ -389,7 +389,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h
+                {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('childnodeanchor = :childAnchorPoint')->toSql()} h
             WHERE
                 h.childnodeanchor = :childAnchorPoint
         SQL;
@@ -419,7 +419,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->toSql()} h
+                {$this->hierarchyRelationStatement->andInnerWhereRelationIdMatches('childnodeanchor = :childAnchorPoint')->toSql()} h
             WHERE
                 h.childnodeanchor = :childAnchorPoint
         SQL;
@@ -460,7 +460,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->toSql()} h
+                {$this->hierarchyRelationStatement->andInnerWhereRelationIdMatches('parentnodeanchor = :parentAnchorPoint')->toSql()} h
             WHERE
                 h.parentnodeanchor = :parentAnchorPoint
         SQL;
@@ -501,7 +501,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash IN (:dimensionSpacePointHashes)')->toSql()} h
+                {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash IN (:dimensionSpacePointHashes)')->andInnerWhereRelationIdMatches('parentnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h
                 INNER JOIN {$this->tableNames->node()} n ON h.parentnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
@@ -533,7 +533,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->where($dimensionSpacePointSet !== null ? 'h.dimensionspacepointhash IN (:dimensionSpacePointHashes)' : '')->toSql()} h
+                {$this->hierarchyRelationStatement->where($dimensionSpacePointSet !== null ? 'h.dimensionspacepointhash IN (:dimensionSpacePointHashes)' : '')->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h
                 INNER JOIN {$this->tableNames->node()} n ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -67,8 +67,8 @@ class ProjectionContentGraph
                 p.*, ph.subtreetags, dsp.dimensionspacepoint AS origindimensionspacepoint
             FROM
                 {$this->tableNames->node()} p
-                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->toSql()} ph ON ph.childnodeanchor = p.relationanchorpoint
-                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->toSql()} ch ON ch.parentnodeanchor = p.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhere('dimensionspacepointhash = :coveredDimensionSpacePointHash')->toSql()} ph ON ph.childnodeanchor = p.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhere('dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :childNodeAggregateId)')->toSql()} ch ON ch.parentnodeanchor = p.relationanchorpoint
                 INNER JOIN {$this->tableNames->node()} c ON ch.childnodeanchor = c.relationanchorpoint
                 INNER JOIN {$this->tableNames->dimensionSpacePoints()} dsp ON p.origindimensionspacepointhash = dsp.hash
             WHERE
@@ -101,7 +101,7 @@ class ProjectionContentGraph
                 n.*, h.subtreetags, dsp.dimensionspacepoint AS origindimensionspacepoint
             FROM
                 {$this->tableNames->node()} n
-                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
                 INNER JOIN {$this->tableNames->dimensionSpacePoints()} dsp ON n.origindimensionspacepointhash = dsp.hash
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
@@ -131,7 +131,7 @@ class ProjectionContentGraph
                 DISTINCT n.relationanchorpoint
             FROM
                 {$this->tableNames->node()} n
-                INNER JOIN {$this->hierarchyRelationStatement->toSql()} AS h ON h.childnodeanchor = n.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} AS h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
                 AND n.origindimensionspacepointhash = :originDimensionSpacePointHash
@@ -166,7 +166,7 @@ class ProjectionContentGraph
                 DISTINCT n.relationanchorpoint
             FROM
                 {$this->tableNames->node()} n
-                INNER JOIN {$this->hierarchyRelationStatement->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
         SQL;

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -67,8 +67,8 @@ class ProjectionContentGraph
                 p.*, ph.subtreetags, dsp.dimensionspacepoint AS origindimensionspacepoint
             FROM
                 {$this->tableNames->node()} p
-                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhere('dimensionspacepointhash = :coveredDimensionSpacePointHash')->toSql()} ph ON ph.childnodeanchor = p.relationanchorpoint
-                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhere('dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :childNodeAggregateId)')->toSql()} ch ON ch.parentnodeanchor = p.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhereRelationIdMatches('dimensionspacepointhash = :coveredDimensionSpacePointHash')->toSql()} ph ON ph.childnodeanchor = p.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhereRelationIdMatches('dimensionspacepointhash = :coveredDimensionSpacePointHash')->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :childNodeAggregateId)')->toSql()} ch ON ch.parentnodeanchor = p.relationanchorpoint
                 INNER JOIN {$this->tableNames->node()} c ON ch.childnodeanchor = c.relationanchorpoint
                 INNER JOIN {$this->tableNames->dimensionSpacePoints()} dsp ON p.origindimensionspacepointhash = dsp.hash
             WHERE
@@ -101,7 +101,7 @@ class ProjectionContentGraph
                 n.*, h.subtreetags, dsp.dimensionspacepoint AS origindimensionspacepoint
             FROM
                 {$this->tableNames->node()} n
-                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
                 INNER JOIN {$this->tableNames->dimensionSpacePoints()} dsp ON n.origindimensionspacepointhash = dsp.hash
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
@@ -131,7 +131,7 @@ class ProjectionContentGraph
                 DISTINCT n.relationanchorpoint
             FROM
                 {$this->tableNames->node()} n
-                INNER JOIN {$this->hierarchyRelationStatement->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} AS h ON h.childnodeanchor = n.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} AS h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
                 AND n.origindimensionspacepointhash = :originDimensionSpacePointHash
@@ -166,7 +166,7 @@ class ProjectionContentGraph
                 DISTINCT n.relationanchorpoint
             FROM
                 {$this->tableNames->node()} n
-                INNER JOIN {$this->hierarchyRelationStatement->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
+                INNER JOIN {$this->hierarchyRelationStatement->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId
         SQL;
@@ -533,7 +533,7 @@ class ProjectionContentGraph
             SELECT
                 h.*
             FROM
-                {$this->hierarchyRelationStatement->where($dimensionSpacePointSet !== null ? 'h.dimensionspacepointhash IN (:dimensionSpacePointHashes)' : '')->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h
+                {$this->hierarchyRelationStatement->where($dimensionSpacePointSet !== null ? 'h.dimensionspacepointhash IN (:dimensionSpacePointHashes)' : '')->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE nodeaggregateid = :nodeAggregateId)')->toSql()} h
                 INNER JOIN {$this->tableNames->node()} n ON h.childnodeanchor = n.relationanchorpoint
             WHERE
                 n.nodeaggregateid = :nodeAggregateId

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationStatement.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationStatement.php
@@ -12,9 +12,11 @@ final readonly class HierarchyRelationStatement
     /**
      * @param array<string> $whereClauses applied to the outer (already layer-resolved) hierarchy relation `h`
      * @param array<string> $innerWhereClauses applied inside the derived "max layer per id" subquery, BEFORE the GROUP BY.
-     *        Only safe for predicates on columns that are layer-invariant for a given relation id (e.g. dimensionspacepointhash)
-     *        or that match across all layers (e.g. childnodeanchor restricted to a node aggregate, since node rows are shared
-     *        across layers). Pushing these down lets the optimizer use an index instead of grouping the whole relation table.
+     *        These MUST only ever reference the `id` column (see {@see andInnerWhereRelationIdMatches()}): node removal
+     *        writes a tombstone row (same id, highest contentstreamlayer, every other column NULL) that has to *win* the
+     *        MAX(contentstreamlayer) GROUP BY id resolution so the removed node drops out. A predicate filtering the inner
+     *        rows directly on a nullable column (childnodeanchor, parentnodeanchor, dimensionspacepointhash) would exclude
+     *        that tombstone, making MAX(layer) resolve to the pre-removal layer and resurrecting the deleted node.
      */
     private function __construct(
         private ContentGraphTableNames $tableNames,
@@ -47,10 +49,11 @@ final readonly class HierarchyRelationStatement
     }
 
     /**
-     * Adds a predicate applied INSIDE the derived "max layer per id" subquery (referencing the unaliased relation columns).
-     * See the constructor docblock for the correctness constraints.
+     * Adds a predicate applied INSIDE the derived "max layer per id" subquery, BEFORE the GROUP BY.
+     * Private on purpose: the only tombstone-safe inner predicate is one keyed on `id` (see the constructor docblock),
+     * so all inner pushdowns must go through {@see andInnerWhereRelationIdMatches()}.
      */
-    public function andInnerWhere(string $where): self
+    private function andInnerWhere(string $where): self
     {
         return new self(
             tableNames: $this->tableNames,
@@ -60,22 +63,26 @@ final readonly class HierarchyRelationStatement
     }
 
     /**
-     * Restricts the derived "max layer per id" subquery to the relation ids that satisfy the given anchor predicate in
-     * *some* layer. This is the move-safe way to push down an outer single-anchor filter (e.g. `h.childnodeanchor = :x`
-     * or `h.parentnodeanchor = :x`): a single anchor or a parent anchor is NOT layer-invariant for a relation id
-     * (copy-on-write reassigns the child anchor across layers, a move reassigns the parent), so filtering the inner rows
-     * directly by the anchor could drop the winning-layer row and elect a stale MAX(layer). Filtering by `id` instead
-     * keeps *all* layers of every candidate relation, so MAX(layer) stays exact; the resulting superset is then trimmed
-     * by the caller's outer WHERE on the same anchor. Selective because the anchor columns are indexed.
+     * Restricts the derived "max layer per id" subquery to the relation ids that satisfy the given predicate in *some*
+     * layer, by pushing down `id IN (SELECT id FROM hierarchyrelation WHERE $relationPredicate)`. This is the only
+     * tombstone-safe and move-safe way to push an outer filter into the subquery:
      *
-     * $anchorPredicate must reference unaliased relation columns, e.g. 'childnodeanchor = :x'.
+     * - Tombstone-safe: filtering by `id` keeps *all* layers of every candidate relation in the GROUP BY, including the
+     *   removal tombstone (NULL anchors/dsp but same id and highest layer), so MAX(layer) stays exact and removed nodes
+     *   correctly drop out. A direct predicate on a nullable column would exclude the tombstone and resurrect the node.
+     * - Move-safe: a single anchor or a parent anchor is not layer-invariant for a relation id (copy-on-write reassigns
+     *   the child anchor across layers, a move reassigns the parent); the id-based superset still keeps every layer of
+     *   the matching relations, and the caller's outer WHERE trims the extras.
+     *
+     * Selective because the filtered columns (childnodeanchor, parentnodeanchor, dimensionspacepointhash) are indexed.
+     * $relationPredicate must reference unaliased relation columns, e.g. 'childnodeanchor = :x'.
      */
-    public function andInnerWhereRelationIdMatches(string $anchorPredicate): self
+    public function andInnerWhereRelationIdMatches(string $relationPredicate): self
     {
         return $this->andInnerWhere(sprintf(
             'id IN (SELECT id FROM %s WHERE %s)',
             $this->tableNames->hierarchyRelation(),
-            $anchorPredicate
+            $relationPredicate
         ));
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationStatement.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationStatement.php
@@ -59,6 +59,26 @@ final readonly class HierarchyRelationStatement
         );
     }
 
+    /**
+     * Restricts the derived "max layer per id" subquery to the relation ids that satisfy the given anchor predicate in
+     * *some* layer. This is the move-safe way to push down an outer single-anchor filter (e.g. `h.childnodeanchor = :x`
+     * or `h.parentnodeanchor = :x`): a single anchor or a parent anchor is NOT layer-invariant for a relation id
+     * (copy-on-write reassigns the child anchor across layers, a move reassigns the parent), so filtering the inner rows
+     * directly by the anchor could drop the winning-layer row and elect a stale MAX(layer). Filtering by `id` instead
+     * keeps *all* layers of every candidate relation, so MAX(layer) stays exact; the resulting superset is then trimmed
+     * by the caller's outer WHERE on the same anchor. Selective because the anchor columns are indexed.
+     *
+     * $anchorPredicate must reference unaliased relation columns, e.g. 'childnodeanchor = :x'.
+     */
+    public function andInnerWhereRelationIdMatches(string $anchorPredicate): self
+    {
+        return $this->andInnerWhere(sprintf(
+            'id IN (SELECT id FROM %s WHERE %s)',
+            $this->tableNames->hierarchyRelation(),
+            $anchorPredicate
+        ));
+    }
+
     public function toSql(): string
     {
         $additionalWhereClauses = $this->whereClauses === [] ? '' : sprintf("  WHERE %s\n", join("\n  AND ", $this->whereClauses));

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationStatement.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationStatement.php
@@ -10,17 +10,22 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 final readonly class HierarchyRelationStatement
 {
     /**
-     * @param array<string> $whereClauses
+     * @param array<string> $whereClauses applied to the outer (already layer-resolved) hierarchy relation `h`
+     * @param array<string> $innerWhereClauses applied inside the derived "max layer per id" subquery, BEFORE the GROUP BY.
+     *        Only safe for predicates on columns that are layer-invariant for a given relation id (e.g. dimensionspacepointhash)
+     *        or that match across all layers (e.g. childnodeanchor restricted to a node aggregate, since node rows are shared
+     *        across layers). Pushing these down lets the optimizer use an index instead of grouping the whole relation table.
      */
     private function __construct(
         private ContentGraphTableNames $tableNames,
         private array $whereClauses,
+        private array $innerWhereClauses,
     ) {
     }
 
     public static function for(ContentGraphTableNames $tableNames): self
     {
-        return new self($tableNames, []);
+        return new self($tableNames, [], []);
     }
 
     public function where(string $where): self
@@ -28,6 +33,7 @@ final readonly class HierarchyRelationStatement
         return new self(
             tableNames: $this->tableNames,
             whereClauses: $where === '' ? [] : [$where],
+            innerWhereClauses: $this->innerWhereClauses,
         );
     }
 
@@ -36,20 +42,35 @@ final readonly class HierarchyRelationStatement
         return new self(
             tableNames: $this->tableNames,
             whereClauses: [...$this->whereClauses, ...($where === '' ? [] : [$where])],
+            innerWhereClauses: $this->innerWhereClauses,
+        );
+    }
+
+    /**
+     * Adds a predicate applied INSIDE the derived "max layer per id" subquery (referencing the unaliased relation columns).
+     * See the constructor docblock for the correctness constraints.
+     */
+    public function andInnerWhere(string $where): self
+    {
+        return new self(
+            tableNames: $this->tableNames,
+            whereClauses: $this->whereClauses,
+            innerWhereClauses: [...$this->innerWhereClauses, ...($where === '' ? [] : [$where])],
         );
     }
 
     public function toSql(): string
     {
         $additionalWhereClauses = $this->whereClauses === [] ? '' : sprintf("  WHERE %s\n", join("\n  AND ", $this->whereClauses));
+        $innerAdditionalWhereClauses = $this->innerWhereClauses === [] ? '' : sprintf("\n      AND %s", join("\n      AND ", $this->innerWhereClauses));
 
         return <<<SQL
             (SELECT h.*
               FROM {$this->tableNames->hierarchyRelation()} AS h
               INNER JOIN (
                 SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-                  FROM {$this->tableNames->hierarchyRelation()} FORCE INDEX (UNIQ_id_layer)
-                    WHERE (contentstreamlayer IN (:contentStreamLayers))
+                  FROM {$this->tableNames->hierarchyRelation()}
+                    WHERE (contentstreamlayer IN (:contentStreamLayers)){$innerAdditionalWhereClauses}
                 GROUP BY id
               ) AS readHierarchy
                 ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -44,13 +44,28 @@ final readonly class NodeQueryBuilder
         $this->hierarchyRelationStatement = HierarchyRelationStatement::for($this->tableNames);
     }
 
-    public function buildBasicNodeAggregateQuery(): QueryBuilder
+    /**
+     * @param string|null $childNodeAggregateAnchorPushdown an optional SQL predicate (referencing already-bound parameters)
+     *        that selects the node aggregate this query targets, e.g. 'nodeaggregateid = :nodeAggregateId'. When given, it is
+     *        pushed into the layer-resolution subquery as a childnodeanchor restriction so the GROUP BY only touches the
+     *        relations of that aggregate instead of the whole table. Safe because a relation always points at the same child
+     *        aggregate across all its layers (only the anchor value changes via copy-on-write, never the aggregate).
+     */
+    public function buildBasicNodeAggregateQuery(?string $childNodeAggregateAnchorPushdown = null): QueryBuilder
     {
         return $this->createQueryBuilder()
             ->select('n.*, h.subtreetags, dsp.dimensionspacepoint AS covereddimensionspacepoint')
             ->from($this->tableNames->node(), 'n')
-            ->innerJoin('n', $this->hierarchyRelationStatement->toSql(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
+            ->innerJoin('n', $this->hierarchyRelationStatementWithChildAnchorPushdown($childNodeAggregateAnchorPushdown)->toSql(), 'h', 'h.childnodeanchor = n.relationanchorpoint')
             ->innerJoin('h', $this->tableNames->dimensionSpacePoints(), 'dsp', 'dsp.hash = h.dimensionspacepointhash');
+    }
+
+    private function hierarchyRelationStatementWithChildAnchorPushdown(?string $childNodeAggregateAnchorPushdown): HierarchyRelationStatement
+    {
+        if ($childNodeAggregateAnchorPushdown === null) {
+            return $this->hierarchyRelationStatement;
+        }
+        return $this->hierarchyRelationStatement->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE ' . $childNodeAggregateAnchorPushdown . ')');
     }
 
     public function buildChildNodeAggregateQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamLayers $contentStreamLayers): QueryBuilder
@@ -89,12 +104,12 @@ final readonly class NodeQueryBuilder
         return $queryBuilder;
     }
 
-    public function buildBasicNodeQuery(ContentStreamLayers $contentStreamLayers, DimensionSpacePoint $dimensionSpacePoint, string $nodeTableAlias = 'n', string $select = 'n.*, h.subtreetags'): QueryBuilder
+    public function buildBasicNodeQuery(ContentStreamLayers $contentStreamLayers, DimensionSpacePoint $dimensionSpacePoint, string $nodeTableAlias = 'n', string $select = 'n.*, h.subtreetags', ?string $childNodeAggregateAnchorPushdown = null): QueryBuilder
     {
         return $this->createQueryBuilder()
             ->select($select)
             ->from($this->tableNames->node(), $nodeTableAlias)
-            ->innerJoin($nodeTableAlias, $this->hierarchyRelationStatement->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql(), 'h', 'h.childnodeanchor = ' . $nodeTableAlias . '.relationanchorpoint')
+            ->innerJoin($nodeTableAlias, $this->hierarchyRelationStatementWithChildAnchorPushdown($childNodeAggregateAnchorPushdown)->where('h.dimensionspacepointhash = :dimensionSpacePointHash')->toSql(), 'h', 'h.childnodeanchor = ' . $nodeTableAlias . '.relationanchorpoint')
             ->setParameter('contentStreamLayers', $contentStreamLayers->toIntArray(), ArrayParameterType::INTEGER)
             ->setParameter('dimensionSpacePointHash', $dimensionSpacePoint->hash);
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -65,7 +65,7 @@ final readonly class NodeQueryBuilder
         if ($childNodeAggregateAnchorPushdown === null) {
             return $this->hierarchyRelationStatement;
         }
-        return $this->hierarchyRelationStatement->andInnerWhere('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE ' . $childNodeAggregateAnchorPushdown . ')');
+        return $this->hierarchyRelationStatement->andInnerWhereRelationIdMatches('childnodeanchor IN (SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' WHERE ' . $childNodeAggregateAnchorPushdown . ')');
     }
 
     public function buildChildNodeAggregateQuery(NodeAggregateId $parentNodeAggregateId, ContentStreamLayers $contentStreamLayers): QueryBuilder

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -120,6 +120,65 @@ Feature: Tag subtree with dimensions
       a1a (tag1,tag2)
     """
 
+  # KNOWN BUG (expected to FAIL until removeSubtreeTag decides "still inherited?" per dimension):
+  # removeSubtreeTag computes ONCE, globally across all affected dimensions, whether the untagged node
+  # still inherits the tag from an ancestor, then applies that single decision to every dimension.
+  # When the ancestor carries the tag in some dimensions but not others, the node is untagged
+  # incorrectly in the dimension(s) where it does NOT actually inherit.
+  Scenario: Untagging is decided per dimension when an ancestor is tagged only in some dimensions
+    Given the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName | originDimensionSpacePoint |
+      | b               | Neos.ContentRepository.Testing:Document | a                     | b        | {"language":"mul"}        |
+      | b1              | Neos.ContentRepository.Testing:Document | b                     | b1       | {"language":"mul"}        |
+
+    # ancestor "a" is tagged only in the "de" specialization branch (de, gsw, ltz) - NOT in mul or en
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"language":"de"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "tag1"               |
+
+    # "b" is then tagged EXPLICITLY in every dimension
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "b"                  |
+      | coveredDimensionSpacePoint   | {"language":"mul"}   |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "tag1"               |
+
+    # untag "b" everywhere at once: in "de" it STILL inherits tag1 from "a" (explicit true -> inherited
+    # null), but in "en"/"mul" it does NOT inherit, so tag1 must be removed entirely from b and b1.
+    When the command UntagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "b"                  |
+      | coveredDimensionSpacePoint   | {"language":"mul"}   |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "tag1"               |
+
+    # de: "a" is tagged, so "b" still inherits -> b keeps tag1 as inherited, b1 keeps it inherited.
+    # (a1/a1a from the Background are children of "a" in "de" too, so they also inherit tag1.)
+    When I am in dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (tag1*)
+     a1 (tag1)
+      a1a (tag1)
+     b (tag1)
+      b1 (tag1)
+    """
+
+    # en: "a" is NOT tagged, so "b" no longer inherits -> tag1 removed entirely from b and b1
+    When I am in dimension space point {"language":"en"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     b
+      b1
+    """
+
   Scenario: Subtree tags are properly copied upon node variant recreation
     When the command CreateWorkspace is executed with payload:
       | Key                | Value        |


### PR DESCRIPTION
**This is part of a big concept update which heavily speeds up Neos 9.2+, by removing the full copy of Hierarchy Relations, and replacing it with so-called "hierarchy layers".**. This functionality needs MULTIPLE pull requests to form a consistent state:

- #5776 for base implementation and functioning concept (still SLOW on big sites)
-  #5874 for heavy performance optimizations (tested with > 150k nodes), but still slow with subtree tagging
  - **💪💪THIS PR💪💪** initial prototype and measurement for performance optimizations was #5873
- #5879 for rewritten and performant subtree tagging in PHP

---


**This was an experiment and measurement PR.** The actual cleaned up changes go in via #5874 and #5879


- [x] behavioral tests run through with this change (locally)