### PR TITLE
BUGFIX:  Constraint checks for initial node references during creation

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/05-NodeReferencing/01-SetNodeReferences_ConstraintChecks.feature
@@ -112,6 +112,16 @@ Feature: Constraint checks on SetNodeReferences
       | references            | [{"referenceName": "referenceProperty", "references": [{"target":"i-do-not-exist"}]}] |
     Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotExist" with code 1541678486
 
+  Scenario: Try to reference a non-existent node aggregate (creation)
+    Given the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                                                                                 |
+      | nodeAggregateId           | "sir-david-nodenborough"                                                              |
+      | nodeTypeName              | "Neos.ContentRepository.Testing:NodeWithReferences"                                   |
+      | originDimensionSpacePoint | {"language":"en"}                                                                     |
+      | parentNodeAggregateId     | "lady-eleonode-rootford"                                                              |
+      | references                | [{"referenceName": "referenceProperty", "references": [{"target":"i-do-not-exist"}]}] |
+    Then the last command should have thrown an exception of type "NodeAggregateCurrentlyDoesNotExist" with code 1541678486
+
   Scenario: Try to reference a root node aggregate
     When the command SetNodeReferences is executed with payload and exceptions are caught:
       | Key                   | Value                                 |


### PR DESCRIPTION
API to specify `references` on `CreateNodeAggregateWithNode` was introduced via https://github.com/neos/neos-development-collection/pull/5148 but we kinda missed the whole deal with constraint checks \o/

```
Scenario: Try to reference a non-existent node aggregate (creation)
  Given the command CreateNodeAggregateWithNode is executed with payload:
    | Key                       | Value                                                                                 |
    | nodeAggregateId           | "sir-david-nodenborough"                                                              |
    | nodeTypeName              | "Neos.ContentRepository.Testing:NodeWithReferences"                                   |
    | originDimensionSpacePoint | {"language":"en"}                                                                     |
    | parentNodeAggregateId     | "lady-eleonode-rootford"                                                              |
    | references                | [{"referenceName": "referenceProperty", "references": [{"target":"i-do-not-exist"}]}] |
```

Works and adds a pretty empty row

| name | position | nodeanchorpoint | properties | destinationnodeaggregateid |
| :--- | :--- | :--- | :--- | :--- |
| referenceProperty | 0 | 5 | null | i-do-not-exist |


Technically the state of orphaned references rows in the graph is not impossible by design as we never clean those up if a node was removed: https://github.com/neos/neos-development-collection/issues/5809 But we usually prevent the reference creation if its hopeless and the node does not exist at the beginning

TODO:
- add tests for all cases
- find out where to place tests, `02-NodeCreation` or `05-NodeReferencing`? cc @nezaniel 