### PR TITLE
BUGFIX: Prevent command handling (`NodeTypeChange`) on currently invalid dimension subspace

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/11-NodeTypeChange/01-ChangeNodeAggregateType_ConstraintChecks.feature
@@ -226,3 +226,23 @@ Feature: Change node aggregate type - basic error cases
       | strategy                           | "happypath"                                                                                |
       | tetheredDescendantNodeAggregateIds | { "child-of-type-b": "nodimer-tetherton", "child-of-type-b/tethered": "nodewyn-tetherton"} |
     Then the last command should have thrown an exception of type "NodeAggregateCurrentlyExists"
+
+  Scenario: Try to change a node to a type while the dimension configuration was also changed
+    And the command CreateNodeVariant is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "sir-david-nodenborough" |
+      | sourceOrigin    | {"language": "de"}       |
+      | targetOrigin    | {"language": "gsw"}      |
+
+    And I change the content dimensions in content repository "default" to:
+      | Identifier | Values | Generalizations |
+      | language   | de, ch | ch->de          |
+
+    # If we are not migrated to the new configuration we cannot ensure that the variation events are issued correctly.
+    And the command ChangeNodeAggregateType is executed with payload and exceptions are caught:
+      | Key                                | Value                                      |
+      | nodeAggregateId                    | "sir-david-nodenborough"                   |
+      | newNodeTypeName                    | "Neos.ContentRepository.Testing:NodeTypeA" |
+      | strategy                           | "delete"                                   |
+      | tetheredDescendantNodeAggregateIds | { "childoftypea": "new-tethered"}          |
+    Then the last command should have thrown an exception of type "DimensionSpacePointNotFound"

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature
@@ -22,8 +22,14 @@ Feature: Move dimension space point
         nodeTypes:
           'Neos.ContentRepository.Testing:Document': true
           'Neos.ContentRepository.Testing:OtherDocument': true
-    'Neos.ContentRepository.Testing:Document': []
-    'Neos.ContentRepository.Testing:OtherDocument': []
+    'Neos.ContentRepository.Testing:Document':
+      properties:
+        text:
+          type: string
+    'Neos.ContentRepository.Testing:OtherDocument':
+      properties:
+        text:
+          type: string
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -37,12 +43,12 @@ Feature: Move dimension space point
       | nodeAggregateId | "lady-eleonode-rootford"      |
       | nodeTypeName    | "Neos.ContentRepository:Root" |
     And the following CreateNodeAggregateWithNode commands are executed:
-      | nodeAggregateId                  | nodeTypeName                            | parentNodeAggregateId  | nodeName                     | originDimensionSpacePoint |
-      | sir-david-nodenborough           | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document                     | {"language": "de"}        |
-      | varied-nodenborough              | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | varied-document              | {"language": "de"}        |
-      | only-specialization-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | only-specialization-document | {"language": "ch"}        |
-      | only-source-nodenborough         | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | only-source-document         | {"language": "de"}        |
-      | nody-mc-nodeface                 | Neos.ContentRepository.Testing:Document | varied-nodenborough    | child-document               | {"language": "de"}        |
+      | nodeAggregateId                  | nodeTypeName                            | parentNodeAggregateId  | nodeName                     | originDimensionSpacePoint | initialPropertyValues      |
+      | sir-david-nodenborough           | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | document                     | {"language": "de"}        | {"text": "original value"} |
+      | varied-nodenborough              | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | varied-document              | {"language": "de"}        | {}                          |
+      | only-specialization-nodenborough | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | only-specialization-document | {"language": "ch"}        | {}                          |
+      | only-source-nodenborough         | Neos.ContentRepository.Testing:Document | lady-eleonode-rootford | only-source-document         | {"language": "de"}        | {}                          |
+      | nody-mc-nodeface                 | Neos.ContentRepository.Testing:Document | varied-nodenborough    | child-document               | {"language": "de"}        | {}                          |
     And the command CreateNodeVariant is executed with payload:
       | Key             | Value                 |
       | nodeAggregateId | "varied-nodenborough" |
@@ -198,17 +204,6 @@ Feature: Move dimension space point
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
 
   Scenario: Success Case - other migrations do not block this with changes on this workspace
-
-    Given I change the node types in content repository "default" to:
-    """yaml
-    'Neos.ContentRepository:Root':
-      constraints:
-        nodeTypes:
-          'Neos.ContentRepository.Testing:OtherDocument': true
-
-    'Neos.ContentRepository.Testing:OtherDocument': []
-    """
-
     And I change the content dimensions in content repository "default" to:
       | Identifier | Values           | Generalizations       |
       | language   | mul, de, en, gsw | gsw->de->mul, en->mul |
@@ -224,9 +219,10 @@ Feature: Move dimension space point
               nodeType: 'Neos.ContentRepository.Testing:Document'
         transformations:
           -
-            type: 'ChangeNodeType'
+            type: 'ChangePropertyValue'
             settings:
-              newType: 'Neos.ContentRepository.Testing:OtherDocument'
+              property: 'text'
+              newSerializedValue: 'migrated value'
       -
         transformations:
           -
@@ -239,13 +235,17 @@ Feature: Move dimension space point
     When I am in workspace "live" and dimension space point {"language": "ch"}
     Then I expect a node identified by cs-identifier;sir-david-nodenborough;{"language": "de"} to exist in the content graph
     And I expect this node to be of type "Neos.ContentRepository.Testing:Document"
-
+    And I expect this node to have the following properties:
+      | Key  | Value            |
+      | text | "original value" |
     # we find the node underneath the new DimensionSpacePoint, but not underneath the old.
     When I am in workspace "migration-workspace" and dimension space point {"language": "ch"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to no node
     When I am in workspace "migration-workspace" and dimension space point {"language": "gsw"}
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node migration-cs;sir-david-nodenborough;{"language": "de"}
-    And I expect this node to be of type "Neos.ContentRepository.Testing:OtherDocument"
+    And I expect this node to have the following properties:
+      | Key  | Value            |
+      | text | "migrated value" |
 
   Scenario: Success Case - after eliminating all fallbacks via variation, a generalization can be moved while changing the specialization structure
     # Eliminate all fallbacks by varying the nodes

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -214,6 +214,7 @@ trait NodeTypeChange
         # Handle property adjustments
         $newNodeType = $this->requireNodeType($command->newNodeTypeName);
         foreach ($nodeAggregate->getNodes() as $node) {
+            $this->requireDimensionSpacePointToExist($node->originDimensionSpacePoint->toDimensionSpacePoint());
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
             $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
                 $newNodeType,


### PR DESCRIPTION
Preparation for https://github.com/neos/neos-development-collection/pull/5824

### Require all dimensions of NodeAggregate to be allowed during `NodeTypeChange`

During looping over the occupied nodes we should ensure that we don't sort out or keep invalid dimension space points. That can happen when a dimension was renamed via configuration or removed.

Now we require that the dimension configuration is still up to date with the NodeAggregate (with #5824 also for its children) which are attempted to be changed.

That is a sane limitation and during node create and create variate already enforced where we specify the dimensions explicitly. There we use `requireDimensionSpacePointToExist` to ensure the provided DSP's of the command are allowed and `requireNodeAggregateToOccupyDimensionSpacePoint` to further check if we can vary a node or create a child node.

Now because NodeTypeChange affects all dimensions we dont require to provide any dimension space points and thus dont validate that they are allowed. Still we take all covered dimension space points of the NodeAggregate and do further calculations. That is rather implicit to ensure there are no unexpected side-effects when reading both from the NodeAggregate and partially from the variation graph we first fully ensure that the node aggregate is up to date with the variation graph.

The new constraint check "Try to change a node to a type while the dimension configuration was also changed" highlights that. Before this PR the test would pass without any errors but it was not able to satisfy

```
Then I expect the node aggregate "new-tethered" to exist
Then I expect this node aggregate to occupy dimension space points [{"language":"de"}]
Then I expect this node aggregate to cover dimension space points [{"language":"de"},{"language":"gsw"}]
```

As neither `{"language":"gsw"}` nor `{"language":"ch"}` will be covered.

---------------

As a side effect another test in 9.x would fail without adjustment as it mistakenly tests that it _is_ possibly to run a `NodeTypeChange` on a changed dimension configuration.

Now the test would fail

```
Features/D3-MoveDimensionSpacePoint/MoveDimensionSpacePoint.feature

The dimension space points [{"language":"ch"}] were not found in the allowed dimension subspace [{"language":"mul"},{"language":"de"},{"language":"en"},{"language":"gsw"}]
```

because of the the method call

```
NodeTypeChange/NodeTypeChange.php(216): NodeAggregateCommandHandler->requireOrderedOriginDimensionSpacePoints
```

As this is a new limitation by design we now use a simpler NodeProperty migration which is still allowed a passes while dimensions are being changed - still questionable but not as "dangerous".