### PR TITLE
BUGFIX: Fix timeable node visibility inheritance

### DIFF
--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -48,8 +48,8 @@ class TimeableNodeVisibilityService
 
         /** @var Node $node */
         foreach ($nodes as $node) {
-            $nodeIsDisabled = $node->tags->contain(NeosSubtreeTag::disabled());
-            if ($this->needsEnabling($node, $now) && $nodeIsDisabled) {
+            $nodeIsExplicitlyDisabled = $node->tags->withoutInherited()->contain(NeosSubtreeTag::disabled());
+            if ($this->needsEnabling($node, $now) && $nodeIsExplicitlyDisabled) {
                 $contentRepository->handle(
                     EnableNodeAggregate::create(
                         $workspaceName,
@@ -63,7 +63,7 @@ class TimeableNodeVisibilityService
                 $this->logResult($result);
 
             }
-            if ($this->needsDisabling($node, $now) && !$nodeIsDisabled) {
+            if ($this->needsDisabling($node, $now) && !$nodeIsExplicitlyDisabled) {
                 $contentRepository->handle(
                     DisableNodeAggregate::create(
                         $workspaceName,

--- a/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
+++ b/Neos.TimeableNodeVisibility/Classes/Service/TimeableNodeVisibilityService.php
@@ -48,8 +48,7 @@ class TimeableNodeVisibilityService
 
         /** @var Node $node */
         foreach ($nodes as $node) {
-            $nodeIsExplicitlyDisabled = $node->tags->withoutInherited()->contain(NeosSubtreeTag::disabled());
-            if ($this->needsEnabling($node, $now) && $nodeIsExplicitlyDisabled) {
+            if ($this->needsEnabling($node, $now)) {
                 $contentRepository->handle(
                     EnableNodeAggregate::create(
                         $workspaceName,
@@ -63,7 +62,7 @@ class TimeableNodeVisibilityService
                 $this->logResult($result);
 
             }
-            if ($this->needsDisabling($node, $now) && !$nodeIsExplicitlyDisabled) {
+            if ($this->needsDisabling($node, $now)) {
                 $contentRepository->handle(
                     DisableNodeAggregate::create(
                         $workspaceName,
@@ -128,7 +127,8 @@ class TimeableNodeVisibilityService
 
     private function needsEnabling(Node $node, \DateTimeImmutable $now): bool
     {
-        return $node->hasProperty('enableAfterDateTime')
+        return $node->tags->withoutInherited()->contain(NeosSubtreeTag::disabled())
+            && $node->hasProperty('enableAfterDateTime')
             && $node->getProperty('enableAfterDateTime') != null
             && $node->getProperty('enableAfterDateTime') < $now
             && (
@@ -141,7 +141,8 @@ class TimeableNodeVisibilityService
 
     private function needsDisabling(Node $node, \DateTimeImmutable $now): bool
     {
-        return $node->hasProperty('disableAfterDateTime')
+        return !$node->tags->withoutInherited()->contain(NeosSubtreeTag::disabled())
+            && $node->hasProperty('disableAfterDateTime')
             && $node->getProperty('disableAfterDateTime') != null
             && $node->getProperty('disableAfterDateTime') < $now
             && (

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
@@ -379,6 +379,30 @@ Feature: Simple handling of nodes with exceeded enableAfter and disableAfter dat
     And I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
 
 
+  Scenario: A node that only inherits the disabled tag, i.e. is not disabled itself, must be disabled explicitly when disableAfter is exceeded
+    When the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId      | parentNodeAggregateId  | nodeTypeName          | initialPropertyValues                                                          |
+      | shernode-homes       | lady-eleonode-rootford | Some.Package:Homepage | {}                                                                             |
+      | duke-of-contentshire | shernode-homes         | Some.Package:Content  | {"disableAfterDateTime": {"__type": "DateTimeImmutable", "value": "-10 days"}} |
+    Then I expect node aggregate identifier "duke-of-contentshire" to lead to node cs-identifier;duke-of-contentshire;{}
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value            |
+      | nodeAggregateId              | "shernode-homes" |
+      | nodeVariantSelectionStrategy | "allVariants"    |
+    And I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
+
+    And I expect node aggregate identifier "duke-of-contentshire" to lead to node cs-identifier;duke-of-contentshire;{}
+    And I expect this node to be exactly explicitly tagged ""
+    And I expect this node to exactly inherit the tags "disabled"
+
+    Then I handle exceeded node dates
+
+    And I expect node aggregate identifier "duke-of-contentshire" to lead to node cs-identifier;duke-of-contentshire;{}
+    And I expect this node to be exactly explicitly tagged "disabled"
+    And I expect this node to exactly inherit the tags ""
+    And I expect exactly 6 events to be published on stream "ContentStream:cs-identifier"
+
+
   # <===========================|now|===========================>
   #  +++++++++++++++++++++++++++|---|+++|Disable|---------------
   Scenario: A disabled node with disableAfter in future must not be changed

--- a/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
+++ b/Neos.TimeableNodeVisibility/Tests/Behavior/Features/HandleExceeded.feature
@@ -358,6 +358,26 @@ Feature: Simple handling of nodes with exceeded enableAfter and disableAfter dat
     And I expect this node to be enabled
     And I expect exactly 4 events to be published on stream "ContentStream:cs-identifier"
 
+  # The parent document is disabled, the child only INHERITS the "disabled"
+  # subtree tag (it is not explicitly tagged). With enableAfter in the past the
+  # service must not try to enable the child (which would attempt to remove a
+  # subtree tag the node aggregate does not explicitly carry, triggering an Exception).
+  Scenario: A node that only inherits the disabled tag, i.e. is not disabled itself, must not be enabled
+    When the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId      | parentNodeAggregateId  | nodeTypeName          | initialPropertyValues                                                                    |
+      | shernode-homes       | lady-eleonode-rootford | Some.Package:Homepage | {}                                                                                       |
+      | duke-of-contentshire | shernode-homes         | Some.Package:Content  | {"enableAfterDateTime": {"__type": "DateTimeImmutable", "value": "-10 days"}} |
+    Then I expect node aggregate identifier "duke-of-contentshire" to lead to node cs-identifier;duke-of-contentshire;{}
+    And the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value            |
+      | nodeAggregateId              | "shernode-homes" |
+      | nodeVariantSelectionStrategy | "allVariants"    |
+    And I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
+
+    Then I handle exceeded node dates
+    Then I expect this node to be disabled
+    And I expect exactly 5 events to be published on stream "ContentStream:cs-identifier"
+
 
   # <===========================|now|===========================>
   #  +++++++++++++++++++++++++++|---|+++|Disable|---------------


### PR DESCRIPTION
`./flow timeablenodevisibility:execute` now does not try to enable disabled nodes that are only disabled because of inheritance.

resolved: https://github.com/neos/neos-development-collection/issues/5876

**Upgrade instructions**

-

**Review instructions**

-

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch:
  - x If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
