### PR TITLE
BUGFIX: Show skipped projections in `cr:setup`

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Subscription/ProjectionErrorTest.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionError;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
+use Neos\ContentRepository\Core\Subscription\SubscriptionStatusCollection;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventEnvelope;
 
@@ -226,6 +227,9 @@ final class ProjectionErrorTest extends AbstractSubscriptionEngineTestCase
         $result = $this->subscriptionEngine->setup();
         self::assertEquals(Result::success(), $result);
         self::assertEquals($expectedFailure, $this->subscriptionStatus('Vendor.Package:SecondFakeProjection'));
+
+        // status with filter would show that setup would exclude it
+        self::assertEquals(SubscriptionStatusCollection::fromArray([$expectedFailure]), $this->subscriptionEngine->subscriptionStatusOfSetupExcluded());
 
         // reactivation will attempt to retry fix this, but can only work if the projection is repaired and will lead to an error otherwise:
         $result = $this->subscriptionEngine->reactivate();

--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
@@ -8,10 +8,13 @@ use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\WorkspaceEventStreamName;
+use Neos\ContentRepository\Core\Projection\ProjectionStatusType;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryStatus;
+use Neos\ContentRepository\Core\Subscription\DetachedSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\Engine\Errors;
 use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngine;
 use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngineCriteria;
+use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatusCollection;
@@ -83,11 +86,40 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
     public function setUp(): Error|null
     {
         $this->eventStore->setup();
-        $eventStoreIsEmpty = iterator_count($this->eventStore->load(VirtualStreamName::all())->limit(1)) === 0;
         $setupResult = $this->subscriptionEngine->setup();
         if ($setupResult->errors !== null) {
             return self::createErrorForReason('Setup failed:', $setupResult->errors);
         }
+
+        $statusOfSkippedSubscriptions = $this->subscriptionEngine->subscriptionStatusOfSetupExcluded();
+        if (!$statusOfSkippedSubscriptions->isEmpty()) {
+            $message = ['Setup skipped subscriptions:'];
+            foreach ($statusOfSkippedSubscriptions as $status) {
+                $message[] = sprintf('  %s:', $status->subscriptionId->value);
+                if ($status instanceof DetachedSubscriptionStatus) {
+                    $message[] = sprintf('    Subscription: %s DETACHED at position %d', $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be', $status->subscriptionPosition->value);
+                }
+                if ($status instanceof ProjectionSubscriptionStatus) {
+                    $message[] = sprintf('    Projection: in %s', $status->subscriptionStatus->value);
+                    if ($status->subscriptionError !== null) {
+                        $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: 'No details available.');
+                        foreach ($lines as $line) {
+                            $message[] = sprintf('      %s', $line);
+                        }
+                    }
+                    $message[] = sprintf('    Setup: %s', $status->setupStatus->type->name);
+                    if ($status->setupStatus->type !== ProjectionStatusType::OK || $status->setupStatus->details) {
+                        $lines = explode(chr(10), $status->setupStatus->details);
+                        foreach ($lines as $line) {
+                            $message[] = '      ' . $line;
+                        }
+                    }
+                }
+            }
+            return new Error(join("\n", $message));
+        }
+
+        $eventStoreIsEmpty = iterator_count($this->eventStore->load(VirtualStreamName::all())->limit(1)) === 0;
         if ($eventStoreIsEmpty) {
             // note: possibly introduce $skipBooting flag instead
             // see https://github.com/patchlevel/event-sourcing/blob/b8591c56b21b049f46bead8e7ab424fd2afe9917/src/Subscription/Engine/DefaultSubscriptionEngine.php#L42

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -177,6 +177,10 @@ final class SubscriptionEngine
                 // this might be a NEW subscription but we dont return it as status is filtered.
                 continue;
             }
+            if ($criteria->status->isEmpty() === false && $criteria->status->contain(SubscriptionStatus::NEW) === false) {
+                // this might be a NEW subscription but we dont return it as status is filtered.
+                continue;
+            }
             // this NEW state is not persisted yet
             $statuses[] = ProjectionSubscriptionStatus::create(
                 subscriptionId: $subscriber->id,

--- a/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/Engine/SubscriptionEngine.php
@@ -130,9 +130,22 @@ final class SubscriptionEngine
 
     public function subscriptionStatus(SubscriptionEngineCriteria|null $criteria = null): SubscriptionStatusCollection
     {
+        return $this->subscriptionStatusForCriteria(SubscriptionCriteria::create(ids: $criteria?->ids));
+    }
+
+    public function subscriptionStatusOfSetupExcluded(): SubscriptionStatusCollection
+    {
+        return $this->subscriptionStatusForCriteria(SubscriptionCriteria::create(status: SubscriptionStatusFilter::fromArray([
+            SubscriptionStatus::ERROR,
+            SubscriptionStatus::DETACHED,
+        ])));
+    }
+
+    private function subscriptionStatusForCriteria(SubscriptionCriteria $criteria): SubscriptionStatusCollection
+    {
         $statuses = [];
         try {
-            $subscriptions = $this->subscriptionStore->findByCriteriaForUpdate(SubscriptionCriteria::create(ids: $criteria?->ids));
+            $subscriptions = $this->subscriptionStore->findByCriteriaForUpdate($criteria);
         } catch (\Doctrine\DBAL\Exception\TableNotFoundException) {
             // todo do not depend on the dbal exception as this is totally implementation specific and the core has no dependency to dbal!
             // the schema is not setup - thus there are no subscribers
@@ -160,7 +173,7 @@ final class SubscriptionEngine
             if ($subscriptions->contain($subscriber->id)) {
                 continue;
             }
-            if ($criteria?->ids?->contain($subscriber->id) === false) {
+            if ($criteria->ids?->contain($subscriber->id) === false) {
                 // this might be a NEW subscription but we dont return it as status is filtered.
                 continue;
             }

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionStatusFilter.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionStatusFilter.php
@@ -44,6 +44,11 @@ final class SubscriptionStatusFilter implements \IteratorAggregate
         return new self([]);
     }
 
+    public function contain(SubscriptionStatus $status): bool
+    {
+        return array_key_exists($status->value, $this->statusByValue);
+    }
+
     public function getIterator(): \Traversable
     {
         yield from array_values($this->statusByValue);

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -58,12 +58,53 @@ final class CrCommandController extends CommandController
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentRepositoryMaintainer = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new ContentRepositoryMaintainerFactory());
 
+        $crStatus = $contentRepositoryMaintainer->status();
+
+        $hasSkippedProjections = false;
+        $outputHeaderForSkippedProjections = function () use (&$hasSkippedProjections) {
+            if (!$hasSkippedProjections) {
+                $hasSkippedProjections = true;
+                $this->outputLine('Skipped subscriptions:');
+            }
+        };
+
+        foreach ($crStatus->subscriptionStatus as $status) {
+            if ($status instanceof ProjectionSubscriptionStatus && $status->subscriptionStatus === SubscriptionStatus::ERROR) {
+                $outputHeaderForSkippedProjections();
+                $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
+                $this->output('    Setup: ');
+                $this->outputLine(match ($status->setupStatus->type) {
+                    ProjectionStatusType::OK => '<success>OK</success>',
+                    ProjectionStatusType::SETUP_REQUIRED => '<comment>SETUP REQUIRED</comment>',
+                    ProjectionStatusType::ERROR => '<error>ERROR</error>',
+                });
+                $this->output('    Projection: ');
+                $this->outputLine('in <error>ERROR</error>');
+                if ($status->subscriptionError !== null) {
+                    $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: '<comment>No details available.</comment>');
+                    foreach ($lines as $line) {
+                        $this->outputLine('<error>      %s</error>', [$line]);
+                    }
+                }
+            }
+            if ($status instanceof DetachedSubscriptionStatus) {
+                $outputHeaderForSkippedProjections();
+                $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
+                $this->output('    Subscription: ');
+                $this->output('%s <comment>DETACHED</comment>', [$status->subscriptionId->value, $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be']);
+            }
+        }
+
         $result = $contentRepositoryMaintainer->setUp();
         if ($result !== null) {
             $this->outputLine('<error>%s</error>', [$result->getMessage()]);
             $this->quit(1);
         }
-        $this->outputLine('<success>Content Repository "%s" was set up</success>', [$contentRepositoryId->value]);
+        if ($hasSkippedProjections) {
+            $this->outputLine('<comment>Content repository "%s" was set up. But some subscriptions were skipped.</comment>', [$contentRepositoryId->value]);
+        } else {
+            $this->outputLine('<success>Content repository "%s" was set up</success>', [$contentRepositoryId->value]);
+        }
     }
 
     /**

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -10,6 +10,7 @@ use Neos\ContentRepository\Core\Subscription\DetachedSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventStore\StatusType;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
@@ -71,27 +72,11 @@ final class CrCommandController extends CommandController
         foreach ($crStatus->subscriptionStatus as $status) {
             if ($status instanceof ProjectionSubscriptionStatus && $status->subscriptionStatus === SubscriptionStatus::ERROR) {
                 $outputHeaderForSkippedProjections();
-                $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
-                $this->output('    Setup: ');
-                $this->outputLine(match ($status->setupStatus->type) {
-                    ProjectionStatusType::OK => '<success>OK</success>',
-                    ProjectionStatusType::SETUP_REQUIRED => '<comment>SETUP REQUIRED</comment>',
-                    ProjectionStatusType::ERROR => '<error>ERROR</error>',
-                });
-                $this->output('    Projection: ');
-                $this->outputLine('in <error>ERROR</error>');
-                if ($status->subscriptionError !== null) {
-                    $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: '<comment>No details available.</comment>');
-                    foreach ($lines as $line) {
-                        $this->outputLine('<error>      %s</error>', [$line]);
-                    }
-                }
+                $this->outputProjectionSubscriptionStatus($status, $crStatus->eventStorePosition, verbose: true);
             }
             if ($status instanceof DetachedSubscriptionStatus) {
                 $outputHeaderForSkippedProjections();
-                $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
-                $this->output('    Subscription: ');
-                $this->output('%s <comment>DETACHED</comment>', [$status->subscriptionId->value, $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be']);
+                $this->outputDetachedSubscriptionStatus($status);
             }
         }
 
@@ -151,52 +136,18 @@ final class CrCommandController extends CommandController
         }
         foreach ($crStatus->subscriptionStatus as $status) {
             if ($status instanceof DetachedSubscriptionStatus) {
-                $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
-                $this->output('    Subscription: ');
-                $this->output('%s <comment>DETACHED</comment>', [$status->subscriptionId->value, $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be']);
-                $this->outputLine(' at position <b>%d</b>', [$status->subscriptionPosition->value]);
+                $this->outputDetachedSubscriptionStatus($status);
             }
             if ($status instanceof ProjectionSubscriptionStatus) {
-                $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
-                $this->output('    Setup: ');
-                $this->outputLine(match ($status->setupStatus->type) {
-                    ProjectionStatusType::OK => '<success>OK</success>',
-                    ProjectionStatusType::SETUP_REQUIRED => '<comment>SETUP REQUIRED</comment>',
-                    ProjectionStatusType::ERROR => '<error>ERROR</error>',
-                });
+                $this->outputProjectionSubscriptionStatus($status, $crStatus->eventStorePosition, $verbose);
+
                 $hasErrors |= $status->setupStatus->type === ProjectionStatusType::ERROR;
                 $setupRequired |= $status->setupStatus->type === ProjectionStatusType::SETUP_REQUIRED;
-                if ($verbose && ($status->setupStatus->type !== ProjectionStatusType::OK || $status->setupStatus->details)) {
-                    $lines = explode(chr(10), $status->setupStatus->details ?: '<comment>No details available.</comment>');
-                    foreach ($lines as $line) {
-                        $this->outputLine('      ' . $line);
-                    }
-                    $this->outputLine();
-                }
-                $this->output('    Projection: ');
-                $this->output(match ($status->subscriptionStatus) {
-                    SubscriptionStatus::NEW => '<comment>NEW</comment>',
-                    SubscriptionStatus::BOOTING => '<comment>BOOTING</comment>',
-                    SubscriptionStatus::ACTIVE => '<success>ACTIVE</success>',
-                    SubscriptionStatus::DETACHED => '<comment>DETACHED</comment>',
-                    SubscriptionStatus::ERROR => '<error>ERROR</error>',
-                });
-                if ($crStatus->eventStorePosition?->value > $status->subscriptionPosition->value) {
-                    // projection is behind
-                    $this->outputLine(' at position <error>%d</error>', [$status->subscriptionPosition->value]);
-                } else {
-                    $this->outputLine(' at position <b>%d</b>', [$status->subscriptionPosition->value]);
-                }
+
                 $hasErrors |= $status->subscriptionStatus === SubscriptionStatus::ERROR;
                 $replayRequired |= $status->subscriptionStatus === SubscriptionStatus::ERROR;
                 $replayRequired |= $status->subscriptionStatus === SubscriptionStatus::BOOTING;
                 $replayRequired |= $status->subscriptionStatus === SubscriptionStatus::DETACHED;
-                if ($verbose && $status->subscriptionError !== null) {
-                    $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: '<comment>No details available.</comment>');
-                    foreach ($lines as $line) {
-                        $this->outputLine('<error>      %s</error>', [$line]);
-                    }
-                }
             }
         }
         if ($verbose) {
@@ -210,6 +161,52 @@ final class CrCommandController extends CommandController
         }
         if ($hasErrors) {
             $this->quit(1);
+        }
+    }
+
+    private function outputDetachedSubscriptionStatus(DetachedSubscriptionStatus $status): void
+    {
+        $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
+        $this->output('    Subscription: ');
+        $this->output('%s <comment>DETACHED</comment>', [$status->subscriptionId->value, $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be']);
+        $this->outputLine(' at position <b>%d</b>', [$status->subscriptionPosition->value]);
+    }
+
+    private function outputProjectionSubscriptionStatus(ProjectionSubscriptionStatus $status, ?SequenceNumber $eventStorePosition, bool $verbose): void
+    {
+        $this->outputLine('  <b>%s</b>:', [$status->subscriptionId->value]);
+        $this->output('    Setup: ');
+        $this->outputLine(match ($status->setupStatus->type) {
+            ProjectionStatusType::OK => '<success>OK</success>',
+            ProjectionStatusType::SETUP_REQUIRED => '<comment>SETUP REQUIRED</comment>',
+            ProjectionStatusType::ERROR => '<error>ERROR</error>',
+        });
+        if ($verbose && ($status->setupStatus->type !== ProjectionStatusType::OK || $status->setupStatus->details)) {
+            $lines = explode(chr(10), $status->setupStatus->details ?: '<comment>No details available.</comment>');
+            foreach ($lines as $line) {
+                $this->outputLine('      ' . $line);
+            }
+        }
+        $this->output('    Projection: ');
+        $this->output(match ($status->subscriptionStatus) {
+            SubscriptionStatus::NEW => '<comment>NEW</comment>',
+            SubscriptionStatus::BOOTING => '<comment>BOOTING</comment>',
+            SubscriptionStatus::ACTIVE => '<success>ACTIVE</success>',
+            SubscriptionStatus::DETACHED => '<comment>DETACHED</comment>',
+            SubscriptionStatus::ERROR => '<error>ERROR</error>',
+        });
+        if ($eventStorePosition?->value > $status->subscriptionPosition->value) {
+            // projection is behind
+            $this->outputLine(' at position <error>%d</error>', [$status->subscriptionPosition->value]);
+        } else {
+            $this->outputLine(' at position <b>%d</b>', [$status->subscriptionPosition->value]);
+        }
+
+        if ($verbose && $status->subscriptionError !== null) {
+            $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: '<comment>No details available.</comment>');
+            foreach ($lines as $line) {
+                $this->outputLine('<error>      %s</error>', [$line]);
+            }
         }
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -59,37 +59,13 @@ final class CrCommandController extends CommandController
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
         $contentRepositoryMaintainer = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new ContentRepositoryMaintainerFactory());
 
-        $crStatus = $contentRepositoryMaintainer->status();
-
-        $hasSkippedProjections = false;
-        $outputHeaderForSkippedProjections = function () use (&$hasSkippedProjections) {
-            if (!$hasSkippedProjections) {
-                $hasSkippedProjections = true;
-                $this->outputLine('Skipped subscriptions:');
-            }
-        };
-
-        foreach ($crStatus->subscriptionStatus as $status) {
-            if ($status instanceof ProjectionSubscriptionStatus && $status->subscriptionStatus === SubscriptionStatus::ERROR) {
-                $outputHeaderForSkippedProjections();
-                $this->outputProjectionSubscriptionStatus($status, $crStatus->eventStorePosition, verbose: true);
-            }
-            if ($status instanceof DetachedSubscriptionStatus) {
-                $outputHeaderForSkippedProjections();
-                $this->outputDetachedSubscriptionStatus($status);
-            }
-        }
-
         $result = $contentRepositoryMaintainer->setUp();
         if ($result !== null) {
+            $this->outputLine('<comment>Failed to fully setup content repository "%s"</comment>', [$contentRepositoryId->value]);
             $this->outputLine('<error>%s</error>', [$result->getMessage()]);
             $this->quit(1);
         }
-        if ($hasSkippedProjections) {
-            $this->outputLine('<comment>Content repository "%s" was set up. But some subscriptions were skipped.</comment>', [$contentRepositoryId->value]);
-        } else {
-            $this->outputLine('<success>Content repository "%s" was set up</success>', [$contentRepositoryId->value]);
-        }
+        $this->outputLine('<success>Content repository "%s" was set up</success>', [$contentRepositoryId->value]);
     }
 
     /**


### PR DESCRIPTION

Before running `cr:setup` once threw and error and successive runs said

> Content Repository "default" was set up

Now it fetches the status of all subscriptions and thus knows which it will skip.

<img width="1163" height="164" alt="image" src="https://github.com/user-attachments/assets/87dd29d0-2fb2-49c3-9e50-371b3fe183fd" />

There is no real error handling for this case except a full destruct and replay ... for the content graph we anticipate with #5896 but im unsure regarding other subscriptions ... maybe we need a new API cli command after all that allows exactly that for one subscription?

The only way currently to escape from this state is by dropping the tables manually and doing the re-setup.
The reason why we remember the error state is because any changes done in the setup up until the error were destructive and done without transaction. We dont know where we failed and thus might be fully corrupted.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
