### PR TITLE
FEATURE: New command `./flow crupgrade:eventsstatus` to check which event migrations are available

### DIFF
--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
@@ -133,14 +133,19 @@ final class CRUpgradeCommandController extends CommandController
      *
      * @param string $contentRepository Identifier of the Content Repository to upgrade
      */
-    public function eventsRecordedAtToUtcCommand(string $contentRepository = 'default', bool $force = false): void
+    public function eventsRecordedAtToUtcCommand(string $contentRepository = 'default', bool $dryRun = false, bool $force = false): void
     {
+        if ($dryRun && $force) {
+            $this->outputLine('<comment>Abort. Cannot force a dry run;)</comment>');
+            return;
+        }
+
         $context = $this->contentRepositoryRegistry->buildService(
             ContentRepositoryId::fromString($contentRepository),
             $this->upgradeContextFactory
         );
 
-        if (!$force && !$this->output->askConfirmation(sprintf('> This will rewrite events of content repository "%s" to use UTC dates consistently and backup the original events. This will take even on big sites less than 5 minutes. To have the UTC changes applied to the graph a replay needs to be done which will take quite some time. Are you sure to proceed? (y/n) ', $context->contentRepositoryId->value), false)) {
+        if ((!$dryRun && !$force) && !$this->output->askConfirmation(sprintf('> This will rewrite events of content repository "%s" to use UTC dates consistently and backup the original events. This will take even on big sites less than 5 minutes. To have the UTC changes applied to the graph a replay needs to be done which will take quite some time. Are you sure to proceed? (y/n) ', $context->contentRepositoryId->value), false)) {
             $this->outputLine('<comment>Abort.</comment>');
             return;
         }
@@ -151,7 +156,8 @@ final class CRUpgradeCommandController extends CommandController
         );
 
         $upgrade->execute(
-            force: $force
+            force: $force,
+            dryRun: $dryRun,
         );
     }
 

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
@@ -46,6 +46,79 @@ final class CRUpgradeCommandController extends CommandController
     protected CRUpgradeContextFactory $upgradeContextFactory;
 
     /**
+     * Analyses which event upgrades are available and which required
+     *
+     * @param string $contentRepository Identifier of the Content Repository to test for event upgrades
+     */
+    public function eventsStatusCommand(string $contentRepository = 'default'): void
+    {
+        $context = $this->contentRepositoryRegistry->buildService(
+            ContentRepositoryId::fromString($contentRepository),
+            $this->upgradeContextFactory
+        );
+
+        $noop = function () {
+        };
+
+        $optionalUpgrades = [
+            [
+                strtolower('crupgrade:eventsRecordedAtToUtc'),
+                new EventsRecordedAtToUtcUpgrade($context, $noop)
+            ]
+        ];
+
+        $requiredUpgrades = [
+            [
+                strtolower('crupgrade:eventsDeduplicateBaseWorkspaceChanges'),
+                new EventsDeduplicateBaseWorkspaceChangesUpgrade($context, $noop)
+            ]
+        ];
+
+        $optionalAvailable = 0;
+        foreach ($optionalUpgrades as [$cliCommandName, $upgrade]) {
+            if ($upgrade->isAvailable()) {
+                if ($optionalAvailable === 0) {
+                    $this->outputLine('Optional migrations:');
+                }
+                $this->outputLine(' - %s', [$upgrade::getShortDescription()]);
+                $this->outputLine('   Run <i>./flow %s</i>', [$cliCommandName]);
+                $this->outputLine();
+                $optionalAvailable++;
+            }
+        }
+
+        $requiredAvailable = 0;
+        foreach ($requiredUpgrades as [$cliCommandName, $upgrade]) {
+            if ($upgrade->isAvailable()) {
+                if ($requiredAvailable === 0) {
+                    $this->outputLine('Required migrations (in order):');
+                }
+                $this->outputLine(' - %s', [$upgrade::getShortDescription()]);
+                $this->outputLine('   Run <i>./flow %s</i>', [$cliCommandName]);
+                $this->outputLine();
+                $requiredAvailable++;
+            }
+        }
+
+        if ($optionalAvailable === 0 && $requiredAvailable === 0) {
+            $this->outputLine('<success>No event upgrades available.</success>');
+            return;
+        }
+
+        $this->outputLine('Note use <i>--dry-run</i> with the upgrades for further details');
+
+        if ($requiredAvailable === 0) {
+            $this->outputLine('<comment>Found %d optional event upgrades available</comment>', [$optionalAvailable]);
+        } else {
+            $this->outputLine('<error>Found %d required%s event upgrades available</error>', [$requiredAvailable, $optionalAvailable ? " and $optionalAvailable optional" : '']);
+        }
+
+        if ($requiredAvailable) {
+            $this->quit(1);
+        }
+    }
+
+    /**
      * Upgrade to allow to empty, set up and replay the graph projection in one step
      *
      * The CR provides a simple setup tooling via "./flow cr:setup" it allows to create the database schemas in the beginning

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.php
@@ -48,6 +48,11 @@ class EventsDeduplicateBaseWorkspaceChangesUpgrade
     ) {
     }
 
+    public static function getShortDescription(): string
+    {
+        return 'Deduplicate parallel base workspace changes';
+    }
+
     public function isAvailable(): bool
     {
         $duplicateContentStreamRemovalWithStreams = $this->findDuplicateContentStreamRemovalWithStreams();

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.php
@@ -5,16 +5,11 @@ declare(strict_types=1);
 namespace Neos\ContentRepositoryRegistry\Upgrade\EventsDeduplicateBaseWorkspaceChanges;
 
 use Doctrine\DBAL\ArrayParameterType;
-use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\CRUpgradeContext;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventEnvelopeFactory;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\EventStoreBackupTrait;
 use Neos\ContentRepositoryRegistry\Upgrade\Shared\OutputMessageTrait;
-use Neos\EventStore\Model\Event\CorrelationId;
-use Neos\EventStore\Model\Event\SequenceNumber;
-use Neos\EventStore\Model\Event\StreamName;
 use Neos\EventStore\Model\EventEnvelope;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Upgrade to deduplicate parallel base workspace changes
@@ -53,19 +48,23 @@ class EventsDeduplicateBaseWorkspaceChangesUpgrade
     ) {
     }
 
+    public function isAvailable(): bool
+    {
+        $duplicateContentStreamRemovalWithStreams = $this->findDuplicateContentStreamRemovalWithStreams();
+
+        if ($duplicateContentStreamRemovalWithStreams === []) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function execute(bool $dryRun): void
     {
         //
         // 1.)
         //
-        $duplicateContentStreamRemovalWithStreams = $this->context->dbal->fetchAllAssociative(<<<SQL
-        SELECT stream, GROUP_CONCAT(sequencenumber ORDER BY sequencenumber) sequenceNumbers, GROUP_CONCAT(correlationid ORDER BY sequencenumber) correlationIds, COUNT(*) removals
-        FROM {$this->context->eventStoreTableName}
-          WHERE type = 'ContentStreamWasRemoved'
-        GROUP BY stream
-        HAVING removals > 1
-        ORDER BY MIN(sequencenumber);
-        SQL);
+        $duplicateContentStreamRemovalWithStreams = $this->findDuplicateContentStreamRemovalWithStreams();
 
         if ($duplicateContentStreamRemovalWithStreams === []) {
             $this->log('Migration was not necessary. No duplicate content stream removals.');
@@ -74,34 +73,23 @@ class EventsDeduplicateBaseWorkspaceChangesUpgrade
 
         $this->log(sprintf('%d content streams were removed more than once:', count($duplicateContentStreamRemovalWithStreams)));
         $this->log('');
-        $this->log(Yaml::dump($duplicateContentStreamRemovalWithStreams, 2));
+        $this->log(join("\n", array_map(fn (IllegalContentStreamRemovalsByStream $i) => $i->toDebugString(), $duplicateContentStreamRemovalWithStreams)));
         $this->log('');
 
         $sequenceNumbersToRemove = [];
 
         foreach ($duplicateContentStreamRemovalWithStreams as $duplicateContentStreamRemovals) {
-            $stream = StreamName::fromString($duplicateContentStreamRemovals['stream']);
+            $stream = $duplicateContentStreamRemovals->stream;
 
-            if (!ContentStreamEventStreamName::isContentStreamStreamName($stream)) {
-                $this->log(sprintf('Error found illegal content stream removal event on non content stream %s', $stream->value));
-            }
-
-            // We dont write "," into correlation ids
-            /** @var list<CorrelationId> $correlationIds */
-            $correlationIds = array_map(CorrelationId::fromString(...), explode(',', $duplicateContentStreamRemovals['correlationIds']));
             //
             // 2.)
             //
-            foreach ($correlationIds as $correlationId) {
+            foreach ($duplicateContentStreamRemovals->correlationIds as $correlationId) {
                 if (!str_starts_with($correlationId->value, 'ChangeBaseWorkspace_')) {
-                    $this->log(sprintf('Error resolve duplicate content stream removal of %s as it was not caused due to a ChangeBaseWorkspace', $duplicateContentStreamRemovals['stream']));
+                    $this->log(sprintf('Error resolve duplicate content stream removal of %s as it was not caused due to a ChangeBaseWorkspace', $stream->value));
                     return;
                 }
             }
-
-            $sequenceNumbers = array_map(intval(...), explode(',', $duplicateContentStreamRemovals['sequenceNumbers']));
-            $lowestSequenceNumber = SequenceNumber::fromInteger(min($sequenceNumbers));
-            $highestSequenceNumber = SequenceNumber::fromInteger(max($sequenceNumbers));
 
             //
             // 3.)
@@ -115,9 +103,9 @@ class EventsDeduplicateBaseWorkspaceChangesUpgrade
                 OR (sequenceNumber >= :lowestSequenceNumber AND sequenceNumber <= :highestSequenceNumber)
             ORDER BY sequencenumber;
             SQL, [
-                'lowestSequenceNumber' => $lowestSequenceNumber->value,
-                'highestSequenceNumber' => $highestSequenceNumber->value,
-                'correlationIds' => array_column($correlationIds, 'value'),
+                'lowestSequenceNumber' => $duplicateContentStreamRemovals->lowestSequenceNumber->value,
+                'highestSequenceNumber' => $duplicateContentStreamRemovals->highestSequenceNumber->value,
+                'correlationIds' => array_column($duplicateContentStreamRemovals->correlationIds, 'value'),
             ], [
                 'correlationIds' => ArrayParameterType::STRING,
             ]));
@@ -129,7 +117,7 @@ class EventsDeduplicateBaseWorkspaceChangesUpgrade
             $changeBaseWorkspaceSequenceNumbersByCorrelationMap = [];
 
             $newForkedContentStreamMap = [];
-            $baseWorkspaceChangeCorrelationIdMap = array_fill_keys(array_column($correlationIds, 'value'), true);
+            $baseWorkspaceChangeCorrelationIdMap = array_fill_keys(array_column($duplicateContentStreamRemovals->correlationIds, 'value'), true);
             $winningChangeBaseWorkspaceCorrelationId = null;
 
             foreach ($conflictingEvents as $conflictingEvent) {
@@ -226,5 +214,22 @@ class EventsDeduplicateBaseWorkspaceChangesUpgrade
         $this->log('');
         $this->log(sprintf('Migration applied to %s events. Please replay the content graph via `./flow crupgrade:resetupandreplaycontentgraph`', $affectedRows));
         $this->log('Done.');
+    }
+
+    /**
+     * @return list<IllegalContentStreamRemovalsByStream>
+     */
+    private function findDuplicateContentStreamRemovalWithStreams(): array
+    {
+        $duplicateContentStreamRemovalWithStreams = $this->context->dbal->fetchAllAssociative(<<<SQL
+        SELECT stream, GROUP_CONCAT(sequencenumber ORDER BY sequencenumber) sequenceNumbers, GROUP_CONCAT(correlationid ORDER BY sequencenumber) correlationIds, COUNT(*) removals
+        FROM {$this->context->eventStoreTableName}
+          WHERE type = 'ContentStreamWasRemoved'
+        GROUP BY stream
+        HAVING removals > 1
+        ORDER BY MIN(sequencenumber);
+        SQL);
+
+        return array_map(IllegalContentStreamRemovalsByStream::fromRow(...), $duplicateContentStreamRemovalWithStreams);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsDeduplicateBaseWorkspaceChanges/IllegalContentStreamRemovalsByStream.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsDeduplicateBaseWorkspaceChanges/IllegalContentStreamRemovalsByStream.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsDeduplicateBaseWorkspaceChanges;
+
+use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
+use Neos\EventStore\Model\Event\CorrelationId;
+use Neos\EventStore\Model\Event\SequenceNumber;
+use Neos\EventStore\Model\Event\StreamName;
+
+final readonly class IllegalContentStreamRemovalsByStream
+{
+    /**
+     * @param list<SequenceNumber> $sequenceNumbers
+     * @param list<CorrelationId> $correlationIds
+     */
+    public function __construct(
+        public StreamName $stream,
+        public array $sequenceNumbers,
+        public SequenceNumber $lowestSequenceNumber,
+        public SequenceNumber $highestSequenceNumber,
+        public array $correlationIds,
+        public int $removals
+    ) {
+        if (!ContentStreamEventStreamName::isContentStreamStreamName($this->stream)) {
+            throw new \InvalidArgumentException(sprintf('Error found illegal content stream removal event on non content stream %s', $this->stream->value));
+        }
+    }
+
+    /** @param array<string,string> $row */
+    public static function fromRow(array $row): self
+    {
+        // We dont write "," into correlation ids
+        /** @var list<CorrelationId> $correlationIds */
+        $correlationIds = array_map(CorrelationId::fromString(...), explode(',', $row['correlationIds']));
+
+        $sequenceNumbers = array_map(intval(...), explode(',', $row['sequenceNumbers']));
+        $lowestSequenceNumber = SequenceNumber::fromInteger(min($sequenceNumbers));
+        $highestSequenceNumber = SequenceNumber::fromInteger(max($sequenceNumbers));
+
+        return new self(
+            stream: StreamName::fromString($row['stream']),
+            sequenceNumbers: array_map(SequenceNumber::fromInteger(...), $sequenceNumbers),
+            lowestSequenceNumber: $lowestSequenceNumber,
+            highestSequenceNumber: $highestSequenceNumber,
+            correlationIds: $correlationIds,
+            removals: (int)$row['removals'],
+        );
+    }
+
+    public function toDebugString(): string
+    {
+        return join("\n    ", [
+            '-',
+            sprintf('stream: %s', $this->stream->value),
+            sprintf('sequenceNumbers: %s', join(', ', array_column($this->sequenceNumbers, 'value'))),
+            sprintf('correlationIds: %s', join(', ', array_column($this->correlationIds, 'value'))),
+            sprintf('removals: %d', $this->removals)
+        ]);
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.php
@@ -38,35 +38,36 @@ final readonly class EventsRecordedAtToUtcUpgrade
     ) {
     }
 
+    public function isAvailable(): bool
+    {
+        $offsetStartsWithSequenceNumber = $this->findOffsetStartsWithSequenceNumber();
+
+        if ($offsetStartsWithSequenceNumber === []) {
+            return false;
+        }
+
+        if (TimezoneOffsetSequenceStarts::isOnlyUtc($offsetStartsWithSequenceNumber)) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function execute(bool $force, bool $dryRun): void
     {
-        $offsetStartsWithSequenceNumber = $this->context->dbal->fetchAllAssociative(<<<SQL
-        SELECT sequenceNumber, tzoffset
-        FROM (
-          SELECT
-            sequenceNumber,
-            SUBSTR(JSON_UNQUOTE(JSON_EXTRACT(e.metadata, '$.initiatingTimestamp')), 20) as tzoffset,
-            LAG(SUBSTR(JSON_UNQUOTE(JSON_EXTRACT(e.metadata, '$.initiatingTimestamp')), 20)) OVER (ORDER BY sequenceNumber) AS prevTzoffset
-          FROM {$this->context->eventStoreTableName} as e
-          WHERE JSON_EXTRACT(e.metadata, '$.initiatingTimestamp') IS NOT NULL
-        ) t
-        WHERE tzoffset != prevTzoffset
-           -- select first row where there is no previous
-           OR prevTzoffset IS NULL
-        ORDER BY sequenceNumber;
-        SQL);
+        $offsetStartsWithSequenceNumber = $this->findOffsetStartsWithSequenceNumber();
 
         if ($offsetStartsWithSequenceNumber === []) {
             $this->log('Migration was not necessary. No events.');
             return;
         }
 
-        if (count($offsetStartsWithSequenceNumber) === 1 && $offsetStartsWithSequenceNumber[0]['tzoffset'] === '+00:00') {
+        if (TimezoneOffsetSequenceStarts::isOnlyUtc($offsetStartsWithSequenceNumber)) {
             $this->log('Migration was not necessary. All dates are UTC. Nothing was changed.');
             return;
         }
 
-        $uniqueOffsets = array_unique(array_column($offsetStartsWithSequenceNumber, 'tzoffset'));
+        $uniqueOffsets = TimezoneOffsetSequenceStarts::uniqueOffsets($offsetStartsWithSequenceNumber);
 
         $this->log(sprintf('Migration necessary. Found following non UTC offsets [%s]', join(', ', array_filter($uniqueOffsets, fn ($value) => $value !== '+00:00'))));
         $this->log(sprintf('    Debug: %s', json_encode($offsetStartsWithSequenceNumber)));
@@ -90,7 +91,7 @@ final readonly class EventsRecordedAtToUtcUpgrade
 
         $affectedRows = 0;
         foreach ($offsetStartsWithSequenceNumber as $index => $offsetStart) {
-            if ($offsetStart['tzoffset'] === '+00:00') {
+            if ($offsetStart->tzOffset === '+00:00') {
                 // nothing to do ;)
                 continue;
             }
@@ -104,9 +105,9 @@ final readonly class EventsRecordedAtToUtcUpgrade
             WHERE sequencenumber >= :start AND (:end IS NULL || sequencenumber < :end);
             SQL,
                 [
-                    'fromOffset' => $offsetStart['tzoffset'],
-                    'start' => $offsetStart['sequenceNumber'],
-                    'end' => $offsetEnd['sequenceNumber'] ?? null,
+                    'fromOffset' => $offsetStart->tzOffset,
+                    'start' => $offsetStart->sequenceNumber->value,
+                    'end' => $offsetEnd?->sequenceNumber->value,
                 ]
             );
 
@@ -159,5 +160,29 @@ final readonly class EventsRecordedAtToUtcUpgrade
         }
 
         return true;
+    }
+
+    /**
+     * @return list<TimezoneOffsetSequenceStarts>
+     */
+    private function findOffsetStartsWithSequenceNumber(): array
+    {
+        $offsetStartsWithSequenceNumber = $this->context->dbal->fetchAllAssociative(<<<SQL
+        SELECT sequenceNumber, tzoffset
+        FROM (
+          SELECT
+            sequenceNumber,
+            SUBSTR(JSON_UNQUOTE(JSON_EXTRACT(e.metadata, '$.initiatingTimestamp')), 20) as tzoffset,
+            LAG(SUBSTR(JSON_UNQUOTE(JSON_EXTRACT(e.metadata, '$.initiatingTimestamp')), 20)) OVER (ORDER BY sequenceNumber) AS prevTzoffset
+          FROM {$this->context->eventStoreTableName} as e
+          WHERE JSON_EXTRACT(e.metadata, '$.initiatingTimestamp') IS NOT NULL
+        ) t
+        WHERE tzoffset != prevTzoffset
+           -- select first row where there is no previous
+           OR prevTzoffset IS NULL
+        ORDER BY sequenceNumber;
+        SQL);
+
+        return array_map(TimezoneOffsetSequenceStarts::fromArray(...), $offsetStartsWithSequenceNumber);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.php
@@ -38,6 +38,11 @@ final readonly class EventsRecordedAtToUtcUpgrade
     ) {
     }
 
+    public static function getShortDescription(): string
+    {
+        return 'Adjust event time stamps and node dates to UTC';
+    }
+
     public function isAvailable(): bool
     {
         $offsetStartsWithSequenceNumber = $this->findOffsetStartsWithSequenceNumber();

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.php
@@ -38,7 +38,7 @@ final readonly class EventsRecordedAtToUtcUpgrade
     ) {
     }
 
-    public function execute(bool $force): void
+    public function execute(bool $force, bool $dryRun): void
     {
         $offsetStartsWithSequenceNumber = $this->context->dbal->fetchAllAssociative(<<<SQL
         SELECT sequenceNumber, tzoffset
@@ -76,6 +76,11 @@ final readonly class EventsRecordedAtToUtcUpgrade
                 $this->log('Nothing was migrated. If you know what you are doing try again by using a bit more force.');
                 return;
             }
+        }
+
+        if ($dryRun) {
+            $this->log('Didnt migrate anything because its a dry run.');
+            return;
         }
 
         // Actual migration

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/TimezoneOffsetSequenceStarts.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/EventsRecordedAtToUtc/TimezoneOffsetSequenceStarts.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentRepositoryRegistry\Upgrade\EventsRecordedAtToUtc;
+
+use Neos\EventStore\Model\Event\SequenceNumber;
+
+final readonly class TimezoneOffsetSequenceStarts implements \JsonSerializable
+{
+    public function __construct(
+        public SequenceNumber $sequenceNumber,
+        public string $tzOffset,
+    ) {
+    }
+
+    /** @param array<int|string,mixed> $array */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            sequenceNumber: SequenceNumber::fromInteger((int)$array['sequenceNumber']),
+            tzOffset: $array['tzoffset'],
+        );
+    }
+
+    /**
+     * @param non-empty-list<self> $sequences
+     */
+    public static function isOnlyUtc(array $sequences): bool
+    {
+        return count($sequences) === 1 && $sequences[0]->tzOffset === '+00:00';
+    }
+
+    /**
+     * @param non-empty-list<self> $sequences
+     * @return list<string>
+     */
+    public static function uniqueOffsets(array $sequences): array
+    {
+        return array_unique(array_column($sequences, 'tzOffset'));
+    }
+
+    /** @return array<int|string,mixed> */
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'sequenceNumber' => $this->sequenceNumber->value,
+            'tzoffset' => $this->tzOffset,
+        ];
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
@@ -51,7 +51,8 @@ trait CrUpgradeTrait
         );
 
         $upgrade->execute(
-            force: $force
+            force: $force,
+            dryRun: false
         );
     }
 

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Bootstrap/CrUpgradeTrait.php
@@ -40,6 +40,24 @@ trait CrUpgradeTrait
     }
 
     /**
+     * @When I attempt to upgrade events recordedAt to utc which I expect not to be available
+     */
+    public function iExecuteEventsRecordedAtToUtcUpgradeNotAvailable(): void
+    {
+        $upgrade = new EventsRecordedAtToUtcUpgrade(
+            $this->getCrUpgradeContext(),
+            $this->outputFn(...)
+        );
+
+        Assert::assertFalse($upgrade->isAvailable(), 'Upgrade is available but was not expected to.');
+
+        $upgrade->execute(
+            force: false,
+            dryRun: false
+        );
+    }
+
+    /**
      * @When I upgrade events recordedAt to utc
      * @When /^I upgrade events recordedAt to utc (with force)$/
      */
@@ -50,8 +68,27 @@ trait CrUpgradeTrait
             $this->outputFn(...)
         );
 
+        Assert::assertTrue($upgrade->isAvailable(), 'Upgrade is not available but was expected to.');
+
         $upgrade->execute(
             force: $force,
+            dryRun: false
+        );
+    }
+
+    /**
+     * @When I attempt to upgrade the events to deduplicate base-workspace-changes which I expect not to be available
+     */
+    public function iExecuteEventsDeduplicateBaseWorkspaceChangesUpgradeNotAvailable(): void
+    {
+        $upgrade = new EventsDeduplicateBaseWorkspaceChangesUpgrade(
+            $this->getCrUpgradeContext(),
+            $this->outputFn(...)
+        );
+
+        Assert::assertFalse($upgrade->isAvailable(), 'Upgrade is available but was not expected to.');
+
+        $upgrade->execute(
             dryRun: false
         );
     }
@@ -65,6 +102,8 @@ trait CrUpgradeTrait
             $this->getCrUpgradeContext(),
             $this->outputFn(...)
         );
+
+        Assert::assertTrue($upgrade->isAvailable(), 'Upgrade is not available but was expected to.');
 
         $upgrade->execute(
             dryRun: false

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.feature
@@ -48,7 +48,7 @@ Feature: As a user of the CR I want to upgrade my events
       | baseWorkspaceName  | "review"         |
       | newContentStreamId | "cs-user-second" |
 
-    When I upgrade the events to deduplicate base-workspace-changes
+    When I attempt to upgrade the events to deduplicate base-workspace-changes which I expect not to be available
     Then I expect the following upgrade output:
       """
       Migration was not necessary. No duplicate content stream removals.

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsDeduplicateBaseWorkspaceChanges/EventsDeduplicateBaseWorkspaceChangesUpgrade.feature
@@ -117,11 +117,10 @@ Feature: As a user of the CR I want to upgrade my events
       1 content streams were removed more than once:
 
       -
-          stream: 'ContentStream:cs-user-first'
-          sequenceNumbers: '11,14'
-          correlationIds: 'ChangeBaseWorkspace_f9819ad4fd7ff5defd,ChangeBaseWorkspace_2871e0770793478646'
+          stream: ContentStream:cs-user-first
+          sequenceNumbers: 11, 14
+          correlationIds: ChangeBaseWorkspace_f9819ad4fd7ff5defd, ChangeBaseWorkspace_2871e0770793478646
           removals: 2
-
 
       Found 3 events to be removed
           Debug: 9,10,11
@@ -218,11 +217,10 @@ Feature: As a user of the CR I want to upgrade my events
       1 content streams were removed more than once:
 
       -
-          stream: 'ContentStream:cs-user-first'
-          sequenceNumbers: '102,105,108'
-          correlationIds: 'ChangeBaseWorkspace_f9819ad4fd7ff5defd,ChangeBaseWorkspace_2871e0770793478646,ChangeBaseWorkspace_a0e998384894634a74'
+          stream: ContentStream:cs-user-first
+          sequenceNumbers: 102, 105, 108
+          correlationIds: ChangeBaseWorkspace_f9819ad4fd7ff5defd, ChangeBaseWorkspace_2871e0770793478646, ChangeBaseWorkspace_a0e998384894634a74
           removals: 3
-
 
       Found 6 events to be removed
           Debug: 100,101,102,103,104,105
@@ -309,11 +307,10 @@ Feature: As a user of the CR I want to upgrade my events
       1 content streams were removed more than once:
 
       -
-          stream: 'ContentStream:cs-user-first'
-          sequenceNumbers: '11,15'
-          correlationIds: 'ChangeBaseWorkspace_f9819ad4fd7ff5defd,ChangeBaseWorkspace_2871e0770793478646'
+          stream: ContentStream:cs-user-first
+          sequenceNumbers: 11, 15
+          correlationIds: ChangeBaseWorkspace_f9819ad4fd7ff5defd, ChangeBaseWorkspace_2871e0770793478646
           removals: 2
-
 
       Stream ContentStream:cs-user-first: Concurrent change during change base workspace sequence affected stream ContentStream:cs-user-first at 12
           Debug: {"event":{"id":{"value":"2c8b9d29-c3fd-44e0-b275-15d336dc38ab"},"type":{"value":"RootNodeAggregateWithNodeWasCreated"},"data":{"value":"{\"workspaceName\":\"user\",\"contentStreamId\":\"cs-user-first\",\"nodeAggregateId\":\"illegal-node\",\"nodeTypeName\":\"Neos.Neos:Sites\",\"coveredDimensionSpacePoints\":[{\"language\":\"en\"},{\"language\":\"de\"}],\"nodeAggregateClassification\":\"root\"}"},"metadata":{"value":[]},"causationId":null,"correlationId":{"value":"CreateNodeAggregateW_e00b8ac2a08c7fbb9b"}},"streamName":{"value":"ContentStream:cs-user-first"},"version":{"value":2},"sequenceNumber":{"value":12},"recordedAt":{"date":"2025-06-11 20:36:33.000000","timezone_type":3,"timezone":"UTC"}}
@@ -366,11 +363,10 @@ Feature: As a user of the CR I want to upgrade my events
       1 content streams were removed more than once:
 
       -
-          stream: 'ContentStream:cs-user-first'
-          sequenceNumbers: '11,15'
-          correlationIds: 'ChangeBaseWorkspace_f9819ad4fd7ff5defd,ChangeBaseWorkspace_2871e0770793478646'
+          stream: ContentStream:cs-user-first
+          sequenceNumbers: 11, 15
+          correlationIds: ChangeBaseWorkspace_f9819ad4fd7ff5defd, ChangeBaseWorkspace_2871e0770793478646
           removals: 2
-
 
       Stream ContentStream:cs-user-first: Concurrent change during change base workspace sequence affected stream ContentStream:cs-user-second at 12
           Debug: {"event":{"id":{"value":"2c8b9d29-c3fd-44e0-b275-15d336dc38ab"},"type":{"value":"RootNodeAggregateWithNodeWasCreated"},"data":{"value":"{\"workspaceName\":\"user\",\"contentStreamId\":\"cs-user-second\",\"nodeAggregateId\":\"illegal-node\",\"nodeTypeName\":\"Neos.Neos:Sites\",\"coveredDimensionSpacePoints\":[{\"language\":\"en\"},{\"language\":\"de\"}],\"nodeAggregateClassification\":\"root\"}"},"metadata":{"value":[]},"causationId":null,"correlationId":{"value":"CreateNodeAggregateW_e00b8ac2a08c7fbb9b"}},"streamName":{"value":"ContentStream:cs-user-second"},"version":{"value":1},"sequenceNumber":{"value":12},"recordedAt":{"date":"2025-06-11 20:36:33.000000","timezone_type":3,"timezone":"UTC"}}
@@ -423,11 +419,10 @@ Feature: As a user of the CR I want to upgrade my events
       1 content streams were removed more than once:
 
       -
-          stream: 'ContentStream:cs-user-first'
-          sequenceNumbers: '11,15'
-          correlationIds: 'ChangeBaseWorkspace_f9819ad4fd7ff5defd,ChangeBaseWorkspace_2871e0770793478646'
+          stream: ContentStream:cs-user-first
+          sequenceNumbers: 11, 15
+          correlationIds: ChangeBaseWorkspace_f9819ad4fd7ff5defd, ChangeBaseWorkspace_2871e0770793478646
           removals: 2
-
 
       Found 3 events to be removed
           Debug: 9,10,11
@@ -513,11 +508,10 @@ Feature: As a user of the CR I want to upgrade my events
       1 content streams were removed more than once:
 
       -
-          stream: 'ContentStream:cs-user-first'
-          sequenceNumbers: '12,14'
-          correlationIds: 'ChangeBaseWorkspace_f9819ad4fd7ff5defd,ChangeBaseWorkspace_2871e0770793478646'
+          stream: ContentStream:cs-user-first
+          sequenceNumbers: 12, 14
+          correlationIds: ChangeBaseWorkspace_f9819ad4fd7ff5defd, ChangeBaseWorkspace_2871e0770793478646
           removals: 2
-
 
       Found 3 events to be removed
           Debug: 9,11,12

--- a/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.feature
+++ b/Neos.ContentRepositoryRegistry/Tests/Behavior/Features/Upgrade/EventsRecordedAtToUtc/EventsRecordedAtToUtcUpgrade.feature
@@ -46,7 +46,7 @@ Feature: As a user of the CR I want to upgrade my events
       | recordedAt                   | "2024-09-22T12:00:00+00:00" |
       | metadata.initiatingTimestamp | "2024-09-22T12:00:00+00:00" |
 
-    And I upgrade events recordedAt to utc
+    And I attempt to upgrade events recordedAt to utc which I expect not to be available
     Then I expect the following upgrade output:
       """
       Migration was not necessary. All dates are UTC. Nothing was changed.


### PR DESCRIPTION
With yet another event migration for the Neos 9.2 upgrade (https://github.com/neos/neos-development-collection/pull/5927) it will be hard to explain when to use what and where.

Thus i propose a little feature to allow to check the event migration status based on the projects events.

### Example

```
./flow crupgrade:eventsstatus

Optional migrations:
 - Adjust event time stamps and node dates to UTC
   Run ./flow crupgrade:eventsrecordedattoutc

Required migrations (in order):
 - Deduplicate parallel base workspace changes
   Run ./flow crupgrade:eventsdeduplicatebaseworkspacechanges

Note use --dry-run with the upgrades for further details
Found 1 required and 1 optional event upgrades available
```