### PR TITLE
TASK: Provide tests for old document uri path projection integer underflow bug

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/GenericCommandExecutionAndEventPublication.php
@@ -530,20 +530,10 @@ trait GenericCommandExecutionAndEventPublication
         };
         $this->getContentRepositoryService($eventStoreAndSubscriptionEngine);
         $eventStoreAndSubscriptionEngine->eventStore->commit($streamName, Events::with($artificiallyConstructedEvent), ExpectedVersion::ANY());
-        $this->lastCatchUpResult = $eventStoreAndSubscriptionEngine->subscriptionEngine->catchUpActive();
-    }
-
-    private ?\Neos\ContentRepository\Core\Subscription\Engine\ProcessedResult $lastCatchUpResult = null;
-
-    /**
-     * @Then catching up projections leads to no errors
-     */
-    public function catchingUpProjectionsLeadsToNoErrors(): void
-    {
-        Assert::assertNotNull($this->lastCatchUpResult, 'No catch-up result available. Did you publish an event before?');
+        $result = $eventStoreAndSubscriptionEngine->subscriptionEngine->catchUpActive();
         Assert::assertFalse(
-            $this->lastCatchUpResult->hadErrors(),
-            'Catch-up had errors: ' . $this->lastCatchUpResult->errors?->getClampedMessage()
+            $result->hadErrors(),
+            'Catch-up had errors: ' . $result->errors?->getClampedMessage()
         );
     }
 

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -454,19 +454,17 @@ final class DocumentUriPathProjection implements ProjectionInterface
             }
             $tagColumn = $event->tag->value;
 
-            if ($event->tag->equals(NeosSubtreeTag::disabled()) || $event->tag->equals(NeosSubtreeTag::removed())) {
-                $nodeTagLevel = $event->tag->equals(NeosSubtreeTag::disabled()) ? $node->getDisableLevel() : $node->getRemovedLevel();
-                $parentNode = $this->tryGetNode(fn () => $this->documentUriPathFinder->getParentNode($node));
-                $parentTagLevel = 0;
-                if ($parentNode !== null) {
-                    $parentTagLevel = $event->tag === NeosSubtreeTag::disabled() ? $parentNode->getDisableLevel() : $parentNode->getRemovedLevel();
-                }
-                if ($nodeTagLevel <= $parentTagLevel) {
-                    // Node was not tagged (its counter matches [or is below - should never happen] the parent's level).
-                    // Decrementing an untagged node ($nodeTagLevel === 0) would cause an unsigned integer underflow.
-                    // A node might not have been tagged in the first place and just untagged with allVariants or the variant was already untagged.
-                    continue;
-                }
+            $nodeTagLevel = $event->tag->equals(NeosSubtreeTag::disabled()) ? $node->getDisableLevel() : $node->getRemovedLevel();
+            $parentNode = $this->tryGetNode(fn () => $this->documentUriPathFinder->getParentNode($node));
+            $parentTagLevel = 0;
+            if ($parentNode !== null) {
+                $parentTagLevel = $event->tag === NeosSubtreeTag::disabled() ? $parentNode->getDisableLevel() : $parentNode->getRemovedLevel();
+            }
+            if ($nodeTagLevel <= $parentTagLevel) {
+                // Node was not tagged (its counter matches [or is below - should never happen] the parent's level).
+                // Decrementing an untagged node ($nodeTagLevel === 0) would cause an unsigned integer underflow.
+                // A node might not have been tagged in the first place and just untagged with allVariants or the variant was already untagged.
+                continue;
             }
 
             $this->updateNodeQuery('SET ' . $tagColumn . ' = ' . $tagColumn . ' - 1

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -452,21 +452,25 @@ final class DocumentUriPathProjection implements ProjectionInterface
                 // Probably not a document node
                 continue;
             }
-            $tagColumn = $event->tag->value;
 
-            $nodeTagLevel = $event->tag->equals(NeosSubtreeTag::disabled()) ? $node->getDisableLevel() : $node->getRemovedLevel();
-            $parentNode = $this->tryGetNode(fn () => $this->documentUriPathFinder->getParentNode($node));
-            $parentTagLevel = 0;
-            if ($parentNode !== null) {
-                $parentTagLevel = $event->tag === NeosSubtreeTag::disabled() ? $parentNode->getDisableLevel() : $parentNode->getRemovedLevel();
-            }
-            if ($nodeTagLevel <= $parentTagLevel) {
-                // Node was not tagged (its counter matches [or is below - should never happen] the parent's level).
-                // Decrementing an untagged node ($nodeTagLevel === 0) would cause an unsigned integer underflow.
-                // A node might not have been tagged in the first place and just untagged with allVariants or the variant was already untagged.
+            $parentNode = $this->tryGetNode(fn () => $this->getState()->getByIdAndDimensionSpacePointHash(
+                $node->getParentNodeAggregateId(),
+                $node->getDimensionSpacePointHash()
+            ));
+
+            // If a node was not tagged, decrementing an untagged node ($nodeTagLevel === 0) would cause an unsigned integer underflow.
+            // A node might not have been tagged in the first place and just untagged with allVariants or the variant was already untagged.
+            /** @phpstan-ignore match.unhandled */
+            if (
+                match ($event->tag) {
+                    NeosSubtreeTag::disabled() => !$this->isNodeExplicitlyDisabled($node, $parentNode),
+                    NeosSubtreeTag::removed() => !$this->isNodeExplicitlyRemoved($node, $parentNode),
+                }
+            ) {
                 continue;
             }
 
+            $tagColumn = $event->tag->value;
             $this->updateNodeQuery('SET ' . $tagColumn . ' = ' . $tagColumn . ' - 1
                 WHERE dimensionSpacePointHash = :dimensionSpacePointHash
                     AND (

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -462,11 +462,9 @@ final class DocumentUriPathProjection implements ProjectionInterface
                     $parentTagLevel = $event->tag === NeosSubtreeTag::disabled() ? $parentNode->getDisableLevel() : $parentNode->getRemovedLevel();
                 }
                 if ($nodeTagLevel <= $parentTagLevel) {
-                    // Node was not explicitly tagged (its counter matches [or is below - should never happen] the parent's level).
-                    // Decrementing might cause an unsigned integer underflow. This can happen when
-                    // a duplicate SubtreeWasUntagged event reaches the live stream (e.g. due to
-                    // concurrent workspace publishes with stale projection state). See https://github.com/neos/neos-development-collection/issues/5778
-                    // for more details.
+                    // Node was not tagged (its counter matches [or is below - should never happen] the parent's level).
+                    // Decrementing an untagged node ($nodeTagLevel === 0) would cause an unsigned integer underflow.
+                    // A node might not have been tagged in the first place and just untagged with allVariants or the variant was already untagged.
                     continue;
                 }
             }

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -460,8 +460,8 @@ final class DocumentUriPathProjection implements ProjectionInterface
 
             // If a node was not tagged, decrementing an untagged node ($nodeTagLevel === 0) would cause an unsigned integer underflow.
             // A node might not have been tagged in the first place and just untagged with allVariants or the variant was already untagged.
-            /** @phpstan-ignore match.unhandled */
             if (
+                /** @phpstan-ignore match.unhandled (phpstan does not understand flyweights) */
                 match ($event->tag) {
                     NeosSubtreeTag::disabled() => !$this->isNodeExplicitlyDisabled($node, $parentNode),
                     NeosSubtreeTag::removed() => !$this->isNodeExplicitlyRemoved($node, $parentNode),
@@ -754,7 +754,7 @@ final class DocumentUriPathProjection implements ProjectionInterface
         try {
             $this->dbal->insert($this->tableNamePrefix . '_uri', $data, self::COLUMN_TYPES_DOCUMENT_URIS);
         } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to insert node: %s', $e->getMessage()), 1599646694, $e);
+            throw new \RuntimeException(sprintf('Failed to insert node %s: %s', json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR), $e->getMessage()), 1599646694, $e);
         }
     }
 
@@ -790,8 +790,9 @@ final class DocumentUriPathProjection implements ProjectionInterface
             );
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf(
-                'Failed to update node "%s": %s',
+                'Failed to update node "%s" in dimension %s: %s',
                 $nodeAggregateId->value,
+                $dimensionSpacePointHash,
                 $e->getMessage()
             ), 1599646777, $e);
         }
@@ -810,8 +811,9 @@ final class DocumentUriPathProjection implements ProjectionInterface
             );
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf(
-                'Failed to update node via custom query: %s',
-                $e->getMessage()
+                'Failed to update node via custom query: %s and parameters %s',
+                $e->getMessage(),
+                json_encode($parameters, JSON_PARTIAL_OUTPUT_ON_ERROR)
             ), 1599659170, $e);
         }
     }
@@ -831,8 +833,9 @@ final class DocumentUriPathProjection implements ProjectionInterface
             );
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf(
-                'Failed to delete node "%s": %s',
+                'Failed to delete node "%s" in dimension %s: %s',
                 $nodeAggregateId->value,
+                $dimensionSpacePointHash,
                 $e->getMessage()
             ), 1599655284, $e);
         }
@@ -851,8 +854,9 @@ final class DocumentUriPathProjection implements ProjectionInterface
             );
         } catch (DBALException $e) {
             throw new \RuntimeException(sprintf(
-                'Failed to delete node via custom query: %s',
-                $e->getMessage()
+                'Failed to delete node via custom query: %s and parameters %s',
+                $e->getMessage(),
+                json_encode($parameters, JSON_PARTIAL_OUTPUT_ON_ERROR)
             ), 1599659226, $e);
         }
     }

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/RoutingTrait.php
@@ -265,6 +265,9 @@ trait RoutingTrait
         $actualResult = $dbal->fetchAllAssociative('SELECT ' . $columns . ' FROM ' . $tablePrefix . '_uri ORDER BY nodeaggregateidpath, dimensionspacepointhash');
         $expectedResult = array_map(static function (array $row) {
             return array_map(static function (string $cell) {
+                if (str_starts_with($cell, 'hash')) {
+                    return DimensionSpacePoint::fromJsonString(substr($cell, strlen('hash')))->hash;
+                }
                 return json_decode($cell, true, 512, JSON_THROW_ON_ERROR);
             }, $row);
         }, $expectedRows->getHash());

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/DisableNodes.feature
@@ -185,51 +185,6 @@ Feature: Routing behavior of removed, disabled and re-enabled nodes
     When I am on URL "/nody/nody-child"
     Then the matched node should be "nody-mc-nodeface-child" in dimension "{}"
 
-  Scenario: Duplicate SubtreeWasUntagged on live must not crash projection (issue #5778)
-    # Root cause identified in production:
-    #   SQLSTATE[22003]: Numeric value out of range: 1690
-    #   BIGINT UNSIGNED value is out of range in `disabled` - 1
-    #
-    # In production, a duplicate SubtreeWasUntagged event reached the live content stream
-    # The first untag set disabled from 1 to 0. The second untag tried 0 - 1 → unsigned underflow.
-    #
-    # We reproduce this by injecting a raw SubtreeWasUntagged event directly onto the live
-    # content stream, bypassing the command handler guard (SubtreeIsNotTagged).
-    # NOT SURE HOW THIS COULD BE TRIGGERED BY A USER -> WAS NOT ABLE TO REPRODUCE IT THROUGH THE UI, although the history showed
-    # that TWO UntagCommands for the same node were added a few seconds apart from each other.
-    # DETAILS: https://github.com/neos/neos-development-collection/issues/5778
-    When the command DisableNodeAggregate is executed with payload:
-      | Key                          | Value              |
-      | nodeAggregateId              | "nody-mc-nodeface" |
-      | coveredDimensionSpacePoint   | {}                 |
-      | nodeVariantSelectionStrategy | "allVariants"      |
-    Then No node should match URL "/nody"
-
-    # First enable via normal command → disabled goes from 1 to 0
-    When the command EnableNodeAggregate is executed with payload:
-      | Key                          | Value              |
-      | nodeAggregateId              | "nody-mc-nodeface" |
-      | coveredDimensionSpacePoint   | {}                 |
-      | nodeVariantSelectionStrategy | "allVariants"      |
-    When I am on URL "/nody"
-    Then the matched node should be "nody-mc-nodeface" in dimension "{}"
-
-    # Inject a SECOND SubtreeWasUntagged event directly on live, bypassing the guard.
-    # This simulates the production scenario where a duplicate event reached live.
-    # Without the fix, this causes: disabled = 0 - 1 → UNSIGNED underflow crash.
-    And the event SubtreeWasUntagged was published with payload:
-      | Key                          | Value              |
-      | workspaceName                | "live"             |
-      | contentStreamId              | "cs-identifier"    |
-      | nodeAggregateId              | "nody-mc-nodeface" |
-      | affectedDimensionSpacePoints | [{}]               |
-      | tag                          | "disabled"         |
-    Then catching up projections leads to no errors
-
-    # The projection must NOT crash and the node must still be accessible
-    When I am on URL "/nody"
-    Then the matched node should be "nody-mc-nodeface" in dimension "{}"
-
   Scenario: Disable leaf node and create sibling with same uri path segment
     When I am on URL "/david-nodenborough/earl-document/leaf"
     Then the matched node should be "leaf-mc-node" in dimension "{}"

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_SubtreeUntag.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_SubtreeUntag.feature
@@ -28,21 +28,21 @@ Feature:
       | a1              | Neos.ContentRepository.Testing:Document | a                     | a1       | {"example":"general"}     |
       | a1a             | Neos.ContentRepository.Testing:Document | a1                    | a1a      | {"example":"general"}     |
 
-  Scenario: Untag with greater variant selection (allVariants)
+  Scenario Outline: Untag "<subtreeTag>" with greater variant selection (allVariants)
     And the command TagSubtree is executed with payload:
       | Key                          | Value                |
       | nodeAggregateId              | "a"                  |
       | coveredDimensionSpacePoint   | {"example":"source"} |
       | nodeVariantSelectionStrategy | "allSpecializations" |
-      | tag                          | "disabled"           |
+      | tag                          | "<subtreeTag>"       |
 
     When I am in dimension space point {"example":"source"}
     Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
     And I expect this node to have the following subtree with tags:
     """
-    a (disabled*)
-     a1 (disabled)
-      a1a (disabled)
+    a (<subtreeTag>*)
+     a1 (<subtreeTag>)
+      a1a (<subtreeTag>)
     """
 
     When I am in dimension space point {"example":"peer"}
@@ -55,30 +55,30 @@ Feature:
     """
 
     Then I expect the documenturipath table to contain exactly:
-      | nodeaggregateid | dimensionspacepointhash   | disabled |
-      | "root"          | hash{"example":"general"} | 0        |
-      | "root"          | hash{"example":"source"}  | 0        |
-      | "root"          | hash{"example":"spec"}    | 0        |
-      | "root"          | hash{"example":"peer"}    | 0        |
-      | "a"             | hash{"example":"general"} | 0        |
-      | "a"             | hash{"example":"source"}  | 1        |
-      | "a"             | hash{"example":"spec"}    | 1        |
-      | "a"             | hash{"example":"peer"}    | 0        |
-      | "a1"            | hash{"example":"general"} | 0        |
-      | "a1"            | hash{"example":"source"}  | 1        |
-      | "a1"            | hash{"example":"spec"}    | 1        |
-      | "a1"            | hash{"example":"peer"}    | 0        |
-      | "a1a"           | hash{"example":"general"} | 0        |
-      | "a1a"           | hash{"example":"source"}  | 1        |
-      | "a1a"           | hash{"example":"spec"}    | 1        |
-      | "a1a"           | hash{"example":"peer"}    | 0        |
+      | nodeaggregateid | dimensionspacepointhash   | <subtreeTagColumn> |
+      | "root"          | hash{"example":"general"} | 0                  |
+      | "root"          | hash{"example":"source"}  | 0                  |
+      | "root"          | hash{"example":"spec"}    | 0                  |
+      | "root"          | hash{"example":"peer"}    | 0                  |
+      | "a"             | hash{"example":"general"} | 0                  |
+      | "a"             | hash{"example":"source"}  | 1                  |
+      | "a"             | hash{"example":"spec"}    | 1                  |
+      | "a"             | hash{"example":"peer"}    | 0                  |
+      | "a1"            | hash{"example":"general"} | 0                  |
+      | "a1"            | hash{"example":"source"}  | 1                  |
+      | "a1"            | hash{"example":"spec"}    | 1                  |
+      | "a1"            | hash{"example":"peer"}    | 0                  |
+      | "a1a"           | hash{"example":"general"} | 0                  |
+      | "a1a"           | hash{"example":"source"}  | 1                  |
+      | "a1a"           | hash{"example":"spec"}    | 1                  |
+      | "a1a"           | hash{"example":"peer"}    | 0                  |
 
     When the command UntagSubtree is executed with payload:
       | Key                          | Value                |
       | nodeAggregateId              | "a"                  |
       | coveredDimensionSpacePoint   | {"example":"source"} |
       | nodeVariantSelectionStrategy | "allVariants"        |
-      | tag                          | "disabled"           |
+      | tag                          | "<subtreeTag>"       |
 
     When I am in dimension space point {"example":"source"}
     Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
@@ -99,23 +99,28 @@ Feature:
     """
 
     Then I expect the documenturipath table to contain exactly:
-      | nodeaggregateid | dimensionspacepointhash   | disabled |
-      | "root"          | hash{"example":"general"} | 0        |
-      | "root"          | hash{"example":"source"}  | 0        |
-      | "root"          | hash{"example":"spec"}    | 0        |
-      | "root"          | hash{"example":"peer"}    | 0        |
-      | "a"             | hash{"example":"general"} | 0        |
-      | "a"             | hash{"example":"source"}  | 0        |
-      | "a"             | hash{"example":"spec"}    | 0        |
-      | "a"             | hash{"example":"peer"}    | 0        |
-      | "a1"            | hash{"example":"general"} | 0        |
-      | "a1"            | hash{"example":"source"}  | 0        |
-      | "a1"            | hash{"example":"spec"}    | 0        |
-      | "a1"            | hash{"example":"peer"}    | 0        |
-      | "a1a"           | hash{"example":"general"} | 0        |
-      | "a1a"           | hash{"example":"source"}  | 0        |
-      | "a1a"           | hash{"example":"spec"}    | 0        |
-      | "a1a"           | hash{"example":"peer"}    | 0        |
+      | nodeaggregateid | dimensionspacepointhash   | <subtreeTagColumn> |
+      | "root"          | hash{"example":"general"} | 0                  |
+      | "root"          | hash{"example":"source"}  | 0                  |
+      | "root"          | hash{"example":"spec"}    | 0                  |
+      | "root"          | hash{"example":"peer"}    | 0                  |
+      | "a"             | hash{"example":"general"} | 0                  |
+      | "a"             | hash{"example":"source"}  | 0                  |
+      | "a"             | hash{"example":"spec"}    | 0                  |
+      | "a"             | hash{"example":"peer"}    | 0                  |
+      | "a1"            | hash{"example":"general"} | 0                  |
+      | "a1"            | hash{"example":"source"}  | 0                  |
+      | "a1"            | hash{"example":"spec"}    | 0                  |
+      | "a1"            | hash{"example":"peer"}    | 0                  |
+      | "a1a"           | hash{"example":"general"} | 0                  |
+      | "a1a"           | hash{"example":"source"}  | 0                  |
+      | "a1a"           | hash{"example":"spec"}    | 0                  |
+      | "a1a"           | hash{"example":"peer"}    | 0                  |
+
+    Examples:
+      | subtreeTag | subtreeTagColumn |
+      | disabled   | disabled         |
+      | removed    | removed          |
 
   Scenario: Untag child node with greater variant selection (allVariants)
     And the command TagSubtree is executed with payload:
@@ -170,11 +175,11 @@ Feature:
       | "a1a"           | hash{"example":"peer"}    | 1        |
 
     When the command UntagSubtree is executed with payload:
-      | Key                          | Value                |
-      | nodeAggregateId              | "a1"                 |
-      | coveredDimensionSpacePoint   | {"example":"peer"}   |
-      | nodeVariantSelectionStrategy | "allVariants"        |
-      | tag                          | "disabled"           |
+      | Key                          | Value              |
+      | nodeAggregateId              | "a1"               |
+      | coveredDimensionSpacePoint   | {"example":"peer"} |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+      | tag                          | "disabled"         |
 
     When I am in dimension space point {"example":"source"}
     Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_SubtreeUntag.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_SubtreeUntag.feature
@@ -1,0 +1,214 @@
+Feature:
+
+  Background:
+    Given using the following content dimensions:
+      | Identifier | Values                      | Generalizations                      |
+      | example    | general, source, spec, peer | spec->source->general, peer->general |
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Document': {}
+    'Neos.ContentRepository.Testing:Document':
+      superTypes:
+        'Neos.Neos:Document': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live"
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | nodeAggregateId | "root"                        |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeTypeName                            | parentNodeAggregateId | nodeName | originDimensionSpacePoint |
+      | a               | Neos.ContentRepository.Testing:Document | root                  | a        | {"example":"general"}     |
+      | a1              | Neos.ContentRepository.Testing:Document | a                     | a1       | {"example":"general"}     |
+      | a1a             | Neos.ContentRepository.Testing:Document | a1                    | a1a      | {"example":"general"}     |
+
+  Scenario: Untag with greater variant selection (allVariants)
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"example":"source"} |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (disabled*)
+     a1 (disabled)
+      a1a (disabled)
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 1        |
+      | "a"             | hash{"example":"spec"}    | 1        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 1        |
+      | "a1"            | hash{"example":"spec"}    | 1        |
+      | "a1"            | hash{"example":"peer"}    | 0        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 1        |
+      | "a1a"           | hash{"example":"spec"}    | 1        |
+      | "a1a"           | hash{"example":"peer"}    | 0        |
+
+    When the command UntagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"example":"source"} |
+      | nodeVariantSelectionStrategy | "allVariants"        |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 0        |
+      | "a"             | hash{"example":"spec"}    | 0        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 0        |
+      | "a1"            | hash{"example":"spec"}    | 0        |
+      | "a1"            | hash{"example":"peer"}    | 0        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 0        |
+      | "a1a"           | hash{"example":"spec"}    | 0        |
+      | "a1a"           | hash{"example":"peer"}    | 0        |
+
+  Scenario: Untag child node with greater variant selection (allVariants)
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"example":"source"} |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "disabled"           |
+
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a1"                 |
+      | coveredDimensionSpacePoint   | {"example":"peer"}   |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (disabled*)
+     a1 (disabled)
+      a1a (disabled)
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1 (disabled*)
+      a1a (disabled)
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 1        |
+      | "a"             | hash{"example":"spec"}    | 1        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 1        |
+      | "a1"            | hash{"example":"spec"}    | 1        |
+      | "a1"            | hash{"example":"peer"}    | 1        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 1        |
+      | "a1a"           | hash{"example":"spec"}    | 1        |
+      | "a1a"           | hash{"example":"peer"}    | 1        |
+
+    When the command UntagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a1"                 |
+      | coveredDimensionSpacePoint   | {"example":"peer"}   |
+      | nodeVariantSelectionStrategy | "allVariants"        |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (disabled*)
+     a1 (disabled)
+      a1a (disabled)
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 1        |
+      | "a"             | hash{"example":"spec"}    | 1        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 1        |
+      | "a1"            | hash{"example":"spec"}    | 1        |
+      | "a1"            | hash{"example":"peer"}    | 0        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 1        |
+      | "a1a"           | hash{"example":"spec"}    | 1        |
+      | "a1a"           | hash{"example":"peer"}    | 0        |

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_SubtreeUntag.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/Lowlevel_SubtreeUntag.feature
@@ -212,3 +212,166 @@ Feature:
       | "a1a"           | hash{"example":"source"}  | 1        |
       | "a1a"           | hash{"example":"spec"}    | 1        |
       | "a1a"           | hash{"example":"peer"}    | 0        |
+
+  Scenario: Untag a node first in spezialisation then in source
+    And the command TagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"example":"source"} |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (disabled*)
+     a1 (disabled)
+      a1a (disabled)
+    """
+
+    When I am in dimension space point {"example":"spec"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (disabled*)
+     a1 (disabled)
+      a1a (disabled)
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 1        |
+      | "a"             | hash{"example":"spec"}    | 1        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 1        |
+      | "a1"            | hash{"example":"spec"}    | 1        |
+      | "a1"            | hash{"example":"peer"}    | 0        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 1        |
+      | "a1a"           | hash{"example":"spec"}    | 1        |
+      | "a1a"           | hash{"example":"peer"}    | 0        |
+
+    When the command UntagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"example":"spec"}   |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a (disabled*)
+     a1 (disabled)
+      a1a (disabled)
+    """
+
+    When I am in dimension space point {"example":"spec"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 1        |
+      # untagged
+      | "a"             | hash{"example":"spec"}    | 0        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 1        |
+      # untagged
+      | "a1"            | hash{"example":"spec"}    | 0        |
+      | "a1"            | hash{"example":"peer"}    | 0        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 1        |
+      # untagged
+      | "a1a"           | hash{"example":"spec"}    | 0        |
+      | "a1a"           | hash{"example":"peer"}    | 0        |
+
+    When the command UntagSubtree is executed with payload:
+      | Key                          | Value                |
+      | nodeAggregateId              | "a"                  |
+      | coveredDimensionSpacePoint   | {"example":"source"} |
+      | nodeVariantSelectionStrategy | "allSpecializations" |
+      | tag                          | "disabled"           |
+
+    When I am in dimension space point {"example":"source"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    When I am in dimension space point {"example":"spec"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    When I am in dimension space point {"example":"peer"}
+    Then I expect node aggregate identifier "a" to lead to node cs-identifier;a;{"example":"general"}
+    And I expect this node to have the following subtree with tags:
+    """
+    a
+     a1
+      a1a
+    """
+
+    Then I expect the documenturipath table to contain exactly:
+      | nodeaggregateid | dimensionspacepointhash   | disabled |
+      | "root"          | hash{"example":"general"} | 0        |
+      | "root"          | hash{"example":"source"}  | 0        |
+      | "root"          | hash{"example":"spec"}    | 0        |
+      | "root"          | hash{"example":"peer"}    | 0        |
+      | "a"             | hash{"example":"general"} | 0        |
+      | "a"             | hash{"example":"source"}  | 0        |
+      | "a"             | hash{"example":"spec"}    | 0        |
+      | "a"             | hash{"example":"peer"}    | 0        |
+      | "a1"            | hash{"example":"general"} | 0        |
+      | "a1"            | hash{"example":"source"}  | 0        |
+      | "a1"            | hash{"example":"spec"}    | 0        |
+      | "a1"            | hash{"example":"peer"}    | 0        |
+      | "a1a"           | hash{"example":"general"} | 0        |
+      | "a1a"           | hash{"example":"source"}  | 0        |
+      | "a1a"           | hash{"example":"spec"}    | 0        |
+      | "a1a"           | hash{"example":"peer"}    | 0        |


### PR DESCRIPTION
While https://github.com/neos/neos-development-collection/issues/5778 is kindof fixed we have no tests and dont actually know how the scenario came to play. It is definitely not a race condition (https://github.com/neos/neos-development-collection/pull/5788).

As described here https://github.com/neos/neos-development-collection/issues/5778#issuecomment-4797475672 i was able to provoke the old error - when reverting sebs patch - via just two commands. Tag and untag. The untag command must use a greater variant selection strategy than the tag.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
