### PR TITLE
FEATURE: Version new content graph projection schema | Smooth 9.2 upgrade

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphTableNames.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ContentGraphTableNames.php
@@ -19,7 +19,7 @@ final readonly class ContentGraphTableNames
 
     public static function create(ContentRepositoryId $contentRepositoryId): self
     {
-        return new self(sprintf('cr_%s_p_graph', $contentRepositoryId->value));
+        return new self(sprintf('cr_%s_p_v1_graph', $contentRepositoryId->value));
     }
 
     public function node(): string

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjectionFactory.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjectionFactory.php
@@ -12,6 +12,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ProjectionContentGraph;
 use Neos\ContentRepository\Core\Factory\SubscriberFactoryDependencies;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphProjectionFactoryInterface;
+use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 use Neos\ContentRepository\Dbal\MysqlPlatformContentRepositoryLocker;
 
 /**
@@ -24,6 +25,11 @@ final class DoctrineDbalContentGraphProjectionFactory implements ContentGraphPro
     public function __construct(
         private readonly Connection $dbal,
     ) {
+    }
+
+    public function getSubscriptionId(): SubscriptionId
+    {
+        return SubscriptionId::fromString('contentGraph_v1');
     }
 
     public function build(

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -109,14 +109,14 @@ final class ContentRepositoryFactory
         }
         $this->additionalProjectionStates = ProjectionStates::fromArray($additionalProjectionStates);
         $this->contentGraphProjection = $contentGraphProjectionFactory->build($subscriberFactoryDependencies);
-        $subscribers[] = $this->buildContentGraphSubscriber();
+        $subscribers[] = $this->buildContentGraphSubscriber($contentGraphProjectionFactory->getSubscriptionId());
         $this->subscriptionEngine = new SubscriptionEngine($this->eventStore, $subscriptionStore, Subscribers::fromArray($subscribers), $this->eventNormalizer, $this->performanceTracer, $logger);
     }
 
-    private function buildContentGraphSubscriber(): ProjectionSubscriber
+    private function buildContentGraphSubscriber(SubscriptionId $subscriptionId): ProjectionSubscriber
     {
         return new ProjectionSubscriber(
-            SubscriptionId::fromString('contentGraph'),
+            $subscriptionId,
             $this->contentGraphProjection,
             $this->contentGraphCatchUpHookFactory?->build(CatchUpHookFactoryDependencies::create(
                 $this->contentRepositoryId,

--- a/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphProjectionFactoryInterface.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ContentGraph/ContentGraphProjectionFactoryInterface.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Neos\ContentRepository\Core\Projection\ContentGraph;
 
 use Neos\ContentRepository\Core\Factory\SubscriberFactoryDependencies;
+use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 
 /**
  * @api for creating a custom content repository graph projection implementation, **not for users of the CR**
  */
 interface ContentGraphProjectionFactoryInterface
 {
+    public function getSubscriptionId(): SubscriptionId;
+
     public function build(
         SubscriberFactoryDependencies $projectionFactoryDependencies,
     ): ContentGraphProjectionInterface;

--- a/Neos.ContentRepository.Core/Classes/Projection/ProjectionStates.php
+++ b/Neos.ContentRepository.Core/Classes/Projection/ProjectionStates.php
@@ -36,9 +36,6 @@ final readonly class ProjectionStates
             if (!$state instanceof ProjectionStateInterface) {
                 throw new \InvalidArgumentException(sprintf('Expected instance of %s, got: %s', ProjectionStateInterface::class, get_debug_type($state)), 1729687661);
             }
-            if ($state instanceof ContentGraphReadModelInterface) {
-                throw new \InvalidArgumentException(sprintf('The content graph state (%s) must not be part of the additional projection states', ContentGraphReadModelInterface::class), 1732390657);
-            }
             if (array_key_exists($state::class, $statesByClassName)) {
                 throw new \InvalidArgumentException(sprintf('An instance of %s is already part of the set', $state::class), 1729687716);
             }


### PR DESCRIPTION
implementes https://github.com/neos/neos-development-collection/issues/5907
see https://github.com/neos/contentgraph-doctrinedbaladapter-compatibility/pull/1


TODO:
- [ ] release https://github.com/neos/contentgraph-doctrinedbaladapter-compatibility to composer
- [ ] ProjectionStates must know specific ContentGraphProjectionState union
- [ ] no longer hardcode `contentGraph`
- [ ] adapters cant determine the content graph subscription id fully as they dont know each other
- [ ] possibly allow subversioning the graph projection further, in case event migrations become necessary again?


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
