### PR TITLE
BUGFIX: Resolve error when publishing selected changes

### DIFF
--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewActions.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Components/ReviewActions.fusion
@@ -104,7 +104,7 @@ prototype(Neos.Workspace.Ui:Component.ReviewActions) < prototype(Neos.Fusion:Com
               disabled={!props.canPublishToBaseWorkspace}
               attributes.hx-target={'#popover-container'}
               attributes.hx-swap='innerHTML'
-              attributes.hx-post={private.confirmPublishSelectedChanges}
+              attributes.hx-get={private.confirmPublishSelectedChanges}
               attributes.hx-on--after-request={'document.getElementById("' + private.publishSelectedChangesPopoverId + '").showPopover()'}
             />
           </div>

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmDiscardSelectedChanges.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmDiscardSelectedChanges.fusion
@@ -40,7 +40,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.ConfirmDiscardSelectedChanges) < pro
           <Neos.Workspace.Ui:Component.Button
             isDanger
             autofocus
-            label={"discard"}
+            label={private.i18n.id('workspaces.discardChanges')}
             icon="trash-alt icon-white"
             attributes.form="publishOrDiscardNodes"
             attributes.name="moduleArguments[action]"

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmPublishSelectedChanges.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmPublishSelectedChanges.fusion
@@ -46,6 +46,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.ConfirmPublishSelectedChanges) < pro
             attributes.name="moduleArguments[action]"
             attributes.value="publish"
             attributes.type="submit"
+            attributes.hx-select='#workspace-module-content'
             attributes.hx-target='#workspace-module-content'
             attributes.hx-include="#publishOrDiscardNodesForm"
             attributes.hx-swap='outerHTML'

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmPublishSelectedChanges.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmPublishSelectedChanges.fusion
@@ -40,7 +40,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.ConfirmPublishSelectedChanges) < pro
           <Neos.Workspace.Ui:Component.Button
             isSuccess
             autofocus
-            label={"publish"}
+            label={private.i18n.id('workspaces.publishChanges')}
             icon="fas fa-check-double icon-white"
             attributes.form="publishOrDiscardNodes"
             attributes.name="moduleArguments[action]"

--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmPublishSelectedChanges.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Review/Modals/ConfirmPublishSelectedChanges.fusion
@@ -46,7 +46,7 @@ prototype(Neos.Workspace.Ui:Component.Modal.ConfirmPublishSelectedChanges) < pro
             attributes.name="moduleArguments[action]"
             attributes.value="publish"
             attributes.type="submit"
-            attributes.hx-target='table'
+            attributes.hx-target='#workspace-module-content'
             attributes.hx-include="#publishOrDiscardNodesForm"
             attributes.hx-swap='outerHTML'
             attributes.hx-on--after-request={'document.getElementById("' + private.popoverId + '").hidePopover()'}

--- a/Neos.Workspace.Ui/Resources/Private/Translations/de/Main.xlf
+++ b/Neos.Workspace.Ui/Resources/Private/Translations/de/Main.xlf
@@ -159,6 +159,14 @@
         <source>Publish selected changes to {0}</source>
         <target state="final">Ausgewählte Änderungen nach {0} veröffentlichen</target>
       </trans-unit>
+      <trans-unit id="workspaces.publishChanges" xml:space="preserve">
+        <source>Publish</source>
+        <target state="final">Veröffentlichen</target>
+      </trans-unit>
+      <trans-unit id="workspaces.discardChanges" xml:space="preserve">
+        <source>Discard</source>
+        <target state="final">Verwerfen</target>
+      </trans-unit>
       <trans-unit id="workspaces.discardAllChanges" xml:space="preserve" approved="yes">
         <source>Discard all changes</source>
         <target state="final">Alle Änderungen verwerfen</target>

--- a/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
+++ b/Neos.Workspace.Ui/Resources/Private/Translations/en/Main.xlf
@@ -228,6 +228,12 @@
       <trans-unit id="workspaces.publishSelectedChangesTo" xml:space="preserve">
 				<source>Publish selected changes to {0}</source>
 			</trans-unit>
+      <trans-unit id="workspaces.publishChanges" xml:space="preserve">
+				<source>Publish</source>
+			</trans-unit>
+      <trans-unit id="workspaces.discardChanges" xml:space="preserve">
+        <source>Discard</source>
+      </trans-unit>
       <trans-unit id="workspaces.discardAllChanges" xml:space="preserve">
 				<source>Discard all changes</source>
 			</trans-unit>


### PR DESCRIPTION
### What I did

Change hx-post to hx-get  since this is only the first step that only brings up the confirmation dialog. 
User clicks "Publish selected" → GET confirmPublishSelectedChanges → loads the modal HTML. With the post request the CSRF-Token was missing.

Second problem:
When confirming the changes the workspace-module-content is returned to the wrong target. It leads to the content being doubled.

###  How I did it

Change  POST to GET Method and change the target for the updated workspace-module-content. I basically just adjusted it to how the other buttons work aswell.

fixes https://github.com/neos/neos-development-collection/issues/5895