### PR TITLE
TASK: Allow core developers (me) to use cli tools like `flow setup` or others to work and inspect the testing content repository

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Fakes/FakeContentDimensionSourceFactory.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Fakes/FakeContentDimensionSourceFactory.php
@@ -24,7 +24,7 @@ class FakeContentDimensionSourceFactory implements ContentDimensionSourceFactory
     public function build(ContentRepositoryId $contentRepositoryId, array $options): ContentDimensionSourceInterface
     {
         if (!self::$contentDimensionSource) {
-            throw new \RuntimeException('Content dimension source not initialized.');
+            return self::getWithoutDimensions();
         }
         return self::$contentDimensionSource;
     }
@@ -39,7 +39,17 @@ class FakeContentDimensionSourceFactory implements ContentDimensionSourceFactory
      */
     public static function setWithoutDimensions(): void
     {
-        self::$contentDimensionSource = new class implements ContentDimensionSourceInterface
+        self::$contentDimensionSource = self::getWithoutDimensions();
+    }
+
+    public static function reset(): void
+    {
+        self::$contentDimensionSource = null;
+    }
+
+    private static function getWithoutDimensions(): ContentDimensionSourceInterface
+    {
+        return new class implements ContentDimensionSourceInterface
         {
             public function getDimension(ContentDimensionId $dimensionId): ?ContentDimension
             {
@@ -50,10 +60,5 @@ class FakeContentDimensionSourceFactory implements ContentDimensionSourceFactory
                 return [];
             }
         };
-    }
-
-    public static function reset(): void
-    {
-        self::$contentDimensionSource = null;
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Fakes/FakeNodeTypeManagerFactory.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Fakes/FakeNodeTypeManagerFactory.php
@@ -38,7 +38,7 @@ final class FakeNodeTypeManagerFactory implements NodeTypeManagerFactoryInterfac
             // allows to be configured for testing
             return NodeTypeManager::createFromArrayConfiguration($options['nodeTypes']);
         }
-        throw new \RuntimeException('NodeTypeManagerFactory uninitialized');
+        return NodeTypeManager::createFromArrayConfiguration([]);
     }
 
     /**


### PR DESCRIPTION
But as the testing cr uses these two tunnel through space factories that know no mercy its impossible.

As this is merely an adjustment in the test fakes there is not much to consider.

Might come in handy to setup the behat testing db initially.

Also with #5896 it definitely comes in handy when using

```
FLOW_CONTEXT=Testing/Behat flow crupgrade:resetgraphandsetup
```

For switching branches with different schemas - which i do a lot - and i always drop the tables by hand --- thousand times.
