### PR TITLE
BUGFIX: Adjust spacing of long workspace visibility label

### DIFF
--- a/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Create.fusion
+++ b/Neos.Workspace.Ui/Resources/Private/Fusion/Features/Workspace/Modals/Create.fusion
@@ -85,20 +85,20 @@ prototype(Neos.Workspace.Ui:Component.Modal.Create) < prototype(Neos.Fusion:Comp
                 field.value="shared"
               >
                 {private.i18n.id('workspaces.workspace.visibility.shared').translate()}
+                <p class="radio-extended-label">
+                  {private.i18n.id('workspaces.workspace.visibility.shared.help').translate()}
+                </p>
               </Neos.Fusion.Form:Radio>
-              <p>
-                {private.i18n.id('workspaces.workspace.visibility.shared.help').translate()}
-              </p>
               <br/>
               <Neos.Fusion.Form:Radio
                 field.name="visibility"
                 field.value="private"
               >
                 {private.i18n.id('workspaces.workspace.visibility.private').translate()}
+                <p class="radio-extended-label">
+                  {private.i18n.id('workspaces.workspace.visibility.private.help').translate()}
+                </p>
               </Neos.Fusion.Form:Radio>
-              <p>
-                {private.i18n.id('workspaces.workspace.visibility.private.help').translate()}
-              </p>
             </Neos.Fusion.Form:Neos.BackendModule.FieldContainer>
           </fieldset>
         </section>

--- a/Neos.Workspace.Ui/Resources/Public/Styles/Module.css
+++ b/Neos.Workspace.Ui/Resources/Public/Styles/Module.css
@@ -222,6 +222,7 @@ button .icon:not(:last-child) {
 
   fieldset {
     padding: 0;
+    width: 100%;
   }
 
   legend {
@@ -285,10 +286,18 @@ button .icon:not(:last-child) {
 .neos-control-group {
   textarea,
   select,
-  input[type="text"] {
+  input[type="text"],
+  .radio-extended-label {
     width: 100%;
     max-width: 500px;
   }
+}
+
+p.radio-extended-label {
+  color: var(--textSubtleLight);
+  padding-left: 30px;
+  margin-bottom: 5px;
+  box-sizing: border-box;
 }
 
 /**


### PR DESCRIPTION

<img width="619" height="626" alt="image" src="https://github.com/user-attachments/assets/0abf59ea-7e27-4a6f-a690-12058030888c" />

Before the labels were not indented and also not adjusted to the fixed width. 

That took a lot of CSS effort more CSS you will not get from me for the next 2 months again.

Thank you @pKallert for motivating me to do this change.