### PR TITLE
TASK: Provide event migration for rebases on already removed content streams

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
@@ -73,7 +73,11 @@ final class CRUpgradeCommandController extends CommandController
             [
                 strtolower('crupgrade:eventsDeduplicateBaseWorkspaceChanges'),
                 new EventsDeduplicateBaseWorkspaceChangesUpgrade($context, $noop)
-            ]
+            ],
+            [
+                strtolower('crupgrade:eventsConcurrentWorkspaceRebases'),
+                new EventsConcurrentWorkspaceRebasesUpgrade($context, $noop)
+            ],
         ];
 
         $optionalAvailable = 0;

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
@@ -294,6 +294,31 @@ final class CRUpgradeCommandController extends CommandController
     }
 
     /**
+     * Upgrade to deduplicate illegal concurrent workspace rebases
+     *
+     * https://github.com/neos/neos-development-collection/issues/5849
+     *
+     * Content stream forking was not thread safe before not expressing the assertion to the source content stream
+     * e.g. that the sourceContentStreamVersion should match the reality in the event store.
+     * This resulted in the possibility that a source content stream was not constraint from being forked when it was already removed.
+     * The resulting illegal ContentStreamWasForked event and its RebaseWorkspace sequence must be removed.
+     *
+     * The upgrade first determines any ContentStreamWasForked events where the source content stream was already removed via ContentStreamWasRemoved.
+     * We assume all illegally found forks are restricted to being caused by a RebaseWorkspace command (via correlation id).
+     * Further we expect a simple RebaseWorkspace without any changes on the "user" workspace but just an empty fork.
+     * On this empty fork we expect only a new second RebaseWorkspace, starting with a ContentStreamWasClosed or nothing if the event stream ended.
+     * This second RebaseWorkspace is either also illegal and to be removed or a valid rebase if the source content stream existed at that point.
+     * If valid we want to keep this rebase, but a rebase sequence refers to its previous content stream to remove it and indicate projections which was the last.
+     * The original information is no longer valid as we have removed the existence of the original previous content stream.
+     * Instead, we need to patch the events to use the previous content stream of the first illegal fork - the previous-previous content stream.
+     * Thus, we patch the field $previousContentStreamId of the WorkspaceWasRebased event and rewrite the ContentStreamWasClosed
+     * and ContentStreamWasRemoved events to affect the now new last content stream.
+     *
+     * After the migration is applied the workspace will have its last successfully rebased content stream as without the migration,
+     * but we deduplicated any temporary illegal rebases that happened in a race condition. No content on the workspaces is affected.
+     *
+     * Included in July 2026 - part of the minor 9.2.0 release
+     *
      * @param string $contentRepository Identifier of the Content Repository to migrate
      */
     public function eventsConcurrentWorkspaceRebasesCommand(string $contentRepository = 'default', bool $dryRun = false, bool $force = false): void

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
@@ -7,6 +7,7 @@ namespace Neos\ContentRepositoryRegistry\Upgrade\Command;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainerFactory;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases\EventsConcurrentWorkspaceRebasesUpgrade;
 use Neos\ContentRepositoryRegistry\Upgrade\EventsDeduplicateBaseWorkspaceChanges\EventsDeduplicateBaseWorkspaceChangesUpgrade;
 use Neos\ContentRepositoryRegistry\Upgrade\EventsRecordedAtToUtc\EventsRecordedAtToUtcUpgrade;
 use Neos\ContentRepositoryRegistry\Upgrade\ResetupAndReplayContentGraph\ResetupAndReplayContentGraphUpgrade;
@@ -279,6 +280,36 @@ final class CRUpgradeCommandController extends CommandController
         }
 
         $upgrade = new EventsDeduplicateBaseWorkspaceChangesUpgrade(
+            $context,
+            $this->output->outputLine(...)
+        );
+
+        $upgrade->execute(
+            dryRun: $dryRun
+        );
+    }
+
+    /**
+     * @param string $contentRepository Identifier of the Content Repository to migrate
+     */
+    public function eventsConcurrentWorkspaceRebasesCommand(string $contentRepository = 'default', bool $dryRun = false, bool $force = false): void
+    {
+        if ($dryRun && $force) {
+            $this->outputLine('<comment>Abort. Cannot force a dry run;)</comment>');
+            return;
+        }
+
+        $context = $this->contentRepositoryRegistry->buildService(
+            ContentRepositoryId::fromString($contentRepository),
+            $this->upgradeContextFactory
+        );
+
+        if ((!$dryRun && !$force) && !$this->output->askConfirmation(sprintf('> This will rewrite events of content repository "%s" to remove duplicated rebase workspaces and backup the original events. This will take even on big sites less than 5 minutes. Are you sure to proceed? (y/n) ', $context->contentRepositoryId->value), false)) {
+            $this->outputLine('<comment>Abort.</comment>');
+            return;
+        }
+
+        $upgrade = new EventsConcurrentWorkspaceRebasesUpgrade(
             $context,
             $this->output->outputLine(...)
         );

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -27,6 +27,18 @@ class EventsConcurrentWorkspaceRebasesUpgrade
     ) {
     }
 
+    public static function getShortDescription(): string
+    {
+        return 'Deduplicate illegal concurrent rebase workspaces';
+    }
+
+    public function isAvailable(): bool
+    {
+        $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->findForkedContentStreamsWithAlreadyRemovedSourceContentStream();
+
+        return $forkedContentStreamsWithAlreadyRemovedSourceContentStream !== [];
+    }
+
     public function execute(bool $dryRun): void
     {
         $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->findForkedContentStreamsWithAlreadyRemovedSourceContentStream();
@@ -144,7 +156,8 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
         if ($rebaseSequencesToPatchContentStream !== []) {
             $this->log(sprintf('Found %d remaining workspace rebases to be adjusted after the deletion', count($rebaseSequencesToPatchContentStream)));
-            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf('Previous stream "%s" instead "%s" (%s)', $patch->initialPreviousContentStreamId->value, $patch->rebaseSequence->previousContentStreamId->value, $patch->rebaseSequence->correlationId->value, ), $rebaseSequencesToPatchContentStream))));
+            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf('Previous stream "%s" instead "%s" (%s)', $patch->initialPreviousContentStreamId->value, $patch->rebaseSequence->previousContentStreamId->value, $patch->rebaseSequence->correlationId->value
+            ), $rebaseSequencesToPatchContentStream))));
         }
 
         if ($dryRun) {

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -75,7 +75,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             ]));
 
             $rebasedWorkspaceName = null;
-            $rebaseWorkspaceSequence = RebaseWorkspaceSequence::start();
+            $rebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::start();
             foreach ($rebaseWorkspaceEvents as $rebaseWorkspaceEvent) {
                 if ($rebaseWorkspaceEvent->event->type->value !== $rebaseWorkspaceSequence->value) {
                     $this->log(sprintf('Stream %s: Invalid rebase workspace sequence, expected %s got %s at %s', $rebaseWorkspaceEvent->streamName->value, $rebaseWorkspaceSequence->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->sequenceNumber->value));
@@ -83,13 +83,13 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                     return;
                 }
 
-                if ($rebaseWorkspaceSequence === RebaseWorkspaceSequence::WorkspaceWasRebased) {
+                if ($rebaseWorkspaceSequence === RebaseEmptyWorkspaceSequence::WorkspaceWasRebased) {
                     $rebasedWorkspaceName = WorkspaceName::fromString(
                         json_decode($rebaseWorkspaceEvent->event->data->value, true, flags: JSON_THROW_ON_ERROR)['workspaceName']
                     );
                 }
 
-                if ($rebaseWorkspaceSequence === RebaseWorkspaceSequence::ContentStreamWasForked) {
+                if ($rebaseWorkspaceSequence === RebaseEmptyWorkspaceSequence::ContentStreamWasForked) {
                     if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName())) {
                         $this->log(sprintf('Stream %s: Invalid stream, expected %s as %s', $rebaseWorkspaceEvent->streamName->value, $newContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
                         $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
@@ -99,8 +99,8 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                 $rebaseWorkspaceSequence = $rebaseWorkspaceSequence->next();
                 $sequenceNumbersToRemove[] = $rebaseWorkspaceEvent->sequenceNumber->value;
             }
-            if ($rebaseWorkspaceSequence !== RebaseWorkspaceSequence::ENDED || $rebasedWorkspaceName === null) {
-                $this->log(sprintf('Invalid end of rebase workspace sequence %s, got %s', $forkCorrelationId->value, $rebaseWorkspaceSequence->value));
+            if ($rebaseWorkspaceSequence !== RebaseEmptyWorkspaceSequence::ENDED || $rebasedWorkspaceName === null) {
+                $this->log(sprintf('Invalid end of rebase workspace sequence %s expected %s', $forkCorrelationId->value, $rebaseWorkspaceSequence->value));
                 $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
                 return;
             }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -13,7 +13,31 @@ use Neos\ContentRepositoryRegistry\Upgrade\Shared\OutputMessageTrait;
 use Neos\EventStore\Model\EventEnvelope;
 
 /**
- * TODO
+ * Upgrade to deduplicate illegal concurrent workspace rebases
+ *
+ * https://github.com/neos/neos-development-collection/issues/5849
+ *
+ * Content stream forking was not thread safe before not expressing the assertion to the source content stream
+ * e.g. that the sourceContentStreamVersion should match the reality in the event store.
+ * This resulted in the possibility that a source content stream was not constraint from being forked when it was already removed.
+ * The resulting illegal ContentStreamWasForked event and its RebaseWorkspace sequence must be removed.
+ *
+ * The upgrade first determines any ContentStreamWasForked events where the source content stream was already removed via ContentStreamWasRemoved.
+ * We assume all illegally found forks are restricted to being caused by a RebaseWorkspace command (via correlation id).
+ * Further we expect a simple RebaseWorkspace without any changes on the "user" workspace but just an empty fork.
+ * On this empty fork we expect only a new second RebaseWorkspace, starting with a ContentStreamWasClosed or nothing if the event stream ended.
+ * This second RebaseWorkspace is either also illegal and to be removed or a valid rebase if the source content stream existed at that point.
+ * If valid we want to keep this rebase, but a rebase sequence refers to its previous content stream to remove it and indicate projections which was the last.
+ * The original information is no longer valid as we have removed the existence of the original previous content stream.
+ * Instead, we need to patch the events to use the previous content stream of the first illegal fork - the previous-previous content stream.
+ * Thus, we patch the field $previousContentStreamId of the WorkspaceWasRebased event and rewrite the ContentStreamWasClosed
+ * and ContentStreamWasRemoved events to affect the now new last content stream.
+ *
+ * After the migration is applied the workspace will have its last successfully rebased content stream as without the migration,
+ * but we deduplicated any temporary illegal rebases that happened in a race condition. No content on the workspaces is affected.
+ *
+ * Included in July 2026 - part of the minor 9.2.0 release
+ *
  * @internal
  */
 class EventsConcurrentWorkspaceRebasesUpgrade
@@ -29,7 +53,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
     public static function getShortDescription(): string
     {
-        return 'Deduplicate illegal concurrent rebase workspaces';
+        return 'Deduplicate illegal concurrent workspace rebases';
     }
 
     public function isAvailable(): bool

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -229,20 +229,22 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         $rows = $this->context->dbal->fetchAllAssociative(<<<SQL
         SELECT
           -- invariant: single entry as content stream can only be removed once 
-          MIN(IF (type = 'ContentStreamWasRemoved', sequencenumber, null)) as removalSequenceNumber,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasRemoved', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as sourceContentStreamId,
+          MIN(IF(type = 'ContentStreamWasRemoved', sequencenumber, null)) as removalSequenceNumber,
+          GROUP_CONCAT(IF(type = 'ContentStreamWasRemoved', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as sourceContentStreamId,
           -- multiple forks of source content stream
-          MAX(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as maxForkSequenceNumber,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as forkSequenceNumbers,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', correlationid, null)) as forkCorrelationIds,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as newContentStreamIds
+          MAX(IF(type = 'ContentStreamWasForked', sequencenumber, null)) as maxForkSequenceNumber,
+          GROUP_CONCAT(IF(type = 'ContentStreamWasForked', sequencenumber, null)) as forkSequenceNumbers,
+          GROUP_CONCAT(IF(type = 'ContentStreamWasForked', correlationid, null)) as forkCorrelationIds,
+          GROUP_CONCAT(IF(type = 'ContentStreamWasForked', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as newContentStreamIds
         FROM
           {$this->context->eventStoreTableName}
         WHERE type = 'ContentStreamWasForked' OR type = 'ContentStreamWasRemoved'
-        GROUP BY CASE type
-          WHEN 'ContentStreamWasForked' THEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId'))
-          WHEN 'ContentStreamWasRemoved' THEN SUBSTR(stream, LENGTH('ContentStream:') + 1)
-        END
+        GROUP BY IF(
+          type = 'ContentStreamWasForked',
+          JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId')),
+          -- else, ContentStreamWasRemoved
+          SUBSTR(stream, LENGTH('ContentStream:') + 1)
+        )
         HAVING removalSequenceNumber < maxForkSequenceNumber
         ORDER BY sequencenumber;        
         SQL);

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -6,13 +6,10 @@ namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebase
 
 use Doctrine\DBAL\ArrayParameterType;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
-use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\CRUpgradeContext;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventEnvelopeFactory;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventStoreBackupTrait;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\OutputMessageTrait;
-use Neos\EventStore\Model\Event\CorrelationId;
-use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventEnvelope;
 
 /**
@@ -32,26 +29,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
     public function execute(bool $dryRun): void
     {
-        $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->context->dbal->fetchAllAssociative(<<<SQL
-        SELECT
-          -- invariant: single entry as content stream can only be removed once 
-          MIN(IF (type = 'ContentStreamWasRemoved', sequencenumber, null)) as removalSequenceNumber,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasRemoved', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as sourceContentStreamId,
-          -- multiple forks of source content stream
-          MAX(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as maxForkSequenceNumber,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as forkSequenceNumbers,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', correlationid, null)) as forkCorrelationIds,
-          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as newContentStreamIds
-        FROM
-          {$this->context->eventStoreTableName}
-        WHERE type = 'ContentStreamWasForked' OR type = 'ContentStreamWasRemoved'
-        GROUP BY CASE type
-          WHEN 'ContentStreamWasForked' THEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId'))
-          WHEN 'ContentStreamWasRemoved' THEN SUBSTR(stream, LENGTH('ContentStream:') + 1)
-        END
-        HAVING removalSequenceNumber < maxForkSequenceNumber
-        ORDER BY sequencenumber;        
-        SQL);
+        $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->findForkedContentStreamsWithAlreadyRemovedSourceContentStream();
 
         if ($forkedContentStreamsWithAlreadyRemovedSourceContentStream === []) {
             $this->log('Migration was not necessary. No forks on already removed content streams.');
@@ -62,35 +40,10 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         /** @var array<string,RebaseSequenceContentStreamPatch> $rebaseSequencesToPatchContentStream */
         $rebaseSequencesToPatchContentStream = [];
 
-        foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $forkedContentStreamWithAlreadyRemovedSourceContentStream) {
-
-            if (str_contains($forkedContentStreamWithAlreadyRemovedSourceContentStream['sourceContentStreamId'], ',')) {
-                $this->log(sprintf('Error: Expected content stream to be removed only once got %s', $forkedContentStreamWithAlreadyRemovedSourceContentStream['sourceContentStreamId']));
-                $this->log(sprintf('    Debug: %s', json_encode($forkedContentStreamWithAlreadyRemovedSourceContentStream)));
-                return;
-            }
-            $sourceContentStreamId = ContentStreamId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['sourceContentStreamId']);
-            $removalSequenceNumber = SequenceNumber::fromInteger($forkedContentStreamWithAlreadyRemovedSourceContentStream['removalSequenceNumber']);
-
-            /** @var list<array{SequenceNumber,CorrelationId,ContentStreamId}> $allContentStreamForks */
-            $allContentStreamForks = array_map(
-                null,
-                array_map(SequenceNumber::fromInteger(...), array_map(intval(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['forkSequenceNumbers']))),
-                array_map(CorrelationId::fromString(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['forkCorrelationIds'])),
-                array_map(ContentStreamId::fromString(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['newContentStreamIds'])),
-            );
-
-            $illegalContentStreamForks = array_filter(
-                $allContentStreamForks,
-                function (array $_) use ($removalSequenceNumber) {
-                    [$forkSequenceNumber] = $_;
-                    return $removalSequenceNumber < $forkSequenceNumber;
-                }
-            );
-
-            $this->log(sprintf('Content stream "%s" was forked %d times after removal at %d', $sourceContentStreamId, count($illegalContentStreamForks), $removalSequenceNumber->value));
-            foreach ($illegalContentStreamForks as [$forkSequenceNumber, $forkCorrelationId, $newContentStreamId]) {
-                $this->log(sprintf('    Debug: Fork "%s" of "%s" at %d (%s)', $newContentStreamId->value, $sourceContentStreamId->value, $forkSequenceNumber->value, $forkCorrelationId->value));
+        foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $illegalForksEnvelope) {
+            $this->log(sprintf('Content stream "%s" was forked %d times after removal at %d', $illegalForksEnvelope->sourceContentStreamId->value, count($illegalForksEnvelope->illegalForks), $illegalForksEnvelope->removalSequenceNumber->value));
+            foreach ($illegalForksEnvelope->illegalForks as [$forkSequenceNumber, $forkCorrelationId, $newContentStreamId]) {
+                $this->log(sprintf('    Debug: Fork "%s" of "%s" at %d (%s)', $newContentStreamId->value, $illegalForksEnvelope->sourceContentStreamId->value, $forkSequenceNumber->value, $forkCorrelationId->value));
 
                 if (!str_starts_with($forkCorrelationId->value, 'RebaseWorkspace_')) {
                     $this->log(sprintf('Error fork content stream %s from removed source was not caused due to a RebaseWorkspace and cannot be migrated', $newContentStreamId->value));
@@ -261,5 +214,34 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         $this->log('');
         $this->log(sprintf('Migration applied to %s events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`', $affectedRows));
         $this->log('Done.');
+    }
+
+    /**
+     * @return list<IllegalContentStreamForks>
+     */
+    private function findForkedContentStreamsWithAlreadyRemovedSourceContentStream(): array
+    {
+        $rows = $this->context->dbal->fetchAllAssociative(<<<SQL
+        SELECT
+          -- invariant: single entry as content stream can only be removed once 
+          MIN(IF (type = 'ContentStreamWasRemoved', sequencenumber, null)) as removalSequenceNumber,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasRemoved', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as sourceContentStreamId,
+          -- multiple forks of source content stream
+          MAX(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as maxForkSequenceNumber,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as forkSequenceNumbers,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', correlationid, null)) as forkCorrelationIds,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as newContentStreamIds
+        FROM
+          {$this->context->eventStoreTableName}
+        WHERE type = 'ContentStreamWasForked' OR type = 'ContentStreamWasRemoved'
+        GROUP BY CASE type
+          WHEN 'ContentStreamWasForked' THEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId'))
+          WHEN 'ContentStreamWasRemoved' THEN SUBSTR(stream, LENGTH('ContentStream:') + 1)
+        END
+        HAVING removalSequenceNumber < maxForkSequenceNumber
+        ORDER BY sequencenumber;        
+        SQL);
+
+        return array_map(IllegalContentStreamForks::fromRow(...), $rows);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -271,18 +271,18 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         SELECT
           -- invariant: single entry as content stream can only be removed once 
           MIN(IF(type = 'ContentStreamWasRemoved', sequencenumber, null)) as removalSequenceNumber,
-          GROUP_CONCAT(IF(type = 'ContentStreamWasRemoved', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as sourceContentStreamId,
+          GROUP_CONCAT(IF(type = 'ContentStreamWasRemoved', JSON_VALUE(payload, '$.contentStreamId'), null)) as sourceContentStreamId,
           -- multiple forks of source content stream
           MAX(IF(type = 'ContentStreamWasForked', sequencenumber, null)) as maxForkSequenceNumber,
           GROUP_CONCAT(IF(type = 'ContentStreamWasForked', sequencenumber, null)) as forkSequenceNumbers,
           GROUP_CONCAT(IF(type = 'ContentStreamWasForked', correlationid, null)) as forkCorrelationIds,
-          GROUP_CONCAT(IF(type = 'ContentStreamWasForked', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as newContentStreamIds
+          GROUP_CONCAT(IF(type = 'ContentStreamWasForked', JSON_VALUE(payload, '$.newContentStreamId'), null)) as newContentStreamIds
         FROM
           {$this->context->eventStoreTableName}
         WHERE type = 'ContentStreamWasForked' OR type = 'ContentStreamWasRemoved'
         GROUP BY CASE type
-          WHEN 'ContentStreamWasForked' THEN CAST(JSON_VALUE(payload, '$.sourceContentStreamId') AS VARCHAR(100) COLLATE ascii_general_ci)
-          WHEN 'ContentStreamWasRemoved' THEN SUBSTR(stream, LENGTH('ContentStream:') + 1)
+          WHEN 'ContentStreamWasForked' THEN JSON_VALUE(payload, '$.sourceContentStreamId')
+          WHEN 'ContentStreamWasRemoved' THEN JSON_VALUE(payload, '$.contentStreamId')
         END
         HAVING removalSequenceNumber < maxForkSequenceNumber
         ORDER BY sequencenumber;        

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -7,7 +7,6 @@ namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebase
 use Doctrine\DBAL\ArrayParameterType;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
-use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\CRUpgradeContext;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventEnvelopeFactory;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventStoreBackupTrait;
@@ -32,9 +31,6 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
     public function execute(bool $dryRun): void
     {
-        //
-        // 1.)
-        //
         $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->context->dbal->fetchAllAssociative(<<<SQL
         SELECT forked.sequencenumber AS sourceForkedAtPosition, forked.correlationId AS forkCorrelationId, forked.newContentStreamId, removals.sequencenumber AS removedAtPosition, removals.contentstreamid AS sourceContentStreamId FROM (
           SELECT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.contentStreamId')) AS contentStreamId, sequencenumber FROM {$this->context->eventStoreTableName}
@@ -50,10 +46,9 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             return;
         }
 
-        # todo
-        # assert that there are no new events on that stream except its next rebase
-
         $sequenceNumbersToRemove = [];
+        /** @var list<RebaseSequenceContentStreamPatch> $rebaseSequencesToPatchContentStream */
+        $rebaseSequencesToPatchContentStream = [];
 
         foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $forkedContentStreamWithAlreadyRemovedSourceContentStream) {
             $forkCorrelationId = CorrelationId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['forkCorrelationId']);
@@ -74,38 +69,23 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                 'correlationId' => $forkCorrelationId->value
             ]));
 
-            $rebasedWorkspaceName = null;
-            $rebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::start();
-            foreach ($rebaseWorkspaceEvents as $rebaseWorkspaceEvent) {
-                if ($rebaseWorkspaceEvent->event->type->value !== $rebaseWorkspaceSequence->value) {
-                    $this->log(sprintf('Stream %s: Invalid rebase workspace sequence, expected %s got %s at %s', $rebaseWorkspaceEvent->streamName->value, $rebaseWorkspaceSequence->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->sequenceNumber->value));
-                    $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
-                    return;
-                }
 
-                if ($rebaseWorkspaceSequence === RebaseEmptyWorkspaceSequence::WorkspaceWasRebased) {
-                    $rebasedWorkspaceName = WorkspaceName::fromString(
-                        json_decode($rebaseWorkspaceEvent->event->data->value, true, flags: JSON_THROW_ON_ERROR)['workspaceName']
-                    );
-                }
-
-                if ($rebaseWorkspaceSequence === RebaseEmptyWorkspaceSequence::ContentStreamWasForked) {
-                    if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName())) {
-                        $this->log(sprintf('Stream %s: Invalid stream, expected %s as %s', $rebaseWorkspaceEvent->streamName->value, $newContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
-                        $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
-                    }
-                }
-
-                $rebaseWorkspaceSequence = $rebaseWorkspaceSequence->next();
-                $sequenceNumbersToRemove[] = $rebaseWorkspaceEvent->sequenceNumber->value;
-            }
-            if ($rebaseWorkspaceSequence !== RebaseEmptyWorkspaceSequence::ENDED || $rebasedWorkspaceName === null) {
-                $this->log(sprintf('Invalid end of rebase workspace sequence %s expected %s', $forkCorrelationId->value, $rebaseWorkspaceSequence->value));
+            try {
+                $rebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($rebaseWorkspaceEvents);
+            } catch (\Exception $exception) {
+                $this->log(sprintf('Error: %s', $exception->getMessage()));
                 $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
                 return;
             }
 
-            /** @var list<EventEnvelope> $rebaseWorkspaceEvents */
+            if (!$rebaseWorkspaceSequence->newContentStreamId->equals($newContentStreamId)) {
+                $this->log(sprintf('Error: Expected rebase of %s got %s', $newContentStreamId->value, $rebaseWorkspaceSequence->newContentStreamId->value));
+                $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
+            }
+
+            $sequenceNumbersToRemove = [...$sequenceNumbersToRemove, ...$rebaseWorkspaceSequence->getSequenceNumbers()];
+
+            /** @var list<EventEnvelope> $remainingContentStreamEvents */
             $remainingContentStreamEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
             SELECT *
             FROM {$this->context->eventStoreTableName}
@@ -119,8 +99,37 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             ]));
 
             if ($remainingContentStreamEvents !== []) {
-                $this->log(sprintf('TODO', json_encode($rebaseWorkspaceEvents)));
-                return;
+                try {
+                    $nextRebaseCorrelationId = RebaseWorkspaceCorrelationId::fromEvents($remainingContentStreamEvents);
+                } catch (\Exception $exception) {
+                    $this->log(sprintf('Error: %s', $exception->getMessage()));
+                    $this->log(sprintf('    Debug: %s', json_encode($remainingContentStreamEvents)));
+                    return;
+                }
+
+                /** @var list<EventEnvelope> $nextRebaseWorkspaceEvents */
+                $nextRebaseWorkspaceEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
+                SELECT *
+                FROM {$this->context->eventStoreTableName}
+                  WHERE
+                    correlationId = :correlationId
+                ORDER BY sequencenumber
+                SQL, [
+                    'correlationId' => $nextRebaseCorrelationId->value
+                ]));
+
+                try {
+                    $nextRebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($nextRebaseWorkspaceEvents);
+                } catch (\Exception $exception) {
+                    $this->log(sprintf('Error: %s', $exception->getMessage()));
+                    $this->log(sprintf('    Debug: %s', json_encode($nextRebaseWorkspaceEvents)));
+                    return;
+                }
+
+                $rebaseSequencesToPatchContentStream[] = new RebaseSequenceContentStreamPatch(
+                    rebaseSequence: $nextRebaseWorkspaceSequence,
+                    previousContentStreamIdPatch: $rebaseWorkspaceSequence->previousContentStreamId
+                );
             }
         }
 
@@ -130,7 +139,17 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         }
 
         $this->log(sprintf('Found %d events to be removed', count($sequenceNumbersToRemove)));
-        $this->log(sprintf('    Debug: %s', join(',', $sequenceNumbersToRemove)));
+        $this->log(sprintf('    Debug: %s', join(',', array_column($sequenceNumbersToRemove, 'value'))));
+
+        if ($rebaseSequencesToPatchContentStream !== []) {
+            $this->log(sprintf('Found %d remaining workspace rebases to be adjusted after the deletion', count($rebaseSequencesToPatchContentStream)));
+            $this->log(sprintf('    Debug: %s', join(',', array_map(fn (RebaseSequenceContentStreamPatch $patch) => $patch->rebaseSequence->correlationId->value, $rebaseSequencesToPatchContentStream))));
+        }
+
+        if ($dryRun) {
+            $this->log('Didnt migrate anything because its a dry run.');
+            return;
+        }
 
         // Actual migration
         $this->backupEventTable();
@@ -142,12 +161,55 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             DELETE FROM {$this->context->eventStoreTableName} WHERE sequencenumber IN (:sequenceNumbersToRemove);
             SQL,
             [
-                'sequenceNumbersToRemove' => $sequenceNumbersToRemove,
+                'sequenceNumbersToRemove' => array_column($sequenceNumbersToRemove, 'value'),
             ],
             [
                 'sequenceNumbersToRemove' => ArrayParameterType::INTEGER
             ]
         );
+
+        foreach ($rebaseSequencesToPatchContentStream as $rebaseSequenceContentStreamPatch) {
+            // Update "ContentStreamWasClosed" to previous content stream
+            $affectedRows += $this->context->dbal->executeStatement(
+                <<<SQL
+                UPDATE {$this->context->eventStoreTableName}
+                SET stream = :stream, payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
+                WHERE sequencenumber = :sequenceNumber
+                SQL,
+                [
+                    'sequenceNumber' => $rebaseSequenceContentStreamPatch->rebaseSequence->get(RebaseEmptyWorkspaceSequenceType::ContentStreamWasClosed)->sequenceNumber->value,
+                    'contentStreamId' => $rebaseSequenceContentStreamPatch->previousContentStreamIdPatch->value,
+                    'stream' => ContentStreamEventStreamName::fromContentStreamId($rebaseSequenceContentStreamPatch->previousContentStreamIdPatch)->value,
+                ],
+            );
+
+            // Update "WorkspaceWasRebased" to previous content stream
+            $affectedRows += $this->context->dbal->executeStatement(
+                <<<SQL
+                UPDATE {$this->context->eventStoreTableName}
+                SET payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
+                WHERE sequencenumber = :sequenceNumber
+                SQL,
+                [
+                    'sequenceNumber' => $rebaseSequenceContentStreamPatch->rebaseSequence->get(RebaseEmptyWorkspaceSequenceType::WorkspaceWasRebased)->sequenceNumber->value,
+                    'contentStreamId' => $rebaseSequenceContentStreamPatch->previousContentStreamIdPatch->value,
+                ],
+            );
+
+            // Update "ContentStreamWasRemoved" to previous content stream
+            $affectedRows += $this->context->dbal->executeStatement(
+                <<<SQL
+                UPDATE {$this->context->eventStoreTableName}
+                SET stream = :stream, payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
+                WHERE sequencenumber = :sequenceNumber
+                SQL,
+                [
+                    'sequenceNumber' => $rebaseSequenceContentStreamPatch->rebaseSequence->get(RebaseEmptyWorkspaceSequenceType::ContentStreamWasRemoved)->sequenceNumber->value,
+                    'contentStreamId' => $rebaseSequenceContentStreamPatch->previousContentStreamIdPatch->value,
+                    'stream' => ContentStreamEventStreamName::fromContentStreamId($rebaseSequenceContentStreamPatch->previousContentStreamIdPatch)->value,
+                ],
+            );
+        }
 
         $this->context->dbal->commit();
 

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -239,12 +239,10 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         FROM
           {$this->context->eventStoreTableName}
         WHERE type = 'ContentStreamWasForked' OR type = 'ContentStreamWasRemoved'
-        GROUP BY IF(
-          type = 'ContentStreamWasForked',
-          JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId')),
-          -- else, ContentStreamWasRemoved
-          SUBSTR(stream, LENGTH('ContentStream:') + 1)
-        )
+        GROUP BY CASE type
+          WHEN 'ContentStreamWasForked' THEN CAST(JSON_VALUE(payload, '$.sourceContentStreamId') AS VARCHAR(100) COLLATE ascii_general_ci)
+          WHEN 'ContentStreamWasRemoved' THEN SUBSTR(stream, LENGTH('ContentStream:') + 1)
+        END
         HAVING removalSequenceNumber < maxForkSequenceNumber
         ORDER BY sequencenumber;        
         SQL);

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -285,7 +285,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
           WHEN 'ContentStreamWasRemoved' THEN JSON_VALUE(payload, '$.contentStreamId')
         END
         HAVING removalSequenceNumber < maxForkSequenceNumber
-        ORDER BY sequencenumber;        
+        ORDER BY removalSequenceNumber;        
         SQL);
 
         return array_map(IllegalContentStreamForks::fromRow(...), $rows);

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -6,15 +6,14 @@ namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebase
 
 use Doctrine\DBAL\ArrayParameterType;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\CRUpgradeContext;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventEnvelopeFactory;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventStoreBackupTrait;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\OutputMessageTrait;
 use Neos\EventStore\Model\Event\CorrelationId;
-use Neos\EventStore\Model\Event\SequenceNumber;
-use Neos\EventStore\Model\Event\StreamName;
 use Neos\EventStore\Model\EventEnvelope;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * TODO
@@ -37,11 +36,11 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         // 1.)
         //
         $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->context->dbal->fetchAllAssociative(<<<SQL
-        SELECT forked.sequencenumber AS sourceForkedAtPosition, removals.sequencenumber AS removedAtPosition, removals.contentstreamid FROM (
+        SELECT forked.sequencenumber AS sourceForkedAtPosition, forked.correlationId AS forkCorrelationId, forked.newContentStreamId, removals.sequencenumber AS removedAtPosition, removals.contentstreamid AS sourceContentStreamId FROM (
           SELECT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.contentStreamId')) AS contentStreamId, sequencenumber FROM {$this->context->eventStoreTableName}
             WHERE type = 'ContentStreamWasRemoved'
         ) AS removals
-          JOIN (SELECT sequencenumber, payload, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId')) as sourceContentStreamId FROM {$this->context->eventStoreTableName} WHERE type = 'ContentStreamWasForked') AS forked
+          JOIN (SELECT sequencenumber, correlationId, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.newContentStreamId')) as newContentStreamId, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId')) as sourceContentStreamId FROM {$this->context->eventStoreTableName} WHERE type = 'ContentStreamWasForked') AS forked
             ON removals.contentstreamid = forked.sourcecontentstreamid
             AND removals.sequencenumber < forked.sequencenumber        
         SQL);
@@ -51,25 +50,109 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             return;
         }
 
-        // allow nothing, or just another second ContentStreamWasForked
-
         # todo
-        # assert that its a rebase
         # assert that there are no new events on that stream except its next rebase
-        # assert
 
-        \Neos\Flow\var_dump($forkedContentStreamsWithAlreadyRemovedSourceContentStream);
-        die();
+        $sequenceNumbersToRemove = [];
 
         foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $forkedContentStreamWithAlreadyRemovedSourceContentStream) {
-            $eventsToRemove = $this->context->dbal->fetchAllAssociative(<<<SQL
-                
-            SQL, [
+            $forkCorrelationId = CorrelationId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['forkCorrelationId']);
+            $newContentStreamId = ContentStreamId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['newContentStreamId']);
 
-            ]);
+            if (!str_starts_with($forkCorrelationId->value, 'RebaseWorkspace_')) {
+                $this->log(sprintf('Error fork content stream %s from removed source was not caused due to a RebaseWorkspace and cannot be migrated', $newContentStreamId->value));
+                return;
+            }
+            /** @var list<EventEnvelope> $rebaseWorkspaceEvents */
+            $rebaseWorkspaceEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
+            SELECT *
+            FROM {$this->context->eventStoreTableName}
+              WHERE
+                correlationId = :correlationId
+            ORDER BY sequencenumber
+            SQL, [
+                'correlationId' => $forkCorrelationId->value
+            ]));
+
+            $rebasedWorkspaceName = null;
+            $rebaseWorkspaceSequence = RebaseWorkspaceSequence::start();
+            foreach ($rebaseWorkspaceEvents as $rebaseWorkspaceEvent) {
+                if ($rebaseWorkspaceEvent->event->type->value !== $rebaseWorkspaceSequence->value) {
+                    $this->log(sprintf('Stream %s: Invalid rebase workspace sequence, expected %s got %s at %s', $rebaseWorkspaceEvent->streamName->value, $rebaseWorkspaceSequence->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+                    $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
+                    return;
+                }
+
+                if ($rebaseWorkspaceSequence === RebaseWorkspaceSequence::WorkspaceWasRebased) {
+                    $rebasedWorkspaceName = WorkspaceName::fromString(
+                        json_decode($rebaseWorkspaceEvent->event->data->value, true, flags: JSON_THROW_ON_ERROR)['workspaceName']
+                    );
+                }
+
+                if ($rebaseWorkspaceSequence === RebaseWorkspaceSequence::ContentStreamWasForked) {
+                    if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName())) {
+                        $this->log(sprintf('Stream %s: Invalid stream, expected %s as %s', $rebaseWorkspaceEvent->streamName->value, $newContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+                        $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
+                    }
+                }
+
+                $rebaseWorkspaceSequence = $rebaseWorkspaceSequence->next();
+                $sequenceNumbersToRemove[] = $rebaseWorkspaceEvent->sequenceNumber->value;
+            }
+            if ($rebaseWorkspaceSequence !== RebaseWorkspaceSequence::ENDED || $rebasedWorkspaceName === null) {
+                $this->log(sprintf('Invalid end of rebase workspace sequence %s, got %s', $forkCorrelationId->value, $rebaseWorkspaceSequence->value));
+                $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
+                return;
+            }
+
+            /** @var list<EventEnvelope> $rebaseWorkspaceEvents */
+            $remainingContentStreamEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
+            SELECT *
+            FROM {$this->context->eventStoreTableName}
+              WHERE
+                correlationId != :correlationId
+                AND stream = :stream
+            ORDER BY sequencenumber
+            SQL, [
+                'correlationId' => $forkCorrelationId->value,
+                'stream' => ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName()->value,
+            ]));
+
+            if ($remainingContentStreamEvents !== []) {
+                $this->log(sprintf('TODO', json_encode($rebaseWorkspaceEvents)));
+                return;
+            }
         }
 
-        \Neos\Flow\var_dump($forkedContentStreamsWithAlreadyRemovedSourceContentStream);
-        die();
+        if ($sequenceNumbersToRemove === []) {
+            $this->log('Error no sequence numbers found to remove.');
+            return;
+        }
+
+        $this->log(sprintf('Found %d events to be removed', count($sequenceNumbersToRemove)));
+        $this->log(sprintf('    Debug: %s', join(',', $sequenceNumbersToRemove)));
+
+        // Actual migration
+        $this->backupEventTable();
+
+        $this->context->dbal->beginTransaction();
+
+        $affectedRows = $this->context->dbal->executeStatement(
+            <<<SQL
+            DELETE FROM {$this->context->eventStoreTableName} WHERE sequencenumber IN (:sequenceNumbersToRemove);
+            SQL,
+            [
+                'sequenceNumbersToRemove' => $sequenceNumbersToRemove,
+            ],
+            [
+                'sequenceNumbersToRemove' => ArrayParameterType::INTEGER
+            ]
+        );
+
+        $this->context->dbal->commit();
+
+        $this->log('');
+        $this->log(sprintf('Migration applied to %s events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`', $affectedRows));
+        $this->log('Done.');
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -80,10 +80,17 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                 array_map(ContentStreamId::fromString(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['newContentStreamIds'])),
             );
 
-            foreach ($allContentStreamForks as [$forkSequenceNumber, $forkCorrelationId, $newContentStreamId]) {
-                if ($removalSequenceNumber > $forkSequenceNumber) {
-                    continue;
+            $illegalContentStreamForks = array_filter(
+                $allContentStreamForks,
+                function (array $_) use ($removalSequenceNumber) {
+                    [$forkSequenceNumber] = $_;
+                    return $removalSequenceNumber < $forkSequenceNumber;
                 }
+            );
+
+            $this->log(sprintf('Content stream "%s" was forked %d times after removal at %d', $sourceContentStreamId, count($illegalContentStreamForks), $removalSequenceNumber->value));
+            foreach ($illegalContentStreamForks as [$forkSequenceNumber, $forkCorrelationId, $newContentStreamId]) {
+                $this->log(sprintf('    Debug: Fork "%s" of "%s" at %d (%s)', $newContentStreamId->value, $sourceContentStreamId->value, $forkSequenceNumber->value, $forkCorrelationId->value));
 
                 if (!str_starts_with($forkCorrelationId->value, 'RebaseWorkspace_')) {
                     $this->log(sprintf('Error fork content stream %s from removed source was not caused due to a RebaseWorkspace and cannot be migrated', $newContentStreamId->value));

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -12,6 +12,7 @@ use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventEnvelopeFactory;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventStoreBackupTrait;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\OutputMessageTrait;
 use Neos\EventStore\Model\Event\CorrelationId;
+use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventEnvelope;
 
 /**
@@ -32,13 +33,24 @@ class EventsConcurrentWorkspaceRebasesUpgrade
     public function execute(bool $dryRun): void
     {
         $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->context->dbal->fetchAllAssociative(<<<SQL
-        SELECT forked.sequencenumber AS sourceForkedAtPosition, forked.correlationId AS forkCorrelationId, forked.newContentStreamId, removals.sequencenumber AS removedAtPosition, removals.contentstreamid AS sourceContentStreamId FROM (
-          SELECT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.contentStreamId')) AS contentStreamId, sequencenumber FROM {$this->context->eventStoreTableName}
-            WHERE type = 'ContentStreamWasRemoved'
-        ) AS removals
-          JOIN (SELECT sequencenumber, correlationId, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.newContentStreamId')) as newContentStreamId, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId')) as sourceContentStreamId FROM {$this->context->eventStoreTableName} WHERE type = 'ContentStreamWasForked') AS forked
-            ON removals.contentstreamid = forked.sourcecontentstreamid
-            AND removals.sequencenumber < forked.sequencenumber        
+        SELECT
+          -- invariant: single entry as content stream can only be removed once 
+          MIN(IF (type = 'ContentStreamWasRemoved', sequencenumber, null)) as removalSequenceNumber,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasRemoved', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as sourceContentStreamId,
+          -- multiple forks of source content stream
+          MAX(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as maxForkSequenceNumber,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', sequencenumber, null)) as forkSequenceNumbers,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', correlationid, null)) as forkCorrelationIds,
+          GROUP_CONCAT(IF (type = 'ContentStreamWasForked', SUBSTR(stream, LENGTH('ContentStream:') + 1), null)) as newContentStreamIds
+        FROM
+          {$this->context->eventStoreTableName}
+        WHERE type = 'ContentStreamWasForked' OR type = 'ContentStreamWasRemoved'
+        GROUP BY CASE type
+          WHEN 'ContentStreamWasForked' THEN JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId'))
+          WHEN 'ContentStreamWasRemoved' THEN SUBSTR(stream, LENGTH('ContentStream:') + 1)
+        END
+        HAVING removalSequenceNumber < maxForkSequenceNumber
+        ORDER BY sequencenumber;        
         SQL);
 
         if ($forkedContentStreamsWithAlreadyRemovedSourceContentStream === []) {
@@ -51,90 +63,111 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         $rebaseSequencesToPatchContentStream = [];
 
         foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $forkedContentStreamWithAlreadyRemovedSourceContentStream) {
-            $forkCorrelationId = CorrelationId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['forkCorrelationId']);
-            $newContentStreamId = ContentStreamId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['newContentStreamId']);
 
-            if (!str_starts_with($forkCorrelationId->value, 'RebaseWorkspace_')) {
-                $this->log(sprintf('Error fork content stream %s from removed source was not caused due to a RebaseWorkspace and cannot be migrated', $newContentStreamId->value));
+            if (str_contains($forkedContentStreamWithAlreadyRemovedSourceContentStream['sourceContentStreamId'], ',')) {
+                $this->log(sprintf('Error: Expected content stream to be removed only once got %s', $forkedContentStreamWithAlreadyRemovedSourceContentStream['sourceContentStreamId']));
+                $this->log(sprintf('    Debug: %s', json_encode($forkedContentStreamWithAlreadyRemovedSourceContentStream)));
                 return;
             }
-            /** @var list<EventEnvelope> $rebaseWorkspaceEvents */
-            $rebaseWorkspaceEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
-            SELECT *
-            FROM {$this->context->eventStoreTableName}
-              WHERE
-                correlationId = :correlationId
-            ORDER BY sequencenumber
-            SQL, [
-                'correlationId' => $forkCorrelationId->value
-            ]));
+            $sourceContentStreamId = ContentStreamId::fromString($forkedContentStreamWithAlreadyRemovedSourceContentStream['sourceContentStreamId']);
+            $removalSequenceNumber = SequenceNumber::fromInteger($forkedContentStreamWithAlreadyRemovedSourceContentStream['removalSequenceNumber']);
 
-            try {
-                $rebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($rebaseWorkspaceEvents);
-            } catch (\Exception $exception) {
-                $this->log(sprintf('Error: %s', $exception->getMessage()));
-                $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
-                return;
-            }
+            /** @var list<array{SequenceNumber,CorrelationId,ContentStreamId}> $allContentStreamForks */
+            $allContentStreamForks = array_map(
+                null,
+                array_map(SequenceNumber::fromInteger(...), array_map(intval(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['forkSequenceNumbers']))),
+                array_map(CorrelationId::fromString(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['forkCorrelationIds'])),
+                array_map(ContentStreamId::fromString(...), explode(',', $forkedContentStreamWithAlreadyRemovedSourceContentStream['newContentStreamIds'])),
+            );
 
-            if (!$rebaseWorkspaceSequence->newContentStreamId->equals($newContentStreamId)) {
-                $this->log(sprintf('Error: Expected rebase of %s got %s', $newContentStreamId->value, $rebaseWorkspaceSequence->newContentStreamId->value));
-                $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
-            }
-
-            $sequenceNumbersToRemove = [...$sequenceNumbersToRemove, ...$rebaseWorkspaceSequence->getSequenceNumbers()];
-
-            /** @var list<EventEnvelope> $remainingContentStreamEvents */
-            $remainingContentStreamEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
-            SELECT *
-            FROM {$this->context->eventStoreTableName}
-              WHERE
-                correlationId != :correlationId
-                AND stream = :stream
-            ORDER BY sequencenumber
-            SQL, [
-                'correlationId' => $forkCorrelationId->value,
-                'stream' => ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName()->value,
-            ]));
-
-            $previousContentStreamIdPatch = $rebaseWorkspaceSequence->previousContentStreamId;
-            if (isset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value])) {
-                $previousContentStreamIdPatch = $rebaseSequencesToPatchContentStream[$forkCorrelationId->value]->previousContentStreamIdPatch;
-                unset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value]);
-            }
-
-            if ($remainingContentStreamEvents !== []) {
-                try {
-                    $nextRebaseCorrelationId = RebaseWorkspaceCorrelationId::fromEvents($remainingContentStreamEvents);
-                } catch (\Exception $exception) {
-                    $this->log(sprintf('Error: %s', $exception->getMessage()));
-                    $this->log(sprintf('    Debug: %s', json_encode($remainingContentStreamEvents)));
-                    return;
+            foreach ($allContentStreamForks as [$forkSequenceNumber, $forkCorrelationId, $newContentStreamId]) {
+                if ($removalSequenceNumber > $forkSequenceNumber) {
+                    continue;
                 }
 
-                /** @var list<EventEnvelope> $nextRebaseWorkspaceEvents */
-                $nextRebaseWorkspaceEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
+                if (!str_starts_with($forkCorrelationId->value, 'RebaseWorkspace_')) {
+                    $this->log(sprintf('Error fork content stream %s from removed source was not caused due to a RebaseWorkspace and cannot be migrated', $newContentStreamId->value));
+                    return;
+                }
+                /** @var list<EventEnvelope> $rebaseWorkspaceEvents */
+                $rebaseWorkspaceEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
                 SELECT *
                 FROM {$this->context->eventStoreTableName}
                   WHERE
                     correlationId = :correlationId
                 ORDER BY sequencenumber
                 SQL, [
-                    'correlationId' => $nextRebaseCorrelationId->value
+                    'correlationId' => $forkCorrelationId->value
                 ]));
 
                 try {
-                    $nextRebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($nextRebaseWorkspaceEvents);
+                    $rebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($rebaseWorkspaceEvents);
                 } catch (\Exception $exception) {
                     $this->log(sprintf('Error: %s', $exception->getMessage()));
-                    $this->log(sprintf('    Debug: %s', json_encode($nextRebaseWorkspaceEvents)));
+                    $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
                     return;
                 }
 
-                $rebaseSequencesToPatchContentStream[$nextRebaseWorkspaceSequence->correlationId->value] = new RebaseSequenceContentStreamPatch(
-                    rebaseSequence: $nextRebaseWorkspaceSequence,
-                    previousContentStreamIdPatch: $previousContentStreamIdPatch
-                );
+                if (!$rebaseWorkspaceSequence->newContentStreamId->equals($newContentStreamId)) {
+                    $this->log(sprintf('Error: Expected rebase of %s got %s', $newContentStreamId->value, $rebaseWorkspaceSequence->newContentStreamId->value));
+                    $this->log(sprintf('    Debug: %s', json_encode($rebaseWorkspaceEvents)));
+                    return;
+                }
+
+                $sequenceNumbersToRemove = [...$sequenceNumbersToRemove, ...$rebaseWorkspaceSequence->getSequenceNumbers()];
+
+                /** @var list<EventEnvelope> $remainingContentStreamEvents */
+                $remainingContentStreamEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
+                SELECT *
+                FROM {$this->context->eventStoreTableName}
+                  WHERE
+                    correlationId != :correlationId
+                    AND stream = :stream
+                ORDER BY sequencenumber
+                SQL, [
+                    'correlationId' => $forkCorrelationId->value,
+                    'stream' => ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName()->value,
+                ]));
+
+                $previousContentStreamIdPatch = $rebaseWorkspaceSequence->previousContentStreamId;
+                if (isset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value])) {
+                    $previousContentStreamIdPatch = $rebaseSequencesToPatchContentStream[$forkCorrelationId->value]->previousContentStreamIdPatch;
+                    unset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value]);
+                }
+
+                if ($remainingContentStreamEvents !== []) {
+                    try {
+                        $nextRebaseCorrelationId = RebaseWorkspaceCorrelationId::fromEvents($remainingContentStreamEvents);
+                    } catch (\Exception $exception) {
+                        $this->log(sprintf('Error: %s', $exception->getMessage()));
+                        $this->log(sprintf('    Debug: %s', json_encode($remainingContentStreamEvents)));
+                        return;
+                    }
+
+                    /** @var list<EventEnvelope> $nextRebaseWorkspaceEvents */
+                    $nextRebaseWorkspaceEvents = array_map(EventEnvelopeFactory::createFromArray(...), $this->context->dbal->fetchAllAssociative(<<<SQL
+                    SELECT *
+                    FROM {$this->context->eventStoreTableName}
+                      WHERE
+                        correlationId = :correlationId
+                    ORDER BY sequencenumber
+                    SQL, [
+                        'correlationId' => $nextRebaseCorrelationId->value
+                    ]));
+
+                    try {
+                        $nextRebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($nextRebaseWorkspaceEvents);
+                    } catch (\Exception $exception) {
+                        $this->log(sprintf('Error: %s', $exception->getMessage()));
+                        $this->log(sprintf('    Debug: %s', json_encode($nextRebaseWorkspaceEvents)));
+                        return;
+                    }
+
+                    $rebaseSequencesToPatchContentStream[$nextRebaseWorkspaceSequence->correlationId->value] = new RebaseSequenceContentStreamPatch(
+                        rebaseSequence: $nextRebaseWorkspaceSequence,
+                        previousContentStreamIdPatch: $previousContentStreamIdPatch
+                    );
+                }
             }
         }
 

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -206,7 +206,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             $affectedRows += $this->context->dbal->executeStatement(
                 <<<SQL
                 UPDATE {$this->context->eventStoreTableName}
-                SET payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
+                SET payload = JSON_SET(payload, '$.previousContentStreamId', :contentStreamId)
                 WHERE sequencenumber = :sequenceNumber
                 SQL,
                 [

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -47,7 +47,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
         }
 
         $sequenceNumbersToRemove = [];
-        /** @var list<RebaseSequenceContentStreamPatch> $rebaseSequencesToPatchContentStream */
+        /** @var array<string,RebaseSequenceContentStreamPatch> $rebaseSequencesToPatchContentStream */
         $rebaseSequencesToPatchContentStream = [];
 
         foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $forkedContentStreamWithAlreadyRemovedSourceContentStream) {
@@ -68,7 +68,6 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             SQL, [
                 'correlationId' => $forkCorrelationId->value
             ]));
-
 
             try {
                 $rebaseWorkspaceSequence = RebaseEmptyWorkspaceSequence::fromEvents($rebaseWorkspaceEvents);
@@ -98,6 +97,12 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                 'stream' => ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName()->value,
             ]));
 
+            $previousContentStreamIdPatch = $rebaseWorkspaceSequence->previousContentStreamId;
+            if (isset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value])) {
+                $previousContentStreamIdPatch = $rebaseSequencesToPatchContentStream[$forkCorrelationId->value]->previousContentStreamIdPatch;
+                unset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value]);
+            }
+
             if ($remainingContentStreamEvents !== []) {
                 try {
                     $nextRebaseCorrelationId = RebaseWorkspaceCorrelationId::fromEvents($remainingContentStreamEvents);
@@ -126,9 +131,9 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                     return;
                 }
 
-                $rebaseSequencesToPatchContentStream[] = new RebaseSequenceContentStreamPatch(
+                $rebaseSequencesToPatchContentStream[$nextRebaseWorkspaceSequence->correlationId->value] = new RebaseSequenceContentStreamPatch(
                     rebaseSequence: $nextRebaseWorkspaceSequence,
-                    previousContentStreamIdPatch: $rebaseWorkspaceSequence->previousContentStreamId
+                    previousContentStreamIdPatch: $previousContentStreamIdPatch
                 );
             }
         }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
+use Neos\ContentRepositoryRegistry\Upgrade\Shared\CRUpgradeContext;
+use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventEnvelopeFactory;
+use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventStoreBackupTrait;
+use Neos\ContentRepositoryRegistry\Upgrade\Shared\OutputMessageTrait;
+use Neos\EventStore\Model\Event\CorrelationId;
+use Neos\EventStore\Model\Event\SequenceNumber;
+use Neos\EventStore\Model\Event\StreamName;
+use Neos\EventStore\Model\EventEnvelope;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * TODO
+ * @internal
+ */
+class EventsConcurrentWorkspaceRebasesUpgrade
+{
+    use EventStoreBackupTrait;
+    use OutputMessageTrait;
+
+    public function __construct(
+        private CRUpgradeContext $context,
+        private \Closure $outputFn,
+    ) {
+    }
+
+    public function execute(bool $dryRun): void
+    {
+        //
+        // 1.)
+        //
+        $forkedContentStreamsWithAlreadyRemovedSourceContentStream = $this->context->dbal->fetchAllAssociative(<<<SQL
+        SELECT forked.sequencenumber AS sourceForkedAtPosition, removals.sequencenumber AS removedAtPosition, removals.contentstreamid FROM (
+          SELECT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.contentStreamId')) AS contentStreamId, sequencenumber FROM {$this->context->eventStoreTableName}
+            WHERE type = 'ContentStreamWasRemoved'
+        ) AS removals
+          JOIN (SELECT sequencenumber, payload, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.sourceContentStreamId')) as sourceContentStreamId FROM {$this->context->eventStoreTableName} WHERE type = 'ContentStreamWasForked') AS forked
+            ON removals.contentstreamid = forked.sourcecontentstreamid
+            AND removals.sequencenumber < forked.sequencenumber        
+        SQL);
+
+        if ($forkedContentStreamsWithAlreadyRemovedSourceContentStream === []) {
+            $this->log('Migration was not necessary. No forks on already removed content streams.');
+            return;
+        }
+
+        // allow nothing, or just another second ContentStreamWasForked
+
+        # todo
+        # assert that its a rebase
+        # assert that there are no new events on that stream except its next rebase
+        # assert
+
+        \Neos\Flow\var_dump($forkedContentStreamsWithAlreadyRemovedSourceContentStream);
+        die();
+
+        foreach ($forkedContentStreamsWithAlreadyRemovedSourceContentStream as $forkedContentStreamWithAlreadyRemovedSourceContentStream) {
+            $eventsToRemove = $this->context->dbal->fetchAllAssociative(<<<SQL
+                
+            SQL, [
+
+            ]);
+        }
+
+        \Neos\Flow\var_dump($forkedContentStreamsWithAlreadyRemovedSourceContentStream);
+        die();
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -156,7 +156,11 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
         if ($rebaseSequencesToPatchContentStream !== []) {
             $this->log(sprintf('Found %d remaining workspace rebases to be adjusted after the deletion', count($rebaseSequencesToPatchContentStream)));
-            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf('Previous stream "%s" instead "%s" (%s)', $patch->initialPreviousContentStreamId->value, $patch->rebaseSequence->previousContentStreamId->value, $patch->rebaseSequence->correlationId->value
+            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf(
+                'Previous stream "%s" instead "%s" (%s)',
+                $patch->initialPreviousContentStreamId->value,
+                $patch->rebaseSequence->previousContentStreamId->value,
+                $patch->rebaseSequence->correlationId->value
             ), $rebaseSequencesToPatchContentStream))));
         }
 

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -141,7 +141,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
         if ($rebaseSequencesToPatchContentStream !== []) {
             $this->log(sprintf('Found %d remaining workspace rebases to be adjusted after the deletion', count($rebaseSequencesToPatchContentStream)));
-            $this->log(sprintf('    Debug: %s', join(',', array_map(fn (RebaseSequenceContentStreamPatch $patch) => $patch->rebaseSequence->correlationId->value, $rebaseSequencesToPatchContentStream))));
+            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf('Previous stream "%s" instead "%s" (%s)', $patch->previousContentStreamIdPatch->value, $patch->rebaseSequence->previousContentStreamId->value, $patch->rebaseSequence->correlationId->value, ), $rebaseSequencesToPatchContentStream))));
         }
 
         if ($dryRun) {

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebasesUpgrade.php
@@ -89,9 +89,10 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                     'stream' => ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName()->value,
                 ]));
 
-                $previousContentStreamIdPatch = $rebaseWorkspaceSequence->previousContentStreamId;
+                /** @var RebaseEmptyWorkspaceSequence|RebaseSequenceContentStreamPatch $previousContentStreamPatch */
+                $previousContentStreamPatch = $rebaseWorkspaceSequence;
                 if (isset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value])) {
-                    $previousContentStreamIdPatch = $rebaseSequencesToPatchContentStream[$forkCorrelationId->value]->previousContentStreamIdPatch;
+                    $previousContentStreamPatch = $rebaseSequencesToPatchContentStream[$forkCorrelationId->value];
                     unset($rebaseSequencesToPatchContentStream[$forkCorrelationId->value]);
                 }
 
@@ -125,7 +126,9 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
                     $rebaseSequencesToPatchContentStream[$nextRebaseWorkspaceSequence->correlationId->value] = new RebaseSequenceContentStreamPatch(
                         rebaseSequence: $nextRebaseWorkspaceSequence,
-                        previousContentStreamIdPatch: $previousContentStreamIdPatch
+                        initialPreviousContentStreamId: $previousContentStreamPatch instanceof RebaseEmptyWorkspaceSequence ? $previousContentStreamPatch->previousContentStreamId : $previousContentStreamPatch->initialPreviousContentStreamId,
+                        initialContentStreamWasClosedVersion: $previousContentStreamPatch instanceof RebaseEmptyWorkspaceSequence ? $previousContentStreamPatch->get(RebaseEmptyWorkspaceSequenceType::ContentStreamWasClosed)->version : $previousContentStreamPatch->initialContentStreamWasClosedVersion,
+                        initialContentStreamWasRemovedVersion: $previousContentStreamPatch instanceof RebaseEmptyWorkspaceSequence ? $previousContentStreamPatch->get(RebaseEmptyWorkspaceSequenceType::ContentStreamWasRemoved)->version : $previousContentStreamPatch->initialContentStreamWasRemovedVersion,
                     );
                 }
             }
@@ -141,7 +144,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
 
         if ($rebaseSequencesToPatchContentStream !== []) {
             $this->log(sprintf('Found %d remaining workspace rebases to be adjusted after the deletion', count($rebaseSequencesToPatchContentStream)));
-            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf('Previous stream "%s" instead "%s" (%s)', $patch->previousContentStreamIdPatch->value, $patch->rebaseSequence->previousContentStreamId->value, $patch->rebaseSequence->correlationId->value, ), $rebaseSequencesToPatchContentStream))));
+            $this->log(sprintf('    Debug: %s', join("\n           ", array_map(fn (RebaseSequenceContentStreamPatch $patch) => sprintf('Previous stream "%s" instead "%s" (%s)', $patch->initialPreviousContentStreamId->value, $patch->rebaseSequence->previousContentStreamId->value, $patch->rebaseSequence->correlationId->value, ), $rebaseSequencesToPatchContentStream))));
         }
 
         if ($dryRun) {
@@ -171,13 +174,14 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             $affectedRows += $this->context->dbal->executeStatement(
                 <<<SQL
                 UPDATE {$this->context->eventStoreTableName}
-                SET stream = :stream, payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
+                SET stream = :stream, version = :version, payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
                 WHERE sequencenumber = :sequenceNumber
                 SQL,
                 [
                     'sequenceNumber' => $rebaseSequenceContentStreamPatch->rebaseSequence->get(RebaseEmptyWorkspaceSequenceType::ContentStreamWasClosed)->sequenceNumber->value,
-                    'contentStreamId' => $rebaseSequenceContentStreamPatch->previousContentStreamIdPatch->value,
-                    'stream' => ContentStreamEventStreamName::fromContentStreamId($rebaseSequenceContentStreamPatch->previousContentStreamIdPatch)->value,
+                    'contentStreamId' => $rebaseSequenceContentStreamPatch->initialPreviousContentStreamId->value,
+                    'stream' => ContentStreamEventStreamName::fromContentStreamId($rebaseSequenceContentStreamPatch->initialPreviousContentStreamId)->value,
+                    'version' => $rebaseSequenceContentStreamPatch->initialContentStreamWasClosedVersion->value,
                 ],
             );
 
@@ -190,7 +194,7 @@ class EventsConcurrentWorkspaceRebasesUpgrade
                 SQL,
                 [
                     'sequenceNumber' => $rebaseSequenceContentStreamPatch->rebaseSequence->get(RebaseEmptyWorkspaceSequenceType::WorkspaceWasRebased)->sequenceNumber->value,
-                    'contentStreamId' => $rebaseSequenceContentStreamPatch->previousContentStreamIdPatch->value,
+                    'contentStreamId' => $rebaseSequenceContentStreamPatch->initialPreviousContentStreamId->value,
                 ],
             );
 
@@ -198,13 +202,14 @@ class EventsConcurrentWorkspaceRebasesUpgrade
             $affectedRows += $this->context->dbal->executeStatement(
                 <<<SQL
                 UPDATE {$this->context->eventStoreTableName}
-                SET stream = :stream, payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
+                SET stream = :stream, version = :version, payload = JSON_SET(payload, '$.contentStreamId', :contentStreamId)
                 WHERE sequencenumber = :sequenceNumber
                 SQL,
                 [
                     'sequenceNumber' => $rebaseSequenceContentStreamPatch->rebaseSequence->get(RebaseEmptyWorkspaceSequenceType::ContentStreamWasRemoved)->sequenceNumber->value,
-                    'contentStreamId' => $rebaseSequenceContentStreamPatch->previousContentStreamIdPatch->value,
-                    'stream' => ContentStreamEventStreamName::fromContentStreamId($rebaseSequenceContentStreamPatch->previousContentStreamIdPatch)->value,
+                    'contentStreamId' => $rebaseSequenceContentStreamPatch->initialPreviousContentStreamId->value,
+                    'stream' => ContentStreamEventStreamName::fromContentStreamId($rebaseSequenceContentStreamPatch->initialPreviousContentStreamId)->value,
+                    'version' => $rebaseSequenceContentStreamPatch->initialContentStreamWasRemovedVersion->value,
                 ],
             );
         }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/IllegalContentStreamForks.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/IllegalContentStreamForks.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\EventStore\Model\Event\CorrelationId;
+use Neos\EventStore\Model\Event\SequenceNumber;
+
+final readonly class IllegalContentStreamForks
+{
+    /**
+     * @param list<array{SequenceNumber,CorrelationId,ContentStreamId}> $illegalForks
+     */
+    public function __construct(
+        public ContentStreamId $sourceContentStreamId,
+        public SequenceNumber $removalSequenceNumber,
+        public array $illegalForks
+    ) {
+    }
+
+    /**
+     * @param array<string,string> $row
+     */
+    public static function fromRow(array $row): self
+    {
+        if (str_contains($row['sourceContentStreamId'], ',')) {
+            throw new \RuntimeException(sprintf('Error: Expected content stream to be removed only once got %s', $row['sourceContentStreamId']));
+        }
+        $sourceContentStreamId = ContentStreamId::fromString($row['sourceContentStreamId']);
+        $removalSequenceNumber = SequenceNumber::fromInteger((int)$row['removalSequenceNumber']);
+
+        /** @var list<array{SequenceNumber,CorrelationId,ContentStreamId}> $allContentStreamForks */
+        $allContentStreamForks = array_map(
+            null,
+            array_map(SequenceNumber::fromInteger(...), array_map(intval(...), explode(',', $row['forkSequenceNumbers']))),
+            array_map(CorrelationId::fromString(...), explode(',', $row['forkCorrelationIds'])),
+            array_map(ContentStreamId::fromString(...), explode(',', $row['newContentStreamIds'])),
+        );
+
+        $illegalContentStreamForks = array_filter(
+            $allContentStreamForks,
+            function (array $_) use ($removalSequenceNumber) {
+                [$forkSequenceNumber] = $_;
+                return $removalSequenceNumber < $forkSequenceNumber;
+            }
+        );
+
+        return new self(
+            sourceContentStreamId: $sourceContentStreamId,
+            removalSequenceNumber: $removalSequenceNumber,
+            illegalForks: $illegalContentStreamForks,
+        );
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequence.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequence.php
@@ -38,7 +38,7 @@ final readonly class RebaseEmptyWorkspaceSequence
         $sequenceType = RebaseEmptyWorkspaceSequenceType::start();
         foreach ($events as $rebaseWorkspaceEvent) {
             if ($sequenceType === null) {
-                throw new \RuntimeException(sprintf('Expected end of rebase workspace sequence %s. Got at %d type %s with %s', $correlationId?->value, $rebaseWorkspaceEvent->sequenceNumber->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->event->correlationId?->value));
+                throw new \RuntimeException(sprintf('Expected end of rebase workspace sequence %s. Got at %d type %s with %s', $correlationId->value, $rebaseWorkspaceEvent->sequenceNumber->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->event->correlationId?->value));
             }
 
             if ($rebaseWorkspaceEvent->event->type->value !== $sequenceType->value) {
@@ -73,8 +73,8 @@ final readonly class RebaseEmptyWorkspaceSequence
 
             if ($sequenceType === RebaseEmptyWorkspaceSequenceType::ContentStreamWasRemoved) {
                 // sanity check, if events were already modified
-                if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($previousContentStreamId)->getEventStreamName())) {
-                    throw new \RuntimeException(sprintf('Illegal ContentStreamWasClosed event on stream %s: Expected %s at %s', $rebaseWorkspaceEvent->streamName->value, $previousContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+                if (!$previousContentStreamId || !$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($previousContentStreamId)->getEventStreamName())) {
+                    throw new \RuntimeException(sprintf('Illegal ContentStreamWasClosed event on stream %s: Expected %s at %s', $rebaseWorkspaceEvent->streamName->value, $previousContentStreamId?->value, $rebaseWorkspaceEvent->sequenceNumber->value));
                 }
             }
 
@@ -82,8 +82,8 @@ final readonly class RebaseEmptyWorkspaceSequence
 
             $sequenceType = $sequenceType->next();
         }
-        if ($sequenceType !== null || $workspaceName === null || $correlationId === null || $newContentStreamId === null) {
-            throw new \RuntimeException(sprintf('Invalid end of rebase workspace sequence %s expected %s', $correlationId->value, $sequenceType->value));
+        if ($sequenceType !== null || $workspaceName === null || $newContentStreamId === null || $previousContentStreamId === null) {
+            throw new \RuntimeException(sprintf('Invalid end of rebase workspace sequence %s expected %s', $correlationId->value, $sequenceType?->value));
         }
 
         return new self(

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequence.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequence.php
@@ -4,28 +4,111 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
 
-enum RebaseEmptyWorkspaceSequence: string
+use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\EventStore\Model\Event\CorrelationId;
+use Neos\EventStore\Model\Event\SequenceNumber;
+use Neos\EventStore\Model\EventEnvelope;
+
+final readonly class RebaseEmptyWorkspaceSequence
 {
-    // Order defines sequence
-    case ContentStreamWasClosed = 'ContentStreamWasClosed';
-    case ContentStreamWasForked = 'ContentStreamWasForked';
-    case WorkspaceWasRebased = 'WorkspaceWasRebased';
-    case ContentStreamWasRemoved = 'ContentStreamWasRemoved';
-
-    case ENDED = '[ENDED]';
-
-    public static function start(): self
-    {
-        return self::cases()[0];
+    /**
+     * @param array<string,EventEnvelope> $eventsByType
+     */
+    public function __construct(
+        private array $eventsByType,
+        public CorrelationId $correlationId,
+        public WorkspaceName $workspaceName,
+        public ContentStreamId $previousContentStreamId,
+        public ContentStreamId $newContentStreamId,
+    ) {
     }
 
-    public function next(): self
+    /**
+     * @param array<EventEnvelope> $events
+     */
+    public static function fromEvents(array $events): self
     {
-        foreach (self::cases() as $index => $case) {
-            if ($case === $this) {
-                return self::cases()[$index + 1] ?? throw new \RuntimeException('Reached end');
+        $eventsByType = [];
+        $workspaceName = null;
+        $previousContentStreamId = null;
+        $newContentStreamId = null;
+        $correlationId = RebaseWorkspaceCorrelationId::fromEvents($events);
+        $sequenceType = RebaseEmptyWorkspaceSequenceType::start();
+        foreach ($events as $rebaseWorkspaceEvent) {
+            if ($sequenceType === null) {
+                throw new \RuntimeException(sprintf('Expected end of rebase workspace sequence %s. Got at %d type %s with %s', $correlationId?->value, $rebaseWorkspaceEvent->sequenceNumber->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->event->correlationId?->value));
             }
+
+            if ($rebaseWorkspaceEvent->event->type->value !== $sequenceType->value) {
+                throw new \RuntimeException(sprintf('Stream %s: Invalid rebase workspace sequence %s, expected %s got %s at %s', $rebaseWorkspaceEvent->streamName->value, $correlationId->value, $sequenceType->value, $rebaseWorkspaceEvent->event->type->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+            }
+
+            if ($sequenceType === RebaseEmptyWorkspaceSequenceType::WorkspaceWasRebased) {
+                $workspaceName = WorkspaceName::fromString(
+                    json_decode($rebaseWorkspaceEvent->event->data->value, true, flags: JSON_THROW_ON_ERROR)['workspaceName']
+                );
+            }
+
+            if ($sequenceType === RebaseEmptyWorkspaceSequenceType::ContentStreamWasForked) {
+                $newContentStreamId = ContentStreamId::fromString(
+                    json_decode($rebaseWorkspaceEvent->event->data->value, true, flags: JSON_THROW_ON_ERROR)['newContentStreamId']
+                );
+                if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName())) {
+                    // sanity check, if events were already modified
+                    throw new \RuntimeException(sprintf('Illegal ContentStreamWasForked event on stream %s: Expected %s at %s', $rebaseWorkspaceEvent->streamName->value, $newContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+                }
+            }
+
+            if ($sequenceType === RebaseEmptyWorkspaceSequenceType::ContentStreamWasClosed) {
+                $previousContentStreamId = ContentStreamId::fromString(
+                    json_decode($rebaseWorkspaceEvent->event->data->value, true, flags: JSON_THROW_ON_ERROR)['contentStreamId']
+                );
+                if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($previousContentStreamId)->getEventStreamName())) {
+                    // sanity check, if events were already modified
+                    throw new \RuntimeException(sprintf('Illegal ContentStreamWasClosed event on stream %s: Expected %s at %s', $rebaseWorkspaceEvent->streamName->value, $previousContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+                }
+            }
+
+            if ($sequenceType === RebaseEmptyWorkspaceSequenceType::ContentStreamWasRemoved) {
+                // sanity check, if events were already modified
+                if (!$rebaseWorkspaceEvent->streamName->equals(ContentStreamEventStreamName::fromContentStreamId($previousContentStreamId)->getEventStreamName())) {
+                    throw new \RuntimeException(sprintf('Illegal ContentStreamWasClosed event on stream %s: Expected %s at %s', $rebaseWorkspaceEvent->streamName->value, $previousContentStreamId->value, $rebaseWorkspaceEvent->sequenceNumber->value));
+                }
+            }
+
+            $eventsByType[$sequenceType->value] = $rebaseWorkspaceEvent;
+
+            $sequenceType = $sequenceType->next();
         }
-        throw new \RuntimeException(sprintf('Fatal cannot happen'), 1781725195);
+        if ($sequenceType !== null || $workspaceName === null || $correlationId === null || $newContentStreamId === null) {
+            throw new \RuntimeException(sprintf('Invalid end of rebase workspace sequence %s expected %s', $correlationId->value, $sequenceType->value));
+        }
+
+        return new self(
+            eventsByType: $eventsByType,
+            correlationId: $correlationId,
+            workspaceName: $workspaceName,
+            previousContentStreamId: $previousContentStreamId,
+            newContentStreamId: $newContentStreamId,
+        );
+    }
+
+    public function get(RebaseEmptyWorkspaceSequenceType $type): EventEnvelope
+    {
+        return $this->eventsByType[$type->value] ?? throw new \RuntimeException(sprintf('Fatal cannot happen: %s', $type->value), 1784970866);
+    }
+
+    /**
+     * @return array<SequenceNumber>
+     */
+    public function getSequenceNumbers(): array
+    {
+        $sequenceNumbers = [];
+        foreach ($this->eventsByType as $event) {
+            $sequenceNumbers[] = $event->sequenceNumber;
+        }
+        return $sequenceNumbers;
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequence.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequence.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
 
-enum RebaseWorkspaceSequence: string
+enum RebaseEmptyWorkspaceSequence: string
 {
     // Order defines sequence
     case ContentStreamWasClosed = 'ContentStreamWasClosed';
     case ContentStreamWasForked = 'ContentStreamWasForked';
     case WorkspaceWasRebased = 'WorkspaceWasRebased';
+    case ContentStreamWasRemoved = 'ContentStreamWasRemoved';
 
     case ENDED = '[ENDED]';
 

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequenceType.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseEmptyWorkspaceSequenceType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
+
+enum RebaseEmptyWorkspaceSequenceType: string
+{
+    // Order defines sequence
+    case ContentStreamWasClosed = 'ContentStreamWasClosed';
+    case ContentStreamWasForked = 'ContentStreamWasForked';
+    case WorkspaceWasRebased = 'WorkspaceWasRebased';
+    case ContentStreamWasRemoved = 'ContentStreamWasRemoved';
+
+    public static function start(): self
+    {
+        return self::cases()[0];
+    }
+
+    public function next(): ?self
+    {
+        foreach (self::cases() as $index => $case) {
+            if ($case === $this) {
+                return self::cases()[$index + 1] ?? null;
+            }
+        }
+        return null;
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseSequenceContentStreamPatch.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseSequenceContentStreamPatch.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+
+final readonly class RebaseSequenceContentStreamPatch
+{
+    public function __construct(
+        public RebaseEmptyWorkspaceSequence $rebaseSequence,
+        public ContentStreamId $previousContentStreamIdPatch,
+    ) {
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseSequenceContentStreamPatch.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseSequenceContentStreamPatch.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
 
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\EventStore\Model\Event\Version;
 
 final readonly class RebaseSequenceContentStreamPatch
 {
     public function __construct(
         public RebaseEmptyWorkspaceSequence $rebaseSequence,
-        public ContentStreamId $previousContentStreamIdPatch,
+        public ContentStreamId $initialPreviousContentStreamId,
+        public Version $initialContentStreamWasClosedVersion,
+        public Version $initialContentStreamWasRemovedVersion,
     ) {
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseSequenceContentStreamPatch.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseSequenceContentStreamPatch.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceCorrelationId.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceCorrelationId.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
+
+use Neos\EventStore\Model\Event\CorrelationId;
+
+final readonly class RebaseWorkspaceCorrelationId
+{
+    private function __construct()
+    {
+    }
+
+    public static function fromEvents(array $events): CorrelationId
+    {
+        if ($events === []) {
+            throw new \InvalidArgumentException('Events are empty', 1785008755);
+        }
+        $correlationId = null;
+        foreach ($events as $eventEnvelope) {
+            if ($correlationId === null) {
+                if ($eventEnvelope->event->correlationId === null || !str_starts_with($eventEnvelope->event->correlationId->value, 'RebaseWorkspace_')) {
+                    throw new \RuntimeException(sprintf('Expected no events or another RebaseWorkspace sequence. Got at %d type %s with %s',  $eventEnvelope->sequenceNumber->value, $eventEnvelope->event->type->value, $eventEnvelope->event->correlationId?->value));
+                }
+                $correlationId = $eventEnvelope->event->correlationId;
+                continue;
+            }
+            if ($correlationId->value !== $eventEnvelope->event->correlationId?->value) {
+                throw new \RuntimeException(sprintf('Expected RebaseWorkspace (%s). Got at %d type %s with %s', $correlationId->value, $eventEnvelope->sequenceNumber->value, $eventEnvelope->event->type->value, $eventEnvelope->event->correlationId?->value));
+            }
+        }
+        return $correlationId;
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceCorrelationId.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceCorrelationId.php
@@ -25,7 +25,7 @@ final readonly class RebaseWorkspaceCorrelationId
         foreach ($events as $eventEnvelope) {
             if ($correlationId === null) {
                 if ($eventEnvelope->event->correlationId === null || !str_starts_with($eventEnvelope->event->correlationId->value, 'RebaseWorkspace_')) {
-                    throw new \RuntimeException(sprintf('Expected no events or another RebaseWorkspace sequence. Got at %d type %s with %s',  $eventEnvelope->sequenceNumber->value, $eventEnvelope->event->type->value, $eventEnvelope->event->correlationId?->value));
+                    throw new \RuntimeException(sprintf('Expected no events or another RebaseWorkspace sequence. Got at %d type %s with %s', $eventEnvelope->sequenceNumber->value, $eventEnvelope->event->type->value, $eventEnvelope->event->correlationId?->value));
                 }
                 $correlationId = $eventEnvelope->event->correlationId;
                 continue;

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceCorrelationId.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceCorrelationId.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
 
 use Neos\EventStore\Model\Event\CorrelationId;
+use Neos\EventStore\Model\EventEnvelope;
 
 final readonly class RebaseWorkspaceCorrelationId
 {
@@ -12,6 +13,9 @@ final readonly class RebaseWorkspaceCorrelationId
     {
     }
 
+    /**
+     * @param array<EventEnvelope> $events
+     */
     public static function fromEvents(array $events): CorrelationId
     {
         if ($events === []) {

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceSequence.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsConcurrentWorkspaceRebases/RebaseWorkspaceSequence.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases;
+
+enum RebaseWorkspaceSequence: string
+{
+    // Order defines sequence
+    case ContentStreamWasClosed = 'ContentStreamWasClosed';
+    case ContentStreamWasForked = 'ContentStreamWasForked';
+    case WorkspaceWasRebased = 'WorkspaceWasRebased';
+
+    case ENDED = '[ENDED]';
+
+    public static function start(): self
+    {
+        return self::cases()[0];
+    }
+
+    public function next(): self
+    {
+        foreach (self::cases() as $index => $case) {
+            if ($case === $this) {
+                return self::cases()[$index + 1] ?? throw new \RuntimeException('Reached end');
+            }
+        }
+        throw new \RuntimeException(sprintf('Fatal cannot happen'), 1781725195);
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
@@ -112,6 +112,23 @@ trait CrUpgradeTrait
     }
 
     /**
+     * @When I attempt to upgrade the events to concurrent workspace-rebases which I expect not to be available
+     */
+    public function iExecuteEventsConcurrentWorkspaceRebasesUpgradeNotAvailable(): void
+    {
+        $upgrade = new EventsConcurrentWorkspaceRebasesUpgrade(
+            $this->getCrUpgradeContext(),
+            $this->outputFn(...)
+        );
+
+        Assert::assertFalse($upgrade->isAvailable(), 'Upgrade is available but was not expected to.');
+
+        $upgrade->execute(
+            dryRun: false
+        );
+    }
+
+    /**
      * @When I upgrade the events to concurrent workspace-rebases
      */
     public function iExecuteEventsConcurrentWorkspaceRebasesUpgrade(): void
@@ -120,6 +137,8 @@ trait CrUpgradeTrait
             $this->getCrUpgradeContext(),
             $this->outputFn(...)
         );
+
+        Assert::assertTrue($upgrade->isAvailable(), 'Upgrade is not available but was expected to.');
 
         $upgrade->execute(
             dryRun: false

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
@@ -16,6 +16,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Neos\ContentRepository\TestSuite\Behavior\Features\Bootstrap\CRTestSuiteRuntimeVariables;
 use Neos\ContentRepositoryRegistry\Upgrade\Command\CRUpgradeContextFactory;
+use Neos\ContentRepositoryRegistry\Upgrade\EventsConcurrentWorkspaceRebases\EventsConcurrentWorkspaceRebasesUpgrade;
 use Neos\ContentRepositoryRegistry\Upgrade\EventsDeduplicateBaseWorkspaceChanges\EventsDeduplicateBaseWorkspaceChangesUpgrade;
 use Neos\ContentRepositoryRegistry\Upgrade\EventsRecordedAtToUtc\EventsRecordedAtToUtcUpgrade;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\CRUpgradeContext;
@@ -104,6 +105,21 @@ trait CrUpgradeTrait
         );
 
         Assert::assertTrue($upgrade->isAvailable(), 'Upgrade is not available but was expected to.');
+
+        $upgrade->execute(
+            dryRun: false
+        );
+    }
+
+    /**
+     * @When I upgrade the events to concurrent workspace-rebases
+     */
+    public function iExecuteEventsConcurrentWorkspaceRebasesUpgrade(): void
+    {
+        $upgrade = new EventsConcurrentWorkspaceRebasesUpgrade(
+            $this->getCrUpgradeContext(),
+            $this->outputFn(...)
+        );
 
         $upgrade->execute(
             dryRun: false

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -131,6 +131,8 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 1 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
       Error: Invalid end of rebase workspace sequence RebaseWorkspace_123 expected ContentStreamWasRemoved
           Debug: [{"event":{"id":{"value":"19d9edb6-bb47-464e-ace9-64e3d80dbe92"},"type":{"value":"ContentStreamWasClosed"},"data":{"value":"{\"contentStreamId\":\"cs-user-first\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-first"},"version":{"value":4},"sequenceNumber":{"value":100},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"0e27354f-2bd8-47fe-bfe3-2ab6e7ace856"},"type":{"value":"ContentStreamWasForked"},"data":{"value":"{\"newContentStreamId\":\"cs-user-second\",\"sourceContentStreamId\":\"cs-review-first\",\"versionOfSourceContentStream\":1}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":0},"sequenceNumber":{"value":101},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"01df0edb-6412-4144-92a3-013ef5ec1af4"},"type":{"value":"WorkspaceWasRebased"},"data":{"value":"{\"workspaceName\":\"user\",\"previousContentStreamId\": \"cs-user-first\", \"newContentStreamId\":\"cs-user-second\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"Workspace:user"},"version":{"value":2},"sequenceNumber":{"value":102},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
       """
@@ -191,6 +193,8 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 1 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
       Error: Expected no events or another RebaseWorkspace sequence. Got at 104 type RootNodeAggregateWithNodeWasCreated with CreateNodeAggregateW_e00b8ac2a08c7fbb9b
           Debug: [{"event":{"id":{"value":"2c8b9d29-c3fd-44e0-b275-15d336dc38ab"},"type":{"value":"RootNodeAggregateWithNodeWasCreated"},"data":{"value":"{\"workspaceName\":\"user\",\"contentStreamId\":\"cs-user-second\",\"nodeAggregateId\":\"illegal-node\",\"nodeTypeName\":\"Neos.Neos:Sites\",\"coveredDimensionSpacePoints\":[{\"language\":\"en\"},{\"language\":\"de\"}],\"nodeAggregateClassification\":\"root\"}"},"metadata":{"value":[]},"causationId":null,"correlationId":{"value":"CreateNodeAggregateW_e00b8ac2a08c7fbb9b"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":1},"sequenceNumber":{"value":104},"recordedAt":{"date":"2026-04-30 11:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
       """
@@ -250,6 +254,8 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 1 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
       Found 4 events to be removed
           Debug: 100,101,102,103
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
@@ -340,6 +346,9 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 2 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
+          Debug: Fork "cs-user-third" of "cs-review-first" at 105 (RebaseWorkspace_456)
       Found 8 events to be removed
           Debug: 100,101,102,103,104,105,106,107
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
@@ -431,6 +440,8 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 1 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
       Found 4 events to be removed
           Debug: 100,101,102,103
       Found 1 remaining workspace rebases to be adjusted after the deletion
@@ -551,6 +562,9 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 2 times after removal at 16
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
+          Debug: Fork "cs-user2-second" of "cs-review-first" at 201 (RebaseWorkspace_456)
       Found 8 events to be removed
           Debug: 100,101,102,103,200,201,202,203
       Found 1 remaining workspace rebases to be adjusted after the deletion
@@ -679,6 +693,9 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 2 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
+          Debug: Fork "cs-user-third" of "cs-review-first" at 201 (RebaseWorkspace_456)
       Found 8 events to be removed
           Debug: 100,101,102,103,200,201,202,203
       Found 1 remaining workspace rebases to be adjusted after the deletion
@@ -796,6 +813,8 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
+      Content stream "cs-review-first" was forked 1 times after removal at 14
+          Debug: Fork "cs-user-second" of "cs-review-first" at 102 (RebaseWorkspace_123)
       Found 4 events to be removed
           Debug: 100,102,103,104
       Found 1 remaining workspace rebases to be adjusted after the deletion

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -129,11 +129,26 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
-      Migration was not necessary. No forks on already removed content streams.
+      Found 3 events to be removed
+          Debug: 100,101,102
+      Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
+
+      Migration applied to 3 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Done.
       """
 
-    # todo assert which events are remaining
-    # Then I expect exactly 2 events to be published on stream with prefix "ContentStream:cs-user-first"
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user-first"   |
+      | sourceContentStreamId | "cs-review-first" |
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
+    Then I expect exactly 1 events to be published on stream with prefix "Workspace:user"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
 
     # replay works
     When I replay the contentGraph projection
@@ -141,7 +156,7 @@ Feature: As a user of the CR I want to upgrade my events
       | name     | base workspace | status       | content stream     | publishable changes |
       | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
-      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-second"   | false               |
+      | "user"   | "review"       | "OUTDATED"   | "cs-user-first"    | false               |
 
   Scenario: Duplicate workspace rebase during publishing only second attempt correct
     And the command CreateRootWorkspace is executed with payload:

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -75,7 +75,7 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "UP_TO_DATE" | "cs-user-second"   | false               |
 
-  Scenario: Constraint Invalid workspace rebase sequence
+  Scenario: Constraint Invalid workspace rebase sequence because of wrong correlation ids
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |
@@ -131,8 +131,68 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
-      Invalid end of rebase workspace sequence RebaseWorkspace_123 expected ContentStreamWasRemoved
+      Error: Invalid end of rebase workspace sequence RebaseWorkspace_123 expected ContentStreamWasRemoved
           Debug: [{"event":{"id":{"value":"19d9edb6-bb47-464e-ace9-64e3d80dbe92"},"type":{"value":"ContentStreamWasClosed"},"data":{"value":"{\"contentStreamId\":\"cs-user-first\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-first"},"version":{"value":4},"sequenceNumber":{"value":100},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"0e27354f-2bd8-47fe-bfe3-2ab6e7ace856"},"type":{"value":"ContentStreamWasForked"},"data":{"value":"{\"newContentStreamId\":\"cs-user-second\",\"sourceContentStreamId\":\"cs-review-first\",\"versionOfSourceContentStream\":1}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":0},"sequenceNumber":{"value":101},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"01df0edb-6412-4144-92a3-013ef5ec1af4"},"type":{"value":"WorkspaceWasRebased"},"data":{"value":"{\"workspaceName\":\"user\",\"previousContentStreamId\": \"cs-user-first\", \"newContentStreamId\":\"cs-user-second\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"Workspace:user"},"version":{"value":2},"sequenceNumber":{"value":102},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
+      """
+
+  Scenario: Constraint Invalid workspace rebase sequence because new content stream event
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                       | version | type                                | payload                                                                                                                                                                                                                                | metadata                                                                         | id                                   | correlationid                           | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                    | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked              | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}                                                                                                                     | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased                 | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}                                                                                                                             | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-first"}                                                                                                                                                                                                   | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 104            | ContentStream:cs-user-second | 1       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"user","contentStreamId":"cs-user-second","nodeAggregateId":"illegal-node","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"} | []                                                                               | 2c8b9d29-c3fd-44e0-b275-15d336dc38ab | CreateNodeAggregateW_e00b8ac2a08c7fbb9b | 2026-04-30 11:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Error: Expected no events or another RebaseWorkspace sequence. Got at 104 type RootNodeAggregateWithNodeWasCreated with CreateNodeAggregateW_e00b8ac2a08c7fbb9b
+          Debug: [{"event":{"id":{"value":"2c8b9d29-c3fd-44e0-b275-15d336dc38ab"},"type":{"value":"RootNodeAggregateWithNodeWasCreated"},"data":{"value":"{\"workspaceName\":\"user\",\"contentStreamId\":\"cs-user-second\",\"nodeAggregateId\":\"illegal-node\",\"nodeTypeName\":\"Neos.Neos:Sites\",\"coveredDimensionSpacePoints\":[{\"language\":\"en\"},{\"language\":\"de\"}],\"nodeAggregateClassification\":\"root\"}"},"metadata":{"value":[]},"causationId":null,"correlationId":{"value":"CreateNodeAggregateW_e00b8ac2a08c7fbb9b"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":1},"sequenceNumber":{"value":104},"recordedAt":{"date":"2026-04-30 11:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
       """
 
   Scenario: Workspace rebase during publishing
@@ -280,11 +340,44 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
-      Migration was not necessary. No forks on already removed content streams.
+      Found 4 events to be removed
+          Debug: 100,101,102,103
+      Found 1 remaining workspace rebases to be adjusted after the deletion
+          Debug: RebaseWorkspace_456
+      Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
+
+      Migration applied to 7 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Done.
       """
 
-    # todo assert which events are remaining
-    # Then I expect exactly 2 events to be published on stream with prefix "ContentStream:cs-user-first"
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
+
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-user-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user-first"   |
+      | sourceContentStreamId | "cs-review-first" |
+    And event at index 1 is of type "ContentStreamWasClosed" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user-third"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected           |
+      | newContentStreamId    | "cs-user-third"    |
+      | sourceContentStreamId | "cs-review-second" |
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | newContentStreamId | "cs-user-third" |
 
     # replay works
     When I replay the contentGraph projection

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -75,6 +75,66 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "UP_TO_DATE" | "cs-user-second"   | false               |
 
+  Scenario: Constraint Invalid workspace rebase sequence
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value             |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"            |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                              |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      # wrong correlation id, must be _123
+      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_456 | 2026-04-30 10:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Invalid end of rebase workspace sequence RebaseWorkspace_123 expected ContentStreamWasRemoved
+          Debug: [{"event":{"id":{"value":"19d9edb6-bb47-464e-ace9-64e3d80dbe92"},"type":{"value":"ContentStreamWasClosed"},"data":{"value":"{\"contentStreamId\":\"cs-user-first\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-first"},"version":{"value":4},"sequenceNumber":{"value":100},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"0e27354f-2bd8-47fe-bfe3-2ab6e7ace856"},"type":{"value":"ContentStreamWasForked"},"data":{"value":"{\"newContentStreamId\":\"cs-user-second\",\"sourceContentStreamId\":\"cs-review-first\",\"versionOfSourceContentStream\":1}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":0},"sequenceNumber":{"value":101},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"01df0edb-6412-4144-92a3-013ef5ec1af4"},"type":{"value":"WorkspaceWasRebased"},"data":{"value":"{\"workspaceName\":\"user\",\"previousContentStreamId\": \"cs-user-first\", \"newContentStreamId\":\"cs-user-second\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"Workspace:user"},"version":{"value":2},"sequenceNumber":{"value":102},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
+      """
+
   Scenario: Workspace rebase during publishing
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -120,20 +180,21 @@ Feature: As a user of the CR I want to upgrade my events
       | newContentStreamId | "cs-review-second" |
 
     Given I have the following additional raw events to upgrade:
-      | sequencenumber | stream                       | version | type                   | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 102            | Workspace:user               | 2       | WorkspaceWasRebased    | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
-      Found 3 events to be removed
-          Debug: 100,101,102
+      Found 4 events to be removed
+          Debug: 100,101,102,103
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
 
-      Migration applied to 3 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Migration applied to 4 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
       Done.
       """
 
@@ -203,16 +264,18 @@ Feature: As a user of the CR I want to upgrade my events
       | newContentStreamId | "cs-review-second" |
 
     Given I have the following additional raw events to upgrade:
-      | sequencenumber | stream                       | version | type                   | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 102            | Workspace:user               | 2       | WorkspaceWasRebased    | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
       # second correct rebase, but it refers to illegal forked content stream "cs-user-second"
-      | 103            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
-      | 104            | ContentStream:cs-user-third  | 0       | ContentStreamWasForked | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-second","versionOfSourceContentStream":0} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
-      | 105            | Workspace:user               | 3       | WorkspaceWasRebased    | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 104            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 105            | ContentStream:cs-user-third  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-second","versionOfSourceContentStream":0} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 106            | Workspace:user               | 3       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-second", "newContentStreamId":"cs-user-third"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 107            | ContentStream:cs-user-second | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-second"}                                                                              | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | cbd8c63f-259f-45c4-b8a4-ee480b0fd0d2 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
 
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -279,7 +279,7 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "OUTDATED"   | "cs-user-first"    | false               |
 
-  Scenario: Duplicate workspace rebase during publishing but second attempt is not correct
+  Scenario: Concurrent workspace rebase during publishing but second attempt is not correct
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |
@@ -370,7 +370,7 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "OUTDATED"   | "cs-user-first"    | false               |
 
-  Scenario: Duplicate workspace rebase during publishing only second attempt correct
+  Scenario: Concurrent workspace rebase during publishing only second attempt correct
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |
@@ -478,7 +478,141 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "UP_TO_DATE" | "cs-user-third"    | false               |
 
-  Scenario: Duplicate workspace rebase during publishing only third attempt correct
+  Scenario: Concurrent workspace rebase during publishing two workspaces attempted to rebase
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user2"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user2-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                        | version | type                    | payload                                                                                                             | metadata                                                                          | id                                   | correlationid       | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first   | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                 | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}  | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user                | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}          | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first   | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+
+      # second illegal rebase from user2 workspace on already removed content stream (should be cs-review-second)
+      | 200            | ContentStream:cs-user2-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user2-first"}                                                                                | {"initiatingUserId": "user2", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 201            | ContentStream:cs-user2-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user2-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user2", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 202            | Workspace:user2               | 2       | WorkspaceWasRebased     | {"workspaceName":"user2","previousContentStreamId": "cs-user2-first", "newContentStreamId":"cs-user2-second"}       | {"initiatingUserId": "user2", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 203            | ContentStream:cs-user2-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user2-first"}                                                                               | {"initiatingUserId": "user2", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | cbd8c63f-259f-45c4-b8a4-ee480b0fd0d2 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+
+      # third correct rebase, but it refers to illegal forked content stream "cs-user-second"
+      | 300            | ContentStream:cs-user-second  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"}  | 5f4d9764-2a18-43cf-8f36-0a465bd30e2d | RebaseWorkspace_789 | 2026-04-30 11:00:00 |
+      | 301            | ContentStream:cs-user-third   | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-second","versionOfSourceContentStream":0}  | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"}  | 0de9cf52-5d90-4c13-abd9-696f608f27a7 | RebaseWorkspace_789 | 2026-04-30 11:00:00 |
+      | 302            | Workspace:user                | 3       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-second", "newContentStreamId":"cs-user-third"}          | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"}  | d4043b21-59b9-4ffe-b9a6-b2f0596f70b3 | RebaseWorkspace_789 | 2026-04-30 11:00:00 |
+      | 303            | ContentStream:cs-user-second  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"}  | a5308b17-9ad7-4f83-a63e-18c7cf448fd2 | RebaseWorkspace_789 | 2026-04-30 11:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Found 8 events to be removed
+          Debug: 100,101,102,103,200,201,202,203
+      Found 1 remaining workspace rebases to be adjusted after the deletion
+          Debug: RebaseWorkspace_789
+      Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
+
+      Migration applied to 11 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Done.
+      """
+
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user2-second"
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
+
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-user-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user-first"   |
+      | sourceContentStreamId | "cs-review-first" |
+    And event at index 1 is of type "ContentStreamWasClosed" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user-third"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected           |
+      | newContentStreamId    | "cs-user-third"    |
+      | sourceContentStreamId | "cs-review-second" |
+    Then I expect exactly 2 events to be published on stream "Workspace:user"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | newContentStreamId | "cs-user-third" |
+
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user2-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user2-first"  |
+      | sourceContentStreamId | "cs-review-first" |
+    Then I expect exactly 1 events to be published on stream "Workspace:user2"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected         |
+      | workspaceName      | "user2"          |
+      | baseWorkspaceName  | "review"         |
+      | newContentStreamId | "cs-user2-first" |
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
+      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-third"    | false               |
+      | "user2"  | "review"       | "OUTDATED"   | "cs-user2-first"   | false               |
+
+  Scenario: Concurrent workspace rebase during publishing only third attempt correct
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |
@@ -530,7 +664,7 @@ Feature: As a user of the CR I want to upgrade my events
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
-      # second correct rebase on already removed content stream (should be cs-review-second)
+      # second illegal rebase workspace on already removed content stream (should be cs-review-second)
       | 200            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
       | 201            | ContentStream:cs-user-third  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}  | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
       | 202            | Workspace:user               | 3       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-second", "newContentStreamId":"cs-user-third"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
@@ -593,7 +727,7 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "UP_TO_DATE" | "cs-user-forth"    | false               |
 
-  Scenario: Duplicate workspace rebase during publishing only second attempt correct with other allowed content stream events
+  Scenario: Concurrent workspace rebase during publishing only second attempt correct with other allowed content stream events
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "live"          |

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -445,7 +445,7 @@ Feature: As a user of the CR I want to upgrade my events
       Found 4 events to be removed
           Debug: 100,101,102,103
       Found 1 remaining workspace rebases to be adjusted after the deletion
-          Debug: RebaseWorkspace_456
+          Debug: Previous stream "cs-user-first" instead "cs-user-second" (RebaseWorkspace_456)
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
 
       Migration applied to 7 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
@@ -568,7 +568,7 @@ Feature: As a user of the CR I want to upgrade my events
       Found 8 events to be removed
           Debug: 100,101,102,103,200,201,202,203
       Found 1 remaining workspace rebases to be adjusted after the deletion
-          Debug: RebaseWorkspace_789
+          Debug: Previous stream "cs-user-first" instead "cs-user-second" (RebaseWorkspace_789)
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
 
       Migration applied to 11 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
@@ -699,7 +699,7 @@ Feature: As a user of the CR I want to upgrade my events
       Found 8 events to be removed
           Debug: 100,101,102,103,200,201,202,203
       Found 1 remaining workspace rebases to be adjusted after the deletion
-          Debug: RebaseWorkspace_789
+          Debug: Previous stream "cs-user-first" instead "cs-user-third" (RebaseWorkspace_789)
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
 
       Migration applied to 11 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
@@ -818,7 +818,7 @@ Feature: As a user of the CR I want to upgrade my events
       Found 4 events to be removed
           Debug: 100,102,103,104
       Found 1 remaining workspace rebases to be adjusted after the deletion
-          Debug: RebaseWorkspace_456
+          Debug: Previous stream "cs-user-first" instead "cs-user-second" (RebaseWorkspace_456)
       Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
 
       Migration applied to 7 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -1,0 +1,217 @@
+Feature: As a user of the CR I want to upgrade my events
+
+  Background:
+    And the current date and time is "2026-04-30T09:00:00+00:00"
+    Given using the following content dimensions:
+      | Identifier | Values | Generalizations |
+      | language   | de, en | de, en          |
+    And using the following node types:
+    """yaml
+    Neos.ContentRepository.Testing:Node: []
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+
+  Scenario: Noop for new setup
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    And the command RebaseWorkspace is executed with payload:
+      | Key                    | Value            |
+      | workspaceName          | "user"           |
+      | rebasedContentStreamId | "cs-user-second" |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Migration was not necessary. No forks on already removed content streams.
+      """
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
+      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-second"   | false               |
+
+  Scenario: Workspace rebase during publishing
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                       | version | type                   | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased    | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Migration was not necessary. No forks on already removed content streams.
+      """
+
+    # todo assert which events are remaining
+    # Then I expect exactly 2 events to be published on stream with prefix "ContentStream:cs-user-first"
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
+      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-second"   | false               |
+
+  Scenario: Duplicate workspace rebase during publishing only second attempt correct
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                       | version | type                   | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased    | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+
+      # second correct rebase, but it refers to illegal forked content stream "cs-user-second"
+      | 103            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 104            | ContentStream:cs-user-third  | 0       | ContentStreamWasForked | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-second","versionOfSourceContentStream":0} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 105            | Workspace:user               | 3       | WorkspaceWasRebased    | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Migration was not necessary. No forks on already removed content streams.
+      """
+
+    # todo assert which events are remaining
+    # Then I expect exactly 2 events to be published on stream with prefix "ContentStream:cs-user-first"
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
+      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-third"    | false               |

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -122,11 +122,11 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       # wrong correlation id, must be _123
-      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_456 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_456 | 2026-04-30 10:00:00 |
 
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
@@ -134,7 +134,7 @@ Feature: As a user of the CR I want to upgrade my events
       Content stream "cs-review-first" was forked 1 times after removal at 14
           Debug: Fork "cs-user-second" of "cs-review-first" at 101 (RebaseWorkspace_123)
       Error: Invalid end of rebase workspace sequence RebaseWorkspace_123 expected ContentStreamWasRemoved
-          Debug: [{"event":{"id":{"value":"19d9edb6-bb47-464e-ace9-64e3d80dbe92"},"type":{"value":"ContentStreamWasClosed"},"data":{"value":"{\"contentStreamId\":\"cs-user-first\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-first"},"version":{"value":4},"sequenceNumber":{"value":100},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"0e27354f-2bd8-47fe-bfe3-2ab6e7ace856"},"type":{"value":"ContentStreamWasForked"},"data":{"value":"{\"newContentStreamId\":\"cs-user-second\",\"sourceContentStreamId\":\"cs-review-first\",\"versionOfSourceContentStream\":1}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":0},"sequenceNumber":{"value":101},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"01df0edb-6412-4144-92a3-013ef5ec1af4"},"type":{"value":"WorkspaceWasRebased"},"data":{"value":"{\"workspaceName\":\"user\",\"previousContentStreamId\": \"cs-user-first\", \"newContentStreamId\":\"cs-user-second\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"Workspace:user"},"version":{"value":2},"sequenceNumber":{"value":102},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
+          Debug: [{"event":{"id":{"value":"19d9edb6-bb47-464e-ace9-64e3d80dbe92"},"type":{"value":"ContentStreamWasClosed"},"data":{"value":"{\"contentStreamId\":\"cs-user-first\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-first"},"version":{"value":1},"sequenceNumber":{"value":100},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"0e27354f-2bd8-47fe-bfe3-2ab6e7ace856"},"type":{"value":"ContentStreamWasForked"},"data":{"value":"{\"newContentStreamId\":\"cs-user-second\",\"sourceContentStreamId\":\"cs-review-first\",\"versionOfSourceContentStream\":1}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":0},"sequenceNumber":{"value":101},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}},{"event":{"id":{"value":"01df0edb-6412-4144-92a3-013ef5ec1af4"},"type":{"value":"WorkspaceWasRebased"},"data":{"value":"{\"workspaceName\":\"user\",\"previousContentStreamId\": \"cs-user-first\", \"newContentStreamId\":\"cs-user-second\"}"},"metadata":{"value":{"initiatingUserId":"user","initiatingTimestamp":"2026-04-30T10:00:00+00:00"}},"causationId":null,"correlationId":{"value":"RebaseWorkspace_123"}},"streamName":{"value":"Workspace:user"},"version":{"value":2},"sequenceNumber":{"value":102},"recordedAt":{"date":"2026-04-30 10:00:00.000000","timezone_type":3,"timezone":"UTC"}}]
       """
 
   Scenario: Constraint Invalid workspace rebase sequence because new content stream event
@@ -184,10 +184,10 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                       | version | type                                | payload                                                                                                                                                                                                                                | metadata                                                                         | id                                   | correlationid                           | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                    | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 1       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                    | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked              | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}                                                                                                                     | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased                 | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}                                                                                                                             | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
-      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-first"}                                                                                                                                                                                                   | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 2       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-first"}                                                                                                                                                                                                   | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
       | 104            | ContentStream:cs-user-second | 1       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"user","contentStreamId":"cs-user-second","nodeAggregateId":"illegal-node","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"} | []                                                                               | 2c8b9d29-c3fd-44e0-b275-15d336dc38ab | CreateNodeAggregateW_e00b8ac2a08c7fbb9b | 2026-04-30 11:00:00 |
 
     When I upgrade the events to concurrent workspace-rebases
@@ -246,10 +246,10 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
@@ -332,10 +332,10 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
       # second correct rebase on already removed content stream (should be cs-review-second)
       | 104            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
@@ -426,10 +426,10 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
       # second correct rebase, but it refers to illegal forked content stream "cs-user-second"
       | 104            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
@@ -542,10 +542,10 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                        | version | type                    | payload                                                                                                             | metadata                                                                          | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first   | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                 | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first   | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                 | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}  | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 102            | Workspace:user                | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}          | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 103            | ContentStream:cs-user-first   | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first   | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"}  | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
       # second illegal rebase from user2 workspace on already removed content stream (should be cs-review-second)
       | 200            | ContentStream:cs-user2-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user2-first"}                                                                                | {"initiatingUserId": "user2", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
@@ -673,10 +673,10 @@ Feature: As a user of the CR I want to upgrade my events
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
       | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
-      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
 
       # second illegal rebase workspace on already removed content stream (should be cs-review-second)
       | 200            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
@@ -756,28 +756,38 @@ Feature: As a user of the CR I want to upgrade my events
       | nodeTypeName    | "Neos.ContentRepository:Root" |
 
     And the command CreateWorkspace is executed with payload:
-      | Key                | Value           |
+      | Key                | Value             |
       | workspaceName      | "review"          |
-      | baseWorkspaceName  | "live"          |
-      | newContentStreamId | "cs-review-first" |
+      | baseWorkspaceName  | "live"            |
+      | newContentStreamId | "cs-review-zero"  |
 
     And the command CreateWorkspace is executed with payload:
       | Key                | Value           |
       | workspaceName      | "user"          |
-      | baseWorkspaceName  | "review"          |
-      | newContentStreamId | "cs-user-first" |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-zero"  |
 
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                 |
-      | workspaceName             | "live"                                |
+      | workspaceName             | "user"                                |
       | originDimensionSpacePoint | {"language": "de"}                    |
       | nodeAggregateId           | "nody-mc-nodeface"                    |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
       | parentNodeAggregateId     | "lady-eleonode-rootford"              |
 
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value             |
+      | workspaceName      | "review"          |
+      | newContentStreamId | "cs-review-first" |
+
     And the command CreateNodeAggregateWithNode is executed with payload:
       | Key                       | Value                                 |
-      | workspaceName             | "review"                                |
+      | workspaceName             | "review"                              |
       | originDimensionSpacePoint | {"language": "de"}                    |
       | nodeAggregateId           | "sir-david-nodenborough"              |
       | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
@@ -790,13 +800,17 @@ Feature: As a user of the CR I want to upgrade my events
 
     Given I have the following additional raw events to upgrade:
       | sequencenumber | stream                         | version | type                                | payload                                                                                                                                                                                                                                        | metadata                                                                         | id                                   | correlationid                           | recordedat          |
+      # some noop events raising the content stream version
+      | 50             | ContentStream:cs-user-first    | 1       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                            | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T09:00:00+00:00"} | 0f111a85-ccb1-4442-b9ab-27b980e59040 | PublishIndividual_123                   | 2026-04-30 09:00:00 |
+      | 51             | ContentStream:cs-user-first    | 2       | ContentStreamWasReopened            | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                            | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T09:00:00+00:00"} | 30398779-a2f8-4f38-bc05-d4fee74672d7 | PublishIndividual_123                   | 2026-04-30 09:00:00 |
+
       # illegal rebase workspace on already removed content stream (should be cs-review-second)
-      | 100            | ContentStream:cs-user-first    | 4       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                            | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 100            | ContentStream:cs-user-first    | 3       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                            | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
       # some other stream
       | 101            | ContentStream:cs-review-second | 1       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"review","contentStreamId":"cs-review-second","nodeAggregateId":"unrelated-node-1","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"} | []                                                                               | 2c8b9d29-c3fd-44e0-b275-15d336dc38ab | CreateNodeAggregateW_e00b8ac2a08c7fbb9b | 2026-04-30 11:00:00 |
       | 102            | ContentStream:cs-user-second   | 0       | ContentStreamWasForked              | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}                                                                                                                             | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
       | 103            | Workspace:user                 | 2       | WorkspaceWasRebased                 | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}                                                                                                                                     | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
-      | 104            | ContentStream:cs-user-first    | 5       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-first"}                                                                                                                                                                                                           | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 104            | ContentStream:cs-user-first    | 4       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-first"}                                                                                                                                                                                                           | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
 
       # some other stream
       | 200            | ContentStream:cs-identifier    | 4       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"live","contentStreamId":"cs-identifier","nodeAggregateId":"unrelated-node-2","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"}      | []                                                                               | 57b715a1-3bec-409f-8253-88c9b5e5b7db | CreateNodeAggregateW_57b715a13bec       | 2026-04-30 11:00:00 |
@@ -813,7 +827,7 @@ Feature: As a user of the CR I want to upgrade my events
     When I upgrade the events to concurrent workspace-rebases
     Then I expect the following upgrade output:
       """
-      Content stream "cs-review-first" was forked 1 times after removal at 14
+      Content stream "cs-review-first" was forked 1 times after removal at 24
           Debug: Fork "cs-user-second" of "cs-review-first" at 102 (RebaseWorkspace_123)
       Found 4 events to be removed
           Debug: 100,102,103,104
@@ -827,15 +841,21 @@ Feature: As a user of the CR I want to upgrade my events
 
     Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
 
-    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-user-first"
+    Then I expect exactly 5 events to be published on stream with prefix "ContentStream:cs-user-first"
     And event at index 0 is of type "ContentStreamWasForked" with payload:
       | Key                   | Expected          |
       | newContentStreamId    | "cs-user-first"   |
-      | sourceContentStreamId | "cs-review-first" |
+      | sourceContentStreamId | "cs-review-zero"  |
     And event at index 1 is of type "ContentStreamWasClosed" with payload:
       | Key             | Expected        |
       | contentStreamId | "cs-user-first" |
-    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+    And event at index 2 is of type "ContentStreamWasReopened" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    And event at index 3 is of type "ContentStreamWasClosed" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    And event at index 4 is of type "ContentStreamWasRemoved" with payload:
       | Key             | Expected        |
       | contentStreamId | "cs-user-first" |
     Then I expect exactly 2 events to be published on stream with prefix "ContentStream:cs-user-third"
@@ -848,13 +868,17 @@ Feature: As a user of the CR I want to upgrade my events
       | contentStreamId | "cs-user-third" |
       | nodeAggregateId | "new-node"      |
 
-    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user"
+    Then I expect exactly 3 events to be published on stream with prefix "Workspace:user"
     And event at index 0 is of type "WorkspaceWasCreated" with payload:
-      | Key                | Expected        |
-      | workspaceName      | "user"          |
-      | baseWorkspaceName  | "review"        |
-      | newContentStreamId | "cs-user-first" |
-    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                | Expected       |
+      | workspaceName      | "user"         |
+      | baseWorkspaceName  | "review"       |
+      | newContentStreamId | "cs-user-zero" |
+    And event at index 1 is of type "WorkspaceWasPublished" with payload:
+      | Key                      | Expected        |
+      | sourceWorkspaceName      | "user"          |
+      | newSourceContentStreamId | "cs-user-first" |
+    And event at index 2 is of type "WorkspaceWasRebased" with payload:
       | Key                | Expected        |
       | workspaceName      | "user"          |
       | newContentStreamId | "cs-user-third" |

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -477,9 +477,10 @@ Feature: As a user of the CR I want to upgrade my events
       | baseWorkspaceName  | "review"        |
       | newContentStreamId | "cs-user-first" |
     And event at index 1 is of type "WorkspaceWasRebased" with payload:
-      | Key                | Expected        |
-      | workspaceName      | "user"          |
-      | newContentStreamId | "cs-user-third" |
+      | Key                     | Expected        |
+      | workspaceName           | "user"          |
+      | newContentStreamId      | "cs-user-third" |
+      | previousContentStreamId | "cs-user-first" |
 
     # replay works
     When I replay the contentGraph projection
@@ -601,9 +602,10 @@ Feature: As a user of the CR I want to upgrade my events
       | baseWorkspaceName  | "review"        |
       | newContentStreamId | "cs-user-first" |
     And event at index 1 is of type "WorkspaceWasRebased" with payload:
-      | Key                | Expected        |
-      | workspaceName      | "user"          |
-      | newContentStreamId | "cs-user-third" |
+      | Key                     | Expected        |
+      | workspaceName           | "user"          |
+      | newContentStreamId      | "cs-user-third" |
+      | previousContentStreamId | "cs-user-first" |
 
     Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user2-first"
     And event at index 0 is of type "ContentStreamWasForked" with payload:
@@ -732,9 +734,10 @@ Feature: As a user of the CR I want to upgrade my events
       | baseWorkspaceName  | "review"        |
       | newContentStreamId | "cs-user-first" |
     And event at index 1 is of type "WorkspaceWasRebased" with payload:
-      | Key                | Expected        |
-      | workspaceName      | "user"          |
-      | newContentStreamId | "cs-user-forth" |
+      | Key                     | Expected        |
+      | workspaceName           | "user"          |
+      | newContentStreamId      | "cs-user-forth" |
+      | previousContentStreamId | "cs-user-first" |
 
     # replay works
     When I replay the contentGraph projection
@@ -879,9 +882,10 @@ Feature: As a user of the CR I want to upgrade my events
       | sourceWorkspaceName      | "user"          |
       | newSourceContentStreamId | "cs-user-first" |
     And event at index 2 is of type "WorkspaceWasRebased" with payload:
-      | Key                | Expected        |
-      | workspaceName      | "user"          |
-      | newContentStreamId | "cs-user-third" |
+      | Key                     | Expected        |
+      | workspaceName           | "user"          |
+      | newContentStreamId      | "cs-user-third" |
+      | previousContentStreamId | "cs-user-first" |
 
     # replay works
     When I replay the contentGraph projection

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -592,3 +592,124 @@ Feature: As a user of the CR I want to upgrade my events
       | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "UP_TO_DATE" | "cs-user-forth"    | false               |
+
+  Scenario: Duplicate workspace rebase during publishing only second attempt correct with other allowed content stream events
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                         | version | type                                | payload                                                                                                                                                                                                                                        | metadata                                                                         | id                                   | correlationid                           | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first    | 4       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-first"}                                                                                                                                                                                                            | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      # some other stream
+      | 101            | ContentStream:cs-review-second | 1       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"review","contentStreamId":"cs-review-second","nodeAggregateId":"unrelated-node-1","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"} | []                                                                               | 2c8b9d29-c3fd-44e0-b275-15d336dc38ab | CreateNodeAggregateW_e00b8ac2a08c7fbb9b | 2026-04-30 11:00:00 |
+      | 102            | ContentStream:cs-user-second   | 0       | ContentStreamWasForked              | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}                                                                                                                             | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 103            | Workspace:user                 | 2       | WorkspaceWasRebased                 | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}                                                                                                                                     | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+      | 104            | ContentStream:cs-user-first    | 5       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-first"}                                                                                                                                                                                                           | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123                     | 2026-04-30 10:00:00 |
+
+      # some other stream
+      | 200            | ContentStream:cs-identifier    | 4       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"live","contentStreamId":"cs-identifier","nodeAggregateId":"unrelated-node-2","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"}      | []                                                                               | 57b715a1-3bec-409f-8253-88c9b5e5b7db | CreateNodeAggregateW_57b715a13bec       | 2026-04-30 11:00:00 |
+
+      # second correct rebase, but it refers to illegal forked content stream "cs-user-second"
+      | 301            | ContentStream:cs-user-second   | 1       | ContentStreamWasClosed              | {"contentStreamId":"cs-user-second"}                                                                                                                                                                                                           | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456                     | 2026-04-30 11:00:00 |
+      | 302            | ContentStream:cs-user-third    | 0       | ContentStreamWasForked              | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-second","versionOfSourceContentStream":1}                                                                                                                             | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456                     | 2026-04-30 11:00:00 |
+      | 303            | Workspace:user                 | 3       | WorkspaceWasRebased                 | {"workspaceName":"user","previousContentStreamId": "cs-user-second", "newContentStreamId":"cs-user-third"}                                                                                                                                     | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456                     | 2026-04-30 11:00:00 |
+      # some other stream
+      | 304            | ContentStream:cs-identifier    | 5       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"live","contentStreamId":"cs-identifier","nodeAggregateId":"unrelated-node-3","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"}      | []                                                                               | a0cd6fef-8bdb-4003-a754-b8a0c507005b | CreateNodeAggregateW_a0cd6fef8bdb       | 2026-04-30 11:00:00 |
+      | 305            | ContentStream:cs-user-second   | 2       | ContentStreamWasRemoved             | {"contentStreamId": "cs-user-second"}                                                                                                                                                                                                          | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | cbd8c63f-259f-45c4-b8a4-ee480b0fd0d2 | RebaseWorkspace_456                     | 2026-04-30 11:00:00 |
+      | 306            | ContentStream:cs-user-third    | 1       | RootNodeAggregateWithNodeWasCreated | {"workspaceName":"user","contentStreamId":"cs-user-third","nodeAggregateId":"new-node","nodeTypeName":"Neos.Neos:Sites","coveredDimensionSpacePoints":[{"language":"en"},{"language":"de"}],"nodeAggregateClassification":"root"}              | []                                                                               | c152253a-0a35-4b4f-a689-2a3440b6f01e | CreateNodeAggregateW_c152253a0a35       | 2026-04-30 11:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Found 4 events to be removed
+          Debug: 100,102,103,104
+      Found 1 remaining workspace rebases to be adjusted after the deletion
+          Debug: RebaseWorkspace_456
+      Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
+
+      Migration applied to 7 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Done.
+      """
+
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
+
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-user-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user-first"   |
+      | sourceContentStreamId | "cs-review-first" |
+    And event at index 1 is of type "ContentStreamWasClosed" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    Then I expect exactly 2 events to be published on stream with prefix "ContentStream:cs-user-third"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected           |
+      | newContentStreamId    | "cs-user-third"    |
+      | sourceContentStreamId | "cs-review-second" |
+    And event at index 1 is of type "RootNodeAggregateWithNodeWasCreated" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-third" |
+      | nodeAggregateId | "new-node"      |
+
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | newContentStreamId | "cs-user-third" |
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "OUTDATED"   | "cs-review-second" | true                |
+      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-third"    | true                |

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -61,7 +61,7 @@ Feature: As a user of the CR I want to upgrade my events
       | workspaceName          | "user"           |
       | rebasedContentStreamId | "cs-user-second" |
 
-    When I upgrade the events to concurrent workspace-rebases
+    When I attempt to upgrade the events to concurrent workspace-rebases which I expect not to be available
     Then I expect the following upgrade output:
       """
       Migration was not necessary. No forks on already removed content streams.

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsConcurrentWorkspaceRebases/EventsConcurrentWorkspaceRebases.feature
@@ -279,6 +279,97 @@ Feature: As a user of the CR I want to upgrade my events
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "OUTDATED"   | "cs-user-first"    | false               |
 
+  Scenario: Duplicate workspace rebase during publishing but second attempt is not correct
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+
+      # second correct rebase on already removed content stream (should be cs-review-second)
+      | 104            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 105            | ContentStream:cs-user-third  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}  | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 106            | Workspace:user               | 3       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-second", "newContentStreamId":"cs-user-third"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 107            | ContentStream:cs-user-second | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-second"}                                                                              | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | cbd8c63f-259f-45c4-b8a4-ee480b0fd0d2 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Found 8 events to be removed
+          Debug: 100,101,102,103,104,105,106,107
+      Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
+
+      Migration applied to 8 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Done.
+      """
+
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user-first"   |
+      | sourceContentStreamId | "cs-review-first" |
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-third"
+    Then I expect exactly 1 events to be published on stream with prefix "Workspace:user"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
+      | "user"   | "review"       | "OUTDATED"   | "cs-user-first"    | false               |
+
   Scenario: Duplicate workspace rebase during publishing only second attempt correct
     And the command CreateRootWorkspace is executed with payload:
       | Key                | Value           |
@@ -386,3 +477,118 @@ Feature: As a user of the CR I want to upgrade my events
       | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
       | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
       | "user"   | "review"       | "UP_TO_DATE" | "cs-user-third"    | false               |
+
+  Scenario: Duplicate workspace rebase during publishing only third attempt correct
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                         |
+      | workspaceName   | "live"                        |
+      | nodeAggregateId | "lady-eleonode-rootford"      |
+      | nodeTypeName    | "Neos.ContentRepository:Root" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "review"          |
+      | baseWorkspaceName  | "live"          |
+      | newContentStreamId | "cs-review-first" |
+
+    And the command CreateWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"          |
+      | newContentStreamId | "cs-user-first" |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "live"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "nody-mc-nodeface"                    |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                 |
+      | workspaceName             | "review"                                |
+      | originDimensionSpacePoint | {"language": "de"}                    |
+      | nodeAggregateId           | "sir-david-nodenborough"              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"              |
+
+    And the command PublishWorkspace is executed with payload:
+      | Key                | Value              |
+      | workspaceName      | "review"           |
+      | newContentStreamId | "cs-review-second" |
+
+    Given I have the following additional raw events to upgrade:
+      | sequencenumber | stream                       | version | type                    | payload                                                                                                            | metadata                                                                         | id                                   | correlationid       | recordedat          |
+      # illegal rebase workspace on already removed content stream (should be cs-review-second)
+      | 100            | ContentStream:cs-user-first  | 4       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-first"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 19d9edb6-bb47-464e-ace9-64e3d80dbe92 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 101            | ContentStream:cs-user-second | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-second","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 0e27354f-2bd8-47fe-bfe3-2ab6e7ace856 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 102            | Workspace:user               | 2       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-first", "newContentStreamId":"cs-user-second"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | 01df0edb-6412-4144-92a3-013ef5ec1af4 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+      | 103            | ContentStream:cs-user-first  | 5       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-first"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T10:00:00+00:00"} | a49edee3-6022-4834-b9d2-59bde62be391 | RebaseWorkspace_123 | 2026-04-30 10:00:00 |
+
+      # second correct rebase on already removed content stream (should be cs-review-second)
+      | 200            | ContentStream:cs-user-second | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-second"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 2f89545a-7464-47a6-97cf-767fe403987a | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 201            | ContentStream:cs-user-third  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-third","sourceContentStreamId":"cs-review-first","versionOfSourceContentStream":1}  | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6b6ba121-a7c0-4983-89b6-d26801a9ee89 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 202            | Workspace:user               | 3       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-second", "newContentStreamId":"cs-user-third"}         | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 727e396a-feec-4fe3-be95-7a1e5ef1fb26 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+      | 203            | ContentStream:cs-user-second | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-second"}                                                                              | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | cbd8c63f-259f-45c4-b8a4-ee480b0fd0d2 | RebaseWorkspace_456 | 2026-04-30 11:00:00 |
+
+      # third correct rebase, but it refers to illegal forked content stream "cs-user-second"
+      | 300            | ContentStream:cs-user-third  | 1       | ContentStreamWasClosed  | {"contentStreamId":"cs-user-third"}                                                                                | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 05135d7c-9619-412e-b16f-305c696e4374 | RebaseWorkspace_789 | 2026-04-30 12:00:00 |
+      | 301            | ContentStream:cs-user-forth  | 0       | ContentStreamWasForked  | {"newContentStreamId":"cs-user-forth","sourceContentStreamId":"cs-review-second","versionOfSourceContentStream":0} | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 13dafeff-2aa1-4d51-84b6-3bdcd954956d | RebaseWorkspace_789 | 2026-04-30 12:00:00 |
+      | 302            | Workspace:user               | 4       | WorkspaceWasRebased     | {"workspaceName":"user","previousContentStreamId": "cs-user-third", "newContentStreamId":"cs-user-forth"}          | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | 6663874d-516c-4267-a7d3-9aeba334fdf8 | RebaseWorkspace_789 | 2026-04-30 12:00:00 |
+      | 303            | ContentStream:cs-user-third  | 2       | ContentStreamWasRemoved | {"contentStreamId": "cs-user-third"}                                                                               | {"initiatingUserId": "user", "initiatingTimestamp": "2026-04-30T11:00:00+00:00"} | fe992949-efcb-4042-8a1f-1d90aee4f22c | RebaseWorkspace_789 | 2026-04-30 12:00:00 |
+
+    When I upgrade the events to concurrent workspace-rebases
+    Then I expect the following upgrade output:
+      """
+      Found 8 events to be removed
+          Debug: 100,101,102,103,200,201,202,203
+      Found 1 remaining workspace rebases to be adjusted after the deletion
+          Debug: RebaseWorkspace_789
+      Backup: copying events table to cr_default_events_bkp_2026_04_30_09_00_00
+
+      Migration applied to 11 events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`
+      Done.
+      """
+
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-second"
+    Then I expect exactly 0 events to be published on stream with prefix "ContentStream:cs-user-third"
+
+    Then I expect exactly 3 events to be published on stream with prefix "ContentStream:cs-user-first"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected          |
+      | newContentStreamId    | "cs-user-first"   |
+      | sourceContentStreamId | "cs-review-first" |
+    And event at index 1 is of type "ContentStreamWasClosed" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    And event at index 2 is of type "ContentStreamWasRemoved" with payload:
+      | Key             | Expected        |
+      | contentStreamId | "cs-user-first" |
+    Then I expect exactly 1 events to be published on stream with prefix "ContentStream:cs-user-forth"
+    And event at index 0 is of type "ContentStreamWasForked" with payload:
+      | Key                   | Expected           |
+      | newContentStreamId    | "cs-user-forth"    |
+      | sourceContentStreamId | "cs-review-second" |
+    Then I expect exactly 2 events to be published on stream with prefix "Workspace:user"
+    And event at index 0 is of type "WorkspaceWasCreated" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | baseWorkspaceName  | "review"        |
+      | newContentStreamId | "cs-user-first" |
+    And event at index 1 is of type "WorkspaceWasRebased" with payload:
+      | Key                | Expected        |
+      | workspaceName      | "user"          |
+      | newContentStreamId | "cs-user-forth" |
+
+    # replay works
+    When I replay the contentGraph projection
+    Then I expect the following workspaces to exist:
+      | name     | base workspace | status       | content stream     | publishable changes |
+      | "live"   | null           | "UP_TO_DATE" | "cs-identifier"    | false               |
+      | "review" | "live"         | "UP_TO_DATE" | "cs-review-second" | false               |
+      | "user"   | "review"       | "UP_TO_DATE" | "cs-user-forth"    | false               |


### PR DESCRIPTION
Upgrade to deduplicate illegal concurrent workspace rebases

See issue https://github.com/neos/neos-development-collection/issues/5849

Content stream forking was not thread safe before not expressing the assertion to the source content stream
e.g. that the `sourceContentStreamVersion` should match the reality in the event store.
This resulted in the possibility that a source content stream was not constraint from being forked when it was already removed.
The resulting illegal `ContentStreamWasForked` event and its `RebaseWorkspace` sequence must be removed.

Required to ensure 9.2 can be replayed. Otherwise the graph will reject this event - in Neos 9.0 and 9.1 this was ignored accidentally

> Content stream "cs-review-first" does not exist. No layers found.

### 

The upgrade first determines any `ContentStreamWasForked` events where the source content stream was already removed via `ContentStreamWasRemoved`.
We assume all illegally found forks are restricted to being caused by a `RebaseWorkspace` command (via correlation id).
Further we expect a simple `RebaseWorkspace` without any changes on the "user" workspace but just an empty fork.
On this empty fork we expect only a new second `RebaseWorkspace`, starting with a `ContentStreamWasClosed` event or nothing if the event stream ended.
This second `RebaseWorkspace` is either also illegal and to be removed or a valid rebase if the source content stream existed at that point.
If valid we want to keep this rebase, but a rebase sequence refers to its previous content stream to remove it and indicate projections which was the last. The original information is no longer valid as we have removed the existence of the original previous content stream. Instead we need to patch the events to use the previous content stream of the first illegal fork - the previous-previous content stream.
Thus we patch the field `$previousContentStreamId` of the `WorkspaceWasRebased` event and rewrite the
`ContentStreamWasClosed` and `ContentStreamWasRemoved` events to affect the now new last content stream.

After the migration is applied the workspace will have its last successfully rebased content stream as without the migration,
but we deduplicated any temporary illegal rebases that happened in a race condition. No content on the workspaces is affected.
