### PR TITLE
BUGFIX: Fix exception message in Neos.Neos:ConvertUris

### DIFF
--- a/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
+++ b/Neos.Neos/Classes/Fusion/ConvertUrisImplementation.php
@@ -87,7 +87,7 @@ class ConvertUrisImplementation extends AbstractFusionObject
         $node = $this->fusionValue('node');
 
         if (!$node instanceof NodeInterface) {
-            throw new Exception(sprintf('The current node must be an instance of NodeInterface, given: "%s".', gettype($text)), 1382624087);
+            throw new Exception(sprintf('The current node must be an instance of NodeInterface, given: "%s".', gettype($node)), 1382624087);
         }
 
         if (!($this->fusionValue('forceConversion')) && $node->getContext()->getWorkspace()->getName() !== 'live') {

--- a/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
+++ b/Neos.Neos/Tests/Behavior/Features/Fusion/ConvertUris.feature
@@ -14,10 +14,11 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
         'Neos.Neos:Document': true
     """
     And I have the following nodes:
-      | Identifier | Path        | Node Type                   | Properties                                   |
-      | root       | /sites      | unstructured                |                                              |
-      | a          | /sites/a    | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a", "title": "Node a"}   |
-      | a1         | /sites/a/a1 | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a1", "title": "Node a1"} |
+      | Identifier | Path        | Node Type                   | Properties                                   | Hidden |
+      | root       | /sites      | unstructured                |                                              | false  |
+      | a          | /sites/a    | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a", "title": "Node a"}   | false  |
+      | a1         | /sites/a/a1 | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a1", "title": "Node a1"} | false  |
+      | a2         | /sites/a/a2 | Neos.Neos:Test.DocumentType | {"uriPathSegment": "a2", "title": "Node a2"} | true   |
     And the Fusion context node is "a"
     And the Fusion context request URI is "http://localhost"
 
@@ -78,6 +79,22 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
     Some value with node URI: /en/a1.
     """
 
+  Scenario: URI to hidden node
+    When I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      node = ${q(node).context({'invisibleContentShown': false}).get(0)}
+      value = 'Some value with node URI to hidden node: node://a2.'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    Some value with node URI to hidden node: .
+    """
+
   Scenario: Anchor tag without node or asset URI
     When I execute the following Fusion code:
     """fusion
@@ -121,6 +138,22 @@ Feature: Tests for the "Neos.Neos:ConvertUris" Fusion prototype
     Then I expect the following Fusion rendering result:
     """
     some <a href="/en/a1">Link</a>
+    """
+
+  Scenario: Anchor tag with node URI to hidden node
+    When I execute the following Fusion code:
+    """fusion
+    include: resource://Neos.Fusion/Private/Fusion/Root.fusion
+    include: resource://Neos.Neos/Private/Fusion/Root.fusion
+
+    test = Neos.Neos:ConvertUris {
+      node = ${q(node).context({'invisibleContentShown': false}).get(0)}
+      value = 'some <a href="node://a2">Link</a>'
+    }
+    """
+    Then I expect the following Fusion rendering result:
+    """
+    some Link
     """
 
   Scenario: URI to non-existing asset


### PR DESCRIPTION
This fixes an exception message in `Neos.Neos:ConvertUris` (wrong `get_debug_type()`). It also adds tests for scenarios that behave differently in the current Neos 9 release.

**Upgrade instructions**
n/a

**Review instructions**

See https://github.com/neos/neos-development-collection/pull/5926#discussion_r3727980323

Sorry for not also adjusting the documentation. It took me quite a while to check it in the Neos 9 branch and I currently don't have the time to check it again for Neos 8.3.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
