### PR TITLE
TASK: Bind `CommandHandlingDependencies` to CommandHandlers

### DIFF
--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandBus.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandBus.php
@@ -22,8 +22,6 @@ final readonly class CommandBus
     private array $handlers;
 
     public function __construct(
-        // todo pass $commandHandlingDependencies in each command handler instead of into the commandBus
-        private CommandHandlingDependencies $commandHandlingDependencies,
         CommandHandlerInterface ...$handlers
     ) {
         $this->handlers = $handlers;
@@ -40,7 +38,7 @@ final readonly class CommandBus
         // multiple handlers must not handle the same command
         foreach ($this->handlers as $handler) {
             if ($handler->canHandle($command)) {
-                return $handler->handle($command, $this->commandHandlingDependencies);
+                return $handler->handle($command);
             }
         }
         throw new \RuntimeException(sprintf('No handler found for Command "%s"', get_debug_type($command)), 1649582778);
@@ -49,7 +47,6 @@ final readonly class CommandBus
     public function withAdditionalHandlers(CommandHandlerInterface ...$handlers): self
     {
         return new self(
-            $this->commandHandlingDependencies,
             ...$this->handlers,
             ...$handlers,
         );

--- a/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHandlerInterface.php
+++ b/Neos.ContentRepository.Core/Classes/CommandHandler/CommandHandlerInterface.php
@@ -10,8 +10,6 @@ use Neos\ContentRepository\Core\Feature\Common\RebasableToOtherWorkspaceInterfac
 /**
  * Common interface for all Content Repository command handlers
  *
- * The {@see CommandHandlingDependencies} are available during handling to do soft-constraint checks
- *
  * @internal no public API, because commands are no extension points of the CR
  */
 interface CommandHandlerInterface
@@ -26,5 +24,5 @@ interface CommandHandlerInterface
      *
      * @return EventsToPublish|\Generator<int, EventsToPublish>
      */
-    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command, CommandHandlingDependencies $commandHandlingDependencies): EventsToPublish|\Generator;
+    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command): EventsToPublish|\Generator;
 }

--- a/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
+++ b/Neos.ContentRepository.Core/Classes/Factory/ContentRepositoryFactory.php
@@ -150,14 +150,15 @@ final class ContentRepositoryFactory
 
         // we dont need full recursion in rebase - e.g apply workspace commands - and thus we can use this set for simulation
         $commandBusForRebaseableCommands = new CommandBus(
-            $commandHandlingDependencies,
             new NodeAggregateCommandHandler(
+                $commandHandlingDependencies,
                 $this->nodeTypeManager,
                 $this->contentDimensionZookeeper,
                 $this->interDimensionalVariationGraph,
                 $this->propertyConverter,
             ),
             new DimensionSpaceCommandHandler(
+                $commandHandlingDependencies,
                 $this->interDimensionalVariationGraph,
                 $this->nodeTypeManager,
             )
@@ -171,6 +172,7 @@ final class ContentRepositoryFactory
 
         $publicCommandBus = $commandBusForRebaseableCommands->withAdditionalHandlers(
             new WorkspaceCommandHandler(
+                $commandHandlingDependencies,
                 $commandSimulatorFactory,
                 $this->eventStore,
                 $this->eventNormalizer,

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\Common;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
@@ -78,10 +77,9 @@ trait ConstraintChecks
      */
     protected function requireContentStream(
         WorkspaceName $workspaceName,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): ContentStreamId {
-        $contentStreamId = $commandHandlingDependencies->getContentGraph($workspaceName)->getContentStreamId();
-        $isContentStreamClosed = $commandHandlingDependencies->isContentStreamClosed($contentStreamId);
+        $contentStreamId = $this->commandHandlingDependencies->getContentGraph($workspaceName)->getContentStreamId();
+        $isContentStreamClosed = $this->commandHandlingDependencies->isContentStreamClosed($contentStreamId);
 
         if ($isContentStreamClosed) {
             throw new ContentStreamIsClosed(
@@ -697,11 +695,10 @@ trait ConstraintChecks
 
     protected function getExpectedVersionOfContentStream(
         ContentStreamId $contentStreamId,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): ExpectedVersion {
 
         return ExpectedVersion::fromVersion(
-            $commandHandlingDependencies->getContentStreamVersion($contentStreamId)
+            $this->commandHandlingDependencies->getContentStreamVersion($contentStreamId)
         );
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/ConstraintChecks.php
@@ -19,12 +19,9 @@ use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\NodeModification\Dto\PropertyValuesToWrite;
-use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
 use Neos\ContentRepository\Core\Feature\NodeVariation\Exception\DimensionSpacePointIsAlreadyOccupied;
 use Neos\ContentRepository\Core\Infrastructure\Property\PropertyType;
-use Neos\ContentRepository\Core\NodeType\ConstraintCheck;
 use Neos\ContentRepository\Core\NodeType\NodeType;
-use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
 use Neos\ContentRepository\Core\NodeType\NodeTypeName;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFilter;
@@ -52,7 +49,6 @@ use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeIsAbstract;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeIsNotOfTypeRoot;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeIsOfTypeRoot;
 use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFound;
-use Neos\ContentRepository\Core\SharedModel\Exception\PropertyCannotBeSet;
 use Neos\ContentRepository\Core\SharedModel\Exception\ReferenceCannotBeSet;
 use Neos\ContentRepository\Core\SharedModel\Exception\RootNodeAggregateTypeIsAlreadyOccupied;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
@@ -68,7 +64,7 @@ use Neos\EventStore\Model\EventStream\ExpectedVersion;
  */
 trait ConstraintChecks
 {
-    abstract protected function getNodeTypeManager(): NodeTypeManager;
+    use NodeTypeConstraintChecks;
 
     abstract protected function getAllowedDimensionSubspace(): DimensionSpacePointSet;
 
@@ -100,19 +96,6 @@ trait ConstraintChecks
         if (!$this->getAllowedDimensionSubspace()->contains($dimensionSpacePoint)) {
             throw DimensionSpacePointNotFound::becauseItIsNotWithinTheAllowedDimensionSubspace($dimensionSpacePoint);
         }
-    }
-
-    /**
-     * @param NodeTypeName $nodeTypeName
-     * @return NodeType
-     * @throws NodeTypeNotFound
-     */
-    protected function requireNodeType(NodeTypeName $nodeTypeName): NodeType
-    {
-        return $this->getNodeTypeManager()->getNodeType($nodeTypeName) ?? throw new NodeTypeNotFound(
-            'Node type "' . $nodeTypeName->value . '" is unknown to the node type manager.',
-            1541671070
-        );
     }
 
     protected function requireNodeTypeToNotBeAbstract(NodeType $nodeType): void
@@ -211,74 +194,6 @@ trait ConstraintChecks
         }
     }
 
-    protected function requireNodeTypeToDeclareProperty(NodeTypeName $nodeTypeName, PropertyName $propertyName): void
-    {
-        $nodeType = $this->requireNodeType($nodeTypeName);
-        if (!$nodeType->hasProperty($propertyName->value)) {
-            throw PropertyCannotBeSet::becauseTheNodeTypeDoesNotDeclareIt(
-                $propertyName,
-                $nodeTypeName
-            );
-        }
-    }
-
-    protected function requireNodeTypeToDeclareReference(NodeTypeName $nodeTypeName, ReferenceName $referenceName): void
-    {
-        $nodeType = $this->requireNodeType($nodeTypeName);
-        if ($nodeType->hasReference($referenceName->value)) {
-            return;
-        }
-        throw ReferenceCannotBeSet::becauseTheNodeTypeDoesNotDeclareIt($referenceName, $nodeTypeName);
-    }
-
-    protected function requireNodeTypeNotToDeclareTetheredChildNodeName(NodeTypeName $nodeTypeName, NodeName $nodeName): void
-    {
-        $nodeType = $this->requireNodeType($nodeTypeName);
-        if ($nodeType->tetheredNodeTypeDefinitions->contain($nodeName)) {
-            throw new NodeNameIsAlreadyCovered(
-                'Node name "' . $nodeName->value . '" is reserved for a tethered child of parent node aggregate of type "'
-                . $nodeTypeName->value . '".'
-            );
-        }
-    }
-
-    protected function requireNodeTypeToAllowNodesOfTypeInReference(
-        NodeTypeName $nodeTypeName,
-        ReferenceName $referenceName,
-        NodeTypeName $nodeTypeNameInQuestion
-    ): void {
-        $nodeType = $this->requireNodeType($nodeTypeName);
-        $constraints = $nodeType->getReferences()[$referenceName->value]['constraints']['nodeTypes'] ?? [];
-
-        if (!ConstraintCheck::create($constraints)->isNodeTypeAllowed($this->requireNodeType($nodeTypeNameInQuestion))) {
-            throw ReferenceCannotBeSet::becauseTheNodeTypeConstraintsAreNotMatched(
-                $referenceName,
-                $nodeTypeName,
-                $nodeTypeNameInQuestion
-            );
-        }
-    }
-
-    protected function requireNodeTypeToAllowNumberOfReferencesInReference(SerializedNodeReferences $nodeReferences, NodeTypeName $nodeTypeName): void
-    {
-        $nodeType = $this->requireNodeType($nodeTypeName);
-
-        foreach ($nodeReferences->references as $referencesByName) {
-            $maxItems = $nodeType->getReferences()[$referencesByName->referenceName->value]['constraints']['maxItems'] ?? null;
-            if ($maxItems === null) {
-                continue;
-            }
-
-            if ($maxItems < $referencesByName->count()) {
-                throw ReferenceCannotBeSet::becauseTheItemsCountConstraintsAreNotMatched(
-                    $referencesByName->referenceName,
-                    $nodeTypeName,
-                    $referencesByName->count()
-                );
-            }
-        }
-    }
-
     /**
      * @param array|NodeAggregateId[] $parentNodeAggregateIds
      * @throws NodeConstraintException
@@ -322,68 +237,6 @@ trait ConstraintChecks
                 }
             }
         }
-    }
-
-    /**
-     * @throws NodeTypeNotFound
-     * @throws NodeConstraintException
-     */
-    protected function requireNodeTypeConstraintsImposedByParentToBeMet(
-        NodeType $parentsNodeType,
-        NodeType $nodeType
-    ): void {
-        // !!! IF YOU ADJUST THIS METHOD, also adjust the method below.
-        if (!$parentsNodeType->allowsChildNodeType($nodeType)) {
-            throw new NodeConstraintException(
-                'Node type "' . $nodeType->name->value . '" is not allowed for child nodes of type '
-                    . $parentsNodeType->name->value,
-                1707561400
-            );
-        }
-    }
-
-    protected function areNodeTypeConstraintsImposedByParentValid(
-        NodeType $parentsNodeType,
-        NodeType $nodeType
-    ): bool {
-        // !!! IF YOU ADJUST THIS METHOD, also adjust the method above.
-        if (!$parentsNodeType->allowsChildNodeType($nodeType)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * @throws NodeConstraintException
-     */
-    protected function requireNodeTypeConstraintsImposedByGrandparentToBeMet(
-        NodeType $grandParentsNodeType,
-        ?NodeName $parentNodeName,
-        NodeType $nodeType
-    ): void {
-        if (
-            !$this->areNodeTypeConstraintsImposedByGrandparentValid(
-                $grandParentsNodeType,
-                $parentNodeName,
-                $nodeType
-            )
-        ) {
-            throw new NodeConstraintException(
-                'Node type "' . $nodeType->name->value . '" is not allowed below tethered child nodes "' . $parentNodeName?->value
-                    . '" of nodes of type "' . $grandParentsNodeType->name->value . '"',
-                1520011791
-            );
-        }
-    }
-
-    protected function areNodeTypeConstraintsImposedByGrandparentValid(
-        NodeType $grandParentsNodeType,
-        ?NodeName $parentNodeName,
-        NodeType $nodeType
-    ): bool {
-        return !($parentNodeName
-            && $grandParentsNodeType->tetheredNodeTypeDefinitions->contain($parentNodeName)
-            && !$this->getNodeTypeManager()->isNodeTypeAllowedAsChildToTetheredNode($grandParentsNodeType->name, $parentNodeName, $nodeType->name));
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeChangeInternals.php
@@ -27,7 +27,7 @@ use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
  */
 trait NodeTypeChangeInternals
 {
-    use ConstraintChecks;
+    use NodeTypeConstraintChecks;
 
     /**
      * NOTE: when changing this method, also check {@see NodeTypeChange::requireConstraintsImposedByHappyPathStrategyAreMet}

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/NodeTypeConstraintChecks.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Feature\Common;
+
+use Neos\ContentRepository\Core\Feature\NodeReferencing\Dto\SerializedNodeReferences;
+use Neos\ContentRepository\Core\NodeType\ConstraintCheck;
+use Neos\ContentRepository\Core\NodeType\NodeType;
+use Neos\ContentRepository\Core\NodeType\NodeTypeManager;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\Exception\NodeConstraintException;
+use Neos\ContentRepository\Core\SharedModel\Exception\NodeNameIsAlreadyCovered;
+use Neos\ContentRepository\Core\SharedModel\Exception\NodeTypeNotFound;
+use Neos\ContentRepository\Core\SharedModel\Exception\PropertyCannotBeSet;
+use Neos\ContentRepository\Core\SharedModel\Exception\ReferenceCannotBeSet;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
+use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
+use Neos\ContentRepository\Core\SharedModel\Node\ReferenceName;
+
+/**
+ * @internal implementation details of command handlers; Constraint checks only operating on the NodeTypes's not on the content graph
+ */
+trait NodeTypeConstraintChecks
+{
+    abstract protected function getNodeTypeManager(): NodeTypeManager;
+
+    /**
+     * @param NodeTypeName $nodeTypeName
+     * @return NodeType
+     * @throws NodeTypeNotFound
+     */
+    protected function requireNodeType(NodeTypeName $nodeTypeName): NodeType
+    {
+        return $this->getNodeTypeManager()->getNodeType($nodeTypeName) ?? throw new NodeTypeNotFound(
+            'Node type "' . $nodeTypeName->value . '" is unknown to the node type manager.',
+            1541671070
+        );
+    }
+
+    final protected function requireNodeTypeToDeclareProperty(NodeTypeName $nodeTypeName, PropertyName $propertyName): void
+    {
+        $nodeType = $this->requireNodeType($nodeTypeName);
+        if (!$nodeType->hasProperty($propertyName->value)) {
+            throw PropertyCannotBeSet::becauseTheNodeTypeDoesNotDeclareIt(
+                $propertyName,
+                $nodeTypeName
+            );
+        }
+    }
+
+    final protected function requireNodeTypeToDeclareReference(NodeTypeName $nodeTypeName, ReferenceName $referenceName): void
+    {
+        $nodeType = $this->requireNodeType($nodeTypeName);
+        if ($nodeType->hasReference($referenceName->value)) {
+            return;
+        }
+        throw ReferenceCannotBeSet::becauseTheNodeTypeDoesNotDeclareIt($referenceName, $nodeTypeName);
+    }
+
+    final protected function requireNodeTypeNotToDeclareTetheredChildNodeName(NodeTypeName $nodeTypeName, NodeName $nodeName): void
+    {
+        $nodeType = $this->requireNodeType($nodeTypeName);
+        if ($nodeType->tetheredNodeTypeDefinitions->contain($nodeName)) {
+            throw new NodeNameIsAlreadyCovered(
+                'Node name "' . $nodeName->value . '" is reserved for a tethered child of parent node aggregate of type "'
+                . $nodeTypeName->value . '".'
+            );
+        }
+    }
+
+    final protected function requireNodeTypeToAllowNodesOfTypeInReference(
+        NodeTypeName $nodeTypeName,
+        ReferenceName $referenceName,
+        NodeTypeName $nodeTypeNameInQuestion
+    ): void {
+        $nodeType = $this->requireNodeType($nodeTypeName);
+        $constraints = $nodeType->getReferences()[$referenceName->value]['constraints']['nodeTypes'] ?? [];
+
+        if (!ConstraintCheck::create($constraints)->isNodeTypeAllowed($this->requireNodeType($nodeTypeNameInQuestion))) {
+            throw ReferenceCannotBeSet::becauseTheNodeTypeConstraintsAreNotMatched(
+                $referenceName,
+                $nodeTypeName,
+                $nodeTypeNameInQuestion
+            );
+        }
+    }
+
+    final protected function requireNodeTypeToAllowNumberOfReferencesInReference(SerializedNodeReferences $nodeReferences, NodeTypeName $nodeTypeName): void
+    {
+        $nodeType = $this->requireNodeType($nodeTypeName);
+
+        foreach ($nodeReferences->references as $referencesByName) {
+            $maxItems = $nodeType->getReferences()[$referencesByName->referenceName->value]['constraints']['maxItems'] ?? null;
+            if ($maxItems === null) {
+                continue;
+            }
+
+            if ($maxItems < $referencesByName->count()) {
+                throw ReferenceCannotBeSet::becauseTheItemsCountConstraintsAreNotMatched(
+                    $referencesByName->referenceName,
+                    $nodeTypeName,
+                    $referencesByName->count()
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws NodeTypeNotFound
+     * @throws NodeConstraintException
+     */
+    final protected function requireNodeTypeConstraintsImposedByParentToBeMet(
+        NodeType $parentsNodeType,
+        NodeType $nodeType
+    ): void {
+        // !!! IF YOU ADJUST THIS METHOD, also adjust the method below.
+        if (!$parentsNodeType->allowsChildNodeType($nodeType)) {
+            throw new NodeConstraintException(
+                'Node type "' . $nodeType->name->value . '" is not allowed for child nodes of type '
+                . $parentsNodeType->name->value,
+                1707561400
+            );
+        }
+    }
+
+    final protected function areNodeTypeConstraintsImposedByParentValid(
+        NodeType $parentsNodeType,
+        NodeType $nodeType
+    ): bool {
+        // !!! IF YOU ADJUST THIS METHOD, also adjust the method above.
+        if (!$parentsNodeType->allowsChildNodeType($nodeType)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @throws NodeConstraintException
+     */
+    final protected function requireNodeTypeConstraintsImposedByGrandparentToBeMet(
+        NodeType $grandParentsNodeType,
+        ?NodeName $parentNodeName,
+        NodeType $nodeType
+    ): void {
+        if (
+            !$this->areNodeTypeConstraintsImposedByGrandparentValid(
+                $grandParentsNodeType,
+                $parentNodeName,
+                $nodeType
+            )
+        ) {
+            throw new NodeConstraintException(
+                'Node type "' . $nodeType->name->value . '" is not allowed below tethered child nodes "' . $parentNodeName?->value
+                . '" of nodes of type "' . $grandParentsNodeType->name->value . '"',
+                1520011791
+            );
+        }
+    }
+
+    final protected function areNodeTypeConstraintsImposedByGrandparentValid(
+        NodeType $grandParentsNodeType,
+        ?NodeName $parentNodeName,
+        NodeType $nodeType
+    ): bool {
+        return !($parentNodeName
+            && $grandParentsNodeType->tetheredNodeTypeDefinitions->contain($parentNodeName)
+            && !$this->getNodeTypeManager()->isNodeTypeAllowedAsChildToTetheredNode($grandParentsNodeType->name, $parentNodeName, $nodeType->name));
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/Common/WorkspaceConstraintChecks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\Common;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Exception\DimensionSpacePointAlreadyExists;
 use Neos\ContentRepository\Core\Feature\DimensionSpaceAdjustment\Exception\InvalidDimensionAdjustmentTargetWorkspace;
@@ -23,9 +22,9 @@ trait WorkspaceConstraintChecks
     /**
      * @throws WorkspaceDoesNotExist
      */
-    private function requireWorkspace(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): Workspace
+    private function requireWorkspace(WorkspaceName $workspaceName): Workspace
     {
-        $workspace = $commandHandlingDependencies->findWorkspaceByName($workspaceName);
+        $workspace = $this->commandHandlingDependencies->findWorkspaceByName($workspaceName);
         if (is_null($workspace)) {
             throw WorkspaceDoesNotExist::butWasSupposedTo($workspaceName);
         }
@@ -37,23 +36,23 @@ trait WorkspaceConstraintChecks
      * @throws WorkspaceHasNoBaseWorkspaceName
      * @throws BaseWorkspaceDoesNotExist
      */
-    private function requireBaseWorkspace(Workspace $workspace, CommandHandlingDependencies $commandHandlingDependencies): Workspace
+    private function requireBaseWorkspace(Workspace $workspace): Workspace
     {
         if (is_null($workspace->baseWorkspaceName)) {
             throw WorkspaceHasNoBaseWorkspaceName::butWasSupposedTo($workspace->workspaceName);
         }
-        $baseWorkspace = $commandHandlingDependencies->findWorkspaceByName($workspace->baseWorkspaceName);
+        $baseWorkspace = $this->commandHandlingDependencies->findWorkspaceByName($workspace->baseWorkspaceName);
         if (is_null($baseWorkspace)) {
             throw BaseWorkspaceDoesNotExist::butWasSupposedTo($workspace->workspaceName);
         }
         return $baseWorkspace;
     }
 
-    private function requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): void
+    private function requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment(WorkspaceName $workspaceName): void
     {
-        $workspace = $this->requireWorkspace($workspaceName, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($workspaceName);
         if (!$workspace->isRootWorkspace()) {
-            $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+            $baseWorkspace = $this->requireBaseWorkspace($workspace);
             if (!$baseWorkspace->isRootWorkspace()) {
                 throw InvalidDimensionAdjustmentTargetWorkspace::becauseWorkspaceMustBeRootOrRootBased($workspace->workspaceName);
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\EventStore\DecoratedEvent;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
@@ -121,14 +120,12 @@ trait ContentStreamHandling
 
     /**
      * @param ContentStreamId $contentStreamId
-     * @param CommandHandlingDependencies $commandHandlingDependencies
      * @throws ContentStreamAlreadyExists
      */
     private function requireContentStreamToNotExistYet(
         ContentStreamId $contentStreamId,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): void {
-        if ($commandHandlingDependencies->contentStreamExists($contentStreamId)) {
+        if ($this->commandHandlingDependencies->contentStreamExists($contentStreamId)) {
             throw new ContentStreamAlreadyExists(
                 'Content stream "' . $contentStreamId->value . '" already exists.',
                 1521386345
@@ -138,9 +135,8 @@ trait ContentStreamHandling
 
     private function requireContentStreamToNotBeClosed(
         ContentStreamId $contentStreamId,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): void {
-        if ($commandHandlingDependencies->isContentStreamClosed($contentStreamId)) {
+        if ($this->commandHandlingDependencies->isContentStreamClosed($contentStreamId)) {
             throw new ContentStreamIsClosed(
                 'Content stream "' . $contentStreamId->value . '" is closed.',
                 1710260081

--- a/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/DimensionSpaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/DimensionSpaceAdjustment/DimensionSpaceCommandHandler.php
@@ -49,6 +49,7 @@ final readonly class DimensionSpaceCommandHandler implements CommandHandlerInter
     use WorkspaceConstraintChecks;
 
     public function __construct(
+        private CommandHandlingDependencies $commandHandlingDependencies,
         private InterDimensionalVariationGraph $interDimensionalVariationGraph,
         private NodeTypeManager $nodeTypeManager,
     ) {
@@ -59,33 +60,32 @@ final readonly class DimensionSpaceCommandHandler implements CommandHandlerInter
         return method_exists($this, 'handle' . (new \ReflectionClass($command))->getShortName());
     }
 
-    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command, CommandHandlingDependencies $commandHandlingDependencies): EventsToPublish
+    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command): EventsToPublish
     {
         /** @phpstan-ignore-next-line */
         return match ($command::class) {
-            MoveDimensionSpacePoint::class => $this->handleMoveDimensionSpacePoint($command, $commandHandlingDependencies),
-            AddDimensionShineThrough::class => $this->handleAddDimensionShineThrough($command, $commandHandlingDependencies),
+            MoveDimensionSpacePoint::class => $this->handleMoveDimensionSpacePoint($command),
+            AddDimensionShineThrough::class => $this->handleAddDimensionShineThrough($command),
         };
     }
 
     private function handleMoveDimensionSpacePoint(
         MoveDimensionSpacePoint $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = ExpectedVersion::fromVersion($commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = ExpectedVersion::fromVersion($this->commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentGraph->getContentStreamId())
             ->getEventStreamName();
 
         $this->requireDimensionSpacePointToExist($command->target);
-        $this->requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment($command->workspaceName, $commandHandlingDependencies);
-        $relevantWorkspaces = $commandHandlingDependencies->findAllWorkspaces()->filter(
+        $this->requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment($command->workspaceName);
+        $relevantWorkspaces = $this->commandHandlingDependencies->findAllWorkspaces()->filter(
             fn (Workspace $workspace): bool => $workspace->isRootWorkspace()
                 || !$workspace->workspaceName->equals($command->initialWorkspaceName)
         );
         foreach ($relevantWorkspaces as $workspace) {
             self::requireDimensionSpacePointToBeEmptyInContentStream(
-                $commandHandlingDependencies->getContentGraph($workspace->workspaceName),
+                $this->commandHandlingDependencies->getContentGraph($workspace->workspaceName),
                 $command->target,
             );
         }
@@ -123,23 +123,22 @@ final readonly class DimensionSpaceCommandHandler implements CommandHandlerInter
 
     private function handleAddDimensionShineThrough(
         AddDimensionShineThrough $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = ExpectedVersion::fromVersion($commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = ExpectedVersion::fromVersion($this->commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
         $streamName = ContentStreamEventStreamName::fromContentStreamId($contentGraph->getContentStreamId())
             ->getEventStreamName();
 
         $this->requireDimensionSpacePointToExist($command->target);
         $this->requireDimensionSpacePointToBeSpecialization($command->target, $command->source);
-        $this->requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment($command->workspaceName, $commandHandlingDependencies);
-        $relevantWorkspaces = $commandHandlingDependencies->findAllWorkspaces()->filter(
+        $this->requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment($command->workspaceName);
+        $relevantWorkspaces = $this->commandHandlingDependencies->findAllWorkspaces()->filter(
             fn (Workspace $workspace): bool => $workspace->isRootWorkspace()
                 || !$workspace->workspaceName->equals($command->initialWorkspaceName)
         );
         foreach ($relevantWorkspaces as $workspace) {
             self::requireDimensionSpacePointToBeEmptyInContentStream(
-                $commandHandlingDependencies->getContentGraph($workspace->workspaceName),
+                $this->commandHandlingDependencies->getContentGraph($workspace->workspaceName),
                 $command->target,
             );
         }

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeAggregateCommandHandler.php
@@ -77,6 +77,7 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
     private bool $ancestorNodeTypeConstraintChecksEnabled = true;
 
     public function __construct(
+        private readonly CommandHandlingDependencies $commandHandlingDependencies,
         private readonly NodeTypeManager $nodeTypeManager,
         private readonly DimensionSpace\ContentDimensionZookeeper $contentDimensionZookeeper,
         private readonly DimensionSpace\InterDimensionalVariationGraph $interDimensionalVariationGraph,
@@ -89,31 +90,31 @@ final class NodeAggregateCommandHandler implements CommandHandlerInterface
         return method_exists($this, 'handle' . (new \ReflectionClass($command))->getShortName());
     }
 
-    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command, CommandHandlingDependencies $commandHandlingDependencies): EventsToPublish
+    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command): EventsToPublish
     {
         /** @phpstan-ignore-next-line */
         return match ($command::class) {
-            SetNodeProperties::class => $this->handleSetNodeProperties($command, $commandHandlingDependencies),
+            SetNodeProperties::class => $this->handleSetNodeProperties($command),
             SetSerializedNodeProperties::class
-            => $this->handleSetSerializedNodeProperties($command, $commandHandlingDependencies),
-            SetNodeReferences::class => $this->handleSetNodeReferences($command, $commandHandlingDependencies),
+            => $this->handleSetSerializedNodeProperties($command),
+            SetNodeReferences::class => $this->handleSetNodeReferences($command),
             SetSerializedNodeReferences::class
-            => $this->handleSetSerializedNodeReferences($command, $commandHandlingDependencies),
-            ChangeNodeAggregateType::class => $this->handleChangeNodeAggregateType($command, $commandHandlingDependencies),
-            RemoveNodeAggregate::class => $this->handleRemoveNodeAggregate($command, $commandHandlingDependencies),
+            => $this->handleSetSerializedNodeReferences($command),
+            ChangeNodeAggregateType::class => $this->handleChangeNodeAggregateType($command),
+            RemoveNodeAggregate::class => $this->handleRemoveNodeAggregate($command),
             CreateNodeAggregateWithNode::class
-            => $this->handleCreateNodeAggregateWithNode($command, $commandHandlingDependencies),
+            => $this->handleCreateNodeAggregateWithNode($command),
             CreateNodeAggregateWithNodeAndSerializedProperties::class
-            => $this->handleCreateNodeAggregateWithNodeAndSerializedProperties($command, $commandHandlingDependencies),
-            MoveNodeAggregate::class => $this->handleMoveNodeAggregate($command, $commandHandlingDependencies),
-            CreateNodeVariant::class => $this->handleCreateNodeVariant($command, $commandHandlingDependencies),
+            => $this->handleCreateNodeAggregateWithNodeAndSerializedProperties($command),
+            MoveNodeAggregate::class => $this->handleMoveNodeAggregate($command),
+            CreateNodeVariant::class => $this->handleCreateNodeVariant($command),
             CreateRootNodeAggregateWithNode::class
-            => $this->handleCreateRootNodeAggregateWithNode($command, $commandHandlingDependencies),
+            => $this->handleCreateRootNodeAggregateWithNode($command),
             UpdateRootNodeAggregateDimensions::class
-            => $this->handleUpdateRootNodeAggregateDimensions($command, $commandHandlingDependencies),
-            TagSubtree::class => $this->handleTagSubtree($command, $commandHandlingDependencies),
-            UntagSubtree::class => $this->handleUntagSubtree($command, $commandHandlingDependencies),
-            ChangeNodeAggregateName::class => $this->handleChangeNodeAggregateName($command, $commandHandlingDependencies),
+            => $this->handleUpdateRootNodeAggregateDimensions($command),
+            TagSubtree::class => $this->handleTagSubtree($command),
+            UntagSubtree::class => $this->handleUntagSubtree($command),
+            ChangeNodeAggregateName::class => $this->handleChangeNodeAggregateName($command),
         };
     }
 

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeCreation/NodeCreation.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeCreation;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
@@ -75,7 +74,6 @@ trait NodeCreation
 
     private function handleCreateNodeAggregateWithNode(
         CreateNodeAggregateWithNode $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
         $this->requireNodeType($command->nodeTypeName);
         $this->validateProperties($command->initialPropertyValues, $command->nodeTypeName);
@@ -100,7 +98,7 @@ trait NodeCreation
             $lowLevelCommand = $lowLevelCommand->withNodeName($command->nodeName);
         }
 
-        return $this->handleCreateNodeAggregateWithNodeAndSerializedProperties($lowLevelCommand, $commandHandlingDependencies);
+        return $this->handleCreateNodeAggregateWithNodeAndSerializedProperties($lowLevelCommand);
     }
 
     private function validateProperties(?PropertyValuesToWrite $propertyValues, NodeTypeName $nodeTypeName): void
@@ -133,11 +131,10 @@ trait NodeCreation
      */
     private function handleCreateNodeAggregateWithNodeAndSerializedProperties(
         CreateNodeAggregateWithNodeAndSerializedProperties $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $this->requireDimensionSpacePointToExist($command->originDimensionSpacePoint->toDimensionSpacePoint());
         $nodeType = $this->requireNodeType($command->nodeTypeName);
         $this->requireNodeTypeToNotBeAbstract($nodeType);

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeModification/NodeModification.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeModification/NodeModification.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeModification;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Feature\ContentStreamEventStreamName;
@@ -45,10 +44,9 @@ trait NodeModification
 
     private function handleSetNodeProperties(
         SetNodeProperties $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
         $this->requireDimensionSpacePointToExist($command->originDimensionSpacePoint->toDimensionSpacePoint());
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,
@@ -70,15 +68,14 @@ trait NodeModification
             $command->propertyValues->getPropertiesToUnset()
         );
 
-        return $this->handleSetSerializedNodeProperties($lowLevelCommand, $commandHandlingDependencies);
+        return $this->handleSetSerializedNodeProperties($lowLevelCommand);
     }
 
     private function handleSetSerializedNodeProperties(
         SetSerializedNodeProperties $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): EventsToPublish {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         // Check if node exists
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeMove/NodeMove.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeMove/NodeMove.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeMove;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
@@ -83,11 +82,10 @@ trait NodeMove
      */
     private function handleMoveNodeAggregate(
         MoveNodeAggregate $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $contentStreamId = $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentStreamId, $commandHandlingDependencies);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $contentStreamId = $this->requireContentStream($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentStreamId);
         $this->requireDimensionSpacePointToExist($command->dimensionSpacePoint);
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/NodeReferencing.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeReferencing/NodeReferencing.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeReferencing;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Feature\Common\ConstraintChecks;
@@ -48,10 +47,9 @@ trait NodeReferencing
 
     private function handleSetNodeReferences(
         SetNodeReferences $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
         $this->requireDimensionSpacePointToExist($command->sourceOriginDimensionSpacePoint->toDimensionSpacePoint());
         $sourceNodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,
@@ -79,7 +77,7 @@ trait NodeReferencing
             $this->mapNodeReferencesToSerializedNodeReferences($command->references, $nodeTypeName),
         );
 
-        return $this->handleSetSerializedNodeReferences($lowLevelCommand, $commandHandlingDependencies);
+        return $this->handleSetSerializedNodeReferences($lowLevelCommand);
     }
 
     /**
@@ -87,10 +85,9 @@ trait NodeReferencing
      */
     private function handleSetSerializedNodeReferences(
         SetSerializedNodeReferences $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $this->requireDimensionSpacePointToExist(
             $command->sourceOriginDimensionSpacePoint->toDimensionSpacePoint()
         );

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/NodeRemoval.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRemoval/NodeRemoval.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeRemoval;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Core\EventStore\Events;
@@ -45,11 +44,10 @@ trait NodeRemoval
      */
     private function handleRemoveNodeAggregate(
         RemoveNodeAggregate $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,
             $command->nodeAggregateId

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/NodeRenaming.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeRenaming/NodeRenaming.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeRenaming;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Feature\Common\ConstraintChecks;
@@ -30,11 +29,11 @@ trait NodeRenaming
 {
     use ConstraintChecks;
 
-    private function handleChangeNodeAggregateName(ChangeNodeAggregateName $command, CommandHandlingDependencies $commandHandlingDependencies): EventsToPublish
+    private function handleChangeNodeAggregateName(ChangeNodeAggregateName $command): EventsToPublish
     {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $this->requireContentStream($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,
             $command->nodeAggregateId

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeTypeChange/NodeTypeChange.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeTypeChange;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePointSet;
 use Neos\ContentRepository\Core\EventStore\EventInterface;
@@ -125,15 +124,14 @@ trait NodeTypeChange
      */
     private function handleChangeNodeAggregateType(
         ChangeNodeAggregateType $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
         /**************
          * Constraint checks
          **************/
         // existence of content stream, node type and node aggregate
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $newNodeType = $this->requireNodeType($command->newNodeTypeName);
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,

--- a/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/NodeVariation.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/NodeVariation/NodeVariation.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\NodeVariation;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
 use Neos\ContentRepository\Core\Feature\Common\ConstraintChecks;
@@ -47,11 +46,10 @@ trait NodeVariation
      */
     private function handleCreateNodeVariant(
         CreateNodeVariant $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,
             $command->nodeAggregateId

--- a/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/RootNodeCreation/RootNodeHandling.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Neos\ContentRepository\Core\Feature\RootNodeCreation;
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePointSet;
 use Neos\ContentRepository\Core\DimensionSpace\OriginDimensionSpacePoint;
@@ -66,7 +65,6 @@ trait RootNodeHandling
 
     /**
      * @param CreateRootNodeAggregateWithNode $command
-     * @param CommandHandlingDependencies $commandHandlingDependencies
      * @return EventsToPublish
      * @throws ContentStreamDoesNotExistYet
      * @throws NodeAggregateCurrentlyExists
@@ -75,11 +73,10 @@ trait RootNodeHandling
      */
     private function handleCreateRootNodeAggregateWithNode(
         CreateRootNodeAggregateWithNode $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $this->requireProjectedNodeAggregateToNotExist(
             $contentGraph,
             $command->nodeAggregateId
@@ -160,10 +157,9 @@ trait RootNodeHandling
      */
     private function handleUpdateRootNodeAggregateDimensions(
         UpdateRootNodeAggregateDimensions $command,
-        CommandHandlingDependencies $commandHandlingDependencies
     ): EventsToPublish {
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId(), $commandHandlingDependencies);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = $this->getExpectedVersionOfContentStream($contentGraph->getContentStreamId());
         $rootNodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,
             $command->nodeAggregateId
@@ -172,8 +168,8 @@ trait RootNodeHandling
             throw new NodeAggregateIsNotRoot('The node aggregate ' . $rootNodeAggregate->nodeAggregateId->value . ' is not classified as root, but should be for command UpdateRootNodeAggregateDimensions.', 1678647355);
         }
 
-        $this->requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment($command->workspaceName, $commandHandlingDependencies);
-        $relevantWorkspaces = $commandHandlingDependencies->findAllWorkspaces()->filter(
+        $this->requireWorkspaceToBeRootOrRootBasedForDimensionAdjustment($command->workspaceName);
+        $relevantWorkspaces = $this->commandHandlingDependencies->findAllWorkspaces()->filter(
             fn (Workspace $workspace): bool => !$workspace->workspaceName->equals($command->initialWorkspaceName)
         );
         self::requireNoWorkspaceToHaveChanges($relevantWorkspaces);
@@ -184,7 +180,7 @@ trait RootNodeHandling
         foreach ($newDimensionSpacePoints as $newDimensionSpacePoint) {
             foreach ($relevantWorkspaces as $workspace) {
                 self::requireDimensionSpacePointToBeEmptyInContentStream(
-                    $commandHandlingDependencies->getContentGraph($workspace->workspaceName),
+                    $this->commandHandlingDependencies->getContentGraph($workspace->workspaceName),
                     $newDimensionSpacePoint,
                 );
             }

--- a/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/SubtreeTagging.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/SubtreeTagging/SubtreeTagging.php
@@ -14,7 +14,6 @@ namespace Neos\ContentRepository\Core\Feature\SubtreeTagging;
  * source code.
  */
 
-use Neos\ContentRepository\Core\CommandHandler\CommandHandlingDependencies;
 use Neos\ContentRepository\Core\DimensionSpace;
 use Neos\ContentRepository\Core\EventStore\Events;
 use Neos\ContentRepository\Core\EventStore\EventsToPublish;
@@ -38,11 +37,11 @@ trait SubtreeTagging
 
     abstract protected function getInterDimensionalVariationGraph(): DimensionSpace\InterDimensionalVariationGraph;
 
-    private function handleTagSubtree(TagSubtree $command, CommandHandlingDependencies $commandHandlingDependencies): EventsToPublish
+    private function handleTagSubtree(TagSubtree $command): EventsToPublish
     {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = ExpectedVersion::fromVersion($commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = ExpectedVersion::fromVersion($this->commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
         $this->requireDimensionSpacePointToExist($command->coveredDimensionSpacePoint);
         $nodeAggregate = $this->requireProjectedNodeAggregate($contentGraph, $command->nodeAggregateId);
         $this->requireNodeAggregateToCoverDimensionSpacePoint(
@@ -83,11 +82,11 @@ trait SubtreeTagging
         );
     }
 
-    public function handleUntagSubtree(UntagSubtree $command, CommandHandlingDependencies $commandHandlingDependencies): EventsToPublish
+    public function handleUntagSubtree(UntagSubtree $command): EventsToPublish
     {
-        $this->requireContentStream($command->workspaceName, $commandHandlingDependencies);
-        $contentGraph = $commandHandlingDependencies->getContentGraph($command->workspaceName);
-        $expectedVersion = ExpectedVersion::fromVersion($commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
+        $this->requireContentStream($command->workspaceName);
+        $contentGraph = $this->commandHandlingDependencies->getContentGraph($command->workspaceName);
+        $expectedVersion = ExpectedVersion::fromVersion($this->commandHandlingDependencies->getContentStreamVersion($contentGraph->getContentStreamId()));
         $this->requireDimensionSpacePointToExist($command->coveredDimensionSpacePoint);
         $nodeAggregate = $this->requireProjectedNodeAggregate(
             $contentGraph,

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -83,6 +83,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
     use WorkspaceConstraintChecks;
 
     public function __construct(
+        private CommandHandlingDependencies $commandHandlingDependencies,
         private CommandSimulatorFactory $commandSimulatorFactory,
         private EventStoreInterface $eventStore,
         private EventNormalizer $eventNormalizer,
@@ -97,19 +98,19 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
     /**
      * @return \Generator<int, EventsToPublish>
      */
-    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command, CommandHandlingDependencies $commandHandlingDependencies): \Generator
+    public function handle(CommandInterface|RebasableToOtherWorkspaceInterface $command): \Generator
     {
         /** @phpstan-ignore-next-line */
         return match ($command::class) {
-            CreateWorkspace::class => $this->handleCreateWorkspace($command, $commandHandlingDependencies),
-            CreateRootWorkspace::class => $this->handleCreateRootWorkspace($command, $commandHandlingDependencies),
-            PublishWorkspace::class => $this->handlePublishWorkspace($command, $commandHandlingDependencies),
-            RebaseWorkspace::class => $this->handleRebaseWorkspace($command, $commandHandlingDependencies),
-            PublishIndividualNodesFromWorkspace::class => $this->handlePublishIndividualNodesFromWorkspace($command, $commandHandlingDependencies),
-            DiscardIndividualNodesFromWorkspace::class => $this->handleDiscardIndividualNodesFromWorkspace($command, $commandHandlingDependencies),
-            DiscardWorkspace::class => $this->handleDiscardWorkspace($command, $commandHandlingDependencies),
-            DeleteWorkspace::class => $this->handleDeleteWorkspace($command, $commandHandlingDependencies),
-            ChangeBaseWorkspace::class => $this->handleChangeBaseWorkspace($command, $commandHandlingDependencies),
+            CreateWorkspace::class => $this->handleCreateWorkspace($command),
+            CreateRootWorkspace::class => $this->handleCreateRootWorkspace($command),
+            PublishWorkspace::class => $this->handlePublishWorkspace($command),
+            RebaseWorkspace::class => $this->handleRebaseWorkspace($command),
+            PublishIndividualNodesFromWorkspace::class => $this->handlePublishIndividualNodesFromWorkspace($command),
+            DiscardIndividualNodesFromWorkspace::class => $this->handleDiscardIndividualNodesFromWorkspace($command),
+            DiscardWorkspace::class => $this->handleDiscardWorkspace($command),
+            DeleteWorkspace::class => $this->handleDeleteWorkspace($command),
+            ChangeBaseWorkspace::class => $this->handleChangeBaseWorkspace($command),
         };
     }
 
@@ -121,10 +122,9 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleCreateWorkspace(
         CreateWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $this->requireWorkspaceToNotExist($command->workspaceName, $commandHandlingDependencies);
-        $baseWorkspace = $commandHandlingDependencies->findWorkspaceByName($command->baseWorkspaceName);
+        $this->requireWorkspaceToNotExist($command->workspaceName);
+        $baseWorkspace = $this->commandHandlingDependencies->findWorkspaceByName($command->baseWorkspaceName);
         if ($baseWorkspace === null) {
             throw new BaseWorkspaceDoesNotExist(sprintf(
                 'The workspace %s (base workspace of %s) does not exist',
@@ -132,9 +132,9 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->workspaceName->value
             ), 1513890708);
         }
-        $sourceContentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($baseWorkspace->currentContentStreamId);
-        $this->requireContentStreamToNotBeClosed($baseWorkspace->currentContentStreamId, $commandHandlingDependencies);
-        $this->requireContentStreamToNotExistYet($command->newContentStreamId, $commandHandlingDependencies);
+        $sourceContentStreamVersion = $this->commandHandlingDependencies->getContentStreamVersion($baseWorkspace->currentContentStreamId);
+        $this->requireContentStreamToNotBeClosed($baseWorkspace->currentContentStreamId);
+        $this->requireContentStreamToNotExistYet($command->newContentStreamId);
 
         // When the workspace is created, we first have to fork the content stream
         yield $this->forkContentStream(
@@ -170,10 +170,9 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleCreateRootWorkspace(
         CreateRootWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $this->requireWorkspaceToNotExist($command->workspaceName, $commandHandlingDependencies);
-        $this->requireContentStreamToNotExistYet($command->newContentStreamId, $commandHandlingDependencies);
+        $this->requireWorkspaceToNotExist($command->workspaceName);
+        $this->requireContentStreamToNotExistYet($command->newContentStreamId);
 
         yield new EventsToPublish(
             ContentStreamEventStreamName::fromContentStreamId($command->newContentStreamId)->getEventStreamName(),
@@ -205,15 +204,14 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
 
     private function handlePublishWorkspace(
         PublishWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $baseWorkspace = $this->requireBaseWorkspace($workspace);
         if (!$workspace->hasPublishableChanges()) {
             throw WorkspaceCommandSkipped::becauseWorkspaceToPublishIsEmpty($command->workspaceName);
         }
-        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace, $commandHandlingDependencies);
-        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace, $commandHandlingDependencies);
+        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace);
+        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace);
 
         $rebaseableCommands = RebaseableCommands::extractFromEventStream(
             $this->eventStore->load(
@@ -361,13 +359,12 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleRebaseWorkspace(
         RebaseWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $baseWorkspace = $this->requireBaseWorkspace($workspace);
 
-        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace, $commandHandlingDependencies);
-        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace, $commandHandlingDependencies);
+        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace);
+        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace);
 
         if (
             $workspace->status === WorkspaceStatus::UP_TO_DATE
@@ -472,17 +469,16 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handlePublishIndividualNodesFromWorkspace(
         PublishIndividualNodesFromWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $baseWorkspace = $this->requireBaseWorkspace($workspace);
 
         if (!$workspace->hasPublishableChanges()) {
             throw WorkspaceCommandSkipped::becauseWorkspaceToPublishIsEmpty($command->workspaceName);
         }
 
-        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace, $commandHandlingDependencies);
-        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace, $commandHandlingDependencies);
+        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace);
+        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace);
 
         $rebaseableCommands = RebaseableCommands::extractFromEventStream(
             $this->eventStore->load(
@@ -604,17 +600,16 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleDiscardIndividualNodesFromWorkspace(
         DiscardIndividualNodesFromWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $baseWorkspace = $this->requireBaseWorkspace($workspace);
 
         if (!$workspace->hasPublishableChanges()) {
             throw WorkspaceCommandSkipped::becauseWorkspaceToDiscardIsEmpty($command->workspaceName);
         }
 
-        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace, $commandHandlingDependencies);
-        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace, $commandHandlingDependencies);
+        $workspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($workspace);
+        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace);
 
         $rebaseableCommands = RebaseableCommands::extractFromEventStream(
             $this->eventStore->load(
@@ -714,17 +709,16 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleDiscardWorkspace(
         DiscardWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $baseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $baseWorkspace = $this->requireBaseWorkspace($workspace);
 
         if (!$workspace->hasPublishableChanges()) {
             throw WorkspaceCommandSkipped::becauseWorkspaceToDiscardIsEmpty($command->workspaceName);
         }
 
-        $this->requireContentStreamToNotBeClosed($workspace->currentContentStreamId, $commandHandlingDependencies);
-        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace, $commandHandlingDependencies);
+        $this->requireContentStreamToNotBeClosed($workspace->currentContentStreamId);
+        $baseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($baseWorkspace);
 
         yield from $this->discardWorkspace(
             $workspace,
@@ -776,12 +770,11 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleChangeBaseWorkspace(
         ChangeBaseWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $currentBaseWorkspace = $this->requireBaseWorkspace($workspace, $commandHandlingDependencies);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $currentBaseWorkspace = $this->requireBaseWorkspace($workspace);
 
-        $this->requireContentStreamToNotBeClosed($workspace->currentContentStreamId, $commandHandlingDependencies);
+        $this->requireContentStreamToNotBeClosed($workspace->currentContentStreamId);
 
         if ($currentBaseWorkspace->workspaceName->equals($command->baseWorkspaceName)) {
             throw WorkspaceCommandSkipped::becauseTheBaseWorkspaceIsUnchanged($command->baseWorkspaceName, $command->workspaceName);
@@ -791,10 +784,10 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             throw WorkspaceContainsPublishableChanges::butWasNotSupposedToForBaseWorkspaceChange($workspace->workspaceName);
         }
 
-        $newBaseWorkspace = $this->requireWorkspace($command->baseWorkspaceName, $commandHandlingDependencies);
-        $this->requireNonCircularRelationBetweenWorkspaces($workspace, $newBaseWorkspace, $commandHandlingDependencies);
+        $newBaseWorkspace = $this->requireWorkspace($command->baseWorkspaceName);
+        $this->requireNonCircularRelationBetweenWorkspaces($workspace, $newBaseWorkspace);
 
-        $newBaseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($newBaseWorkspace, $commandHandlingDependencies);
+        $newBaseWorkspaceContentStreamVersion = $this->requireOpenContentStreamAndVersion($newBaseWorkspace);
 
         yield $this->forkContentStream(
             $command->newContentStreamId,
@@ -823,10 +816,9 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
      */
     private function handleDeleteWorkspace(
         DeleteWorkspace $command,
-        CommandHandlingDependencies $commandHandlingDependencies,
     ): \Generator {
-        $workspace = $this->requireWorkspace($command->workspaceName, $commandHandlingDependencies);
-        $contentStreamVersion = $commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
+        $workspace = $this->requireWorkspace($command->workspaceName);
+        $contentStreamVersion = $this->commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
 
         yield new EventsToPublish(
             ContentStreamEventStreamName::fromContentStreamId($workspace->currentContentStreamId)->getEventStreamName(),
@@ -883,9 +875,9 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         );
     }
 
-    private function requireWorkspaceToNotExist(WorkspaceName $workspaceName, CommandHandlingDependencies $commandHandlingDependencies): void
+    private function requireWorkspaceToNotExist(WorkspaceName $workspaceName): void
     {
-        if ($commandHandlingDependencies->findWorkspaceByName($workspaceName) === null) {
+        if ($this->commandHandlingDependencies->findWorkspaceByName($workspaceName) === null) {
             return;
         }
 
@@ -895,22 +887,22 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         ), 1715341085);
     }
 
-    private function requireOpenContentStreamAndVersion(Workspace $workspace, CommandHandlingDependencies $commandHandlingDependencies): Version
+    private function requireOpenContentStreamAndVersion(Workspace $workspace): Version
     {
-        if ($commandHandlingDependencies->isContentStreamClosed($workspace->currentContentStreamId)) {
+        if ($this->commandHandlingDependencies->isContentStreamClosed($workspace->currentContentStreamId)) {
             throw new ContentStreamIsClosed(
                 'Content stream "' . $workspace->currentContentStreamId . '" is closed.',
                 1730730516
             );
         }
-        return $commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
+        return $this->commandHandlingDependencies->getContentStreamVersion($workspace->currentContentStreamId);
     }
 
     /**
      * @throws BaseWorkspaceEqualsWorkspaceException
      * @throws CircularRelationBetweenWorkspacesException
      */
-    private function requireNonCircularRelationBetweenWorkspaces(Workspace $workspace, Workspace $baseWorkspace, CommandHandlingDependencies $commandHandlingDependencies): void
+    private function requireNonCircularRelationBetweenWorkspaces(Workspace $workspace, Workspace $baseWorkspace): void
     {
         if ($workspace->workspaceName->equals($baseWorkspace->workspaceName)) {
             throw new BaseWorkspaceEqualsWorkspaceException(sprintf('The base workspace of the target must be different from the given workspace "%s".', $workspace->workspaceName->value));
@@ -920,7 +912,7 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
             if ($workspace->workspaceName->equals($nextBaseWorkspace->baseWorkspaceName)) {
                 throw new CircularRelationBetweenWorkspacesException(sprintf('The workspace "%s" is already on the path of the target workspace "%s".', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value));
             }
-            $nextBaseWorkspace = $this->requireBaseWorkspace($nextBaseWorkspace, $commandHandlingDependencies);
+            $nextBaseWorkspace = $this->requireBaseWorkspace($nextBaseWorkspace);
         }
     }
 


### PR DESCRIPTION

History:

In the original draft of the ESCR we passed the `$contentRepository` along through the command handlers to query the graph but also to invoke `$contentRepository->handle()` recursively.

That had the obvious problem of a recursion and did not allow to bind the content repository onto the command handlers.

Over time we introduced the `CommandHandlingDependencies` object which originally contained still the `$contentRepository` (https://github.com/neos/neos-development-collection/pull/5028) but limited access to it. Eventually we got rid of the `handle()` recursion and nowadays the `CommandHandlingDependencies` are only a thin wrapper around the `ContentGraphReadModelInterface` (https://github.com/neos/neos-development-collection/pull/5272) and this read-model is NOT the content repository instance but available _before_ the cr is build and thus we can pass it into the actual command handler instances to simplify their code.

We also don't publish events via the command handlers anymore but since https://github.com/neos/neos-development-collection/pull/5315 introduced generators to yield them into the content repository.

Solves todo from https://github.com/neos/neos-development-collection/pull/5301 / followup to "Dont pass CommandHandlingDependencies through half of the world" https://github.com/neos/neos-development-collection/commit/f0ba01abe76a88d3b40ab8f615e06680f3d5d58a