### PR TITLE
BUGFIX: Include the dimensions of a nodes context as cache identifier

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
+++ b/Neos.Neos/Classes/Fusion/Cache/NodeCacheEntryIdentifier.php
@@ -16,6 +16,7 @@ namespace Neos\Neos\Fusion\Cache;
 
 use Neos\Cache\CacheAwareInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Utility\NodePaths;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -35,9 +36,11 @@ final readonly class NodeCacheEntryIdentifier implements CacheAwareInterface
 
     public static function fromNode(NodeInterface $node): self
     {
-        return new self('Node_' . $node->getWorkspace()->getName()
-            . '_' . $node->getNodeData()->getDimensionsHash()
-            . '_' .  $node->getIdentifier());
+        return new self(NodePaths::generateContextPath(
+            $node->getPath(),
+            $node->getContext()->getWorkspaceName(),
+            $node->getContext()->getDimensions()
+        ));
     }
 
     public function getCacheEntryIdentifier(): string


### PR DESCRIPTION
This solves an error introduced with the forward compatibility layer for Neos 9.

The node cache identifier used the dimensions of the node, which are incorrect when working with fallbacks. Instead the dimensions of the context have to be used. For this we reuse the same mechanism as the Node implementation does by using the NodePaths helper.

This change can be ignored during upmerge, as 9.0 uses a different implementation.