### PR TITLE
TASK: Enforce proper sequence during parallelism for MariaDB 12

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/WorkspacePublicationDuringWriting/WorkspacePublicationDuringWritingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/WorkspacePublicationDuringWriting/WorkspacePublicationDuringWritingTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\WorkspacePublicationDuringWriting;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
 use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
 use Neos\ContentRepository\Core\ContentRepository;
@@ -75,6 +76,21 @@ class WorkspacePublicationDuringWritingTest extends AbstractParallelTestCase
                 ]
             ]
         ]);
+
+        $dbal = $this->objectManager->get(Connection::class);
+        if ($dbal->getDatabasePlatform() instanceof MariaDBPlatform) {
+            $version = $dbal->fetchOne('SELECT VERSION()');
+            if (str_starts_with($version, '12')) {
+                /**
+                 * Hack until https://github.com/neos/neos-development-collection/issues/5869 is fixed
+                 *
+                 * Mariadb 12 reports
+                 *
+                 * An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1020 Record has changed since last read in table 'cr_test_parallel_p_graph_contentstream'
+                 */
+                \Neos\ContentRepository\Dbal\MysqlPlatformContentRepositoryLocker::enableForContentRepository(ContentRepositoryId::fromString('test_parallel'));
+            }
+        }
 
         $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
 


### PR DESCRIPTION
Replaces https://github.com/neos/neos-development-collection/pull/5885

With the new introduction of MariaDB 12 it reports for the test `WorkspacePublicationDuringWritingTest`

> Got exception DriverException: An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1020 Record has changed since last read in table 'cr_test_parallel_p_graph_contentstream'

which is true and probably a sane limitation from Maria. This seems to underline that #5869 will be required.
So as done for the `PublishingDuringPublishingTest` we can and should also limit the parallelism in CI and find out how we can also do this safely for production Neos' #5870 
