### PR TITLE
BUGFIX: Release-able dependencies for Neos 9.2

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/ContentRepositoryMaintenanceCommandControllerTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/ContentRepositoryMaintenanceCommandControllerTest.php
@@ -18,6 +18,7 @@ use Neos\Flow\Cli\Response;
 use Neos\Utility\ObjectAccess;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+// FIXME, this test should reside in Neos.ContentRepositoryRegistry, but requires the "AbstractSubscriptionEngineTestCase" which we dont want to depend on when distributing the package, its a dev dependency
 final class ContentRepositoryMaintenanceCommandControllerTest extends AbstractSubscriptionEngineTestCase
 {
     private CrCommandController $crController;

--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/Upgrade/ResetupAndReplayContentGraph/ResetupAndReplayContentGraphUpgradeTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/Upgrade/ResetupAndReplayContentGraph/ResetupAndReplayContentGraphUpgradeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Neos\ContentRepositoryRegistry\Tests\Functional\Upgrade\ResetupAndReplayContentGraph;
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional\Upgrade\ResetupAndReplayContentGraph;
 
 use Neos\ContentRepository\BehavioralTests\Tests\Functional\Subscription\AbstractSubscriptionEngineTestCase;
 use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
@@ -10,7 +10,6 @@ use Neos\ContentRepository\Core\Projection\ProjectionStatus;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainerFactory;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
-use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngineCriteria;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\ContentRepositoryRegistry\Upgrade\Command\CRUpgradeContextFactory;
@@ -18,6 +17,7 @@ use Neos\ContentRepositoryRegistry\Upgrade\ResetupAndReplayContentGraph\ResetupA
 use Neos\EventStore\Model\Event\SequenceNumber;
 use PHPUnit\Framework\Assert;
 
+// FIXME, this test should reside in Neos.ContentRepositoryRegistry, but requires the "AbstractSubscriptionEngineTestCase" which we dont want to depend on when distributing the package, its a dev dependency
 class ResetupAndReplayContentGraphUpgradeTest extends AbstractSubscriptionEngineTestCase
 {
     private ResetupAndReplayContentGraphUpgrade $resetGraphAndSetupUpgrade;

--- a/Neos.Neos/composer.json
+++ b/Neos.Neos/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "php": "^8.4",
-        "neos/flow": "~9.1.0",
+        "neos/flow": "~9.2.0",
         "neos/media-browser": "self.version",
         "neos/party": "~7.0.3",
         "neos/contentrepository-core": "self.version",
@@ -22,7 +22,7 @@
         "neos/fusion": "self.version",
         "neos/fusion-afx": "self.version",
         "neos/fusion-form": "^2.1 || ^3.0",
-        "neos/fluid-adaptor": "~9.1.0",
+        "neos/fluid-adaptor": "~9.2.0",
         "neos/media": "self.version",
         "neos/workspace-ui": "self.version",
         "behat/transliterator": "~1.0"


### PR DESCRIPTION
- [Fix remaining dependencies to require Flow 9.1](https://github.com/neos/neos-development-collection/commit/b842dd8bc43606a373b68c29c375ca69249b7e5d)
- [Also move ResetupAndReplayContentGraphUpgradeTest to Behavior Test Package](https://github.com/neos/neos-development-collection/commit/73b243bfe896c5789eb913af2c0d4e82e11deb0a)
  - see https://github.com/neos/neos-development-collection/pull/5473#issuecomment-4864333768