### PR TITLE
TASK: Add parallel test that `ChangeBaseWorkspace` is thread safe

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/AbstractParallelTestCase.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/AbstractParallelTestCase.php
@@ -15,10 +15,14 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel;
 
 use Neos\ContentRepository\Core\ContentRepository;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryDependencies;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
+use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 use Neos\ContentRepository\Core\Feature\Security\Dto\UserId;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainerFactory;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngine;
 use Neos\ContentRepository\TestSuite\Fakes\FakeAuthProvider;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\EventStore\EventStoreInterface;
@@ -116,6 +120,24 @@ abstract class AbstractParallelTestCase extends TestCase // we don't use Flows f
         // reset events and projections
         $contentRepositoryMaintainer->prune();
         return $contentRepository;
+    }
+
+    final protected function getEventStore(ContentRepositoryId $contentRepositoryId): EventStoreInterface
+    {
+        $eventStoreAccessor = new class implements ContentRepositoryServiceFactoryInterface {
+            public EventStoreInterface|null $eventStore;
+            public SubscriptionEngine|null $subscriptionEngine;
+            public function build(ContentRepositoryServiceFactoryDependencies $serviceFactoryDependencies): ContentRepositoryServiceInterface
+            {
+                $this->eventStore = $serviceFactoryDependencies->eventStore;
+                $this->subscriptionEngine = $serviceFactoryDependencies->subscriptionEngine;
+                return new class implements ContentRepositoryServiceInterface
+                {
+                };
+            }
+        };
+        $this->contentRepositoryRegistry->buildService($contentRepositoryId, $eventStoreAccessor);
+        return $eventStoreAccessor->eventStore;
     }
 
     final protected function log(string $message): void

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelBaseWorkspaceChange/ParallelBaseWorkspaceChangeTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelBaseWorkspaceChange/ParallelBaseWorkspaceChangeTest.php
@@ -35,6 +35,10 @@ use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
 use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
 use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
 use Neos\EventStore\Exception\ConcurrencyException;
+use Neos\EventStore\Model\Event\EventType;
+use Neos\EventStore\Model\Event\EventTypes;
+use Neos\EventStore\Model\EventStream\EventStreamFilter;
+use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use PHPUnit\Framework\Assert;
 
@@ -190,6 +194,8 @@ class ParallelBaseWorkspaceChangeTest extends AbstractParallelTestCase
 
         $this->log('1. base workspace change finished with: ' . $successFullChanged);
         Assert::assertGreaterThan(1, $successFullChanged, 'Base workspace was not changed');
+
+        $this->assertEventsAreValid();
     }
 
     /**
@@ -229,5 +235,28 @@ class ParallelBaseWorkspaceChangeTest extends AbstractParallelTestCase
 
         $this->log('2. base workspace change finished with: ' . $successFullChanged);
         Assert::assertGreaterThan(1, $successFullChanged, 'Base workspace was not changed');
+
+        $this->assertEventsAreValid();
+    }
+
+    private function assertEventsAreValid(): void
+    {
+        $eventStore = $this->getEventStore($this->contentRepository->id);
+
+        $contentStreamWasRemovedEvents = $eventStore->load(VirtualStreamName::forCategory('ContentStream:'), EventStreamFilter::create(
+            EventTypes::create(
+                EventType::fromString('ContentStreamWasRemoved')
+            )
+        ));
+
+        $removedContentStreamsMap = [];
+        foreach ($contentStreamWasRemovedEvents as $eventEnvelope) {
+            if (array_key_exists($eventEnvelope->streamName->value, $removedContentStreamsMap)) {
+                Assert::fail(sprintf('ContentStream %s was removed twice: %s', $eventEnvelope->streamName->value, json_encode($eventEnvelope)));
+            }
+            $removedContentStreamsMap[$eventEnvelope->streamName->value] = true;
+        }
+
+        Assert::assertNotEmpty($removedContentStreamsMap, 'No content streams were removed at all. Wrong query?');
     }
 }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelBaseWorkspaceChange/ParallelBaseWorkspaceChangeTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ParallelBaseWorkspaceChange/ParallelBaseWorkspaceChangeTest.php
@@ -12,25 +12,21 @@
 
 declare(strict_types=1);
 
-namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\PublishingDuringPublishing;
+namespace Neos\ContentRepository\BehavioralTests\Tests\Parallel\ParallelBaseWorkspaceChange;
 
 use Doctrine\DBAL\Connection;
 use Neos\ContentRepository\BehavioralTests\Tests\Parallel\AbstractParallelTestCase;
-use Neos\ContentRepository\BehavioralTests\Tests\Parallel\WorkspacePublicationDuringWriting\WorkspacePublicationDuringWritingTest;
 use Neos\ContentRepository\BehavioralTests\TestSuite\DebugEventProjection;
 use Neos\ContentRepository\Core\ContentRepository;
-use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\WorkspaceCommandSkipped;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateWorkspace;
-use Neos\ContentRepository\Core\Feature\WorkspacePublication\Command\PublishWorkspace;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Command\ChangeBaseWorkspace;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
-use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
-use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
@@ -43,13 +39,16 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use PHPUnit\Framework\Assert;
 
 /**
- * Test that no DeadlockException like: An exception occurred while executing a query: SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
- * Is thrown during catchup as this would lead to projection failure which cannot be properly recovered from other than a replay.
+ * In Neos 9.0 it occurred that a base workspace change was done without locking and thus the previous content stream was removed twice which is illegal:
+ *
+ * https://github.com/neos/neos-development-collection/issues/5877
  */
-class PublishingDuringPublishingTest extends AbstractParallelTestCase
+class ParallelBaseWorkspaceChangeTest extends AbstractParallelTestCase
 {
     private const SETUP_LOCK_PATH = __DIR__ . '/setup-lock';
     private const WRITING_IS_RUNNING_FLAG_PATH = __DIR__ . '/write-is-running-flag';
+
+    private const VARIETY_SIZE = 5;
 
     private ContentRepository $contentRepository;
 
@@ -99,9 +98,6 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
             ]
         ]);
 
-        /** Hack until https://github.com/neos/neos-development-collection/issues/5869 is fixed */
-        \Neos\ContentRepository\Dbal\MysqlPlatformContentRepositoryLocker::enableForContentRepository(ContentRepositoryId::fromString('test_parallel'));
-
         $setupLockResource = fopen(self::SETUP_LOCK_PATH, 'w+');
 
         $exclusiveNonBlockingLockResult = flock($setupLockResource, LOCK_EX | LOCK_NB);
@@ -139,15 +135,19 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
                 'title' => 'title-original'
             ])
         ));
+
+        for ($i = 0; $i <= self::VARIETY_SIZE ; $i++) {
+            $contentRepository->handle(CreateWorkspace::create(
+                WorkspaceName::fromString('review-' . $i),
+                WorkspaceName::forLive(),
+                ContentStreamId::fromString('cs-review-' . $i)
+            ));
+        }
+
         $contentRepository->handle(CreateWorkspace::create(
-            WorkspaceName::fromString('user-test-one'),
+            WorkspaceName::fromString('user'),
             WorkspaceName::forLive(),
-            ContentStreamId::fromString('user-test-cs-one')
-        ));
-        $contentRepository->handle(CreateWorkspace::create(
-            WorkspaceName::fromString('user-test-two'),
-            WorkspaceName::forLive(),
-            ContentStreamId::fromString('user-test-cs-two')
+            ContentStreamId::fromString('user-cs-initial')
         ));
 
         $this->contentRepository = $contentRepository;
@@ -164,33 +164,23 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
      */
     public function whileANodesArePublishedToLive(): void
     {
-        $this->log('1. writing & publishing started');
+        $this->log('1. change base started');
 
         touch(self::WRITING_IS_RUNNING_FLAG_PATH);
 
+        $successFullChanged = 0;
         try {
-            for ($i = 0; $i <= 100; $i++) {
-                if (!$this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-one'))->hasPublishableChanges()) {
-                    $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
-                        WorkspaceName::fromString('user-test-one'),
-                        NodeAggregateId::fromString('nody-mc-nodeface-' . $i),
-                        NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
-                        OriginDimensionSpacePoint::createWithoutDimensions(),
-                        NodeAggregateId::fromString('lady-eleonode-rootford'),
-                        initialPropertyValues: PropertyValuesToWrite::fromArray([
-                            'title' => 'title'
-                        ])
-                    ));
-                }
-
+            for ($i = 0; $i <= 20; $i++) {
+                $randomTarget = WorkspaceName::fromString('review-' . random_int(0, self::VARIETY_SIZE));
                 try {
-                    $this->contentRepository->handle(PublishWorkspace::create(
-                        WorkspaceName::fromString('user-test-one')
+                    $this->contentRepository->handle(ChangeBaseWorkspace::create(
+                        WorkspaceName::fromString('user'),
+                        $randomTarget,
                     )->withNewContentStreamId(
-                        ContentStreamId::fromString('user-test-cs-one-' . $i)
+                        ContentStreamId::fromString(sprintf('%d-%d', getmypid(), $i))
                     ));
-                } catch (ConcurrencyException $concurrencyException) {
-                    /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
+                    $successFullChanged++;
+                } catch (ConcurrencyException|WorkspaceCommandSkipped $concurrencyException) {
                     $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
                 }
             }
@@ -198,13 +188,8 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
             unlink(self::WRITING_IS_RUNNING_FLAG_PATH);
         }
 
-        $this->log('1. writing & publishing finished');
-        Assert::assertTrue(true, 'No exception was thrown ;)');
-
-        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
-        $childNodes = $subgraph->findChildNodes(NodeAggregateId::fromString('lady-eleonode-rootford'), FindChildNodesFilter::create());
-        $childNodes = $childNodes->filter(fn (Node $node) => str_starts_with($node->aggregateId->value, 'nody-mc-nodeface-'));
-        Assert::assertGreaterThan(20, $childNodes->count(), 'To few nodes actually published and created');
+        $this->log('1. base workspace change finished with: ' . $successFullChanged);
+        Assert::assertGreaterThan(1, $successFullChanged, 'Base workspace was not changed');
     }
 
     /**
@@ -224,41 +209,25 @@ class PublishingDuringPublishingTest extends AbstractParallelTestCase
             usleep(10000);
         }
 
-        $this->log('2. writing & publishing started');
+        $this->log('2. base workspace change started');
 
-        for ($i = 0; $i <= 100; $i++) {
-            if (!$this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-two'))->hasPublishableChanges()) {
-                $this->contentRepository->handle(CreateNodeAggregateWithNode::create(
-                    WorkspaceName::fromString('user-test-two'),
-                    NodeAggregateId::fromString('sir-david-nodenborough-' . $i),
-                    NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'),
-                    OriginDimensionSpacePoint::createWithoutDimensions(),
-                    NodeAggregateId::fromString('lady-eleonode-rootford'),
-                    initialPropertyValues: PropertyValuesToWrite::fromArray([
-                        'title' => 'title'
-                    ])
-                ));
-            }
-
+        $successFullChanged = 0;
+        for ($i = 0; $i <= 20; $i++) {
+            $randomTarget = WorkspaceName::fromString('review-' . random_int(0, self::VARIETY_SIZE));
             try {
-                $this->contentRepository->handle(PublishWorkspace::create(
-                    WorkspaceName::fromString('user-test-two')
+                $this->contentRepository->handle(ChangeBaseWorkspace::create(
+                    WorkspaceName::fromString('user'),
+                    $randomTarget,
                 )->withNewContentStreamId(
-                    ContentStreamId::fromString('user-test-cs-two-' . $i)
+                    ContentStreamId::fromString(sprintf('%d-%d', getmypid(), $i))
                 ));
-            } catch (ConcurrencyException $concurrencyException) {
-                /** Two simultaneous publish operations can get a concurrency exception as anticipated {@see WorkspacePublicationDuringWritingTest} */
+                $successFullChanged++;
+            } catch (ConcurrencyException|WorkspaceCommandSkipped $concurrencyException) {
                 $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
             }
         }
 
-        $this->log('2. writing & publishing finished');
-
-        Assert::assertTrue(true, 'No exception was thrown ;)');
-
-        $subgraph = $this->contentRepository->getContentGraph(WorkspaceName::forLive())->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty());
-        $childNodes = $subgraph->findChildNodes(NodeAggregateId::fromString('lady-eleonode-rootford'), FindChildNodesFilter::create());
-        $childNodes = $childNodes->filter(fn (Node $node) => str_starts_with($node->aggregateId->value, 'sir-david-nodenborough-'));
-        Assert::assertGreaterThan(20, $childNodes->count(), 'To few nodes actually published and created');
+        $this->log('2. base workspace change finished with: ' . $successFullChanged);
+        Assert::assertGreaterThan(1, $successFullChanged, 'Base workspace was not changed');
     }
 }


### PR DESCRIPTION
see https://github.com/neos/neos-development-collection/issues/5877

In Neos 9.0 and 9.1 it was possible to have race conditions during a `ChangeBaseWorkspace`.

With the introduction of the 9.2 hierarchy layer change we noticed this as we found old events removing a content stream twice (see issue).

Now this new test shows that 9.2 solves this problem as it contains https://github.com/neos/neos-development-collection/pull/5488. 

~Note: The tests dont actually fail on 9.0 as the graph did permit a duplicate content stream removal - only with the merge of the 9.2 layers test would fail if we were not thread safe - but we are now. - Tested locally.~
Edit: We now check the events to assert validity

Additionally there is an event migration https://github.com/neos/neos-development-collection/pull/5884 to repair old events
