### PR TITLE
FEATURE: Improve MySQL projection performance by more than factor 8

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/HierarchyRelationSubqueryTest.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/HierarchyRelationSubqueryTest.php
@@ -43,13 +43,14 @@ class HierarchyRelationSubqueryTest extends TestCase
         <<<SQL
         (SELECT h.*
           FROM cr_testing_p_graph_hierarchyrelation AS h
-          INNER JOIN (
-            SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-              FROM cr_testing_p_graph_hierarchyrelation
-                WHERE (contentstreamlayer IN (:contentStreamLayers))
-            GROUP BY id
-          ) AS readHierarchy
-            ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer
+          WHERE (h.contentstreamlayer IN (:contentStreamLayers))
+            AND NOT EXISTS (
+              SELECT 1
+                FROM cr_testing_p_graph_hierarchyrelation hWin
+                WHERE hWin.id = h.id
+                  AND hWin.contentstreamlayer IN (:contentStreamLayers)
+                  AND hWin.contentstreamlayer > h.contentstreamlayer
+            )
         )
         SQL,
             $hierarchyRelationStatement->toSql()
@@ -82,18 +83,19 @@ class HierarchyRelationSubqueryTest extends TestCase
             <<<SQL
             (SELECT h.*
               FROM cr_testing_p_graph_hierarchyrelation AS h
-              INNER JOIN (
-                SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-                  FROM cr_testing_p_graph_hierarchyrelation
-                    WHERE (contentstreamlayer IN (:contentStreamLayers))
-                    AND id IN (
-                      SELECT id FROM cr_testing_p_graph_hierarchyrelation AS h
-                        WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
-                    )
-                GROUP BY id
-              ) AS readHierarchy
-                ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer
-              WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
+              WHERE (h.contentstreamlayer IN (:contentStreamLayers))
+                AND id IN (
+                  SELECT id FROM cr_testing_p_graph_hierarchyrelation AS h
+                    WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
+                )
+                AND NOT EXISTS (
+                  SELECT 1
+                    FROM cr_testing_p_graph_hierarchyrelation hWin
+                    WHERE hWin.id = h.id
+                      AND hWin.contentstreamlayer IN (:contentStreamLayers)
+                      AND hWin.contentstreamlayer > h.contentstreamlayer
+                )
+              AND h.dimensionspacepointhash = :dimensionSpacePointHash
             )
             SQL,
             $hierarchyRelationStatement->toSql()
@@ -129,19 +131,20 @@ class HierarchyRelationSubqueryTest extends TestCase
             <<<SQL
             (SELECT h.*
               FROM cr_testing_p_graph_hierarchyrelation AS h
-              INNER JOIN (
-                SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-                  FROM cr_testing_p_graph_hierarchyrelation
-                    WHERE (contentstreamlayer IN (:contentStreamLayers))
-                    AND id IN (
-                      SELECT id FROM cr_testing_p_graph_hierarchyrelation AS h
-                        WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
-                        AND h.childnodeanchor = :childNodeRelationAnchorPoint
-                    )
-                GROUP BY id
-              ) AS readHierarchy
-                ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer
-              WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
+              WHERE (h.contentstreamlayer IN (:contentStreamLayers))
+                AND id IN (
+                  SELECT id FROM cr_testing_p_graph_hierarchyrelation AS h
+                    WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
+                    AND h.childnodeanchor = :childNodeRelationAnchorPoint
+                )
+                AND NOT EXISTS (
+                  SELECT 1
+                    FROM cr_testing_p_graph_hierarchyrelation hWin
+                    WHERE hWin.id = h.id
+                      AND hWin.contentstreamlayer IN (:contentStreamLayers)
+                      AND hWin.contentstreamlayer > h.contentstreamlayer
+                )
+              AND h.dimensionspacepointhash = :dimensionSpacePointHash
               AND h.childnodeanchor = :childNodeRelationAnchorPoint
             )
             SQL,
@@ -169,14 +172,15 @@ class HierarchyRelationSubqueryTest extends TestCase
             <<<SQL
         (SELECT h.*
           FROM cr_testing_p_graph_hierarchyrelation AS h
-          INNER JOIN (
-            SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-              FROM cr_testing_p_graph_hierarchyrelation
-                WHERE (contentstreamlayer IN (:contentStreamLayers))
-            GROUP BY id
-          ) AS readHierarchy
-            ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer
-          WHERE h.subtreetag = :myOwnParameter
+          WHERE (h.contentstreamlayer IN (:contentStreamLayers))
+            AND NOT EXISTS (
+              SELECT 1
+                FROM cr_testing_p_graph_hierarchyrelation hWin
+                WHERE hWin.id = h.id
+                  AND hWin.contentstreamlayer IN (:contentStreamLayers)
+                  AND hWin.contentstreamlayer > h.contentstreamlayer
+            )
+          AND h.subtreetag = :myOwnParameter
         )
         SQL,
             $hierarchyRelationStatement->toSql()
@@ -203,17 +207,18 @@ class HierarchyRelationSubqueryTest extends TestCase
             <<<SQL
         (SELECT h.*
           FROM cr_testing_p_graph_hierarchyrelation AS h
-          INNER JOIN (
-            SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-              FROM cr_testing_p_graph_hierarchyrelation
-                WHERE (contentstreamlayer IN (:contentStreamLayers))
-                AND id IN (
-                  SELECT id FROM cr_testing_p_graph_hierarchyrelation AS h
-                    WHERE h.childnodeanchor = :originalNodeAnchor OR h.parentnodeanchor = :originalNodeAnchor
-                )
-            GROUP BY id
-          ) AS readHierarchy
-            ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer
+          WHERE (h.contentstreamlayer IN (:contentStreamLayers))
+            AND id IN (
+              SELECT id FROM cr_testing_p_graph_hierarchyrelation AS h
+                WHERE h.childnodeanchor = :originalNodeAnchor OR h.parentnodeanchor = :originalNodeAnchor
+            )
+            AND NOT EXISTS (
+              SELECT 1
+                FROM cr_testing_p_graph_hierarchyrelation hWin
+                WHERE hWin.id = h.id
+                  AND hWin.contentstreamlayer IN (:contentStreamLayers)
+                  AND hWin.contentstreamlayer > h.contentstreamlayer
+            )
         )
         SQL,
             $hierarchyRelationStatement->toSql()

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ContentStreamLayer.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ContentStreamLayer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection;
 
 /**
+ * Forms as a set of {@see ContentStreamLayers} an abstraction for a content stream
+ *
  * @internal
  */
 final readonly class ContentStreamLayer

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ContentStreamLayers.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ContentStreamLayers.php
@@ -5,6 +5,16 @@ declare(strict_types=1);
 namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection;
 
 /**
+ * Abstraction for content streams
+ *
+ * Content stream layers allow to share in common hierarchy relations for content streams.
+ *
+ * Content stream layer are auto incrementing. Only the highest layer is to be written and exclusive for a
+ * single content stream. All other layers are shared and must not be mutated.
+ * If the highest layer does not contain a hierarchy row to modify we leverage copy on write.
+ *
+ * Documentation visualized with graphs {@link https://github.com/neos/neos-development-collection/pull/5776}
+ *
  * @internal
  */
 final readonly class ContentStreamLayers

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -23,6 +23,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPo
 use Neos\ContentGraph\DoctrineDbalAdapter\HierarchyRelationSubquery;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
+use Neos\ContentGraph\DoctrineDbalAdapter\ReferenceDestinationNodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\SqlTableSubqueryFactory;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
@@ -585,7 +586,9 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
         $queryBuilder = $this->createQueryBuilder()
             ->select("sn.*, sh.subtreetags, r.name AS referencename, r.properties AS referenceproperties")
-            ->fromTableSubquery($this->hierarchyRelationQuery, 'sh')
+            ->fromTableSubquery($this->hierarchyRelationQuery->withPossibleChildNodeAggregateId(
+                ReferenceDestinationNodeAggregateIdCondition::forNodeAggregateId($nodeAggregateId)
+            ), 'sh')
             ->innerJoin('sh', $this->tableNames->node(), 'sn', 'sn.relationanchorpoint = sh.childnodeanchor')
             ->innerJoin('sn', $this->tableNames->referenceRelation(), 'r', 'r.nodeanchorpoint = sn.relationanchorpoint')
             // FIXME evaluate to use NodeAggregateIdClause prefiltering here as well? Possibly makes the subquery redundant because results will be prefiltered.

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
@@ -14,6 +14,107 @@ use Neos\ContentRepository\Dbal\Query\SqlTableSubqueryInterface;
 use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
 
 /**
+ * SQL builder that resolves the correct `graph_hierarchyrelation` rows from a set of content stream layers.
+ *
+ * NOTE: the generated SQL only works when the caller binds a prepared statement parameter `:contentStreamLayers`
+ * holding the content stream layers of the current content stream (read from `..._graph_contentstreamlayer`).
+ *
+ *
+ * CONCEPT
+ * =======
+ *
+ * Starting with Neos 9.2, each Content Stream consists of (hierarchy relation) *layers*: the topmost layer is
+ * (usually) mutable, the layers below are immutable. To read a hierarchy relation we must take the TOP-MOST
+ * ContentStreamLayer that exists for a given Hierarchy Relation ID. Layers use an auto-increment, so "top-most"
+ * means the highest `contentstreamlayer` for that hierarchy-relation-edge.
+ *
+ * Conceptually, for every hierarchy relation we need:
+ *
+ *     SELECT MAX(contentstreamlayer) WHERE id = ... AND contentstreamlayer IN (:contentStreamLayers)
+ *
+ * Tombstones: node removal writes a tombstone row (same id, highest contentstreamlayer, every other column NULL).
+ * Because the tombstone has the highest layer it WINS the MAX resolution, so the removed node correctly drops out
+ * (the caller's outer WHERE then discards the NULL row). Any change to the layer resolution must preserve this.
+ *
+ *
+ * ATTEMPT 1 (replaced): MAX(...) GROUP BY id in a derived table
+ * =============================================================
+ *
+ * This approach was fast in MariaDB but slow in MySQL.
+ *
+ * The approach explained step by step:
+ *
+ * 1) We essentially want to run `SELECT MAX(contentstreamlayer) WHERE id = ... AND contentstreamlayer IN (:contentStreamLayers)`
+ *    once per id, but more efficiently. To resolve a whole set of ids in one query, we turn the per-id MAX into a grouped one:
+ *
+ *        SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
+ *          FROM ..._graph_hierarchyrelation
+ *          WHERE contentstreamlayer IN (:contentStreamLayers)
+ *          GROUP BY id
+ *
+ *    This yields one (id, winning-layer) pair per id.
+ *
+ * 2) That pair only tells us which layer wins (for a given id); we still need the full row `h.*`. So we treat the
+ *    grouped result as a derived table `readHierarchy` and INNER JOIN the original table back onto it, matching on
+ *    (id, winning-layer). The INNER JOIN also drops any id that had no row in the allowed layers.
+ *
+ * 3) Finally we add pre-filters as performance improvements for MariaDB: an inner WHERE inside the derived table
+ *    (so MariaDB groups far fewer records, pushed down via {@see withPossibleWhereCondition()}) and an outer WHERE
+ *    on the joined result for the caller's own conditions (via {@see withWhereCondition()}).
+ *
+ * WHY IT WAS REPLACED: MySQL cannot optimize this. The derived table `readHierarchy` has `GROUP BY id`, and MySQL
+ * has no way to push the outer join key (id) into a grouped derived table, so it materializes the full grouped
+ * result for every lookup. MariaDB has the `split_materialized` optimization, which pushes the wanted id INTO the
+ * grouped derived table and thus computes MAX only for the wanted ids via index — MySQL has no equivalent.
+ *
+ *
+ * ATTEMPT 2 (current): anti-join via NOT EXISTS
+ * =============================================
+ *
+ * Restating Attempt 1 mathematically, with L = the allowed layers (:contentStreamLayers):
+ * - for each id, compute m(id) = MAX{ layer : layer ∈ L }
+ * - keep row h where h.id = id AND h.layer = m(id)         -- i.e. the greatest layer per id
+ * - in symbols: h.layer ∈ L  ∧  h.layer = max{ layer ∈ L for id }
+ *
+ * This is equivalent to: "no row of the same id has a layer in L strictly greater than h.layer", i.e.
+ *
+ *     h.layer ∈ L  ∧  ¬∃ same-id row with (layer ∈ L ∧ layer > h.layer)
+ *
+ * which is exactly an anti-join (NOT EXISTS):
+ *
+ *     SELECT h.* FROM hr h
+ *      WHERE h.layer IN L [AND id-pushdown]
+ *        AND NOT EXISTS (
+ *            -- exists a row with same id and bigger layer? -> then the current row is NOT the highest
+ *            -- layer and we DISCARD it.
+ *            SELECT 1 FROM hr hWin
+ *            WHERE hWin.id = h.id AND hWin.layer IN L AND hWin.layer > h.layer)
+ *
+ * NOTE: both forms are equivalent regardless of indexing. The unique index UNIQ_id_layer(id, layer) just guarantees
+ * one winning row per id (without it both forms return all rows tied at the winning layer) and makes the anti-join fast.
+ *
+ * The NOT EXISTS form stays flat and mergeable, lets the optimizer push predicates and use the
+ * `UNIQ_id_layer (id, contentstreamlayer)` index, and avoids materialization on both MySQL and MariaDB.
+ *
+ *
+ * TOMBSTONE / MOVE SAFETY OF THE PUSHDOWN
+ * =======================================
+ *
+ * The "possible" where condition ({@see withPossibleWhereCondition()}, {@see withPossibleChildNodeAggregateId()},
+ * {@see withPossibleParentNodeAggregateId()}) is pushed into the layer resolution as `id IN (SELECT id FROM hr WHERE ...)`.
+ * Filtering by `id` (not directly on the candidate rows) is the only tombstone-safe and move-safe way to prefilter:
+ *
+ * - Tombstone-safe: it keeps *all* layers of every candidate relation in the layer resolution, including the removal
+ *   tombstone (NULL anchors/dsp but same id and highest layer), so the winning layer stays exact and removed nodes
+ *   correctly drop out. A predicate filtering the candidate rows directly on a nullable column (childnodeanchor,
+ *   parentnodeanchor, dimensionspacepointhash) would exclude the tombstone and resurrect the deleted node.
+ * - Move-safe: a single anchor is not layer-invariant for a relation id (copy-on-write reassigns the child anchor
+ *   across layers, a move reassigns the parent); the id-based superset still keeps every layer of the matching
+ *   relations, and the caller's outer WHERE ({@see withWhereCondition()}) trims the extras.
+ *
+ * This is purely a prefilter (like a bloom filter): it MAY keep more rows than the caller ultimately wants, but it must
+ * NEVER keep fewer.
+ *
  * @internal
  */
 final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterface
@@ -253,31 +354,27 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             // We don't actually ensure the final result only contains hierarchies for this node
         }
 
+        // pushed into the layer resolution as `id IN (...)` so the prefilter stays tombstone-safe (see class docblock)
         $possibleWhereConditionSql = $possibleWhereConditions === [] ? '' : sprintf(
-            <<<SQL
-                    AND id IN (
-                      SELECT id FROM {$this->tableNames->hierarchyRelation()} AS h
-                        WHERE %s
-                    )
-            
-            SQL,
-            join("\n            AND ", $possibleWhereConditions)
+            "\n    AND id IN (\n      SELECT id FROM %s AS h\n        WHERE %s\n    )",
+            $this->tableNames->hierarchyRelation(),
+            join("\n        AND ", $possibleWhereConditions)
         );
-        $whereConditionSql = $whereConditions === [] ? '' : sprintf("  WHERE %s\n", join("\n  AND ", $whereConditions));
+        // applied to the already layer-resolved hierarchy relation `h`
+        $whereConditionSql = $whereConditions === [] ? '' : sprintf("\n  AND %s", join("\n  AND ", $whereConditions));
 
         return <<<SQL
             (SELECT h.*
               FROM {$this->tableNames->hierarchyRelation()} AS h
-              INNER JOIN (
-                SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
-                  FROM {$this->tableNames->hierarchyRelation()}
-                    WHERE (contentstreamlayer IN (:contentStreamLayers))
-            {$possibleWhereConditionSql
-            }    GROUP BY id
-              ) AS readHierarchy
-                ON h.id = readHierarchy.id AND h.contentstreamlayer = readHierarchy.contentstreamlayer
-            {$whereConditionSql
-            })
+              WHERE (h.contentstreamlayer IN (:contentStreamLayers)){$possibleWhereConditionSql}
+                AND NOT EXISTS (
+                  SELECT 1
+                    FROM {$this->tableNames->hierarchyRelation()} hWin
+                    WHERE hWin.id = h.id
+                      AND hWin.contentstreamlayer IN (:contentStreamLayers)
+                      AND hWin.contentstreamlayer > h.contentstreamlayer
+                ){$whereConditionSql}
+            )
             SQL;
     }
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
@@ -123,7 +123,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
         private ContentGraphTableNames $tableNames,
         private ContentStreamLayers $contentStreamLayers,
         private DimensionSpacePointSet $dimensionSpacePoints,
-        private NodeRelationAnchorPoint|NodeAggregateIdCondition|null $childNodeAnchor,
+        private NodeRelationAnchorPoint|NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|null $childNodeAnchor,
         private NodeRelationAnchorPoint|NodeAggregateIdCondition|null $parentNodeAnchor,
         private SqlWhereConditionInterface|null $whereCondition,
         private SqlWhereConditionInterface|null $possibleWhereCondition,
@@ -190,7 +190,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
      * As with a bloom filter, false positive matches are possible, but false negatives are not.
      * The matching hierarchy relations still must be filtered again.
      */
-    public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
+    public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
     {
         return new self(
             tableNames: $this->tableNames,
@@ -295,7 +295,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             $parameters[] = Parameter::integer('childNodeRelationAnchorPoint', $this->childNodeAnchor->value);
         }
 
-        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition) {
+        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition) {
             $parameters = [...$parameters, ...iterator_to_array($this->childNodeAnchor->getParameters())];
         }
 
@@ -339,7 +339,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             $possibleWhereConditions[] = $childNodeRelationAnchorPointWhereCondition;
         }
 
-        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition) {
+        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition) {
             $possibleWhereConditions[] = "h.childnodeanchor IN {$this->childNodeAnchor->toRelationAnchorPointSubquerySql($this->tableNames)}";
             // We don't actually ensure the final result only contains hierarchies for this node
         }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
@@ -14,28 +14,20 @@ use Neos\ContentRepository\Dbal\Query\SqlTableSubqueryInterface;
 use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
 
 /**
- * SQL builder that resolves the correct `graph_hierarchyrelation` rows from a set of content stream layers.
- *
- * NOTE: the generated SQL only works when the caller binds a prepared statement parameter `:contentStreamLayers`
- * holding the content stream layers of the current content stream (read from `..._graph_contentstreamlayer`).
- *
+ * SQL builder that resolves the correct hierarchy-relation rows for a set of content stream layers, and further conditions.
  *
  * CONCEPT
  * =======
  *
- * Starting with Neos 9.2, each Content Stream consists of (hierarchy relation) *layers*: the topmost layer is
- * (usually) mutable, the layers below are immutable. To read a hierarchy relation we must take the TOP-MOST
- * ContentStreamLayer that exists for a given Hierarchy Relation ID. Layers use an auto-increment, so "top-most"
- * means the highest `contentstreamlayer` for that hierarchy-relation-edge.
+ * Starting with Neos 9.2, each Content Stream consists of (hierarchy relation) *layers* {@see ContentStreamLayers}:
+ * To read a hierarchy relation we must take the TOP-MOST ContentStreamLayer that exists for a given Hierarchy Relation ID.
+ * Layers use an auto-increment, so "top-most" means the highest `contentstreamlayer` for that hierarchy-relation-edge.
  *
  * Conceptually, for every hierarchy relation we need:
  *
  *     SELECT MAX(contentstreamlayer) WHERE id = ... AND contentstreamlayer IN (:contentStreamLayers)
  *
- * Tombstones: node removal writes a tombstone row (same id, highest contentstreamlayer, every other column NULL).
- * Because the tombstone has the highest layer it WINS the MAX resolution, so the removed node correctly drops out
- * (the caller's outer WHERE then discards the NULL row). Any change to the layer resolution must preserve this.
- *
+ * Documentation visualized with graphs {@link https://github.com/neos/neos-development-collection/pull/5776}
  *
  * ATTEMPT 1 (replaced): MAX(...) GROUP BY id in a derived table
  * =============================================================
@@ -48,24 +40,20 @@ use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
  *    once per id, but more efficiently. To resolve a whole set of ids in one query, we turn the per-id MAX into a grouped one:
  *
  *        SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
- *          FROM ..._graph_hierarchyrelation
+ *          FROM {hierarchyRelation()}
  *          WHERE contentstreamlayer IN (:contentStreamLayers)
  *          GROUP BY id
  *
  *    This yields one (id, winning-layer) pair per id.
  *
- * 2) That pair only tells us which layer wins (for a given id); we still need the full row `h.*`. So we treat the
- *    grouped result as a derived table `readHierarchy` and INNER JOIN the original table back onto it, matching on
- *    (id, winning-layer). The INNER JOIN also drops any id that had no row in the allowed layers.
- *
- * 3) Finally we add pre-filters as performance improvements for MariaDB: an inner WHERE inside the derived table
- *    (so MariaDB groups far fewer records, pushed down via {@see withPossibleWhereCondition()}) and an outer WHERE
- *    on the joined result for the caller's own conditions (via {@see withWhereCondition()}).
+ * 2) That pair only tells us which layer wins (for a given id); we still need the full row `h.*`. Selecting any other columns
+ *    is undefined behavior and forbidden in strict mode via only_full_group_by. Thus treat the grouped result as a derived table
+ *    `readHierarchy` and INNER JOIN the original table back onto it, matching on (id, winning-layer).
+ *    The INNER JOIN also drops any id that had no row in the allowed layers.
  *
  * WHY IT WAS REPLACED: MySQL cannot optimize this. The derived table `readHierarchy` has `GROUP BY id`, and MySQL
  * has no way to push the outer join key (id) into a grouped derived table, so it materializes the full grouped
- * result for every lookup. MariaDB has the `split_materialized` optimization, which pushes the wanted id INTO the
- * grouped derived table and thus computes MAX only for the wanted ids via index — MySQL has no equivalent.
+ * result for every lookup.
  *
  *
  * ATTEMPT 2 (current): anti-join via NOT EXISTS
@@ -83,37 +71,56 @@ use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
  * which is exactly an anti-join (NOT EXISTS):
  *
  *     SELECT h.* FROM hr h
- *      WHERE h.layer IN L [AND id-pushdown]
+ *      WHERE h.layer IN L [AND id-prefilter]
  *        AND NOT EXISTS (
  *            -- exists a row with same id and bigger layer? -> then the current row is NOT the highest
  *            -- layer and we DISCARD it.
  *            SELECT 1 FROM hr hWin
  *            WHERE hWin.id = h.id AND hWin.layer IN L AND hWin.layer > h.layer)
  *
- * NOTE: both forms are equivalent regardless of indexing. The unique index UNIQ_id_layer(id, layer) just guarantees
- * one winning row per id (without it both forms return all rows tied at the winning layer) and makes the anti-join fast.
- *
  * The NOT EXISTS form stays flat and mergeable, lets the optimizer push predicates and use the
  * `UNIQ_id_layer (id, contentstreamlayer)` index, and avoids materialization on both MySQL and MariaDB.
  *
  *
- * TOMBSTONE / MOVE SAFETY OF THE PUSHDOWN
- * =======================================
+ * Optimisation: Pre-filtering
+ * ===========================
  *
- * The "possible" where condition ({@see withPossibleWhereCondition()}, {@see withPossibleChildNodeAggregateId()},
- * {@see withPossibleParentNodeAggregateId()}) is pushed into the layer resolution as `id IN (SELECT id FROM hr WHERE ...)`.
- * Filtering by `id` (not directly on the candidate rows) is the only tombstone-safe and move-safe way to prefilter:
+ * To reduce the amount of hierarchy rows to consider in subsequent joins and also before applying the NOT EXIST anti-join,
+ * we pre-filter the whole hierarchy table via cheaper conditions.
  *
- * - Tombstone-safe: it keeps *all* layers of every candidate relation in the layer resolution, including the removal
- *   tombstone (NULL anchors/dsp but same id and highest layer), so the winning layer stays exact and removed nodes
- *   correctly drop out. A predicate filtering the candidate rows directly on a nullable column (childnodeanchor,
- *   parentnodeanchor, dimensionspacepointhash) would exclude the tombstone and resurrect the deleted node.
- * - Move-safe: a single anchor is not layer-invariant for a relation id (copy-on-write reassigns the child anchor
- *   across layers, a move reassigns the parent); the id-based superset still keeps every layer of the matching
- *   relations, and the caller's outer WHERE ({@see withWhereCondition()}) trims the extras.
+ * These "possible" where condition are in effect when using all regular conditions like {@see withDimensionSpacePoint()}
+ * and {@see withChildNodeRelationAnchor()} or other variations.
  *
- * This is purely a prefilter (like a bloom filter): it MAY keep more rows than the caller ultimately wants, but it must
- * NEVER keep fewer.
+ * To explicitly force a prefiltering which cannot be inferred from the regular conditions given, {@see withPossibleChildNodeAggregateId()},
+ * {@see withPossibleParentNodeAggregateId()}) as well as {@see withPossibleWhereCondition()} can be used.
+ *
+ * **We MUST only pre-filter by the `id` column (not directly on the candidate rows)**
+ *
+ * Using any other columns would result in undefined behavior, because they are not layer invariant:
+ *
+ * - `parentnodeanchor` see move node
+ * - `childnodeanchor` see copy on write (set properties)
+ *   - in theory its safe to access the nodes' node aggregate id which MUST be invariant across all layers
+ * - `dimensionspacepointhash` see move dimension space point
+ * - `subtreetags` see subtree tagging
+ * - `position` see move node
+ *
+ * Additionally, all of these columns can be set to `NULL` signaling a node removal.
+ * Filtering on these candidates would exclude the NULL values and resurrect the node.
+ *
+ * The pre-filtering leverages a sub-select on the hierarchy relation table to find all possible hierarchy ids:
+ *
+ *     AND id IN (
+ *       SELECT id FROM {hierarchyRelation()} h
+ *         WHERE h.dimensionspacepointhash = :dimensionSpacePointHash
+ *         AND h.childNodeAnchor = :childNodeAnchor
+ *         [...further prefilter]
+ *     )
+ *
+ * The id-based superset still keeps every layer of a possibly matching relations. The outer WHERE is responsible to trim the extras.
+ *
+ * This is purely a prefilter (like a bloom filter): it MAY keep more rows than needed,
+ * but it must NEVER keep fewer.
  *
  * @internal
  */
@@ -189,6 +196,9 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
      *
      * As with a bloom filter, false positive matches are possible, but false negatives are not.
      * The matching hierarchy relations still must be filtered again.
+     *
+     * See documentation: "Optimisation: Pre-filtering"
+     *
      */
     public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
     {
@@ -221,6 +231,9 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
      *
      * As with a bloom filter, false positive matches are possible, but false negatives are not.
      * The matching hierarchy relations still must be filtered again.
+     *
+     * See documentation: "Optimisation: Pre-filtering"
+     *
      */
     public function withPossibleParentNodeAggregateId(NodeAggregateIdCondition $possibleParentNodeAggregateIdCondition): self
     {
@@ -253,6 +266,9 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
      *
      * As with a bloom filter, false positive matches are possible, but false negatives are not.
      * The matching hierarchy relations still must be filtered again.
+     *
+     * See documentation: "Optimisation: Pre-filtering"
+     *
      */
     public function withPossibleWhereCondition(SqlWhereConditionInterface $possibleWhereCondition): self
     {
@@ -354,13 +370,13 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             // We don't actually ensure the final result only contains hierarchies for this node
         }
 
-        // pushed into the layer resolution as `id IN (...)` so the prefilter stays tombstone-safe (see class docblock)
+        // pushed into the layer resolution as `id IN (...)` so the prefilter only relies on the layer invariant id column
         $possibleWhereConditionSql = $possibleWhereConditions === [] ? '' : sprintf(
             "\n    AND id IN (\n      SELECT id FROM %s AS h\n        WHERE %s\n    )",
             $this->tableNames->hierarchyRelation(),
             join("\n        AND ", $possibleWhereConditions)
         );
-        // applied to the already layer-resolved hierarchy relation `h`
+        // applied to the already layer-resolved hierarchy relation
         $whereConditionSql = $whereConditions === [] ? '' : sprintf("\n  AND %s", join("\n  AND ", $whereConditions));
 
         return <<<SQL

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ReferenceDestinationNodeAggregateIdCondition.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ReferenceDestinationNodeAggregateIdCondition.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Dbal\Query\Parameter;
+use Neos\ContentRepository\Dbal\Query\Parameters;
+use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
+
+/**
+ * @internal
+ */
+final readonly class ReferenceDestinationNodeAggregateIdCondition implements SqlWhereConditionInterface
+{
+    private function __construct(
+        private NodeAggregateId $nodeAggregateId
+    ) {
+    }
+
+    public static function forNodeAggregateId(NodeAggregateId $nodeAggregateId): self
+    {
+        return new self(
+            $nodeAggregateId
+        );
+    }
+
+    public function getParameters(): Parameters
+    {
+        return Parameters::create(
+            Parameter::string('nodeAggregateId', $this->nodeAggregateId->value)
+        );
+    }
+
+    public function toWhereSql(string $alias): string
+    {
+        $prefix = $alias !== '' ? "$alias." : '';
+
+        return "{$prefix}destinationnodeaggregateid = :nodeAggregateId";
+    }
+
+    public function toRelationAnchorPointSubquerySql(ContentGraphTableNames $tableNames): string
+    {
+        return "(SELECT nodeanchorpoint FROM {$tableNames->referenceRelation()} WHERE {$this->toWhereSql('')})";
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ReferenceDestinationNodeAggregateIdCondition.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ReferenceDestinationNodeAggregateIdCondition.php
@@ -7,12 +7,11 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Dbal\Query\Parameter;
 use Neos\ContentRepository\Dbal\Query\Parameters;
-use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
 
 /**
  * @internal
  */
-final readonly class ReferenceDestinationNodeAggregateIdCondition implements SqlWhereConditionInterface
+final readonly class ReferenceDestinationNodeAggregateIdCondition
 {
     private function __construct(
         private NodeAggregateId $nodeAggregateId
@@ -33,15 +32,8 @@ final readonly class ReferenceDestinationNodeAggregateIdCondition implements Sql
         );
     }
 
-    public function toWhereSql(string $alias): string
-    {
-        $prefix = $alias !== '' ? "$alias." : '';
-
-        return "{$prefix}destinationnodeaggregateid = :nodeAggregateId";
-    }
-
     public function toRelationAnchorPointSubquerySql(ContentGraphTableNames $tableNames): string
     {
-        return "(SELECT nodeanchorpoint FROM {$tableNames->referenceRelation()} WHERE {$this->toWhereSql('')})";
+        return "(SELECT nodeanchorpoint FROM {$tableNames->referenceRelation()} WHERE destinationnodeaggregateid = :nodeAggregateId)";
     }
 }


### PR DESCRIPTION
### This PR is part **3** of the series Content Stream Layers

**This is part of a big concept update which heavily speeds up Neos 9.2+, by removing the full copy of Hierarchy Relations, and replacing it with so-called "hierarchy layers".**. This functionality needs MULTIPLE pull requests to form a consistent state:

- #5776 for base implementation and functioning concept (still SLOW on big sites)
-  #5874 for heavy performance optimizations (tested with > 150k nodes), but still slow with subtree tagging
  - initial prototype and measurement for performance optimizations was #5873
- **💪💪THIS PR💪💪** #5902 for heavy performance optimizations with MySQL
- #5879 for rewritten and performant subtree tagging in PHP

---

This is an optimization for Content Stream Layers for Neos 9.2

The following numbers are measured locally on MYSQL 8.0:

before this change, replay on neos.io (locally) took 7 minutes
for the first ~35.000 events: replayed ~83 events per second

After this change, replay on neos.io (locally) took 10 minutes
for the first ~450.000 events, and 20 minutes for the
first ~780.000 events: replayed ~650 events per second

The change itself lives only in https://github.com/neos/neos-development-collection/pull/5902/changes/d851c65c9c56aadd4aa68c130ea05f8bad7f6981 -> **see this file for detail explanations**


## Performance Measurement Mariadb (10.11) - neos.io

note: the numbers are NOT comparable with the mysql numbers directly, but just relative to each other.

- WITHOUT this change/pr (including PHP based subtree tagging): 183.000 events / 10 minutes: 305 evt/s.
- WITH this change/pr (including PHP based subtree tagging): 181.000 events / 10 minutes: 301 evt/s.
- **Summary: same as before**

## Performance Measurement Mysql (10.11) - neos.io

- WITHOUT this change/pr (including PHP based subtree tagging): 115.000 events/9 mins (then aborted, because so slow): 212 event/second; ❗ glacially slow events
- WITH this change/pr (including PHP based subtree tagging): 
  - 214.000 events/7 mins: 509 evt/s
  - 305.000 events/10 mins: 508 evt/s
  - 520.000 events/17 mins: 509 evt/s
  - 900.000 events/32 mins: 468 evt/s
  - 1.070.000 events / 45 mins: 396 evt/s
  - 1.230.000 events / 49 mins: 418 evt/s
  - 1.328.000 events / 53 mins: 417 evt/s
- **Summary: this is quick and workable :) WAY better than before**


## Concept

### Original Query, now replaced: MAX(...) GROUP BY id in a derived table
 
This approach was fast in MariaDB but slow in MySQL.
 
The approach explained step by step:
 
1) We essentially want to run `SELECT MAX(contentstreamlayer) WHERE id = ... AND contentstreamlayer IN (:contentStreamLayers)`
 once per id, but more efficiently. To resolve a whole set of ids in one query, we turn the per-id MAX into a grouped one:
 
```sql
 SELECT id, MAX(contentstreamlayer) AS contentstreamlayer
       FROM {hierarchyRelation()}
       WHERE contentstreamlayer IN (:contentStreamLayers)
       GROUP BY id
 ```
This yields one (id, winning-layer) pair per id.
 
2) That pair only tells us which layer wins (for a given id); we still need the full row `h.*`. Selecting any other columns
 is undefined behavior and forbidden in strict mode via only_full_group_by. Thus treat the grouped result as a derived table
 `readHierarchy` and INNER JOIN the original table back onto it, matching on (id, winning-layer).
 The INNER JOIN also drops any id that had no row in the allowed layers.
 
WHY IT WAS REPLACED: MySQL cannot optimize this. The derived table `readHierarchy` has `GROUP BY id`, and MySQL
has no way to push the outer join key (id) into a grouped derived table, so it materializes the full grouped
result for every lookup.
 
 
### This PR: anti-join via NOT EXISTS
 
Restating Attempt 1 mathematically, with L = the allowed layers (:contentStreamLayers):
- for each id, compute m(id) = MAX{ layer : layer ∈ L }
- keep row h where h.id = id AND h.layer = m(id)         -- i.e. the greatest layer per id
- in symbols: h.layer ∈ L  ∧  h.layer = max{ layer ∈ L for id }
 
This is equivalent to: "no row of the same id has a layer in L strictly greater than h.layer", i.e.
 
h.layer ∈ L  ∧  ¬∃ same-id row with (layer ∈ L ∧ layer > h.layer)
 
which is exactly an anti-join (NOT EXISTS):
 
```sql
SELECT h.* FROM hr h
   WHERE h.layer IN L [AND id-prefilter]
     AND NOT EXISTS (
         -- exists a row with same id and bigger layer? -> then the current row is NOT the highest
         -- layer and we DISCARD it.
         SELECT 1 FROM hr hWin
         WHERE hWin.id = h.id AND hWin.layer IN L AND hWin.layer > h.layer)
```
 
The NOT EXISTS form stays flat and mergeable, lets the optimizer push predicates and use the
`UNIQ_id_layer (id, contentstreamlayer)` index, and avoids materialization on both MySQL and MariaDB.

## ToDos

- [x] Behavioral tests still work
- [x] Performance of MYSQL replay (with neos.io)
- [x] Performance or Mariadb replay (with neos.io) 
- [x] manual test: neos.io works snappy

Resolves: #5898