### PR TITLE
BUGFIX: variation coverage restriction

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/07-NodeRemoval/06-CreateNodeSpecializationVariantAfterDeletion.feature
@@ -127,16 +127,16 @@ Feature: Create node specialization
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
-      | Name              | NodeDiscriminator                                         |
-      | document          | cs-identifier;sir-david-nodenborough;{"example":"source"} |
+      | Name     | NodeDiscriminator                                         |
+      | document | cs-identifier;sir-david-nodenborough;{"example":"source"} |
     And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"example":"source"}
     And I expect this node to have the following child nodes:
-      | Name              | NodeDiscriminator                                         |
-      | eldest-document   | cs-identifier;eldest-mc-nodeface;{"example":"source"}     |
-      | elder-document    | cs-identifier;elder-mc-nodeface;{"example":"source"}      |
-      | child-document    | cs-identifier;nody-mc-nodeface;{"example":"spec"}         |
-      | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}    |
-      | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"}   |
+      | Name              | NodeDiscriminator                                       |
+      | eldest-document   | cs-identifier;eldest-mc-nodeface;{"example":"source"}   |
+      | elder-document    | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
+      | child-document    | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
+      | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
+      | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
     And I expect node aggregate identifier "eldest-mc-nodeface" and node path "document/eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
     And I expect this node to have no preceding siblings
     And I expect this node to have the following succeeding siblings:
@@ -196,8 +196,8 @@ Feature: Create node specialization
     Then I expect the subgraph projection to consist of exactly 9 nodes
     Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
     And I expect this node to have the following child nodes:
-      | Name              | NodeDiscriminator                                       |
-      | document   | cs-identifier;sir-david-nodenborough;{"example":"source"}   |
+      | Name     | NodeDiscriminator                                         |
+      | document | cs-identifier;sir-david-nodenborough;{"example":"source"} |
     Then I expect node aggregate identifier "sir-david-nodenborough" to lead to node cs-identifier;sir-david-nodenborough;{"example":"source"}
     And I expect this node to have the following child nodes:
       | Name              | NodeDiscriminator                                       |
@@ -259,3 +259,156 @@ Feature: Create node specialization
       | cs-identifier;elder-mc-nodeface;{"example":"source"}   |
       | cs-identifier;eldest-mc-nodeface;{"example":"source"}  |
     And I expect this node to have no succeeding siblings
+
+  Scenario: Remove the leaf specialization and then create a variant in the source
+    Given the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "sir-david-nodenborough" |
+      | coveredDimensionSpacePoint   | {"example":"leafSpec"}   |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+    When the command CreateNodeVariant is executed with payload:
+      | Key             | Value                |
+      | contentStreamId | "cs-identifier"      |
+      | nodeAggregateId | "nody-mc-nodeface"   |
+      | sourceOrigin    | {"example":"source"} |
+      | targetOrigin    | {"example":"spec"}   |
+
+    Then I expect exactly 21 events to be published on stream with prefix "ContentStream:cs-identifier"
+    And event at index 18 is of type "NodeSpecializationVariantWasCreated" with payload:
+      | Key                    | Expected                                                                               |
+      | workspaceName          | "live"                                                                                 |
+      | contentStreamId        | "cs-identifier"                                                                        |
+      | nodeAggregateId        | "nody-mc-nodeface"                                                                     |
+      | sourceOrigin           | {"example":"source"}                                                                   |
+      | specializationOrigin   | {"example":"spec"}                                                                     |
+      | specializationSiblings | [{"dimensionSpacePoint":{"example":"spec"}, "nodeAggregateId": "younger-mc-nodeface"}] |
+    # the final two are the tethered descendants
+
+    Then I expect the graph projection to consist of exactly 13 nodes
+    And I expect a node identified by cs-identifier;lady-eleonode-rootford;{} to exist in the content graph
+    And I expect a node identified by cs-identifier;sir-david-nodenborough;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;eldest-mc-nodeface;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;elder-mc-nodeface;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;nody-mc-nodeface;{"example":"spec"} to exist in the content graph
+    And I expect a node identified by cs-identifier;nodewyn-tetherton;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;nodewyn-tetherton;{"example":"spec"} to exist in the content graph
+    And I expect a node identified by cs-identifier;nodimer-tetherton;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;nodimer-tetherton;{"example":"spec"} to exist in the content graph
+    And I expect a node identified by cs-identifier;invariable-mc-nodeface;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;younger-mc-nodeface;{"example":"source"} to exist in the content graph
+    And I expect a node identified by cs-identifier;youngest-mc-nodeface;{"example":"source"} to exist in the content graph
+
+    When I am in workspace "live"
+    Then I expect the node aggregate "lady-eleonode-rootford" to exist
+    And I expect this node aggregate to occupy dimension space points [{}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"},{"example":"leafSpec"}]
+
+    And I expect the node aggregate "sir-david-nodenborough" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "eldest-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "elder-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "nody-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"},{"example":"spec"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "nodewyn-tetherton" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"},{"example":"spec"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "nodimer-tetherton" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"},{"example":"spec"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "invariable-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "younger-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    And I expect the node aggregate "youngest-mc-nodeface" to exist
+    And I expect this node aggregate to occupy dimension space points [{"example":"source"}]
+    And I expect this node aggregate to cover dimension space points [{"example":"source"},{"example":"spec"}]
+
+    When I am in dimension space point {"example":"spec"}
+    Then I expect the subgraph projection to consist of exactly 10 nodes
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have the following child nodes:
+      | Name     | NodeDiscriminator                                         |
+      | document | cs-identifier;sir-david-nodenborough;{"example":"source"} |
+    And I expect node aggregate identifier "sir-david-nodenborough" and node path "document" to lead to node cs-identifier;sir-david-nodenborough;{"example":"source"}
+    And I expect this node to have the following child nodes:
+      | Name              | NodeDiscriminator                                       |
+      | eldest-document   | cs-identifier;eldest-mc-nodeface;{"example":"source"}   |
+      | elder-document    | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
+      | child-document    | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
+      | younger-document  | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
+      | youngest-document | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
+    And I expect node aggregate identifier "eldest-mc-nodeface" and node path "document/eldest-document" to lead to node cs-identifier;eldest-mc-nodeface;{"example":"source"}
+    And I expect this node to have no preceding siblings
+    And I expect this node to have the following succeeding siblings:
+      | NodeDiscriminator                                       |
+      | cs-identifier;elder-mc-nodeface;{"example":"source"}    |
+      | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
+      | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
+      | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
+    And I expect node aggregate identifier "elder-mc-nodeface" and node path "document/elder-document" to lead to node cs-identifier;elder-mc-nodeface;{"example":"source"}
+    And I expect this node to have the following preceding siblings:
+      | NodeDiscriminator                                     |
+      | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
+    And I expect this node to have the following succeeding siblings:
+      | NodeDiscriminator                                       |
+      | cs-identifier;nody-mc-nodeface;{"example":"spec"}       |
+      | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
+      | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
+    And I expect node aggregate identifier "nody-mc-nodeface" and node path "document/child-document" to lead to node cs-identifier;nody-mc-nodeface;{"example":"spec"}
+    And I expect this node to have the following child nodes:
+      | Name                | NodeDiscriminator                                         |
+      | tethered-node       | cs-identifier;nodewyn-tetherton;{"example":"spec"}        |
+      | invariable-document | cs-identifier;invariable-mc-nodeface;{"example":"source"} |
+    And I expect this node to have the following preceding siblings:
+      | NodeDiscriminator                                     |
+      | cs-identifier;elder-mc-nodeface;{"example":"source"}  |
+      | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
+    And I expect this node to have the following succeeding siblings:
+      | NodeDiscriminator                                       |
+      | cs-identifier;younger-mc-nodeface;{"example":"source"}  |
+      | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
+    And I expect node aggregate identifier "nodewyn-tetherton" and node path "document/child-document/tethered-node" to lead to node cs-identifier;nodewyn-tetherton;{"example":"spec"}
+    And I expect this node to have the following child nodes:
+      | Name          | NodeDiscriminator                                  |
+      | tethered-leaf | cs-identifier;nodimer-tetherton;{"example":"spec"} |
+    And I expect node aggregate identifier "nodimer-tetherton" and node path "document/child-document/tethered-node/tethered-leaf" to lead to node cs-identifier;nodimer-tetherton;{"example":"spec"}
+    And I expect this node to have no succeeding siblings
+    And I expect node aggregate identifier "younger-mc-nodeface" and node path "document/younger-document" to lead to node cs-identifier;younger-mc-nodeface;{"example":"source"}
+    And I expect this node to have the following preceding siblings:
+      | NodeDiscriminator                                     |
+      | cs-identifier;nody-mc-nodeface;{"example":"spec"}     |
+      | cs-identifier;elder-mc-nodeface;{"example":"source"}  |
+      | cs-identifier;eldest-mc-nodeface;{"example":"source"} |
+    And I expect this node to have the following succeeding siblings:
+      | NodeDiscriminator                                       |
+      | cs-identifier;youngest-mc-nodeface;{"example":"source"} |
+    And I expect node aggregate identifier "youngest-mc-nodeface" and node path "document/youngest-document" to lead to node cs-identifier;youngest-mc-nodeface;{"example":"source"}
+    And I expect this node to have the following preceding siblings:
+      | NodeDiscriminator                                      |
+      | cs-identifier;younger-mc-nodeface;{"example":"source"} |
+      | cs-identifier;nody-mc-nodeface;{"example":"spec"}      |
+      | cs-identifier;elder-mc-nodeface;{"example":"source"}   |
+      | cs-identifier;eldest-mc-nodeface;{"example":"source"}  |
+    And I expect this node to have no succeeding siblings
+
+    When I am in dimension space point {"example":"leafSpec"}
+    Then I expect the subgraph projection to consist of exactly 1 nodes
+    Then I expect node aggregate identifier "lady-eleonode-rootford" to lead to node cs-identifier;lady-eleonode-rootford;{}
+    And I expect this node to have no child nodes

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -39,7 +39,8 @@ trait NodeVariationInternals
         ContentGraphInterface $contentGraph,
         OriginDimensionSpacePoint $sourceOrigin,
         OriginDimensionSpacePoint $targetOrigin,
-        NodeAggregate $nodeAggregate
+        NodeAggregate $nodeAggregate,
+        ?NodeAggregate $parentNodeAggregateForCoverageFilter,
     ): Events {
         return match (
             $this->getInterDimensionalVariationGraph()->getVariantType(
@@ -51,19 +52,22 @@ trait NodeVariationInternals
                 $contentGraph,
                 $sourceOrigin,
                 $targetOrigin,
-                $nodeAggregate
+                $nodeAggregate,
+                $parentNodeAggregateForCoverageFilter,
             ),
             DimensionSpace\VariantType::TYPE_GENERALIZATION => $this->handleCreateNodeGeneralizationVariant(
                 $contentGraph,
                 $sourceOrigin,
                 $targetOrigin,
-                $nodeAggregate
+                $nodeAggregate,
+                $parentNodeAggregateForCoverageFilter,
             ),
             default => $this->handleCreateNodePeerVariant(
                 $contentGraph,
                 $sourceOrigin,
                 $targetOrigin,
-                $nodeAggregate
+                $nodeAggregate,
+                $parentNodeAggregateForCoverageFilter,
             ),
         };
     }
@@ -72,9 +76,14 @@ trait NodeVariationInternals
         ContentGraphInterface $contentGraph,
         OriginDimensionSpacePoint $sourceOrigin,
         OriginDimensionSpacePoint $targetOrigin,
-        NodeAggregate $nodeAggregate
+        NodeAggregate $nodeAggregate,
+        ?NodeAggregate $parentNodeAggregateForCoverageFilter,
     ): Events {
-        $specializationVisibility = $this->calculateEffectiveVisibility($targetOrigin, $nodeAggregate);
+        $specializationVisibility = $this->calculateEffectiveVisibility(
+            $targetOrigin,
+            $nodeAggregate,
+            $parentNodeAggregateForCoverageFilter,
+        );
         $events = $this->collectNodeSpecializationVariantsThatWillHaveBeenCreated(
             $contentGraph,
             $sourceOrigin,
@@ -135,9 +144,14 @@ trait NodeVariationInternals
         ContentGraphInterface $contentGraph,
         OriginDimensionSpacePoint $sourceOrigin,
         OriginDimensionSpacePoint $targetOrigin,
-        NodeAggregate $nodeAggregate
+        NodeAggregate $nodeAggregate,
+        ?NodeAggregate $parentNodeAggregateForCoverageFilter,
     ): Events {
-        $generalizationVisibility = $this->calculateEffectiveVisibility($targetOrigin, $nodeAggregate);
+        $generalizationVisibility = $this->calculateEffectiveVisibility(
+            $targetOrigin,
+            $nodeAggregate,
+            $parentNodeAggregateForCoverageFilter,
+        );
         $events = $this->collectNodeGeneralizationVariantsThatWillHaveBeenCreated(
             $contentGraph,
             $sourceOrigin,
@@ -198,9 +212,14 @@ trait NodeVariationInternals
         ContentGraphInterface $contentGraph,
         OriginDimensionSpacePoint $sourceOrigin,
         OriginDimensionSpacePoint $targetOrigin,
-        NodeAggregate $nodeAggregate
+        NodeAggregate $nodeAggregate,
+        ?NodeAggregate $parentNodeAggregateForCoverageFilter,
     ): Events {
-        $peerVisibility = $this->calculateEffectiveVisibility($targetOrigin, $nodeAggregate);
+        $peerVisibility = $this->calculateEffectiveVisibility(
+            $targetOrigin,
+            $nodeAggregate,
+            $parentNodeAggregateForCoverageFilter,
+        );
         $events = $this->collectNodePeerVariantsThatWillHaveBeenCreated(
             $contentGraph,
             $sourceOrigin,
@@ -307,11 +326,12 @@ trait NodeVariationInternals
 
     private function calculateEffectiveVisibility(
         OriginDimensionSpacePoint $targetOrigin,
-        NodeAggregate $nodeAggregate
+        NodeAggregate $nodeAggregate,
+        ?NodeAggregate $parentNodeAggregateForCoverageFilter,
     ): DimensionSpacePointSet {
         $specializations = $this->getInterDimensionalVariationGraph()
             ->getIndexedSpecializations($targetOrigin->toDimensionSpacePoint());
-        $excludedSet = $specializations->getDifference($nodeAggregate->coveredDimensionSpacePoints);
+        $excludedSet = $specializations->getDifference($parentNodeAggregateForCoverageFilter?->coveredDimensionSpacePoints ?: DimensionSpacePointSet::fromArray([]));
         foreach (
             $specializations->getIntersection(
                 $nodeAggregate->occupiedDimensionSpacePoints->toDimensionSpacePointSet()

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -311,7 +311,7 @@ trait NodeVariationInternals
     ): DimensionSpacePointSet {
         $specializations = $this->getInterDimensionalVariationGraph()
             ->getIndexedSpecializations($targetOrigin->toDimensionSpacePoint());
-        $excludedSet = new DimensionSpacePointSet([]);
+        $excludedSet = $specializations->getDifference($nodeAggregate->coveredDimensionSpacePoints);
         foreach (
             $specializations->getIntersection(
                 $nodeAggregate->occupiedDimensionSpacePoints->toDimensionSpacePointSet()

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeVariationInternals.php
@@ -331,7 +331,9 @@ trait NodeVariationInternals
     ): DimensionSpacePointSet {
         $specializations = $this->getInterDimensionalVariationGraph()
             ->getIndexedSpecializations($targetOrigin->toDimensionSpacePoint());
-        $excludedSet = $specializations->getDifference($parentNodeAggregateForCoverageFilter?->coveredDimensionSpacePoints ?: DimensionSpacePointSet::fromArray([]));
+        $excludedSet = $parentNodeAggregateForCoverageFilter
+            ? $specializations->getDifference($parentNodeAggregateForCoverageFilter->coveredDimensionSpacePoints)
+            : DimensionSpacePointSet::fromArray([]);
         foreach (
             $specializations->getIntersection(
                 $nodeAggregate->occupiedDimensionSpacePoints->toDimensionSpacePointSet()

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -58,7 +58,8 @@ trait TetheredNodeInternals
         ContentGraphInterface $contentGraph,
         OriginDimensionSpacePoint $sourceOrigin,
         OriginDimensionSpacePoint $targetOrigin,
-        NodeAggregate $nodeAggregate
+        NodeAggregate $nodeAggregate,
+        ?NodeAggregate $parentNodeAggregateForCoverageFilter,
     ): Events;
 
     /**
@@ -181,7 +182,8 @@ trait TetheredNodeInternals
             contentGraph: $contentGraph,
             sourceOrigin: $arbitraryOccupiedDimensionSpacePoint,
             targetOrigin: $originDimensionSpacePoint,
-            nodeAggregate: $childNodeAggregate
+            nodeAggregate: $childNodeAggregate,
+            parentNodeAggregateForCoverageFilter: null,
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/NodeVariation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/NodeVariation.php
@@ -89,7 +89,8 @@ trait NodeVariation
             $contentGraph,
             $command->sourceOrigin,
             $command->targetOrigin,
-            $nodeAggregate
+            $nodeAggregate,
+            $parentNodeAggregate,
         );
 
         return new EventsToPublish(


### PR DESCRIPTION
Resolves #5918 

This prefilters the dimension space point set used for variation by evaluating the parent aggregate's coverage

**Review instructions**

Check out the new test case

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch: 9.0
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
