### PR TITLE
!!! BUGFIX: Followup #5899 return all skipped subscriptions in `setup()` as `SetupWarning`

### DIFF
--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer.php
@@ -6,13 +6,11 @@ namespace Neos\ContentRepository\Core\Service;
 
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\Factory\ContentRepositoryServiceInterface;
-use Neos\ContentRepository\Core\Projection\ProjectionStatusType;
+use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer\SetupWarning;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryStatus;
-use Neos\ContentRepository\Core\Subscription\DetachedSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\Engine\Errors;
 use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngine;
 use Neos\ContentRepository\Core\Subscription\Engine\SubscriptionEngineCriteria;
-use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionId;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatusCollection;
@@ -77,40 +75,12 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
     ) {
     }
 
-    public function setUp(): Error|null
+    public function setUp(): Error|SetupWarning|null
     {
         $this->eventStore->setup();
         $setupResult = $this->subscriptionEngine->setup();
         if ($setupResult->errors !== null) {
             return self::createErrorForReason('Setup failed:', $setupResult->errors);
-        }
-
-        $statusOfSkippedSubscriptions = $this->subscriptionEngine->subscriptionStatusOfSetupExcluded();
-        if (!$statusOfSkippedSubscriptions->isEmpty()) {
-            $message = ['Setup skipped subscriptions:'];
-            foreach ($statusOfSkippedSubscriptions as $status) {
-                $message[] = sprintf('  %s:', $status->subscriptionId->value);
-                if ($status instanceof DetachedSubscriptionStatus) {
-                    $message[] = sprintf('    Subscription: %s DETACHED at position %d', $status->subscriptionStatus === SubscriptionStatus::DETACHED ? 'is' : 'will be', $status->subscriptionPosition->value);
-                }
-                if ($status instanceof ProjectionSubscriptionStatus) {
-                    $message[] = sprintf('    Projection: in %s', $status->subscriptionStatus->value);
-                    if ($status->subscriptionError !== null) {
-                        $lines = explode(chr(10), $status->subscriptionError->errorMessage ?: 'No details available.');
-                        foreach ($lines as $line) {
-                            $message[] = sprintf('      %s', $line);
-                        }
-                    }
-                    $message[] = sprintf('    Setup: %s', $status->setupStatus->type->name);
-                    if ($status->setupStatus->type !== ProjectionStatusType::OK || $status->setupStatus->details) {
-                        $lines = explode(chr(10), $status->setupStatus->details);
-                        foreach ($lines as $line) {
-                            $message[] = '      ' . $line;
-                        }
-                    }
-                }
-            }
-            return new Error(join("\n", $message));
         }
 
         $eventStoreIsEmpty = iterator_count($this->eventStore->load(VirtualStreamName::all())->limit(1)) === 0;
@@ -122,6 +92,12 @@ final readonly class ContentRepositoryMaintainer implements ContentRepositorySer
                 return self::createErrorForReason('Initial catchup failed:', $bootResult->errors);
             }
         }
+
+        $statusOfSkippedSubscriptions = $this->subscriptionEngine->subscriptionStatusOfSetupExcluded();
+        if (!$statusOfSkippedSubscriptions->isEmpty()) {
+            return SetupWarning::becauseSubscriptionsWereSkipped($statusOfSkippedSubscriptions);
+        }
+
         return null;
     }
 

--- a/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer/SetupWarning.php
+++ b/Neos.ContentRepository.Core/Classes/Service/ContentRepositoryMaintainer/SetupWarning.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
+
+use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer;
+use Neos\ContentRepository\Core\Subscription\SubscriptionStatusCollection;
+use Neos\Error\Messages\Warning;
+
+/**
+ * @api as returned by {@see ContentRepositoryMaintainer}
+ */
+final class SetupWarning extends Warning
+{
+    private function __construct(
+        string $message,
+        int $code,
+        public readonly SubscriptionStatusCollection $skippedSubscriptions
+    ) {
+        parent::__construct($message, $code);
+    }
+
+    public static function becauseSubscriptionsWereSkipped(SubscriptionStatusCollection $subscriptionStatusCollection): self
+    {
+        return new self(
+            message: sprintf('%d subscriptions were skipped during setup', $subscriptionStatusCollection->count()),
+            code: 1782298982,
+            skippedSubscriptions: $subscriptionStatusCollection,
+        );
+    }
+}

--- a/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionStatusCollection.php
+++ b/Neos.ContentRepository.Core/Classes/Subscription/SubscriptionStatusCollection.php
@@ -17,7 +17,7 @@ namespace Neos\ContentRepository\Core\Subscription;
  * @api
  * @implements \IteratorAggregate<ProjectionSubscriptionStatus|DetachedSubscriptionStatus>
  */
-final readonly class SubscriptionStatusCollection implements \IteratorAggregate
+final readonly class SubscriptionStatusCollection implements \IteratorAggregate, \Countable
 {
     /**
      * @var array<ProjectionSubscriptionStatus|DetachedSubscriptionStatus> $items
@@ -59,5 +59,10 @@ final readonly class SubscriptionStatusCollection implements \IteratorAggregate
     public function isEmpty(): bool
     {
         return $this->items === [];
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
     }
 }

--- a/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Command/CrCommandController.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Neos\ContentRepositoryRegistry\Command;
 
 use Neos\ContentRepository\Core\Projection\ProjectionStatusType;
+use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainer\SetupWarning;
 use Neos\ContentRepository\Core\Service\ContentRepositoryMaintainerFactory;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\Subscription\DetachedSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\ProjectionSubscriptionStatus;
 use Neos\ContentRepository\Core\Subscription\SubscriptionStatus;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Error\Messages\Error;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\EventStore\StatusType;
 use Neos\Flow\Annotations as Flow;
@@ -61,11 +63,30 @@ final class CrCommandController extends CommandController
         $contentRepositoryMaintainer = $this->contentRepositoryRegistry->buildService($contentRepositoryId, new ContentRepositoryMaintainerFactory());
 
         $result = $contentRepositoryMaintainer->setUp();
-        if ($result !== null) {
+        if ($result instanceof Error) {
             $this->outputLine('<comment>Failed to fully setup content repository "%s"</comment>', [$contentRepositoryId->value]);
             $this->outputLine('<error>%s</error>', [$result->getMessage()]);
             $this->quit(1);
         }
+        if ($result instanceof SetupWarning) {
+            $hasErrors = false;
+            foreach ($result->skippedSubscriptions as $status) {
+                if ($status instanceof DetachedSubscriptionStatus) {
+                    $this->outputDetachedSubscriptionStatus($status);
+                }
+                if ($status instanceof ProjectionSubscriptionStatus) {
+                    $this->outputProjectionSubscriptionStatus($status, eventStorePosition: null, verbose: true);
+                    $hasErrors |= $status->setupStatus->type === ProjectionStatusType::ERROR;
+                    $hasErrors |= $status->subscriptionStatus === SubscriptionStatus::ERROR;
+                }
+            }
+
+            if ($hasErrors) {
+                $this->outputLine('<error>Content repository not fully setup. Skipped above projections in error state</error>');
+                $this->quit(1);
+            }
+        }
+
         $this->outputLine('<success>Content repository "%s" was set up</success>', [$contentRepositoryId->value]);
     }
 


### PR DESCRIPTION
Followup to #5899 
Fixes point 2 of https://github.com/neos/neos-development-collection/issues/5925


Adds new return object in as API marked `ContentRepositoryMaintainer::setUp()` see discussion https://github.com/neos/neos-development-collection/pull/5899#discussion_r3465609051


Projection in error still let the setup fail:

<img width="952" height="115" alt="image" src="https://github.com/user-attachments/assets/b384966a-f142-44c0-909d-cb399a33fddc" />

But detached projections do not:

<img width="959" height="81" alt="image" src="https://github.com/user-attachments/assets/8b4980f3-6d63-4fa2-b501-9853b4562ee5" />

