### PR TITLE
BUGFIX: `UntagSubtree` must preserve inherited tags for other affected dimension space points

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -96,18 +96,26 @@ trait SubtreeTagging
         $removeTagStatement = <<<SQL
             UPDATE {$this->tableNames->hierarchyRelation()} h
             JOIN (
-              WITH RECURSIVE cte (id, dsp) AS (
-                SELECT ph.childnodeanchor, ph.dimensionspacepointhash
+              WITH RECURSIVE cte (id, dsp, inheritsTag) AS (
+                SELECT
+                  ph.childnodeanchor,
+                  ph.dimensionspacepointhash,
+                  -- if the parent node of the affected node has the tag explicit or inherited we need to preserve its inheritance recursively when removing an explicit tag
+                  JSON_CONTAINS_PATH(gph.subtreetags, 'one', :tagPath) as inheritsTag
                 FROM {$this->tableNames->hierarchyRelation()} ph
                 INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
+                INNER JOIN {$this->tableNames->hierarchyRelation()} gph ON gph.childnodeanchor = ph.parentnodeanchor AND gph.dimensionspacepointhash = ph.dimensionspacepointhash
                 WHERE
                   n.nodeaggregateid = :nodeAggregateId
                   AND ph.contentstreamid = :contentStreamId
+                  AND gph.contentstreamid = :contentStreamId
                   AND ph.dimensionspacepointhash in (:dimensionSpacePointHashes)
                 UNION ALL
                 SELECT
                   dh.childnodeanchor,
-                  dh.dimensionspacepointhash
+                  dh.dimensionspacepointhash,
+                  -- if the entry node should inherit the tag, all its herby selected descendants do as well
+                  cte.inheritsTag
                 FROM
                   cte
                   JOIN {$this->tableNames->hierarchyRelation()} dh ON dh.parentnodeanchor = cte.id
@@ -119,21 +127,7 @@ trait SubtreeTagging
               SELECT * FROM cte
             ) subquery ON h.dimensionspacepointhash = subquery.dsp
                 AND h.childnodeanchor = subquery.id
-                SET subtreetags = IF(
-                (
-                    SELECT containsTag FROM (SELECT
-                        JSON_CONTAINS_PATH(gph.subtreetags, 'one', :tagPath) as containsTag
-                  FROM
-                    {$this->tableNames->hierarchyRelation()} gph
-                    INNER JOIN {$this->tableNames->hierarchyRelation()} ph ON ph.parentnodeanchor = gph.childnodeanchor
-                    INNER JOIN {$this->tableNames->node()} n ON n.relationanchorpoint = ph.childnodeanchor
-                  WHERE
-                    ph.parentnodeanchor = gph.childnodeanchor
-                    AND n.nodeaggregateid = :nodeAggregateId
-                    AND gph.contentstreamid = :contentStreamId
-                  LIMIT 1) as containsTagSubQuery
-                ), JSON_SET(subtreetags, :tagPath, null), JSON_REMOVE(subtreetags, :tagPath)
-              )
+                SET subtreetags = IF(subquery.inheritsTag, JSON_SET(subtreetags, :tagPath, null), JSON_REMOVE(subtreetags, :tagPath))
               WHERE contentstreamid = :contentStreamId
         SQL;
         try {

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/SubtreeTagging/TagSubtree_WithDimensions.feature
@@ -178,3 +178,53 @@ Feature: Tag subtree with dimensions
      a1 (tag1)
       a1a (tag1)
     """
+
+  Scenario: Untagging preserves inherited tags for each dimension space point
+    Given the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName | originDimensionSpacePoint |
+      | a2              | Neos.ContentRepository.Testing:Document | a                     | a2       | {"language":"mul"}        |
+      | a2a             | Neos.ContentRepository.Testing:Document | a2                    | a2a      | {"language":"mul"}        |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"language":"de"}    |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "tag1"               |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "a2"               |
+      | coveredDimensionSpacePoint   | {"language":"mul"} |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+      | tag                          | "tag1"             |
+
+    # untag the explicit tag on "a2" in all dimensions ...
+    When the command UntagSubtree is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "a2"               |
+      | coveredDimensionSpacePoint   | {"language":"mul"} |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+      | tag                          | "tag1"             |
+
+    # ... only in "de" it STILL inherits tag1 from "a"
+    When I am in dimension space point {"language":"de"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (tag1*)
+     a1 (tag1)
+      a1a (tag1)
+     a2 (tag1)
+      a2a (tag1)
+    """
+
+    # ... while in "en" there are no tags anymore
+    When I am in dimension space point {"language":"en"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"language":"mul"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a2
+      a2a
+    """


### PR DESCRIPTION
Credit goes to @skurfuerst for finding it ;)

See https://github.com/neos/neos-development-collection/issues/5893

The logic in the graph during handling of `SubtreeWasUntagged` is broken when multiple dimension space points are involved during the untagging.

Before to determine if a tag should be removed (json `{}`) or kept as inherited `{tag1: null}` we checked via subquery if the entry node's parent contains the tag. If it does - explicit or inherited - the tag will be kept as inherited. The problem is that we didnt account for the dimension space point as seen in the missing `ph.dimensionspacepointhash` clause. The use of `LIMIT 1` just randomly selected one entry which is only correct for _one_ dimension space point.

Now we calculate the information once for each covered affected entry node - thus respecting dimensions - and during the recursive descend we preserve the `inheritsTag` state as it is true for all children

**Upgrade instructions**


**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

TODO:
- [ ] Find out if we advise a replay or what the effect of this was to existing events?
- [ ] Find out what it meant for soft removal garbage collection which is subtree tag based?