### PR TITLE
BUGFIX: Import assets that share a file with another asset

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Functional/AssetRepositoryImportProcessorTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Functional/AssetRepositoryImportProcessorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\BehavioralTests\Tests\Functional;
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use Neos\ContentRepository\Export\Processors\AssetRepositoryImportProcessor;
+use Neos\ContentRepository\Export\Severity;
+use Neos\ContentRepository\Export\ProcessingContext;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\Flow\ResourceManagement\ResourceRepository;
+use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Repository\AssetRepository;
+use PHPUnit\Framework\TestCase;
+
+// FIXME, like ContentRepositoryMaintenanceCommandControllerTest this test should reside in
+// Neos.ContentRepository.Export, but it requires a fully bootstrapped Flow (persistence,
+// resource management, neos/media) which is only available in this test distribution
+final class AssetRepositoryImportProcessorTest extends TestCase
+{
+    private AssetRepository $assetRepository;
+
+    private PersistenceManagerInterface $persistenceManager;
+
+    /** @var array<string> */
+    private array $importedAssetIds = [];
+
+    public function setUp(): void
+    {
+        $this->assetRepository = $this->getObject(AssetRepository::class);
+        $this->persistenceManager = $this->getObject(PersistenceManagerInterface::class);
+    }
+
+    public function tearDown(): void
+    {
+        foreach ($this->importedAssetIds as $assetId) {
+            $asset = $this->assetRepository->findByIdentifier($assetId);
+            if ($asset !== null) {
+                $this->assetRepository->remove($asset);
+            }
+        }
+        $this->persistenceManager->persistAll();
+    }
+
+    /** @test */
+    public function twoAssetsSharingTheSameResourceContentAreBothImported(): void
+    {
+        $fileContent = 'fake-jpeg-content-' . 'shared';
+        $sha1 = sha1($fileContent);
+
+        $files = new Filesystem(new InMemoryFilesystemAdapter());
+        $files->write('/Resources/' . $sha1, $fileContent);
+        foreach ([['duplicate-asset-1', 'first.jpg'], ['duplicate-asset-2', 'second.jpg']] as [$identifier, $filename]) {
+            $this->importedAssetIds[] = $identifier;
+            $files->write('/Assets/' . $identifier . '.json', json_encode([
+                'identifier' => $identifier,
+                'type' => 'IMAGE',
+                'title' => 'Duplicate content test',
+                'copyrightNotice' => '',
+                'caption' => '',
+                'assetSourceIdentifier' => 'neos',
+                'resource' => [
+                    'filename' => $filename,
+                    'collectionName' => 'persistent',
+                    'mediaType' => 'image/jpeg',
+                    'sha1' => $sha1,
+                ],
+            ], JSON_THROW_ON_ERROR));
+        }
+
+        $processor = new AssetRepositoryImportProcessor(
+            $this->assetRepository,
+            $this->getObject(ResourceRepository::class),
+            $this->getObject(ResourceManager::class),
+            $this->persistenceManager,
+        );
+
+        $errors = [];
+        $processor->run(new ProcessingContext($files, function (Severity $severity, string $message) use (&$errors) {
+            if ($severity === Severity::ERROR) {
+                $errors[] = $message;
+            }
+        }));
+
+        self::assertSame([], $errors);
+
+        $firstAsset = $this->assetRepository->findByIdentifier('duplicate-asset-1');
+        $secondAsset = $this->assetRepository->findByIdentifier('duplicate-asset-2');
+        self::assertInstanceOf(Asset::class, $firstAsset);
+        self::assertInstanceOf(Asset::class, $secondAsset);
+
+        // both assets reference their own resource instance (a resource can only belong to a single asset) …
+        self::assertNotSame(
+            $this->persistenceManager->getIdentifierByObject($firstAsset->getResource()),
+            $this->persistenceManager->getIdentifierByObject($secondAsset->getResource())
+        );
+        // … while sharing the same content
+        self::assertSame($sha1, $firstAsset->getResource()->getSha1());
+        self::assertSame($sha1, $secondAsset->getResource()->getSha1());
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    private function getObject(string $className): object
+    {
+        return Bootstrap::$staticObjectManager->get($className);
+    }
+}

--- a/Neos.ContentRepository.Export/src/Processors/AssetRepositoryImportProcessor.php
+++ b/Neos.ContentRepository.Export/src/Processors/AssetRepositoryImportProcessor.php
@@ -86,6 +86,12 @@ final class AssetRepositoryImportProcessor implements ProcessorInterface
         }
         /** @var PersistentResource|null $resource */
         $resource = $this->resourceRepository->findBySha1AndCollectionName($serializedAsset->resource->sha1, $serializedAsset->resource->collectionName)[0] ?? null;
+        if ($resource !== null && $this->assetRepository->findOneByResourceSha1($resource->getSha1()) !== null) {
+            // The existing resource is already referenced by another asset. A resource can
+            // only belong to a single asset, so a fresh resource has to be imported for this
+            // asset (this happens when two assets share the same file, i.e. the same sha1).
+            $resource = null;
+        }
         if ($resource === null) {
             $content = $context->files->read('/Resources/' . $serializedAsset->resource->sha1);
             $resource = $this->resourceManager->importResourceFromContent($content, $serializedAsset->resource->filename, $serializedAsset->resource->collectionName);


### PR DESCRIPTION
Resolves: #5933

When two assets reference the same file (identical sha1), `AssetRepositoryImportProcessor` reused the existing `PersistentResource` for the second asset. A resource can only belong to a single asset, so persisting the second asset failed with a unique constraint violation — and since the failed insert closes Doctrine's EntityManager, all subsequent asset and image variant imports failed as well.

**Fix:** the existing resource is only reused if it is not yet referenced by another asset (`AssetRepository::findOneByResourceSha1`); otherwise a fresh resource is imported for the new asset. This keeps the idempotency intent of the reuse (re-running a partially failed import) while fixing the duplicate-file case — the underlying file is deduplicated by the resource storage either way, matching the behavior of a regular upload.

**Test:** functional test included that reproduces the exact constraint violation without the fix and passes with it (verified locally against the MariaDB test setup, 6 assertions). `php-cs-fixer` clean.

Background: hit in production during an 8.3 → 9.1 migration (4 duplicate asset pairs aborted the import after 307 of 594 assets).

**Upgrade instructions:** none.