### PR TITLE
FEATURE: CLI to manage subtree tags

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/ContentCommandControllerTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/ContentCommandControllerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional;
+
+use Neos\ContentRepository\BehavioralTests\Tests\Functional\Extensibility\AbstractExtensibilityTestCase;
+use Neos\ContentRepository\Core\CommandHandler\Commands;
+use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
+use Neos\ContentRepository\Core\Feature\NodeCreation\Command\CreateNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\RootNodeCreation\Command\CreateRootNodeAggregateWithNode;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
+use Neos\ContentRepository\Core\Feature\WorkspaceCreation\Command\CreateRootWorkspace;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepositoryRegistry\Command\ContentCommandController;
+use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Cli\Response;
+use Neos\Utility\ObjectAccess;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+// FIXME, like ContentRepositoryMaintenanceCommandControllerTest this test should reside in Neos.ContentRepositoryRegistry,
+// but requires the test case infrastructure of this package which is a dev dependency
+final class ContentCommandControllerTest extends AbstractExtensibilityTestCase
+{
+    private ContentCommandController $contentController;
+
+    private Response $response;
+
+    private BufferedOutput $bufferedOutput;
+
+    /** @before */
+    public function injectController(): void
+    {
+        $this->contentController = $this->getObject(ContentCommandController::class);
+
+        $this->response = new Response();
+        $this->bufferedOutput = new BufferedOutput();
+
+        ObjectAccess::setProperty($this->contentController, 'response', $this->response, true);
+        ObjectAccess::getProperty($this->contentController, 'output', true)->setOutput($this->bufferedOutput);
+    }
+
+    private function setUpContentStructure(): void
+    {
+        $this->fakeCommandHook->method('onBeforeHandle')->willReturnArgument(0);
+        $this->fakeCommandHook->method('onAfterHandle')->willReturn(Commands::createEmpty());
+
+        $this->contentRepository->handle(CreateRootWorkspace::create(WorkspaceName::forLive(), ContentStreamId::fromString('cs-live')));
+        $this->contentRepository->handle(CreateRootNodeAggregateWithNode::create(WorkspaceName::forLive(), NodeAggregateId::fromString('root'), NodeTypeName::fromString(NodeTypeName::ROOT_NODE_TYPE_NAME)));
+        $this->contentRepository->handle(CreateNodeAggregateWithNode::create(WorkspaceName::forLive(), NodeAggregateId::fromString('document-a'), NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'), OriginDimensionSpacePoint::createWithoutDimensions(), NodeAggregateId::fromString('root')));
+        $this->contentRepository->handle(CreateNodeAggregateWithNode::create(WorkspaceName::forLive(), NodeAggregateId::fromString('document-a-child'), NodeTypeName::fromString('Neos.ContentRepository.Testing:Document'), OriginDimensionSpacePoint::createWithoutDimensions(), NodeAggregateId::fromString('document-a')));
+    }
+
+    private function findNodeById(string $nodeAggregateId): ?Node
+    {
+        return $this->contentRepository->getContentGraph(WorkspaceName::forLive())
+            ->getSubgraph(DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty())
+            ->findNodeById(NodeAggregateId::fromString($nodeAggregateId));
+    }
+
+    /** @test */
+    public function tagSubtreeTagsTheNodeAndItsDescendants(): void
+    {
+        $this->setUpContentStructure();
+
+        $this->contentController->tagSubtreeCommand('document-a', 'restricted-area', static::$contentRepositoryId->value);
+
+        self::assertStringContainsString('Tagged node aggregate "document-a" with "restricted-area"', $this->bufferedOutput->fetch());
+
+        $taggedNode = $this->findNodeById('document-a');
+        self::assertNotNull($taggedNode);
+        self::assertTrue($taggedNode->tags->withoutInherited()->contain(SubtreeTag::fromString('restricted-area')));
+
+        $childNode = $this->findNodeById('document-a-child');
+        self::assertNotNull($childNode);
+        self::assertTrue($childNode->tags->contain(SubtreeTag::fromString('restricted-area')));
+        self::assertFalse($childNode->tags->withoutInherited()->contain(SubtreeTag::fromString('restricted-area')));
+    }
+
+    /** @test */
+    public function untagSubtreeRemovesAnExplicitTag(): void
+    {
+        $this->setUpContentStructure();
+
+        $this->contentController->tagSubtreeCommand('document-a', 'restricted-area', static::$contentRepositoryId->value);
+        $this->contentController->untagSubtreeCommand('document-a', 'restricted-area', static::$contentRepositoryId->value);
+
+        self::assertStringContainsString('Removed tag "restricted-area" from node aggregate "document-a"', $this->bufferedOutput->fetch());
+
+        $untaggedNode = $this->findNodeById('document-a');
+        self::assertNotNull($untaggedNode);
+        self::assertFalse($untaggedNode->tags->contain(SubtreeTag::fromString('restricted-area')));
+
+        $childNode = $this->findNodeById('document-a-child');
+        self::assertNotNull($childNode);
+        self::assertFalse($childNode->tags->contain(SubtreeTag::fromString('restricted-area')));
+    }
+
+    /** @test */
+    public function tagSubtreeWithInvalidTagFails(): void
+    {
+        $this->setUpContentStructure();
+
+        try {
+            $this->contentController->tagSubtreeCommand('document-a', 'Not A Valid Tag!', static::$contentRepositoryId->value);
+            self::fail('Expected the command to stop');
+        } catch (StopCommandException) {
+        }
+
+        self::assertSame(1, $this->response->getExitCode());
+        self::assertStringContainsString('does not adhere', $this->bufferedOutput->fetch());
+    }
+
+    /** @test */
+    public function tagSubtreeWithUnknownNodeAggregateFails(): void
+    {
+        $this->setUpContentStructure();
+
+        try {
+            $this->contentController->tagSubtreeCommand('i-do-not-exist', 'restricted-area', static::$contentRepositoryId->value);
+            self::fail('Expected the command to stop');
+        } catch (StopCommandException) {
+        }
+
+        self::assertSame(1, $this->response->getExitCode());
+        self::assertStringContainsString('Node aggregate "i-do-not-exist" does not exist in workspace "live"', $this->bufferedOutput->fetch());
+    }
+
+    /** @test */
+    public function untagSubtreeWithoutExplicitTagFails(): void
+    {
+        $this->setUpContentStructure();
+
+        try {
+            $this->contentController->untagSubtreeCommand('document-a', 'restricted-area', static::$contentRepositoryId->value);
+            self::fail('Expected the command to stop');
+        } catch (StopCommandException) {
+        }
+
+        self::assertSame(1, $this->response->getExitCode());
+        self::assertStringContainsString('is not explicitly tagged', $this->bufferedOutput->fetch());
+    }
+}

--- a/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/ContentCommandController.php
@@ -19,6 +19,11 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Command\CreateNodeVariant;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Exception\DimensionSpacePointIsAlreadyOccupied;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\TagSubtree;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\UntagSubtree;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Dto\SubtreeTag;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Exception\SubtreeIsAlreadyTagged;
+use Neos\ContentRepository\Core\Feature\SubtreeTagging\Exception\SubtreeIsNotTagged;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentSubgraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindRootNodeAggregatesFilter;
@@ -26,6 +31,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeVariantSelectionStrategy;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Cli\CommandController;
@@ -90,6 +96,97 @@ final class ContentCommandController extends CommandController
         }
 
         $this->outputLine('<success>Done!</success>');
+    }
+
+
+    /**
+     * Adds a subtree tag to the given node aggregate, covering all dimension space point variants.
+     *
+     * Subtree tags are inherited by all descendants of the tagged node. They are the basis for
+     * the subtree-tag-based privileges (see {@see \Neos\Neos\Security\Authorization\Privilege\EditNodePrivilege}
+     * and ReadNodePrivilege), whose Policy.yaml matchers refer to tags applied with this command:
+     * ```
+     * ./flow content:tagsubtree 979d1c11-6d1a-4f31-8dfc-31dd45f45b34 my-restricted-area
+     * ```
+     *
+     * @param string $nodeAggregateId The identifier of the node aggregate to tag
+     * @param string $tag The subtree tag to add (lowercase letters, digits, "_", "." and "-", at most 36 characters)
+     * @param string $contentRepository The content repository identifier. (Default: 'default')
+     * @param string $workspace The workspace name. (Default: 'live')
+     */
+    public function tagSubtreeCommand(string $nodeAggregateId, string $tag, string $contentRepository = 'default', string $workspace = WorkspaceName::WORKSPACE_NAME_LIVE): void
+    {
+        ['contentRepository' => $contentRepositoryInstance, 'workspaceName' => $workspaceName, 'nodeAggregate' => $nodeAggregate, 'subtreeTag' => $subtreeTag] = $this->prepareSubtreeTagOperation($nodeAggregateId, $tag, $contentRepository, $workspace);
+
+        try {
+            $contentRepositoryInstance->handle(TagSubtree::create(
+                $workspaceName,
+                $nodeAggregate->nodeAggregateId,
+                array_values($nodeAggregate->coveredDimensionSpacePoints->points)[0],
+                NodeVariantSelectionStrategy::STRATEGY_ALL_VARIANTS,
+                $subtreeTag
+            ));
+        } catch (SubtreeIsAlreadyTagged $exception) {
+            $this->outputLine('<error>%s</error>', [$exception->getMessage()]);
+            $this->quit(1);
+        }
+        $this->outputLine('<success>Tagged node aggregate "%s" with "%s" in workspace "%s" (all variants)</success>', [$nodeAggregate->nodeAggregateId->value, $subtreeTag->value, $workspaceName->value]);
+    }
+
+    /**
+     * Removes a subtree tag from the given node aggregate, covering all dimension space point variants.
+     *
+     * Only explicitly set tags can be removed; tags that a node inherits from an ancestor
+     * have to be removed on the node they were applied to.
+     *
+     * @param string $nodeAggregateId The identifier of the node aggregate to untag
+     * @param string $tag The subtree tag to remove
+     * @param string $contentRepository The content repository identifier. (Default: 'default')
+     * @param string $workspace The workspace name. (Default: 'live')
+     */
+    public function untagSubtreeCommand(string $nodeAggregateId, string $tag, string $contentRepository = 'default', string $workspace = WorkspaceName::WORKSPACE_NAME_LIVE): void
+    {
+        ['contentRepository' => $contentRepositoryInstance, 'workspaceName' => $workspaceName, 'nodeAggregate' => $nodeAggregate, 'subtreeTag' => $subtreeTag] = $this->prepareSubtreeTagOperation($nodeAggregateId, $tag, $contentRepository, $workspace);
+
+        try {
+            $contentRepositoryInstance->handle(UntagSubtree::create(
+                $workspaceName,
+                $nodeAggregate->nodeAggregateId,
+                array_values($nodeAggregate->coveredDimensionSpacePoints->points)[0],
+                NodeVariantSelectionStrategy::STRATEGY_ALL_VARIANTS,
+                $subtreeTag
+            ));
+        } catch (SubtreeIsNotTagged $exception) {
+            $this->outputLine('<error>%s</error>', [$exception->getMessage()]);
+            $this->quit(1);
+        }
+        $this->outputLine('<success>Removed tag "%s" from node aggregate "%s" in workspace "%s" (all variants)</success>', [$subtreeTag->value, $nodeAggregate->nodeAggregateId->value, $workspaceName->value]);
+    }
+
+    /**
+     * @return array{contentRepository: ContentRepository, workspaceName: WorkspaceName, nodeAggregate: \Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate, subtreeTag: SubtreeTag}
+     */
+    private function prepareSubtreeTagOperation(string $nodeAggregateId, string $tag, string $contentRepository, string $workspace): array
+    {
+        try {
+            $subtreeTag = SubtreeTag::fromString($tag);
+        } catch (\InvalidArgumentException $exception) {
+            $this->outputLine('<error>%s</error>', [$exception->getMessage()]);
+            $this->quit(1);
+        }
+        $contentRepositoryInstance = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString($contentRepository));
+        $workspaceName = WorkspaceName::fromString($workspace);
+        try {
+            $nodeAggregate = $contentRepositoryInstance->getContentGraph($workspaceName)->findNodeAggregateById(NodeAggregateId::fromString($nodeAggregateId));
+        } catch (WorkspaceDoesNotExist) {
+            $this->outputLine('<error>Workspace "%s" does not exist</error>', [$workspaceName->value]);
+            $this->quit(1);
+        }
+        if ($nodeAggregate === null) {
+            $this->outputLine('<error>Node aggregate "%s" does not exist in workspace "%s"</error>', [$nodeAggregateId, $workspaceName->value]);
+            $this->quit(1);
+        }
+        return ['contentRepository' => $contentRepositoryInstance, 'workspaceName' => $workspaceName, 'nodeAggregate' => $nodeAggregate, 'subtreeTag' => $subtreeTag];
     }
 
     private function createVariantRecursivelyInternal(int $level, NodeAggregateId $parentNodeAggregateId, ContentSubgraphInterface $sourceSubgraph, OriginDimensionSpacePoint $target, WorkspaceName $workspaceName, ContentRepository $contentRepository): void


### PR DESCRIPTION
Resolves: #5931
Related: neos/neos-ui#4150

Subtree tags are the basis of the Neos 9 tag based privileges (`EditNodePrivilege` / `ReadNodePrivilege`), but could previously only be applied via the PHP API — the docs state this explicitly, and the question keeps coming up in the community.

This adds the missing CLI, following the conventions of `content:createVariantsRecursively`:

```
./flow content:tagsubtree <nodeAggregateId> <tag> [--workspace] [--content-repository]
./flow content:untagsubtree <nodeAggregateId> <tag> [--workspace] [--content-repository]
```

- Tags are applied with `STRATEGY_ALL_VARIANTS` (one command covers all dimension variants)
- Invalid tag values, unknown node aggregates, unknown workspaces and already/not tagged subtrees exit non-zero with a readable message instead of a stack trace
- Functional tests included (5 tests / 17 assertions, passing locally against the MariaDB test setup): tagging incl. inheritance to descendants, untagging, and the three error paths
- `phpstan` and `php-cs-fixer` clean

Background: we use this in production for an 8.3 → 9.1 migration where editor roles are scoped to tagged subtrees.

**Upgrade instructions:** none (new commands only).