### PR TITLE
BUGFIX: Prevent race condition during content stream forking

### DIFF
--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
@@ -188,7 +188,7 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
 
         $this->log('2. forking started');
 
-        $successFullCreated = 0;
+        $successfulCreated = 0;
         for ($i = 0; $i <= 200; $i++) {
             try {
                 $this->contentRepository->handle(CreateWorkspace::create(
@@ -196,19 +196,19 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
                     WorkspaceName::forLive(),
                     ContentStreamId::fromString('user-test-cs-' . $i)
                 ));
-                $successFullCreated++;
+                $successfulCreated++;
             } catch (ConcurrencyException $concurrencyException) {
                 // Expected version: [ContentStream:live-cs-id equals 7], actual version: 13. All: [[no ContentStream:user-test-cs-1], [ContentStream:live-cs-id equals 7], [no Workspace:user-test-1]]
                 $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
             }
         }
 
-        $this->log(sprintf('2. forking %d workspaces finished', $successFullCreated));
+        $this->log(sprintf('2. forking %d workspaces finished', $successfulCreated));
 
         Assert::assertTrue(true, 'No exception was thrown ;)');
 
-        Assert::assertGreaterThanOrEqual(10, $successFullCreated, 'Too few workspace of 200 attempts were created');
+        Assert::assertGreaterThanOrEqual(10, $successfulCreated, 'Too few workspace of 200 attempts were created');
         $workspaces = $this->contentRepository->findWorkspaces();
-        Assert::assertCount($successFullCreated, $workspaces->getDependantWorkspaces(WorkspaceName::forLive()));
+        Assert::assertCount($successfulCreated, $workspaces->getDependantWorkspaces(WorkspaceName::forLive()));
     }
 }

--- a/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Parallel/ForkingDuringWriting/ForkingDuringWritingTest.php
@@ -34,6 +34,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\TestSuite\Fakes\FakeContentDimensionSourceFactory;
 use Neos\ContentRepository\TestSuite\Fakes\FakeNodeTypeManagerFactory;
 use Neos\ContentRepository\TestSuite\Fakes\FakeProjectionFactory;
+use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\Test;
@@ -187,19 +188,27 @@ class ForkingDuringWritingTest extends AbstractParallelTestCase
 
         $this->log('2. forking started');
 
+        $successFullCreated = 0;
         for ($i = 0; $i <= 200; $i++) {
-            $this->contentRepository->handle(CreateWorkspace::create(
-                WorkspaceName::fromString('user-test-' . $i),
-                WorkspaceName::forLive(),
-                ContentStreamId::fromString('user-test-cs-' . $i)
-            ));
+            try {
+                $this->contentRepository->handle(CreateWorkspace::create(
+                    WorkspaceName::fromString('user-test-' . $i),
+                    WorkspaceName::forLive(),
+                    ContentStreamId::fromString('user-test-cs-' . $i)
+                ));
+                $successFullCreated++;
+            } catch (ConcurrencyException $concurrencyException) {
+                // Expected version: [ContentStream:live-cs-id equals 7], actual version: 13. All: [[no ContentStream:user-test-cs-1], [ContentStream:live-cs-id equals 7], [no Workspace:user-test-1]]
+                $this->log(sprintf('Got likely expected exception %s: %s', self::shortClassName($concurrencyException::class), $concurrencyException->getMessage()));
+            }
         }
 
-        $this->log('2. forking finished');
+        $this->log(sprintf('2. forking %d workspaces finished', $successFullCreated));
 
         Assert::assertTrue(true, 'No exception was thrown ;)');
 
-        $workspace = $this->contentRepository->findWorkspaceByName(WorkspaceName::fromString('user-test-200'));
-        Assert::assertNotNull($workspace);
+        Assert::assertGreaterThanOrEqual(10, $successFullCreated, 'Too few workspace of 200 attempts were created');
+        $workspaces = $this->contentRepository->findWorkspaces();
+        Assert::assertCount($successFullCreated, $workspaces->getDependantWorkspaces(WorkspaceName::forLive()));
     }
 }

--- a/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/ContentStreamHandling.php
@@ -28,9 +28,10 @@ trait ContentStreamHandling
         ContentStreamId $newContentStreamId,
         ContentStreamId $sourceContentStreamId,
         Version $sourceContentStreamVersion,
-        string $debugReason
+        string $debugReason,
+        bool $requireSourceContentStreamVersion = true,
     ): EventsToPublish {
-        return EventsToPublish::createEventsForStreamAndExpectedVersion(
+        $eventsToPublish = EventsToPublish::createEventsForStreamAndExpectedVersion(
             ContentStreamEventStreamName::fromContentStreamId($newContentStreamId)->getEventStreamName(),
             Events::with(
                 DecoratedEvent::create(
@@ -45,6 +46,13 @@ trait ContentStreamHandling
             // NO_STREAM to ensure the "fork" happens as the first event of the new content stream
             ExpectedVersion::NO_STREAM()
         );
+        if ($requireSourceContentStreamVersion) {
+            $eventsToPublish = $eventsToPublish->withExpectedVersionForStream(
+                ContentStreamEventStreamName::fromContentStreamId($sourceContentStreamId)->getEventStreamName(),
+                ExpectedVersion::fromVersion($sourceContentStreamVersion)
+            );
+        }
+        return $eventsToPublish;
     }
 
     /**

--- a/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
+++ b/Neos.ContentRepository.Core/Classes/Feature/WorkspaceCommandHandler.php
@@ -239,7 +239,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                 $command->newContentStreamId,
                 $baseWorkspace->currentContentStreamId,
                 Version::fromInteger($baseWorkspaceContentStreamVersion->value + ($eventsOfWorkspaceToPublish?->count() ?? 0)),
-                sprintf('Publish workspace %s and fork base %s', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value)
+                sprintf('Publish workspace %s and fork base %s', $workspace->workspaceName->value, $baseWorkspace->workspaceName->value),
+                requireSourceContentStreamVersion: $eventsOfWorkspaceToPublish === null
             )
         );
 
@@ -503,7 +504,8 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
                     $command->contentStreamIdForRemainingPart,
                     $commandSimulator->eventStream()->withMinimumSequenceNumber($highestSequenceNumberForMatching->next())
                 ),
-                sprintf('Partial publish workspace %s and fork base %s', $command->workspaceName->value, $baseWorkspace->workspaceName->value)
+                sprintf('Partial publish workspace %s and fork base %s', $command->workspaceName->value, $baseWorkspace->workspaceName->value),
+                requireSourceContentStreamVersion: $selectedEventsOfWorkspaceToPublish === null
             )
         );
 
@@ -761,13 +763,15 @@ final readonly class WorkspaceCommandHandler implements CommandHandlerInterface
         Version $sourceContentStreamVersion,
         EventsToPublish $pointWorkspaceToNewContentStream,
         Events|null $eventsToApplyOnNewContentStream,
-        string $debugReasonForFork
+        string $debugReasonForFork,
+        bool $requireSourceContentStreamVersion = true
     ): EventsToPublish {
         $eventsToPublish = $this->forkContentStream(
             $newContentStreamId,
             $sourceContentStreamId,
             $sourceContentStreamVersion,
-            $debugReasonForFork . sprintf('; Apply %d events on new content stream', $eventsToApplyOnNewContentStream?->count() ?? 0)
+            $debugReasonForFork . sprintf('; Apply %d events on new content stream', $eventsToApplyOnNewContentStream?->count() ?? 0),
+            requireSourceContentStreamVersion: $requireSourceContentStreamVersion
         );
 
         $eventsToPublish = $eventsToPublish->merge($pointWorkspaceToNewContentStream);


### PR DESCRIPTION
Fixes: https://github.com/neos/neos-development-collection/issues/5849
Requires https://github.com/neos/neos-development-collection/pull/5830
Requires https://github.com/neos/neos-development-collection/pull/5927
Requires https://github.com/neos/neos-development-collection/pull/5959

Requires https://github.com/neos/eventstore-doctrineadapter/pull/40

This will be possible by leveraging the new API `Neos\EventStore\Model\EventsForCommit::withExpectedVersionForStream()` -> or in this case our mirror in `EventsToPublish`

Requires adjustments of the dbal event-store. Currently, this is not supported yet by the adapter in 3.0 see `DoctrineEventStore::validateAllConstraintStreamsAreWritten`

With 3.1 and this feature the adapter will support that.

[FEATURE: Implement global advisory locking to enforce foreign stream constraints](https://github.com/neos/eventstore-doctrineadapter/pull/40)

-----

Will be tested via https://github.com/neos/neos-development-collection/pull/5937