### PR TITLE
TASK: Introduce `WorkspaceNames` as typed collections for `WorkspaceName`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceNames.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceNames.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\SharedModel\Workspace;
+
+/**
+ * @implements \IteratorAggregate<int,WorkspaceName>
+ * @api
+ */
+final readonly class WorkspaceNames implements \IteratorAggregate, \Countable
+{
+    /** @param array<string,WorkspaceName> $items */
+    private function __construct(
+        private array $items
+    ) {
+    }
+
+    public static function create(
+        WorkspaceName ...$items
+    ): self {
+        $indexed = [];
+        foreach ($items as $item) {
+            $indexed[$item->value] = $item;
+        }
+        return new self(
+            $indexed
+        );
+    }
+
+    public static function fromWorkspaces(Workspaces $workspaces): self
+    {
+        return WorkspaceNames::create(...$workspaces->map(fn (Workspace $workspace) => $workspace->workspaceName));
+    }
+
+    public function contain(WorkspaceName $workspaceName): bool
+    {
+        return array_key_exists($workspaceName->value, $this->items);
+    }
+
+    /** @return list<string> */
+    public function toStringArray(): array
+    {
+        return array_keys($this->items);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from array_values($this->items);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceNames.php
+++ b/Neos.ContentRepository.Core/Classes/SharedModel/Workspace/WorkspaceNames.php
@@ -30,7 +30,12 @@ final readonly class WorkspaceNames implements \IteratorAggregate, \Countable
 
     public static function fromWorkspaces(Workspaces $workspaces): self
     {
-        return WorkspaceNames::create(...$workspaces->map(fn (Workspace $workspace) => $workspace->workspaceName));
+        return self::create(...$workspaces->map(fn (Workspace $workspace) => $workspace->workspaceName));
+    }
+
+    public function merge(self $other): self
+    {
+        return new self(array_merge($this->items, $other->items));
     }
 
     public function contain(WorkspaceName $workspaceName): bool

--- a/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspaceNamesTest.php
+++ b/Neos.ContentRepository.Core/Tests/Unit/SharedModel/Workspace/WorkspaceNamesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Tests\Unit\SharedModel\Workspace;
+
+use Neos\ContentRepository\Core\SharedModel\Workspace\ContentStreamId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceNames;
+use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
+use PHPUnit\Framework\TestCase;
+
+class WorkspaceNamesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function contain()
+    {
+        $workspaceNames = WorkspaceNames::create(
+            $nameInstance = WorkspaceName::fromString('foo'),
+            WorkspaceName::fromString('bar'),
+        );
+
+        self::assertTrue($workspaceNames->contain($nameInstance));
+        self::assertTrue($workspaceNames->contain(WorkspaceName::fromString('foo')));
+        self::assertFalse($workspaceNames->contain(WorkspaceName::fromString('not-included')));
+    }
+
+    /**
+     * @test
+     */
+    public function fromWorkspaces()
+    {
+        $workspaces = Workspaces::fromArray([
+            self::workspace('root', null),
+            self::workspace('regular', 'root'),
+            self::workspace('other-root', null),
+        ]);
+
+        self::assertEquals(
+            WorkspaceNames::create(
+                WorkspaceName::fromString('root'),
+                WorkspaceName::fromString('regular'),
+                WorkspaceName::fromString('other-root'),
+            ),
+            WorkspaceNames::fromWorkspaces($workspaces)
+        );
+    }
+
+    private static function workspace(string $name): Workspace
+    {
+        return Workspace::create(
+            WorkspaceName::fromString($name),
+            null,
+            ContentStreamId::create(),
+            WorkspaceStatus::UP_TO_DATE,
+            false
+        );
+    }
+}

--- a/Neos.Neos/Classes/AssetUsage/Domain/AssetUsageRepository.php
+++ b/Neos.Neos/Classes/AssetUsage/Domain/AssetUsageRepository.php
@@ -14,6 +14,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceNames;
 use Neos\Flow\Annotations\Scope;
 use Neos\Neos\AssetUsage\Dto\AssetUsageFilter;
 use Neos\Neos\AssetUsage\Dto\AssetUsages;
@@ -120,10 +121,9 @@ final class AssetUsageRepository
     }
 
     /**
-     * @param WorkspaceName[] $workspaceNames
      * @return array<AssetUsage>
      */
-    public function findUsageForNodeInWorkspaces(ContentRepositoryId $contentRepositoryId, Node $node, array $workspaceNames): array
+    public function findUsageForNodeInWorkspaces(ContentRepositoryId $contentRepositoryId, Node $node, WorkspaceNames $workspaceNames): array
     {
         $sql = <<<SQL
             SELECT * FROM {$this->getTableName()}
@@ -138,7 +138,7 @@ final class AssetUsageRepository
             'contentRepositoryId' => $contentRepositoryId->value,
             'nodeAggregateId' => $node->aggregateId->value,
             'originDimensionSpacePointHash' => $node->dimensionSpacePoint->hash,
-            'workspaceNames' => array_map(fn ($workspaceName) => $workspaceName->value, $workspaceNames),
+            'workspaceNames' => $workspaceNames->toStringArray(),
         ], [
             'propertyNames' => Connection::PARAM_STR_ARRAY,
             'workspaceNames' => Connection::PARAM_STR_ARRAY,
@@ -226,16 +226,13 @@ final class AssetUsageRepository
         ]);
     }
 
-    /**
-     * @param WorkspaceName[] $workspaceNames
-     */
     public function removeAssetUsagesForNodeAggregateIdAndDimensionSpacePointWithAssetOnPropertyInWorkspaces(
         ContentRepositoryId $contentRepositoryId,
         NodeAggregateId $nodeAggregateId,
         DimensionSpacePoint $dimensionSpacePoint,
         string $propertyName,
         string $assetId,
-        array $workspaceNames
+        WorkspaceNames $workspaceNames
     ): void {
         $sql = <<<SQL
                 DELETE FROM {$this->getTableName()}
@@ -251,7 +248,7 @@ final class AssetUsageRepository
             'contentRepositoryId' => $contentRepositoryId->value,
             'nodeAggregateId' => $nodeAggregateId->value,
             'originDimensionSpacePointHash' => $dimensionSpacePoint->hash,
-            'workspaceNames' => array_map(fn ($workspaceName) => $workspaceName->value, $workspaceNames),
+            'workspaceNames' => $workspaceNames->toStringArray(),
             'propertyName' => $propertyName,
             'assetId' => $assetId,
         ], [

--- a/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
+++ b/Neos.Neos/Classes/AssetUsage/Service/AssetUsageIndexingService.php
@@ -14,6 +14,7 @@ use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceNames;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspaces;
 use Neos\Flow\Annotations\Scope;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
@@ -55,14 +56,14 @@ final class AssetUsageIndexingService
             throw WorkspaceDoesNotExist::butWasSupposedTo($node->workspaceName);
         }
 
-        $workspaceBases = $allWorkspaces->getBaseWorkspaces($node->workspaceName)->map(fn (Workspace $workspace) => $workspace->workspaceName);
-        $workspaceDependents = $allWorkspaces->getDependantWorkspacesRecursively($node->workspaceName)->map(fn (Workspace $workspace) => $workspace->workspaceName);
+        $workspaceBases = WorkspaceNames::fromWorkspaces($allWorkspaces->getBaseWorkspaces($node->workspaceName));
+        $workspaceDependents = WorkspaceNames::fromWorkspaces($allWorkspaces->getDependantWorkspacesRecursively($node->workspaceName));
 
         // 1. Get all asset usages of given node.
         $assetIdsByPropertyOfNode = $this->getAssetIdsByProperty($nodeType, $node->properties);
 
         // 2. Get all existing asset usages of ancestor workspaces.
-        $assetUsagesInAncestorWorkspaces = $this->assetUsageRepository->findUsageForNodeInWorkspaces($contentRepositoryId, $node, [$node->workspaceName, ...$workspaceBases]);
+        $assetUsagesInAncestorWorkspaces = $this->assetUsageRepository->findUsageForNodeInWorkspaces($contentRepositoryId, $node, WorkspaceNames::create($node->workspaceName)->merge($workspaceBases));
 
         // 3a. Filter only asset usages of given node, which are NOT already in place in ancestor workspaces. This way we get new asset usages in this particular workspace.
         $propertiesAndAssetIdsNotExistingInAncestors = [];
@@ -141,7 +142,7 @@ final class AssetUsageIndexingService
                     $node->dimensionSpacePoint,
                     $propertyName,
                     $assetIdAndOriginalAssetId->assetId,
-                    [$node->workspaceName]
+                    WorkspaceNames::create($node->workspaceName)
                 );
             }
         }


### PR DESCRIPTION
... and use new `WorkspaceNames` in internal `AssetUsageRepository`

Extracted from now closed https://github.com/neos/neos-development-collection/pull/5770 which needed it. But we need do need it as well, see our AssetUsage and it would be good that the Neos CR provides this collection.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-12 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
