### PR TITLE
BUGFIX: Followup #5899 don't fail setup for detached projections

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
@@ -97,9 +97,12 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
             foreach ($statusOfSkippedSubscriptions as $status) {
                 $message[] = sprintf('  %s:', $status->subscriptionId->value);
                 if ($status instanceof DetachedSubscriptionStatus) {
-                    $message[] = sprintf('    Subscription: %s DETACHED at position %d', $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be', $status->subscriptionPosition->value);
+                    continue;
                 }
                 if ($status instanceof ProjectionSubscriptionStatus) {
+                    if ($status->subscriptionStatus !== SubscriptionStatus::ERROR) {
+                        continue;
+                    }
                     $message[] = sprintf('    Projection: in %s', $status->subscriptionStatus->value);
                     if ($status->subscriptionError !== null) {
                         $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: 'No details available.');


### PR DESCRIPTION
Followup to https://github.com/neos/neos-development-collection/pull/5899

Fixes point 2 of https://github.com/neos/neos-development-collection/issues/5925 in a non breaking simple way

See https://github.com/neos/neos-development-collection/pull/5948 for a better fix where we dont hide any skipped projections because they are detached.