### PR TITLE
BUGFIX: Don't render links to disabled nodes in Neos.Neos:ConvertUris

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -128,7 +128,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         if (!$node instanceof Node) {
             throw new NeosException(sprintf(
                 'The current node must be an instance of Node, given: "%s".',
-                get_debug_type($text)
+                get_debug_type($node)
             ), 1382624087);
         }
 

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -164,7 +164,13 @@ class ConvertUrisImplementation extends AbstractFusionObject
             $resolvedUri = null;
             switch ($matchedUriScheme) {
                 case 'node':
-                    $targetNodeAggregateId = NodeAggregateId::fromString($matchedUriIdentifier);
+                    $targetNodeAggregateId = NodeAggregateId::tryFromString($matchedUriIdentifier);
+
+                    if ($targetNodeAggregateId === null) {
+                        $this->systemLogger->info(sprintf('Could not resolve "%s" because the identifier is not a valid node aggregate id.', $matchedUri), LogEnvironment::fromMethodName(__METHOD__));
+                        break;
+                    }
+
                     $nodeAddress = $nodeAddress->withAggregateId($targetNodeAggregateId);
 
                     // Note that routing intentionally builds uris for disabled nodes as well

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -43,8 +43,8 @@ use Psr\Log\LoggerInterface;
  *
  *   someTextProperty.@process.1 = Neos.Neos:ConvertUris
  *
- * The optional property ``forceConversion`` can be used to have the links converted even when not
- * rendering the live workspace. This is used for links that are not inline editable (for
+ * The optional property ``forceConversion`` can be used to have the links converted even when
+ * rendering in edit mode. This is used for links that are not inline editable (for
  * example links on images)::
  *
  *   someTextProperty.@process.1 = Neos.Neos:ConvertUris {
@@ -102,8 +102,8 @@ class ConvertUrisImplementation extends AbstractFusionObject
     /**
      * Convert URIs matching a supported scheme with generated URIs
      *
-     * If the workspace of the current node context is not live, no replacement will be done unless forceConversion is
-     * set. This is needed to show the editable links with metadata in the content module.
+     * When rendering in edit mode, no replacement will be done unless forceConversion is set.
+     * This is needed to show the editable links with metadata in the content module.
      *
      * @return string
      * @throws NeosException

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -35,31 +35,38 @@ use Neos\Neos\Fusion\Cache\CacheTag;
 use Psr\Log\LoggerInterface;
 
 /**
- * A Fusion Object that converts link references in the format "<type>://<UUID>" to proper URIs
+ * A Fusion object that converts URIs in the format "<type>://<identifier>" to URLs
  *
- * Right now node://<UUID> and asset://<UUID> are supported URI schemes.
+ * Currently, node://<identifier> and asset://<identifier> are supported URI schemes.
+ *
+ * Anchor tags with an unresolvable URI in their href attribute (for example because the target
+ * node is disabled) are replaced by their inner content. Unresolvable URIs
+ * outside of anchor tags are removed entirely.
  *
  * Usage::
  *
  *   someTextProperty.@process.1 = Neos.Neos:ConvertUris
  *
- * The optional property ``forceConversion`` can be used to have the links converted even when
- * rendering in edit mode. This is used for links that are not inline editable (for
- * example links on images)::
+ * The optional property ``forceConversion`` can be used to have the URIs converted even when
+ * rendering in edit mode. This is used for properties that are not inline editable (for
+ * example the link property of an image element, managed in the inspector)::
  *
  *   someTextProperty.@process.1 = Neos.Neos:ConvertUris {
  *     forceConversion = true
  *   }
  *
  * The optional property ``externalLinkTarget`` can be modified to disable or change the target attribute of the
- * link tag for links to external targets::
+ * anchor tag for links to external targets::
  *
  *   prototype(Neos.Neos:ConvertUris) {
  *     externalLinkTarget = '_blank'
  *     resourceLinkTarget = '_blank'
  *   }
  *
- * The optional property ``absolute`` can be used to convert node uris to absolute links::
+ * Anchor tags pointing to an external host additionally get ``rel="noopener external"``, which can
+ * be disabled with the ``setNoOpener`` and ``setExternal`` options.
+ *
+ * The optional property ``absolute`` can be used to resolve URIs to absolute URLs::
  *
  *   someTextProperty.@process.1 = Neos.Neos:ConvertUris {
  *     absolute = true
@@ -100,7 +107,10 @@ class ConvertUrisImplementation extends AbstractFusionObject
     protected $nodeUriBuilderFactory;
 
     /**
-     * Convert URIs matching a supported scheme with generated URIs
+     * Convert URIs matching a supported scheme to their respective URLs and
+     * replace anchor tags whose URI cannot be resolved by their inner content.
+     * Additionally, the target and rel attributes of anchor tags are adjusted
+     * for external and resource links.
      *
      * When rendering in edit mode, no replacement will be done unless forceConversion is set.
      * This is needed to show the editable links with metadata in the content module.
@@ -141,14 +151,14 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $nodeAddress = NodeAddress::fromNode($node);
 
         $unresolvedUris = [];
-        $options = $this->fusionValue('absolute') ? Options::createForceAbsolute() : Options::createEmpty();
+        $frontendRoutingOptions = $this->fusionValue('absolute') ? Options::createForceAbsolute() : Options::createEmpty();
 
         $possibleRequest = $this->runtime->fusionGlobals->get('request');
         if ($possibleRequest instanceof ActionRequest) {
             $nodeUriBuilder = $this->nodeUriBuilderFactory->forActionRequest($possibleRequest);
             $format = $possibleRequest->getFormat();
             if ($format && $format !== 'html') {
-                $options = $options->withCustomFormat($format);
+                $frontendRoutingOptions = $frontendRoutingOptions->withCustomFormat($format);
             }
         } else {
             // unfortunately, the uri-builder always needs a request at hand and cannot build uris without it
@@ -159,9 +169,9 @@ class ConvertUrisImplementation extends AbstractFusionObject
 
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
 
-        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $uriMatches) use ($nodeAddress, &$unresolvedUris, $nodeUriBuilder, $options, $subgraph) {
+        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $uriMatches) use ($nodeAddress, &$unresolvedUris, $nodeUriBuilder, $frontendRoutingOptions, $subgraph) {
             [$matchedUri, $matchedUriScheme, $matchedUriIdentifier] = $uriMatches;
-            $resolvedUri = null;
+            $resolvedUrl = null;
             switch ($matchedUriScheme) {
                 case 'node':
                     $targetNodeAggregateId = NodeAggregateId::tryFromString($matchedUriIdentifier);
@@ -173,17 +183,17 @@ class ConvertUrisImplementation extends AbstractFusionObject
 
                     $nodeAddress = $nodeAddress->withAggregateId($targetNodeAggregateId);
 
-                    // Note that routing intentionally builds uris for disabled nodes as well
+                    // Note that routing intentionally builds URLs for disabled nodes as well
                     // (see https://github.com/neos/neos-development-collection/pull/4363).
-                    // So we need to check whether the node uri is resolvable in the subgraph of the current node.
+                    // So we need to check whether the target node is accessible in the subgraph of the current node.
                     if ($subgraph->findNodeById($targetNodeAggregateId) === null) {
                         $this->systemLogger->info(sprintf('Could not resolve "%s" because the target node is not accessible in the subgraph of the current node.', $matchedUri), LogEnvironment::fromMethodName(__METHOD__));
                     } else {
                         try {
-                            $resolvedUri = (string)$nodeUriBuilder->uriFor($nodeAddress, $options);
+                            $resolvedUrl = (string)$nodeUriBuilder->uriFor($nodeAddress, $frontendRoutingOptions);
                         } catch (NoMatchingRouteException) {
                             // todo log also arguments?
-                            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri.', $matchedUri), LogEnvironment::fromMethodName(__METHOD__));
+                            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a URL.', $matchedUri), LogEnvironment::fromMethodName(__METHOD__));
                         }
                     }
                     $this->runtime->addCacheTag(
@@ -193,19 +203,19 @@ class ConvertUrisImplementation extends AbstractFusionObject
                 case 'asset':
                     $asset = $this->assetRepository->findByIdentifier($matchedUriIdentifier);
                     if ($asset instanceof AssetInterface) {
-                        $resolvedUri = $this->resourceManager->getPublicPersistentResourceUri(
+                        $resolvedUrl = $this->resourceManager->getPublicPersistentResourceUri(
                             $asset->getResource()
                         );
                     }
                     break;
             }
 
-            if ($resolvedUri === null) {
+            if ($resolvedUrl === null) {
                 $unresolvedUris[] = $matchedUri;
                 return $matchedUri;
             }
 
-            return (string)$resolvedUri;
+            return (string)$resolvedUrl;
         }, $text);
         assert($processedContent !== null, 'preg_* error');
 
@@ -222,7 +232,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
     }
 
     /**
-     * Replace the target attribute of link tags in processedContent with the target
+     * Replace the target attribute of anchor tags in processedContent with the target
      * specified by externalLinkTarget and resourceLinkTarget options.
      * Additionally set rel="noopener external" for external links.
      *

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -159,24 +159,25 @@ class ConvertUrisImplementation extends AbstractFusionObject
 
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
 
-        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $matches) use ($nodeAddress, &$unresolvedUris, $nodeUriBuilder, $options, $subgraph) {
+        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $uriMatches) use ($nodeAddress, &$unresolvedUris, $nodeUriBuilder, $options, $subgraph) {
+            [$matchedUri, $matchedUriScheme, $matchedUriIdentifier] = $uriMatches;
             $resolvedUri = null;
-            switch ($matches[1]) {
+            switch ($matchedUriScheme) {
                 case 'node':
-                    $targetNodeAggregateId = NodeAggregateId::fromString($matches[2]);
+                    $targetNodeAggregateId = NodeAggregateId::fromString($matchedUriIdentifier);
                     $nodeAddress = $nodeAddress->withAggregateId($targetNodeAggregateId);
 
                     // Note that routing intentionally builds uris for disabled nodes as well
                     // (see https://github.com/neos/neos-development-collection/pull/4363).
                     // So we need to check whether the node uri is resolvable in the subgraph of the current node.
                     if ($subgraph->findNodeById($targetNodeAggregateId) === null) {
-                        $this->systemLogger->info(sprintf('Could not resolve "%s" because the target node is not accessible in the subgraph of the current node.', $matches[0]), LogEnvironment::fromMethodName(__METHOD__));
+                        $this->systemLogger->info(sprintf('Could not resolve "%s" because the target node is not accessible in the subgraph of the current node.', $matchedUri), LogEnvironment::fromMethodName(__METHOD__));
                     } else {
                         try {
                             $resolvedUri = (string)$nodeUriBuilder->uriFor($nodeAddress, $options);
                         } catch (NoMatchingRouteException) {
                             // todo log also arguments?
-                            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri.', $matches[0]), LogEnvironment::fromMethodName(__METHOD__));
+                            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri.', $matchedUri), LogEnvironment::fromMethodName(__METHOD__));
                         }
                     }
                     $this->runtime->addCacheTag(
@@ -184,7 +185,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
                     );
                     break;
                 case 'asset':
-                    $asset = $this->assetRepository->findByIdentifier($matches[2]);
+                    $asset = $this->assetRepository->findByIdentifier($matchedUriIdentifier);
                     if ($asset instanceof AssetInterface) {
                         $resolvedUri = $this->resourceManager->getPublicPersistentResourceUri(
                             $asset->getResource()
@@ -194,8 +195,8 @@ class ConvertUrisImplementation extends AbstractFusionObject
             }
 
             if ($resolvedUri === null) {
-                $unresolvedUris[] = $matches[0];
-                return $matches[0];
+                $unresolvedUris[] = $matchedUri;
+                return $matchedUri;
             }
 
             return (string)$resolvedUri;

--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -157,18 +157,27 @@ class ConvertUrisImplementation extends AbstractFusionObject
             $nodeUriBuilder = $this->nodeUriBuilderFactory->forActionRequest(ActionRequest::fromHttpRequest(ServerRequest::fromGlobals()));
         }
 
-        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $matches) use ($nodeAddress, &$unresolvedUris, $nodeUriBuilder, $options) {
+        $subgraph = $this->contentRepositoryRegistry->subgraphForNode($node);
+
+        $processedContent = preg_replace_callback(self::PATTERN_SUPPORTED_URIS, function (array $matches) use ($nodeAddress, &$unresolvedUris, $nodeUriBuilder, $options, $subgraph) {
             $resolvedUri = null;
             switch ($matches[1]) {
                 case 'node':
-                    $nodeAddress = $nodeAddress->withAggregateId(
-                        NodeAggregateId::fromString($matches[2])
-                    );
-                    try {
-                        $resolvedUri = (string)$nodeUriBuilder->uriFor($nodeAddress, $options);
-                    } catch (NoMatchingRouteException) {
-                        // todo log also arguments?
-                        $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri.', $matches[0]), LogEnvironment::fromMethodName(__METHOD__));
+                    $targetNodeAggregateId = NodeAggregateId::fromString($matches[2]);
+                    $nodeAddress = $nodeAddress->withAggregateId($targetNodeAggregateId);
+
+                    // Note that routing intentionally builds uris for disabled nodes as well
+                    // (see https://github.com/neos/neos-development-collection/pull/4363).
+                    // So we need to check whether the node uri is resolvable in the subgraph of the current node.
+                    if ($subgraph->findNodeById($targetNodeAggregateId) === null) {
+                        $this->systemLogger->info(sprintf('Could not resolve "%s" because the target node is not accessible in the subgraph of the current node.', $matches[0]), LogEnvironment::fromMethodName(__METHOD__));
+                    } else {
+                        try {
+                            $resolvedUri = (string)$nodeUriBuilder->uriFor($nodeAddress, $options);
+                        } catch (NoMatchingRouteException) {
+                            // todo log also arguments?
+                            $this->systemLogger->warning(sprintf('Could not resolve "%s" to a node uri.', $matches[0]), LogEnvironment::fromMethodName(__METHOD__));
+                        }
                     }
                     $this->runtime->addCacheTag(
                         CacheTag::forDynamicNodeAggregate($nodeAddress->contentRepositoryId, $nodeAddress->workspaceName, $nodeAddress->aggregateId)->value

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1270,8 +1270,8 @@ overriding the target attribute for external links and resource links.
 :node: (Node) The current node as a reference, defaults to the ``node`` context variable
 :externalLinkTarget: (string) Override the target attribute for external links, defaults to ``_blank``. Can be disabled with an empty value.
 :resourceLinkTarget: (string) Override the target attribute for resource links, defaults to ``_blank``. Can be disabled with an empty value.
-:forceConversion: (boolean) Whether to convert URIs in a non-live workspace, defaults to ``FALSE``
-:absolute: (boolean) Can be used to convert node URIs to absolute links, defaults to ``FALSE``
+:forceConversion: (boolean) Whether to convert URIs even when rendering in edit mode, defaults to ``FALSE``
+:absolute: (boolean) Can be used to resolve node URIs to absolute URLs, defaults to ``FALSE``
 :setNoOpener: (boolean) Sets the rel="noopener" attribute to external links, which is good practice, defaults to ``TRUE``
 :setExternal: (boolean) Sets the rel="external" attribute to external links. Defaults to ``TRUE``
 

--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -1263,8 +1263,12 @@ Example::
 Neos.Neos:ConvertUris
 ---------------------
 
-Convert internal node and asset URIs (``node://...`` or ``asset://...``) in a string to public URIs and allows for
+Converts internal node and asset URIs (``node://...`` or ``asset://...``) in a string to URLs and allows
 overriding the target attribute for external links and resource links.
+
+Anchor tags with an unresolvable URI in their href attribute (for example because the target node is
+disabled) are replaced by their inner content. Unresolvable URIs outside of anchor
+tags are removed entirely.
 
 :value: (string) The string value, defaults to the ``value`` context variable to work as a processor by default
 :node: (Node) The current node as a reference, defaults to the ``node`` context variable

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -113,6 +113,26 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
     Some value with node URI: /a1.
     """
 
+  Scenario: URI to disabled node
+    When the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a1"          |
+      | coveredDimensionSpacePoint   | {}            |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    And I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      value = 'Some value with node URI to disabled node: node://a1.'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    Some value with node URI to disabled node: .
+    """
+
   Scenario: URI preserved in edit mode
     Given the Fusion renderingMode is "inPlace"
     When I execute the following Fusion code:
@@ -161,6 +181,48 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
 
   Scenario: Anchor tag with URI to existing node
     When I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      value = 'some <a href="node://a1">Link</a>'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    some <a href="/a1">Link</a>
+    """
+
+  Scenario: Anchor tag with node URI to disabled node
+    When the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a1"          |
+      | coveredDimensionSpacePoint   | {}            |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    And I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      value = 'some <a href="node://a1">Link</a>'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    some Link
+    """
+
+  Scenario: Anchor tag with node URI to disabled node is still resolved if disabled nodes are not excluded
+    When the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value         |
+      | nodeAggregateId              | "a1"          |
+      | coveredDimensionSpacePoint   | {}            |
+      | nodeVariantSelectionStrategy | "allVariants" |
+    # Note that the following excludes _less_ than the default constraints, which are "removed" and "disabled".
+    And the Fusion context node is "a" with visibility constraints "removed"
+    And I execute the following Fusion code:
     """fusion
     include: resource://Neos.Fusion/Private/Fusion/Root.fusion
     include: resource://Neos.Neos/Private/Fusion/Root.fusion

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -98,6 +98,21 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
     Some value with node URI to non-existing node: .
     """
 
+  Scenario: URI with an invalid node identifier
+    When I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      value = 'Some value with an invalid node identifier: node://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    Some value with an invalid node identifier: .
+    """
+
   Scenario: URI to existing node
     When I execute the following Fusion code:
     """fusion


### PR DESCRIPTION
`Neos.Neos:ConvertUris` now checks whether the target node of a `node://` URI is
accessible in the subgraph of the current node before generating a URL for it.
Links to disabled nodes are thus treated like links to non-existing nodes again.
This restores the behaviour we had in Neos 8.

**Upgrade instructions**

No action is required unless you previously relied on these rendered links to identify inaccessible or broken link targets. In that case, you may want to use https://github.com/NEOSidekick/NEOSidekick.LinkChecker instead.

**Review instructions**

For previous discussion, see https://neos-project.slack.com/archives/C050C8FEK/p1782918992284449

- Please note that not all commits are strictly necessary to fix this but while working on the file I noticed inaccuracies and minor bugs in other parts too. I tried to use consistent names for URIs, URLs and anchor tags.
- I did not remove the line "// todo log also arguments?" but maybe we could do that while we're at it?
- I did not refactor or debug the handling of anchor tags. I did not want to blow up this PR.
- `$this->resourceManager->getPublicPersistentResourceUri()` could return `false` which should probably also be caught. I did not look into that either to not blow up the PR.
- I found this Behat step definition confusing because it refers to "visibility constraints" while the argument actually takes excluded subtree tags. But I didn't dare changing it. What do you think? https://github.com/neos/neos-development-collection/blob/8f30701705d47d3b21598456e159892d70b320ad/Neos.Neos/Tests/Behavior/Features/Bootstrap/FusionTrait.php#L85-L94
- 
**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
