### PR TITLE
BUGFIX: Attempt to speedup find parent and references with layers (9.2)

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -24,6 +24,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\HierarchyRelationSubquery;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
 use Neos\ContentGraph\DoctrineDbalAdapter\ReferenceDestinationNodeAggregateIdCondition;
+use Neos\ContentGraph\DoctrineDbalAdapter\ReferenceSourceNodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\SqlTableSubqueryFactory;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
@@ -524,13 +525,14 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
         $queryBuilder = $this->createQueryBuilder()
             ->select("dn.*, dh.subtreetags, r.name AS referencename, r.properties AS referenceproperties")
-            ->fromTableSubquery($this->hierarchyRelationQuery, 'dh')
+            ->fromTableSubquery($this->hierarchyRelationQuery->withPossibleChildNodeAggregateId(
+                ReferenceSourceNodeAggregateIdCondition::forNodeAggregateId($nodeAggregateId)
+            ), 'dh')
             ->innerJoin('dh', $this->tableNames->node(), 'dn', 'dn.relationanchorpoint = dh.childnodeanchor')
             ->innerJoin('dn', $this->tableNames->referenceRelation(), 'r', 'r.destinationnodeaggregateid = dn.nodeaggregateid')
-            // FIXME evaluate to use NodeAggregateIdClause prefiltering here as well? Possibly makes the subquery redundant because results will be prefiltered.
             ->where('r.nodeanchorpoint = (
                 SELECT relationanchorpoint FROM ' . $this->tableNames->node() . ' sn
-                JOIN ' . $this->hierarchyRelationQuery->toSql() . ' sh ON sn.relationanchorpoint = sh.childnodeanchor
+                JOIN ' . $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId(NodeAggregateIdCondition::forNodeAggregateId($nodeAggregateId))->toSql() . ' sh ON sn.relationanchorpoint = sh.childnodeanchor
                 WHERE sn.nodeaggregateid = :nodeAggregateId  '
                 . $subtreeTagConstraints . '
             )')

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -25,6 +25,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\NodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
 use Neos\ContentGraph\DoctrineDbalAdapter\ReferenceDestinationNodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\ReferenceSourceNodeAggregateIdCondition;
+use Neos\ContentGraph\DoctrineDbalAdapter\ParentNodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\SqlTableSubqueryFactory;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
@@ -674,7 +675,9 @@ final class ContentSubgraph implements ContentSubgraphInterface
             // we need to join with the hierarchy relation, because we need the node name.
             ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
             ->innerJoin('ch', $this->tableNames->node(), 'c', 'c.relationanchorpoint = ch.childnodeanchor')
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery, 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
+            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId(
+                ParentNodeAggregateIdCondition::forNodeAggregateId($entryNodeAggregateId)
+            ), 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
             ->andWhereCondition($nodeAggregateIdCondition, 'c');
         $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
         $this->addSubtreeTagConstraints($queryBuilderInitial, 'ch');

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
@@ -130,7 +130,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
         private ContentGraphTableNames $tableNames,
         private ContentStreamLayers $contentStreamLayers,
         private DimensionSpacePointSet $dimensionSpacePoints,
-        private NodeRelationAnchorPoint|NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|ReferenceSourceNodeAggregateIdCondition|null $childNodeAnchor,
+        private NodeRelationAnchorPoint|NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|ReferenceSourceNodeAggregateIdCondition|ParentNodeAggregateIdCondition|null $childNodeAnchor,
         private NodeRelationAnchorPoint|NodeAggregateIdCondition|null $parentNodeAnchor,
         private SqlWhereConditionInterface|null $whereCondition,
         private SqlWhereConditionInterface|null $possibleWhereCondition,
@@ -201,7 +201,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
      * See documentation: "Optimisation: Pre-filtering"
      *
      */
-    public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|ReferenceSourceNodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
+    public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|ReferenceSourceNodeAggregateIdCondition|ParentNodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
     {
         return new self(
             tableNames: $this->tableNames,
@@ -312,7 +312,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             $parameters[] = Parameter::integer('childNodeRelationAnchorPoint', $this->childNodeAnchor->value);
         }
 
-        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceSourceNodeAggregateIdCondition) {
+        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceSourceNodeAggregateIdCondition || $this->childNodeAnchor instanceof ParentNodeAggregateIdCondition) {
             $parameters = [...$parameters, ...iterator_to_array($this->childNodeAnchor->getParameters())];
         }
 
@@ -356,7 +356,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             $possibleWhereConditions[] = $childNodeRelationAnchorPointWhereCondition;
         }
 
-        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceSourceNodeAggregateIdCondition) {
+        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceSourceNodeAggregateIdCondition || $this->childNodeAnchor instanceof ParentNodeAggregateIdCondition) {
             $possibleWhereConditions[] = "h.childnodeanchor IN {$this->childNodeAnchor->toRelationAnchorPointSubquerySql($this->tableNames)}";
             // We don't actually ensure the final result only contains hierarchies for this node
         }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
@@ -130,7 +130,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
         private ContentGraphTableNames $tableNames,
         private ContentStreamLayers $contentStreamLayers,
         private DimensionSpacePointSet $dimensionSpacePoints,
-        private NodeRelationAnchorPoint|NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|null $childNodeAnchor,
+        private NodeRelationAnchorPoint|NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|ReferenceSourceNodeAggregateIdCondition|null $childNodeAnchor,
         private NodeRelationAnchorPoint|NodeAggregateIdCondition|null $parentNodeAnchor,
         private SqlWhereConditionInterface|null $whereCondition,
         private SqlWhereConditionInterface|null $possibleWhereCondition,
@@ -201,7 +201,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
      * See documentation: "Optimisation: Pre-filtering"
      *
      */
-    public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
+    public function withPossibleChildNodeAggregateId(NodeAggregateIdCondition|ReferenceDestinationNodeAggregateIdCondition|ReferenceSourceNodeAggregateIdCondition $possibleChildNodeAggregateIdCondition): self
     {
         return new self(
             tableNames: $this->tableNames,
@@ -312,7 +312,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             $parameters[] = Parameter::integer('childNodeRelationAnchorPoint', $this->childNodeAnchor->value);
         }
 
-        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition) {
+        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceSourceNodeAggregateIdCondition) {
             $parameters = [...$parameters, ...iterator_to_array($this->childNodeAnchor->getParameters())];
         }
 
@@ -356,7 +356,7 @@ final readonly class HierarchyRelationSubquery implements SqlTableSubqueryInterf
             $possibleWhereConditions[] = $childNodeRelationAnchorPointWhereCondition;
         }
 
-        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition) {
+        if ($this->childNodeAnchor instanceof NodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceDestinationNodeAggregateIdCondition || $this->childNodeAnchor instanceof ReferenceSourceNodeAggregateIdCondition) {
             $possibleWhereConditions[] = "h.childnodeanchor IN {$this->childNodeAnchor->toRelationAnchorPointSubquerySql($this->tableNames)}";
             // We don't actually ensure the final result only contains hierarchies for this node
         }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -106,7 +106,9 @@ final readonly class NodeQueryBuilder
             ->from($this->tableNames->node(), 'pn')
             ->innerJoinTableSubquery('pn', $hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'ph', 'ph.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('pn', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = ph.childnodeanchor')
-            ->innerJoinTableSubquery('pn', $hierarchyRelationQuery, 'ch', 'ch.childnodeanchor = pn.relationanchorpoint')
+            ->innerJoinTableSubquery('pn', $hierarchyRelationQuery->withPossibleChildNodeAggregateId(
+                ParentNodeAggregateIdCondition::forNodeAggregateId($childNodeAggregateId)
+            ), 'ch', 'ch.childnodeanchor = pn.relationanchorpoint')
             ->whereCondition('cn', $nodeAggregateIdCondition);
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ParentNodeAggregateIdCondition.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ParentNodeAggregateIdCondition.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Dbal\Query\Parameter;
+use Neos\ContentRepository\Dbal\Query\Parameters;
+use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
+
+/**
+ * @internal
+ */
+final readonly class ParentNodeAggregateIdCondition
+{
+    private function __construct(
+        private NodeAggregateId $nodeAggregateId
+    ) {
+    }
+
+    public static function forNodeAggregateId(NodeAggregateId $nodeAggregateId): self
+    {
+        return new self(
+            $nodeAggregateId
+        );
+    }
+
+    public function getParameters(): Parameters
+    {
+        return Parameters::create(
+            Parameter::string('nodeAggregateId', $this->nodeAggregateId->value)
+        );
+    }
+
+    public function toRelationAnchorPointSubquerySql(ContentGraphTableNames $tableNames): string
+    {
+        return "(SELECT parentnodeanchor FROM {$tableNames->hierarchyRelation()} WHERE childnodeanchor IN (SELECT relationanchorpoint FROM {$tableNames->node()} WHERE nodeaggregateid = :nodeAggregateId))";
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/ReferenceSourceNodeAggregateIdCondition.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/ReferenceSourceNodeAggregateIdCondition.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter;
+
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Dbal\Query\Parameter;
+use Neos\ContentRepository\Dbal\Query\Parameters;
+
+/**
+ * @internal
+ */
+final readonly class ReferenceSourceNodeAggregateIdCondition
+{
+    private function __construct(
+        private NodeAggregateId $nodeAggregateId
+    ) {
+    }
+
+    public static function forNodeAggregateId(NodeAggregateId $nodeAggregateId): self
+    {
+        return new self(
+            $nodeAggregateId
+        );
+    }
+
+    public function getParameters(): Parameters
+    {
+        return Parameters::create(
+            Parameter::string('nodeAggregateId', $this->nodeAggregateId->value)
+        );
+    }
+
+    public function toRelationAnchorPointSubquerySql(ContentGraphTableNames $tableNames): string
+    {
+        return "(SELECT relationanchorpoint FROM {$tableNames->node()} WHERE nodeaggregateid IN (SELECT destinationnodeaggregateid FROM {$tableNames->referenceRelation()} WHERE nodeanchorpoint IN (SELECT relationanchorpoint FROM {$tableNames->node()} WHERE nodeaggregateid = :nodeAggregateId)))";
+    }
+}


### PR DESCRIPTION
The 9.2 introduced layers #5776 come with more complex queries.

Using https://github.com/neos/contentrepository-benchmarktests and absolute time comparisons i can see on my local mariadb `11.0.5-MariaDB` where we perform not equally good as in Neos 9.1.

- second example of "01-BalancedGraph" subgraph queries

```
parentQueryTime: {
    first: 173
    second: 364
    absoluteDifference: 191
    relativeDifference: 2.1040462427745665
}
ancestorsQueryTime: {
    first: 3648
    second: 2486
    absoluteDifference: -1162
    relativeDifference: 0.6814692982456141 ;)
}
referenceQueryTime: {
    first: 240
    second: 789
    absoluteDifference: 549
    relativeDifference: 3.2875
}
```

- "02-BroadGraph" subgraph queries

```
idQueryTime: {
    first: 144
    second: 299
    absoluteDifference: 155
    relativeDifference: 2.076388888888889
}
parentQueryTime: {
    first: 199
    second: 520
    absoluteDifference: 321
    relativeDifference: 2.613065326633166
}
ancestorsQueryTime: {
    first: 2554
    second: 2327
    absoluteDifference: -227
    relativeDifference: 0.9111198120595145 ;)
}
referenceQueryTime: {
    first: 374
    second: 762
    absoluteDifference: 388
    relativeDifference: 2.037433155080214
}
```


- "03-DeepGraph" subgraph queries

```
parentQueryTime: {
  first: 169
  second: 367
  absoluteDifference: 198
  relativeDifference: 2.171597633136095
}
ancestorsQueryTime: {
  first: 2318
  second: 2473
  absoluteDifference: 155
  relativeDifference: 1.0668679896462467
}
referenceQueryTime: {
  first: 246
  second: 766
  absoluteDifference: 520
  relativeDifference: 3.113821138211382
}
```

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->
