### PR TITLE
BUGFIX: Flush content cache on base workspace change

### DIFF
--- a/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
+++ b/Neos.Neos/Classes/Fusion/Cache/GraphProjectorCatchUpHookForCacheFlushing.php
@@ -31,13 +31,13 @@ use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregate
 use Neos\ContentRepository\Core\Feature\RootNodeCreation\Event\RootNodeAggregateWithNodeWasCreated;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasTagged;
 use Neos\ContentRepository\Core\Feature\SubtreeTagging\Event\SubtreeWasUntagged;
+use Neos\ContentRepository\Core\Feature\WorkspaceModification\Event\WorkspaceBaseWorkspaceWasChanged;
 use Neos\ContentRepository\Core\Feature\WorkspacePublication\Event\WorkspaceWasDiscarded;
 use Neos\ContentRepository\Core\Feature\WorkspaceRebase\Event\WorkspaceWasRebased;
 use Neos\ContentRepository\Core\Projection\CatchUpHook\CatchUpHookInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\ContentGraphReadModelInterface;
 use Neos\ContentRepository\Core\Projection\ContentGraph\NodeAggregate;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
-use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateIds;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
@@ -117,6 +117,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
             RootNodeAggregateWithNodeWasCreated::class,
             SubtreeWasTagged::class,
             SubtreeWasUntagged::class,
+            WorkspaceBaseWorkspaceWasChanged::class,
             WorkspaceWasDiscarded::class,
             WorkspaceWasRebased::class
         ]);
@@ -174,6 +175,7 @@ class GraphProjectorCatchUpHookForCacheFlushing implements CatchUpHookInterface
         if (
             $eventInstance instanceof WorkspaceWasDiscarded
             || $eventInstance instanceof WorkspaceWasRebased
+            || $eventInstance instanceof WorkspaceBaseWorkspaceWasChanged
         ) {
             $this->scheduleCacheFlushJobForWorkspaceName($eventInstance->workspaceName);
         } elseif (

--- a/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
+++ b/Neos.Neos/Tests/Behavior/Features/ContentCache/NodesInUserWorkspace.feature
@@ -296,3 +296,58 @@ Feature: Tests for the ContentCacheFlusher and cache flushing when applied in us
     <div class="neos-contentcollection">secondRender[Text Node at the start of the document]secondRender[Text Node in the middle of the document]secondRender[Text Node at the end of the document]</div>
     """
 
+  Scenario: ContentCache gets flushed when the base workspace of a workspace is changed
+    Given I have Fusion content cache enabled
+    And I am in workspace "user-editor" and dimension space point {}
+    And the Fusion context node is "test-document-with-contents"
+    And I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      prototype(Neos.Neos:Test.TextNode) {
+        cacheVerifier = "firstRender"
+      }
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">firstRender[Text Node at the start of the document]firstRender[Text Node at the end of the document]</div>
+    """
+
+    When the command CreateWorkspace is executed with payload:
+      | Key                | Value                   |
+      | workspaceName      | "preview"               |
+      | baseWorkspaceName  | "live"                  |
+      | newContentStreamId | "preview-cs-identifier" |
+    And I am in workspace "preview" and dimension space point {}
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                              | Value                                                |
+      | nodeAggregateId                  | "text-node-middle"                                   |
+      | nodeTypeName                     | "Neos.Neos:Test.TextNode"                            |
+      | parentNodeAggregateId            | "test-document-with-contents--main"                  |
+      | initialPropertyValues            | {"text": "Text Node only in the preview workspace"}  |
+      | succeedingSiblingNodeAggregateId | "text-node-end"                                      |
+      | nodeName                         | "text-node-middle"                                   |
+
+    When I am in workspace "user-editor" and dimension space point {}
+    And the command ChangeBaseWorkspace is executed with payload:
+      | Key                | Value                               |
+      | workspaceName      | "user-editor"                       |
+      | baseWorkspaceName  | "preview"                            |
+      | newContentStreamId | "user-editor-cs-rebased-to-preview" |
+    Then I expect node aggregate identifier "text-node-middle" to lead to node user-editor-cs-rebased-to-preview;text-node-middle;{}
+
+    When I execute the following Fusion code:
+    """fusion
+    test = Neos.Neos:ContentCollection {
+      prototype(Neos.Neos:Test.TextNode) {
+        cacheVerifier = "secondRender"
+      }
+      nodePath = "main"
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    <div class="neos-contentcollection">secondRender[Text Node at the start of the document]secondRender[Text Node only in the preview workspace]secondRender[Text Node at the end of the document]</div>
+    """
+


### PR DESCRIPTION
With https://github.com/neos/neos-development-collection/pull/5674 we removed a global cache key in Neos 9.1, which contained the workspace chain. The workspace chain had ensured different cache keys per workspace/base workspace combination.

Eg. `live/review/user` vs `live/user`

Now we need to flush the full user workspace cache on each change of the base workspace.

Fixes: https://github.com/neos/neos-development-collection/issues/5924
