### PR TITLE
TASK: Refactor `SerializedPropertyValues::defaultFromNodeType()` and move to factory

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -122,13 +122,13 @@ Feature: Create a node aggregate with complex default values
       | parentNodeAggregateId | "lady-eleonode-rootford"              |
     Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
 
-    And I expect this node to have the following properties:
-      | Key           | Value                                           |
-      | now           | Date:2024-09-22T12:00:00+02:00                  |
-      | tomorrow      | Date:2024-09-23T00:00:00+02:00                  |
-      | lastMonth     | Date:2024-08-22T12:00:00+02:00                  |
+    And I expect this node to have the following serialized properties:
+      | Key       | Type              | Value                       |
+      | now       | DateTimeImmutable | "2024-09-22T12:00:00+02:00" |
+      | tomorrow  | DateTimeImmutable | "2024-09-23T00:00:00+02:00" |
+      | lastMonth | DateTimeImmutable | "2024-08-22T12:00:00+02:00" |
       # Even though we specified the timestamp as ATOM with timezone in the defaults, PHPs date->modify() keeps the original time zone.
-      | date          | Date:2020-08-20T18:56:15+02:00                  |
+      | date      | DateTimeImmutable | "2020-08-20T18:56:15+02:00" |
 
   Scenario: Create a node aggregate with complex initial and default values
     When the command CreateNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -37,6 +37,25 @@ Feature: Create a node aggregate with complex default values
           defaultValue:
             price: 13.37
             priceCurrency: 'EUR'
+
+    'Neos.ContentRepository.Testing:UnsetDefaultsNode':
+      properties:
+        array:
+          type: array
+          # usually unset in inheritance
+          defaultValue: null
+        dayOfWeek:
+          type: Neos\ContentRepository\Core\Tests\Behavior\Fixtures\DayOfWeek
+          defaultValue: null
+        date:
+          type: DateTimeImmutable
+          defaultValue: null
+        uri:
+          type: GuzzleHttp\Psr7\Uri
+          defaultValue: null
+        postalAddress:
+          type: Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress
+          defaultValue: null
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
@@ -101,6 +120,31 @@ Feature: Create a node aggregate with complex default values
       | date          | Date:2021-03-13T17:33:17+00:00                  |
       | uri           | URI:https://www.neos.io                         |
       | price         | PriceSpecification:anotherDummy                 |
+
+  Scenario: Create a node aggregate with unset default values
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                              |
+      | nodeAggregateId       | "nody-mc-nodeface"                                 |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:UnsetDefaultsNode" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                           |
+      | initialPropertyValues | {}                                                 |
+    Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to have no properties
+
+  Scenario: Create a node aggregate with unset default values but defined creation values
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                                                                                                                                                      |
+      | nodeAggregateId       | "nody-mc-nodeface"                                                                                                                                                         |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:UnsetDefaultsNode"                                                                                                                         |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                                                                                                                                                   |
+      | initialPropertyValues | {"dayOfWeek":"DayOfWeek:https://schema.org/Friday","postalAddress":"PostalAddress:anotherDummy", "date":"Date:2021-03-13T17:33:17+00:00", "uri":"URI:https://www.neos.io"} |
+    Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+    And I expect this node to have the following properties:
+      | Key           | Value                                           |
+      | dayOfWeek     | DayOfWeek:https://schema.org/Friday             |
+      | postalAddress | PostalAddress:anotherDummy                      |
+      | date          | Date:2021-03-13T17:33:17+00:00                  |
+      | uri           | URI:https://www.neos.io                         |
 
   Scenario: Create a node aggregate with faulty date time defaultValue fails
     And I change the node types in content repository "default" to:

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -47,6 +47,7 @@ Feature: Create a node aggregate with complex default values
     And using identifier "default", I define a content repository
     And I am in content repository "default"
     And I am user identified by "initiating-user-identifier"
+    And the current date and time is "2024-09-22T12:00:00+00:00"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -73,7 +74,7 @@ Feature: Create a node aggregate with complex default values
       | postalAddress | Neos\ContentRepository\Core\Tests\Behavior\Fixtures\PostalAddress      | {"streetAddress":"28 31st of February Street","postalCode":12345,"addressLocality":"City","addressCountry":"Country"} |
       # DateTime must always be treated as immutable see DateTimeImmutable.
       # And the default value "now" must not be serialized as string "now" but as its actual value of the time of the command:
-      | now           | DateTimeImmutable                                                      | NOT:"now"                                                                                                             |
+      | now           | DateTimeImmutable                                                      | "2024-09-22T12:00:00+00:00"                                                                                           |
       | date          | DateTimeImmutable                                                      | "2020-08-20T18:56:15+00:00"                                                                                           |
       | uri           | GuzzleHttp\Psr7\Uri                                                    | "https://neos.io"                                                                                                     |
       # Defaults while deserializing value objects will be manifested at the time of the command: (valueAddedTaxIncluded was not explicitly declared above)
@@ -84,7 +85,7 @@ Feature: Create a node aggregate with complex default values
       | array         | {"givenName":"Nody", "familyName":"McNodeface"} |
       | dayOfWeek     | DayOfWeek:https://schema.org/Wednesday          |
       | postalAddress | PostalAddress:dummy                             |
-      | now           | Date:now                                        |
+      | now           | Date:2024-09-22T12:00:00+00:00                  |
       | date          | Date:2020-08-20T18:56:15+00:00                  |
       | uri           | URI:https://neos.io                             |
       | price         | PriceSpecification:dummy                        |
@@ -102,7 +103,7 @@ Feature: Create a node aggregate with complex default values
       | dayOfWeek     | DayOfWeek:https://schema.org/Friday             |
       | array         | {"givenName":"Nody", "familyName":"McNodeface"} |
       | postalAddress | PostalAddress:anotherDummy                      |
-      | now           | Date:now                                        |
+      | now           | Date:2024-09-22T12:00:00+00:00                  |
       | date          | Date:2021-03-13T17:33:17+00:00                  |
       | uri           | URI:https://www.neos.io                         |
       | price         | PriceSpecification:anotherDummy                 |
@@ -113,4 +114,4 @@ Feature: Create a node aggregate with complex default values
       | nodeAggregateId       | "nody-mc-nodeface"                              |
       | nodeTypeName          | "Neos.ContentRepository.Testing:FaultyDateNode" |
       | parentNodeAggregateId | "lady-eleonode-rootford"                        |
-    And the last command should have thrown an exception of type "RuntimeException" with code 1708416598
+    And the last command should have thrown an exception of type "RuntimeException" with code 1783085627

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -37,17 +37,11 @@ Feature: Create a node aggregate with complex default values
           defaultValue:
             price: 13.37
             priceCurrency: 'EUR'
-
-    'Neos.ContentRepository.Testing:FaultyDateNode':
-      properties:
-        date:
-          type: DateTimeImmutable
-          defaultValue: 'not a date'
     """
     And using identifier "default", I define a content repository
     And I am in content repository "default"
     And I am user identified by "initiating-user-identifier"
-    And the current date and time is "2024-09-22T12:00:00+00:00"
+      And the current date and time is "2024-09-22T12:00:00+00:00"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -109,6 +103,74 @@ Feature: Create a node aggregate with complex default values
       | price         | PriceSpecification:anotherDummy                 |
 
   Scenario: Create a node aggregate with faulty date time defaultValue fails
+    And I change the node types in content repository "default" to:
+      """yaml
+      'Neos.ContentRepository.Testing:FaultyDateNode':
+        properties:
+          date:
+            type: DateTimeImmutable
+            defaultValue: { object: true }
+      """
+    When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                   | Value                                           |
+      | nodeAggregateId       | "nody-mc-nodeface"                              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:FaultyDateNode" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                        |
+    And the last command should have thrown an exception of type "RuntimeException" with code 1783085240
+
+    And I change the node types in content repository "default" to:
+      """yaml
+      'Neos.ContentRepository.Testing:FaultyDateNode':
+        properties:
+          date:
+            type: DateTimeImmutable
+            defaultValue: false
+      """
+    When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                   | Value                                           |
+      | nodeAggregateId       | "nody-mc-nodeface"                              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:FaultyDateNode" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                        |
+    And the last command should have thrown an exception of type "RuntimeException" with code 1783085240
+
+    And I change the node types in content repository "default" to:
+      """yaml
+      'Neos.ContentRepository.Testing:FaultyDateNode':
+        properties:
+          date:
+            type: DateTimeImmutable
+            defaultValue: 1783086342
+      """
+    When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                   | Value                                           |
+      | nodeAggregateId       | "nody-mc-nodeface"                              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:FaultyDateNode" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                        |
+    And the last command should have thrown an exception of type "RuntimeException" with code 1783085240
+
+    And I change the node types in content repository "default" to:
+      """yaml
+      'Neos.ContentRepository.Testing:FaultyDateNode':
+        properties:
+          date:
+            type: DateTimeImmutable
+            defaultValue: ''
+      """
+    When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
+      | Key                   | Value                                           |
+      | nodeAggregateId       | "nody-mc-nodeface"                              |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:FaultyDateNode" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"                        |
+    And the last command should have thrown an exception of type "RuntimeException" with code 1783085627
+
+    And I change the node types in content repository "default" to:
+      """yaml
+      'Neos.ContentRepository.Testing:FaultyDateNode':
+        properties:
+          date:
+            type: DateTimeImmutable
+            defaultValue: 'not a date'
+      """
     When the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:
       | Key                   | Value                                           |
       | nodeAggregateId       | "nody-mc-nodeface"                              |

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/02-NodeCreation/05-CreateNodeAggregateWithNode_ComplexDefaultAndInitialProperties.feature
@@ -19,6 +19,12 @@ Feature: Create a node aggregate with complex default values
         now:
           type: DateTime
           defaultValue: 'now'
+        tomorrow:
+          type: DateTimeImmutable
+          defaultValue: 'tomorrow'
+        lastMonth:
+          type: DateTimeImmutable
+          defaultValue: '-1 month'
         date:
           type: DateTimeImmutable
           defaultValue: '2020-08-20T18:56:15+00:00'
@@ -60,7 +66,7 @@ Feature: Create a node aggregate with complex default values
     And using identifier "default", I define a content repository
     And I am in content repository "default"
     And I am user identified by "initiating-user-identifier"
-      And the current date and time is "2024-09-22T12:00:00+00:00"
+    And the current date and time is "2024-09-22T12:00:00+00:00"
     And the command CreateRootWorkspace is executed with payload:
       | Key                  | Value                |
       | workspaceName        | "live"               |
@@ -88,6 +94,8 @@ Feature: Create a node aggregate with complex default values
       # DateTime must always be treated as immutable see DateTimeImmutable.
       # And the default value "now" must not be serialized as string "now" but as its actual value of the time of the command:
       | now           | DateTimeImmutable                                                      | "2024-09-22T12:00:00+00:00"                                                                                           |
+      | tomorrow      | DateTimeImmutable                                                      | "2024-09-23T00:00:00+00:00"                                                                                           |
+      | lastMonth     | DateTimeImmutable                                                      | "2024-08-22T12:00:00+00:00"                                                                                           |
       | date          | DateTimeImmutable                                                      | "2020-08-20T18:56:15+00:00"                                                                                           |
       | uri           | GuzzleHttp\Psr7\Uri                                                    | "https://neos.io"                                                                                                     |
       # Defaults while deserializing value objects will be manifested at the time of the command: (valueAddedTaxIncluded was not explicitly declared above)
@@ -99,9 +107,28 @@ Feature: Create a node aggregate with complex default values
       | dayOfWeek     | DayOfWeek:https://schema.org/Wednesday          |
       | postalAddress | PostalAddress:dummy                             |
       | now           | Date:2024-09-22T12:00:00+00:00                  |
+      | tomorrow      | Date:2024-09-23T00:00:00+00:00                  |
+      | lastMonth     | Date:2024-08-22T12:00:00+00:00                  |
       | date          | Date:2020-08-20T18:56:15+00:00                  |
       | uri           | URI:https://neos.io                             |
       | price         | PriceSpecification:dummy                        |
+
+  Scenario: Create a node aggregate with complex default values respecting time zone
+    And the current date and time is "2024-09-22T12:00:00+02:00"
+    When the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                   | Value                                 |
+      | nodeAggregateId       | "nody-mc-nodeface"                    |
+      | nodeTypeName          | "Neos.ContentRepository.Testing:Node" |
+      | parentNodeAggregateId | "lady-eleonode-rootford"              |
+    Then I expect a node identified by cs-identifier;nody-mc-nodeface;{} to exist in the content graph
+
+    And I expect this node to have the following properties:
+      | Key           | Value                                           |
+      | now           | Date:2024-09-22T12:00:00+02:00                  |
+      | tomorrow      | Date:2024-09-23T00:00:00+02:00                  |
+      | lastMonth     | Date:2024-08-22T12:00:00+02:00                  |
+      # Even though we specified the timestamp as ATOM with timezone in the defaults, PHPs date->modify() keeps the original time zone.
+      | date          | Date:2020-08-20T18:56:15+02:00                  |
 
   Scenario: Create a node aggregate with complex initial and default values
     When the command CreateNodeAggregateWithNode is executed with payload:

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\DimensionSpaceC
 use Neos\ContentRepository\Core\Feature\NodeAggregateCommandHandler;
 use Neos\ContentRepository\Core\Feature\WorkspaceCommandHandler;
 use Neos\ContentRepository\Core\Infrastructure\PerformanceTracing\PerformanceTracerInterface;
+use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\Projection\CatchUpHook\CatchUpHookFactoryDependencies;
@@ -156,7 +157,10 @@ final class ContentRepositoryFactory
                 $this->contentDimensionZookeeper,
                 $this->interDimensionalVariationGraph,
                 $this->propertyConverter,
-                $this->clock,
+                new NodeTypeDefaultPropertySerializer(
+                    $this->propertyConverter,
+                    $this->clock,
+                )
             ),
             new DimensionSpaceCommandHandler(
                 $this->interDimensionalVariationGraph,

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -156,6 +156,7 @@ final class ContentRepositoryFactory
                 $this->contentDimensionZookeeper,
                 $this->interDimensionalVariationGraph,
                 $this->propertyConverter,
+                $this->clock,
             ),
             new DimensionSpaceCommandHandler(
                 $this->interDimensionalVariationGraph,

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeReferencingInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeReferencingInternals.php
@@ -18,7 +18,6 @@ use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\NodeReferencesToWrit
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReference;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferencesForName;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeReferencingInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeReferencingInternals.php
@@ -27,8 +27,6 @@ use Neos\ContentRepository\Core\NodeType\NodeTypeName;
  */
 trait NodeReferencingInternals
 {
-    abstract protected function getPropertyConverter(): PropertyConverter;
-
     abstract protected function requireNodeType(NodeTypeName $nodeTypeName): NodeType;
 
     private function mapNodeReferencesToSerializedNodeReferences(NodeReferencesToWrite $references, NodeTypeName $nodeTypeName): SerializedNodeReferences
@@ -39,7 +37,7 @@ trait NodeReferencingInternals
             foreach ($referencesByProperty->references as $reference) {
                 $serializedReferences[] = SerializedNodeReference::fromTargetAndProperties(
                     $reference->targetNodeAggregateId,
-                    $this->getPropertyConverter()->serializeReferencePropertyValues(
+                    $this->propertyConverter->serializeReferencePropertyValues(
                         $reference->properties,
                         $this->requireNodeType($nodeTypeName),
                         $referencesByProperty->referenceName

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -52,8 +52,6 @@ trait TetheredNodeInternals
 {
     use NodeVariationInternals;
 
-    abstract protected function getPropertyConverter(): PropertyConverter;
-
     abstract protected function createEventsForVariations(
         ContentGraphInterface $contentGraph,
         OriginDimensionSpacePoint $sourceOrigin,

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -88,7 +88,7 @@ trait TetheredNodeInternals
 
         $expectedTetheredNodeType = $this->nodeTypeManager->getNodeType($tetheredNodeTypeDefinition->nodeTypeName);
         $defaultProperties = $expectedTetheredNodeType
-            ? SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType, $this->getPropertyConverter(), $this->clock)
+            ? $this->nodeTypeDefaultPropertySerializer->serializeFromNodeType($expectedTetheredNodeType)
             : SerializedPropertyValues::createEmpty();
 
         if ($childNodeAggregate === null) {
@@ -203,11 +203,7 @@ trait TetheredNodeInternals
         $events = [];
         $tetheredNodeType = $this->requireNodeType($tetheredNodeTypeDefinition->nodeTypeName);
         $nodeAggregateId = $nodeAggregateIdsByNodePaths->getNodeAggregateId($currentNodePath) ?? NodeAggregateId::create();
-        $defaultValues = SerializedPropertyValues::defaultFromNodeType(
-            $tetheredNodeType,
-            $this->getPropertyConverter(),
-            $this->clock
-        );
+        $defaultValues = $this->nodeTypeDefaultPropertySerializer->serializeFromNodeType($tetheredNodeType);
 
         // NodeTypeChange is not allowed on root, thus we don't handle the empty dimension case
         $orderedAffectedOriginDimensionSpacePoints = $this->requireOrderedOriginDimensionSpacePoints($affectedOriginDimensionSpacePoints);
@@ -315,11 +311,8 @@ trait TetheredNodeInternals
             $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
 
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
-            $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
-                $tetheredNodeType,
-                $this->propertyConverter,
-                $this->clock
-            )
+            $complementaryPropertyValues = $this->nodeTypeDefaultPropertySerializer
+                ->serializeFromNodeType($tetheredNodeType)
                 ->unsetProperties(PropertyNames::fromArray($presentPropertyKeys));
             $obsoletePropertyNames = PropertyNames::fromArray(
                 array_diff(

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -33,7 +33,6 @@ use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeGeneralizationVa
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodePeerVariantWasCreated;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Event\NodeSpecializationVariantWasCreated;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\NodeType\TetheredNodeTypeDefinition;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/TetheredNodeInternals.php
@@ -88,7 +88,7 @@ trait TetheredNodeInternals
 
         $expectedTetheredNodeType = $this->nodeTypeManager->getNodeType($tetheredNodeTypeDefinition->nodeTypeName);
         $defaultProperties = $expectedTetheredNodeType
-            ? SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType, $this->getPropertyConverter())
+            ? SerializedPropertyValues::defaultFromNodeType($expectedTetheredNodeType, $this->getPropertyConverter(), $this->clock)
             : SerializedPropertyValues::createEmpty();
 
         if ($childNodeAggregate === null) {
@@ -205,7 +205,8 @@ trait TetheredNodeInternals
         $nodeAggregateId = $nodeAggregateIdsByNodePaths->getNodeAggregateId($currentNodePath) ?? NodeAggregateId::create();
         $defaultValues = SerializedPropertyValues::defaultFromNodeType(
             $tetheredNodeType,
-            $this->getPropertyConverter()
+            $this->getPropertyConverter(),
+            $this->clock
         );
 
         // NodeTypeChange is not allowed on root, thus we don't handle the empty dimension case
@@ -316,7 +317,8 @@ trait TetheredNodeInternals
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
             $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
                 $tetheredNodeType,
-                $this->propertyConverter
+                $this->propertyConverter,
+                $this->clock
             )
                 ->unsetProperties(PropertyNames::fromArray($presentPropertyKeys));
             $obsoletePropertyNames = PropertyNames::fromArray(

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -49,6 +49,7 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\RootNodeHandling;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\TagSubtree;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\UntagSubtree;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\SubtreeTagging;
+use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Psr\Clock\ClockInterface;
@@ -77,13 +78,19 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
      */
     private bool $ancestorNodeTypeConstraintChecksEnabled = true;
 
+    private readonly NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer;
+
     public function __construct(
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\ContentDimensionZookeeper $contentDimensionZookeeper,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private readonly PropertyConverter $propertyConverter,
-        private readonly ClockInterface $clock,
+        ClockInterface $clock,
     ) {
+        $this->nodeTypeDefaultPropertySerializer = new NodeTypeDefaultPropertySerializer(
+            $this->propertyConverter,
+            $clock
+        );
     }
 
     public function canHandle(CommandInterface|RebasableToOtherWorkspaceInterface $command): bool

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -51,6 +51,7 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\Command\UntagSubtree;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\SubtreeTagging;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
+use Psr\Clock\ClockInterface;
 
 /**
  * @internal from userland, you'll use ContentRepository::handle to dispatch commands
@@ -81,6 +82,7 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
         private readonly DimensionSpace\ContentDimensionZookeeper $contentDimensionZookeeper,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private readonly PropertyConverter $propertyConverter,
+        private readonly ClockInterface $clock,
     ) {
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -52,7 +52,6 @@ use Neos\ContentRepository\Core\Feature\SubtreeTagging\SubtreeTagging;
 use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
-use Psr\Clock\ClockInterface;
 
 /**
  * @internal from userland, you'll use ContentRepository::handle to dispatch commands

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -146,11 +146,6 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
         return $this->ancestorNodeTypeConstraintChecksEnabled;
     }
 
-    public function getPropertyConverter(): PropertyConverter
-    {
-        return $this->propertyConverter;
-    }
-
     /**
      * Use this closure to run code with the Ancestor Node Type Checks disabled; e.g.
      * during imports.

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -78,19 +78,13 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
      */
     private bool $ancestorNodeTypeConstraintChecksEnabled = true;
 
-    private readonly NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer;
-
     public function __construct(
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\ContentDimensionZookeeper $contentDimensionZookeeper,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private readonly PropertyConverter $propertyConverter,
-        ClockInterface $clock,
+        private readonly NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer,
     ) {
-        $this->nodeTypeDefaultPropertySerializer = new NodeTypeDefaultPropertySerializer(
-            $this->propertyConverter,
-            $clock
-        );
     }
 
     public function canHandle(CommandInterface|RebasableToOtherWorkspaceInterface $command): bool

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -69,8 +69,6 @@ trait NodeCreation
 
     abstract protected function requireNodeTypeNotToDeclareTetheredChildNodeName(NodeTypeName $nodeTypeName, NodeName $nodeName): void;
 
-    abstract protected function getPropertyConverter(): PropertyConverter;
-
     abstract protected function getNodeTypeManager(): NodeTypeManager;
 
     private function handleCreateNodeAggregateWithNode(
@@ -87,7 +85,7 @@ trait NodeCreation
             $command->originDimensionSpacePoint,
             $command->parentNodeAggregateId,
             $command->succeedingSiblingNodeAggregateId,
-            $this->getPropertyConverter()->serializePropertyValues(
+            $this->propertyConverter->serializePropertyValues(
                 $command->initialPropertyValues->withoutUnsets(),
                 $this->requireNodeType($command->nodeTypeName)
             ),

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -32,7 +32,6 @@ use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWri
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
 use Neos\ContentRepository\Core\Feature\RebaseableCommand;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyType;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -199,7 +199,7 @@ trait NodeCreation
             );
         }
 
-        $defaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->getPropertyConverter(), $this->clock);
+        $defaultPropertyValues = $this->nodeTypeDefaultPropertySerializer->serializeFromNodeType($nodeType);
         $initialPropertyValues = $defaultPropertyValues->merge($command->initialPropertyValues);
 
         $events = [
@@ -279,11 +279,7 @@ trait NodeCreation
                 : NodePath::fromString($tetheredNodeTypeDefinition->name->value);
             $childNodeAggregateId = $nodeAggregateIds->getNodeAggregateId($childNodePath)
                 ?? NodeAggregateId::create();
-            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType(
-                $childNodeType,
-                $this->getPropertyConverter(),
-                $this->clock
-            );
+            $initialPropertyValues = $this->nodeTypeDefaultPropertySerializer->serializeFromNodeType($childNodeType);
 
             $events[] = new NodeAggregateWithNodeWasCreated(
                 $contentGraph->getWorkspaceName(),

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -199,7 +199,7 @@ trait NodeCreation
             );
         }
 
-        $defaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->getPropertyConverter());
+        $defaultPropertyValues = SerializedPropertyValues::defaultFromNodeType($nodeType, $this->getPropertyConverter(), $this->clock);
         $initialPropertyValues = $defaultPropertyValues->merge($command->initialPropertyValues);
 
         $events = [
@@ -281,7 +281,8 @@ trait NodeCreation
                 ?? NodeAggregateId::create();
             $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType(
                 $childNodeType,
-                $this->getPropertyConverter()
+                $this->getPropertyConverter(),
+                $this->clock
             );
 
             $events[] = new NodeAggregateWithNodeWasCreated(

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -14,12 +14,9 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeModification\Dto;
 
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyType;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
-use Psr\Clock\ClockInterface;
 
 /**
  * "Raw" property values as saved in the event log // in projections.

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -19,6 +19,7 @@ use Neos\ContentRepository\Core\Infrastructure\Property\PropertyType;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyNames;
+use Psr\Clock\ClockInterface;
 
 /**
  * "Raw" property values as saved in the event log // in projections.
@@ -68,7 +69,7 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
     }
 
     /** @internal */
-    public static function defaultFromNodeType(NodeType $nodeType, PropertyConverter $propertyConverter): self
+    public static function defaultFromNodeType(NodeType $nodeType, PropertyConverter $propertyConverter, ClockInterface $clock): self
     {
         $values = [];
         foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
@@ -77,20 +78,28 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
                 PropertyName::fromString($propertyName),
                 $nodeType->name
             );
-            $deserializedDefaultValue = $propertyConverter->deserializePropertyValue(
-                SerializedPropertyValue::create($defaultValue, $propertyType->getSerializationType())
-            );
+
             // The $defaultValue and $properlySerializedDefaultValue will likely equal, but in some cases diverge.
             // For example relative date time default values like "now" will herby be serialized to the current date.
             // Also, custom value objects might serialize slightly different, but more "correct"
             // (by for example adding default values for undeclared properties)
             // Additionally due the double conversion, we guarantee that a valid property converted exists at this time.
+            if ($propertyType->isDate()) {
+                if (!is_string($defaultValue)) {
+                    throw new \RuntimeException(sprintf('Expected string as defaultValue for DateTime property of "%s" got: %s', $propertyName, get_debug_type($defaultValue)), 1783085240);
+                }
+                try {
+                    $deserializedDefaultValue = $clock->now()->modify($defaultValue);
+                } catch (\DateMalformedStringException $dateMalformedStringException) {
+                    throw new \RuntimeException(sprintf('Invalid DateTime defaultValue "%s" for property "%s": %s', $defaultValue, $propertyName, $dateMalformedStringException->getMessage()), 1783085627, $dateMalformedStringException);
+                }
+            } else {
+                $deserializedDefaultValue = $propertyConverter->deserializePropertyValue(
+                    SerializedPropertyValue::create($defaultValue, $propertyType->getSerializationType())
+                );
+            }
             $properlySerializedDefaultValue = $propertyConverter->serializePropertyValue(
-                PropertyType::fromNodeTypeDeclaration(
-                    $nodeType->getPropertyType($propertyName),
-                    PropertyName::fromString($propertyName),
-                    $nodeType->name
-                ),
+                $propertyType,
                 $deserializedDefaultValue
             );
             $values[$propertyName] = $properlySerializedDefaultValue;

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/Dto/SerializedPropertyValues.php
@@ -68,46 +68,6 @@ final readonly class SerializedPropertyValues implements \IteratorAggregate, \Co
         return new self($values);
     }
 
-    /** @internal */
-    public static function defaultFromNodeType(NodeType $nodeType, PropertyConverter $propertyConverter, ClockInterface $clock): self
-    {
-        $values = [];
-        foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
-            $propertyType = PropertyType::fromNodeTypeDeclaration(
-                $nodeType->getPropertyType($propertyName),
-                PropertyName::fromString($propertyName),
-                $nodeType->name
-            );
-
-            // The $defaultValue and $properlySerializedDefaultValue will likely equal, but in some cases diverge.
-            // For example relative date time default values like "now" will herby be serialized to the current date.
-            // Also, custom value objects might serialize slightly different, but more "correct"
-            // (by for example adding default values for undeclared properties)
-            // Additionally due the double conversion, we guarantee that a valid property converted exists at this time.
-            if ($propertyType->isDate()) {
-                if (!is_string($defaultValue)) {
-                    throw new \RuntimeException(sprintf('Expected string as defaultValue for DateTime property of "%s" got: %s', $propertyName, get_debug_type($defaultValue)), 1783085240);
-                }
-                try {
-                    $deserializedDefaultValue = $clock->now()->modify($defaultValue);
-                } catch (\DateMalformedStringException $dateMalformedStringException) {
-                    throw new \RuntimeException(sprintf('Invalid DateTime defaultValue "%s" for property "%s": %s', $defaultValue, $propertyName, $dateMalformedStringException->getMessage()), 1783085627, $dateMalformedStringException);
-                }
-            } else {
-                $deserializedDefaultValue = $propertyConverter->deserializePropertyValue(
-                    SerializedPropertyValue::create($defaultValue, $propertyType->getSerializationType())
-                );
-            }
-            $properlySerializedDefaultValue = $propertyConverter->serializePropertyValue(
-                $propertyType,
-                $deserializedDefaultValue
-            );
-            $values[$propertyName] = $properlySerializedDefaultValue;
-        }
-
-        return new self($values);
-    }
-
     public static function fromJsonString(string $jsonString): self
     {
         try {

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/NodeModification.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/NodeModification.php
@@ -63,7 +63,7 @@ trait NodeModification
             $command->workspaceName,
             $command->nodeAggregateId,
             $command->originDimensionSpacePoint,
-            $this->getPropertyConverter()->serializePropertyValues(
+            $this->propertyConverter->serializePropertyValues(
                 $command->propertyValues->withoutUnsets(),
                 $this->requireNodeType($nodeTypeName)
             ),

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -220,7 +220,8 @@ trait NodeTypeChange
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
             $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
                 $newNodeType,
-                $this->propertyConverter
+                $this->propertyConverter,
+                $this->clock
             )
                 ->unsetProperties(PropertyNames::fromArray($presentPropertyKeys));
             $obsoletePropertyNames = PropertyNames::fromArray(

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -218,11 +218,8 @@ trait NodeTypeChange
             $node = $nodeAggregate->getNodeByOccupiedDimensionSpacePoint($originDimensionSpacePoint);
 
             $presentPropertyKeys = array_keys(iterator_to_array($node->properties->serialized()));
-            $complementaryPropertyValues = SerializedPropertyValues::defaultFromNodeType(
-                $newNodeType,
-                $this->propertyConverter,
-                $this->clock
-            )
+            $complementaryPropertyValues = $this->nodeTypeDefaultPropertySerializer
+                ->serializeFromNodeType($newNodeType)
                 ->unsetProperties(PropertyNames::fromArray($presentPropertyKeys));
             $obsoletePropertyNames = PropertyNames::fromArray(
                 array_diff(

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -24,7 +24,6 @@ use Neos\ContentRepository\Core\Feature\Common\NodeTypeChangeInternals;
 use Neos\ContentRepository\Core\Feature\Common\TetheredNodeInternals;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\NodeCreation\Dto\NodeAggregateIdsByNodePaths;
-use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
 use Neos\ContentRepository\Core\Feature\NodeModification\Event\NodePropertiesWereSet;
 use Neos\ContentRepository\Core\Feature\NodeRemoval\Event\NodeAggregateWasRemoved;
 use Neos\ContentRepository\Core\Feature\NodeTypeChange\Command\ChangeNodeAggregateType;

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
@@ -269,7 +269,7 @@ trait RootNodeHandling
                 : NodePath::fromNodeNames($tetheredNodeTypeDefinition->name);
             $childNodeAggregateId = $nodeAggregateIdsByNodePath->getNodeAggregateId($childNodePath)
                 ?? NodeAggregateId::create();
-            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType, $this->getPropertyConverter());
+            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType, $this->getPropertyConverter(), $this->clock);
 
             $events[] = $this->createTetheredWithNodeForRoot(
                 $workspaceName,

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
@@ -269,7 +269,7 @@ trait RootNodeHandling
                 : NodePath::fromNodeNames($tetheredNodeTypeDefinition->name);
             $childNodeAggregateId = $nodeAggregateIdsByNodePath->getNodeAggregateId($childNodePath)
                 ?? NodeAggregateId::create();
-            $initialPropertyValues = SerializedPropertyValues::defaultFromNodeType($childNodeType, $this->getPropertyConverter(), $this->clock);
+            $initialPropertyValues = $this->nodeTypeDefaultPropertySerializer->serializeFromNodeType($childNodeType);
 
             $events[] = $this->createTetheredWithNodeForRoot(
                 $workspaceName,

--- a/Neos.ContentRepository.Core/Classes/Infrastructure/Property/NodeTypeDefaultPropertySerializer.php
+++ b/Neos.ContentRepository.Core/Classes/Infrastructure/Property/NodeTypeDefaultPropertySerializer.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Infrastructure\Property;
+
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValue;
+use Neos\ContentRepository\Core\Feature\NodeModification\Dto\SerializedPropertyValues;
+use Neos\ContentRepository\Core\NodeType\NodeType;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
+use Psr\Clock\ClockInterface;
+
+/**
+ * @internal
+ */
+final readonly class NodeTypeDefaultPropertySerializer
+{
+    public function __construct(
+        private PropertyConverter $propertyConverter,
+        private ClockInterface $clock
+    ) {
+    }
+
+    public function serializeFromNodeType(NodeType $nodeType): SerializedPropertyValues
+    {
+        $values = [];
+        foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
+            $propertyType = PropertyType::fromNodeTypeDeclaration(
+                $nodeType->getPropertyType($propertyName),
+                PropertyName::fromString($propertyName),
+                $nodeType->name
+            );
+
+            // The $defaultValue and $properlySerializedDefaultValue will likely equal, but in some cases diverge.
+            // For example relative date time default values like "now" will herby be serialized to the current date.
+            // Also, custom value objects might serialize slightly different, but more "correct"
+            // (by for example adding default values for undeclared properties)
+            // Additionally due the double conversion, we guarantee that a valid property converted exists at this time.
+            if ($propertyType->isDate()) {
+                if (!is_string($defaultValue)) {
+                    throw new \RuntimeException(sprintf('Expected string as defaultValue for DateTime property of "%s" got: %s', $propertyName, get_debug_type($defaultValue)), 1783085240);
+                }
+                try {
+                    $deserializedDefaultValue = $this->clock->now()->modify($defaultValue);
+                } catch (\DateMalformedStringException $dateMalformedStringException) {
+                    throw new \RuntimeException(sprintf('Invalid DateTime defaultValue "%s" for property "%s": %s', $defaultValue, $propertyName, $dateMalformedStringException->getMessage()), 1783085627, $dateMalformedStringException);
+                }
+            } else {
+                $deserializedDefaultValue = $this->propertyConverter->deserializePropertyValue(
+                    SerializedPropertyValue::create($defaultValue, $propertyType->getSerializationType())
+                );
+            }
+            $properlySerializedDefaultValue = $this->propertyConverter->serializePropertyValue(
+                $propertyType,
+                $deserializedDefaultValue
+            );
+            $values[$propertyName] = $properlySerializedDefaultValue;
+        }
+
+        return SerializedPropertyValues::fromArray($values);
+    }
+}

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -16,7 +16,6 @@ use Neos\ContentRepository\Core\Feature\Common\TetheredNodeInternals;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\NodeMove\Event\NodeAggregateWasMoved;
 use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
@@ -29,7 +28,6 @@ use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFound;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
-use Psr\Clock\ClockInterface;
 
 class TetheredNodeAdjustments
 {
@@ -38,19 +36,12 @@ class TetheredNodeAdjustments
     use TetheredNodeInternals;
     use NodeTypeChangeInternals;
 
-    private readonly NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer;
-
     public function __construct(
         private readonly ContentGraphInterface $contentGraph,
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
-        private readonly PropertyConverter $propertyConverter,
-        ClockInterface $clock,
+        private readonly NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer,
     ) {
-        $this->nodeTypeDefaultPropertySerializer = new NodeTypeDefaultPropertySerializer(
-            $propertyConverter,
-            $clock
-        );
     }
 
     /**

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -48,7 +48,7 @@ class TetheredNodeAdjustments
         ClockInterface $clock,
     ) {
         $this->nodeTypeDefaultPropertySerializer = new NodeTypeDefaultPropertySerializer(
-            $this->propertyConverter,
+            $propertyConverter,
             $clock
         );
     }
@@ -221,11 +221,6 @@ class TetheredNodeAdjustments
     protected function getInterDimensionalVariationGraph(): DimensionSpace\InterDimensionalVariationGraph
     {
         return $this->interDimensionalVariationGraph;
-    }
-
-    protected function getPropertyConverter(): PropertyConverter
-    {
-        return $this->propertyConverter;
     }
 
     /**

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -15,6 +15,7 @@ use Neos\ContentRepository\Core\Feature\Common\NodeVariationInternals;
 use Neos\ContentRepository\Core\Feature\Common\TetheredNodeInternals;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
 use Neos\ContentRepository\Core\Feature\NodeMove\Event\NodeAggregateWasMoved;
+use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
 use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
@@ -37,13 +38,19 @@ class TetheredNodeAdjustments
     use TetheredNodeInternals;
     use NodeTypeChangeInternals;
 
+    private readonly NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer;
+
     public function __construct(
         private readonly ContentGraphInterface $contentGraph,
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private readonly PropertyConverter $propertyConverter,
-        private readonly ClockInterface $clock,
+        ClockInterface $clock,
     ) {
+        $this->nodeTypeDefaultPropertySerializer = new NodeTypeDefaultPropertySerializer(
+            $this->propertyConverter,
+            $clock
+        );
     }
 
     /**

--- a/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/Adjustment/TetheredNodeAdjustments.php
@@ -28,6 +28,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFound;
 use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
+use Psr\Clock\ClockInterface;
 
 class TetheredNodeAdjustments
 {
@@ -40,7 +41,8 @@ class TetheredNodeAdjustments
         private readonly ContentGraphInterface $contentGraph,
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
-        private readonly PropertyConverter $propertyConverter
+        private readonly PropertyConverter $propertyConverter,
+        private readonly ClockInterface $clock,
     ) {
     }
 

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\StructureAdjustment\Adjustment\UnknownNodeTypeAdjustm
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Model\Event\CorrelationId;
 use Neos\EventStore\Model\Events;
+use Psr\Clock\ClockInterface;
 
 class StructureAdjustmentService implements ContentRepositoryServiceInterface
 {
@@ -51,6 +52,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
         NodeTypeManager $nodeTypeManager,
         InterDimensionalVariationGraph $interDimensionalVariationGraph,
         PropertyConverter $propertyConverter,
+        ClockInterface $clock,
     ) {
 
         $this->liveContentGraph = $contentRepository->getContentGraph(WorkspaceName::forLive());
@@ -60,6 +62,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
             $nodeTypeManager,
             $interDimensionalVariationGraph,
             $propertyConverter,
+            $clock,
         );
 
         $this->unknownNodeTypeAdjustment = new UnknownNodeTypeAdjustment(

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentService.php
@@ -11,7 +11,7 @@ use Neos\ContentRepository\Core\EventStore\EventInterface;
 use Neos\ContentRepository\Core\EventStore\EventNormalizer;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
-use Neos\ContentRepository\Core\Infrastructure\Property\PropertyConverter;
+use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
 use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
@@ -26,7 +26,6 @@ use Neos\ContentRepository\StructureAdjustment\Adjustment\UnknownNodeTypeAdjustm
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Model\Event\CorrelationId;
 use Neos\EventStore\Model\Events;
-use Psr\Clock\ClockInterface;
 
 class StructureAdjustmentService implements ContentRepositoryServiceInterface
 {
@@ -51,8 +50,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
         private readonly SubscriptionEngine $subscriptionEngine,
         NodeTypeManager $nodeTypeManager,
         InterDimensionalVariationGraph $interDimensionalVariationGraph,
-        PropertyConverter $propertyConverter,
-        ClockInterface $clock,
+        NodeTypeDefaultPropertySerializer $nodeTypeDefaultPropertySerializer,
     ) {
 
         $this->liveContentGraph = $contentRepository->getContentGraph(WorkspaceName::forLive());
@@ -61,8 +59,7 @@ class StructureAdjustmentService implements ContentRepositoryServiceInterface
             $this->liveContentGraph,
             $nodeTypeManager,
             $interDimensionalVariationGraph,
-            $propertyConverter,
-            $clock,
+            $nodeTypeDefaultPropertySerializer,
         );
 
         $this->unknownNodeTypeAdjustment = new UnknownNodeTypeAdjustment(

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentServiceFactory.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentServiceFactory.php
@@ -22,6 +22,7 @@ class StructureAdjustmentServiceFactory implements ContentRepositoryServiceFacto
             $serviceFactoryDependencies->nodeTypeManager,
             $serviceFactoryDependencies->interDimensionalVariationGraph,
             $serviceFactoryDependencies->propertyConverter,
+            $serviceFactoryDependencies->clock,
         );
     }
 }

--- a/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentServiceFactory.php
+++ b/Neos.ContentRepository.StructureAdjustment/src/StructureAdjustmentServiceFactory.php
@@ -6,6 +6,7 @@ namespace Neos\ContentRepository\StructureAdjustment;
 
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryDependencies;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceFactoryInterface;
+use Neos\ContentRepository\Core\Infrastructure\Property\NodeTypeDefaultPropertySerializer;
 
 /**
  * @implements ContentRepositoryServiceFactoryInterface<StructureAdjustmentService>
@@ -21,8 +22,10 @@ class StructureAdjustmentServiceFactory implements ContentRepositoryServiceFacto
             $serviceFactoryDependencies->subscriptionEngine,
             $serviceFactoryDependencies->nodeTypeManager,
             $serviceFactoryDependencies->interDimensionalVariationGraph,
-            $serviceFactoryDependencies->propertyConverter,
-            $serviceFactoryDependencies->clock,
+            new NodeTypeDefaultPropertySerializer(
+                $serviceFactoryDependencies->propertyConverter,
+                $serviceFactoryDependencies->clock,
+            ),
         );
     }
 }

--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/ProjectedNodeTrait.php
@@ -374,14 +374,8 @@ trait ProjectedNodeTrait
             foreach ($expectedPropertyTypes->getHash() as $row) {
                 Assert::assertTrue($serialized->propertyExists($row['Key']), 'Property "' . $row['Key'] . '" not found');
                 Assert::assertEquals($row['Type'], $serialized->getProperty($row['Key'])->type, 'Serialized node property ' . $row['Key'] . ' does not match expected type.');
-                if (str_starts_with($row['Value'], 'NOT:')) {
-                    // special case. assert NOT equals:
-                    $value = json_decode(mb_substr($row['Value'], 4), true, 512, JSON_THROW_ON_ERROR);
-                    Assert::assertNotEquals($value, $serialized->getProperty($row['Key'])->value, 'Serialized node property ' . $row['Key'] . ' does match value it should not.');
-                } else {
-                    $value = json_decode($row['Value'], true, 512, JSON_THROW_ON_ERROR);
-                    Assert::assertEquals($value, $serialized->getProperty($row['Key'])->value, 'Serialized node property ' . $row['Key'] . ' does not match expected value.');
-                }
+                $value = json_decode($row['Value'], true, 512, JSON_THROW_ON_ERROR);
+                Assert::assertEquals($value, $serialized->getProperty($row['Key'])->value, 'Serialized node property ' . $row['Key'] . ' does not match expected value.');
             }
         });
     }


### PR DESCRIPTION
Based on https://github.com/neos/neos-development-collection/pull/5913

`SerializedPropertyValues::defaultFromNodeType()` get a little to overly bloated.



**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-12 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
