### PR TITLE
TASK: Update to PHPUnit 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           distribution-path: ${{ env.NEOS_DIST_FOLDER }}
 
       - name: Run unit tests
-        run: bin/phpunit --colors -c Build/BuildEssentials/PhpUnit/UnitTests.xml --verbose
+        run: bin/phpunit --colors -c Build/BuildEssentials/PhpUnit/UnitTests.xml
 
   functional-tests:
     permissions:
@@ -153,7 +153,7 @@ jobs:
         run: FLOW_CONTEXT=Testing ./flow doctrine:migrate
 
       - name: Run functional tests
-        run: bin/phpunit --colors --stop-on-failure -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml --testsuite "Neos tests" --verbose
+        run: bin/phpunit --colors --stop-on-failure -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml --testsuite "Neos tests"
 
   behavioral-tests:
     permissions:

--- a/Neos.ContentRepository/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
+++ b/Neos.ContentRepository/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php
@@ -445,7 +445,7 @@ trait NodeOperationsTrait
             $workspace = $context->getWorkspace();
 
             /** @var PublishingServiceInterface $publishingService */
-            $publishingService = $this->getObjectManager()->get(\Neos\ContentRepository\Domain\Service\PublishingServiceInterface::class);
+            $publishingService = $this->getObjectManager()->get(PublishingServiceInterface::class);
             $publishingService->discardNodes($publishingService->getUnpublishedNodes($workspace));
 
             $this->objectManager->get(PersistenceManagerInterface::class)->persistAll();

--- a/Neos.ContentRepository/Tests/Functional/AbstractNodeTestCase.php
+++ b/Neos.ContentRepository/Tests/Functional/AbstractNodeTestCase.php
@@ -23,7 +23,7 @@ use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 /**
  * Base test case for nodes
  */
-abstract class AbstractNodeTest extends FunctionalTestCase
+abstract class AbstractNodeTestCase extends FunctionalTestCase
 {
     /**
      * @var boolean

--- a/Neos.ContentRepository/Tests/Functional/Domain/CopyNodeAcrossDimensionsBug3265Test.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/CopyNodeAcrossDimensionsBug3265Test.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
@@ -102,9 +102,7 @@ class CopyNodeAcrossDimensionsBug3265Test extends FunctionalTestCase
         $this->contentDimensionRepository->setDimensionsConfiguration($configuredDimensions);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testForBug3265()
     {
         // FIXTURE SETUP

--- a/Neos.ContentRepository/Tests/Functional/Domain/LayeredWorkspacesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/LayeredWorkspacesTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -140,9 +140,7 @@ class LayeredWorkspacesTest extends FunctionalTestCase
         $this->rootNode = null;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromLiveWorkspaceRemovedInPersonalWorkspaceExistsRemovedInGroupWorkspace()
     {
         $liveContext = $this->contextFactory->create([]);
@@ -164,9 +162,7 @@ class LayeredWorkspacesTest extends FunctionalTestCase
         self::assertTrue($fooNodeInGroupWorkspace->isRemoved());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromLiveWorkspaceChangedInGroupWorkspaceAndRemovedInPersonalWorkspaceExistsRemovedInGroupWorkspace()
     {
         $liveContext = $this->contextFactory->create([]);
@@ -195,9 +191,7 @@ class LayeredWorkspacesTest extends FunctionalTestCase
         self::assertTrue($fooNodeInGroupWorkspace->isRemoved());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromLiveWorkspaceMovedInUserWorkspaceIsInCorrectPlaceAfterPublish()
     {
         $liveContext = $this->contextFactory->create([]);
@@ -219,9 +213,7 @@ class LayeredWorkspacesTest extends FunctionalTestCase
         self::assertNull($oldBazNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromLiveWorkspaceMovedInUserWorkspaceRetainsShadowNodeInGroupWorkspace()
     {
         $liveContext = $this->contextFactory->create([]);

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeConstraintsTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeConstraintsTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Exception\NodeConstraintException;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
@@ -78,9 +78,7 @@ class NodeConstraintsTest extends FunctionalTestCase
         $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function movingNodeToWhereItsTypeIsDisallowedThrowsException()
     {
         $this->expectException(NodeConstraintException::class);
@@ -91,9 +89,7 @@ class NodeConstraintsTest extends FunctionalTestCase
         $documentNode->moveInto($contentNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function movingNodeToWhereItsSuperTypeIsDisallowedThrowsException()
     {
         $this->expectException(NodeConstraintException::class);
@@ -104,9 +100,7 @@ class NodeConstraintsTest extends FunctionalTestCase
         $documentNode->moveInto($contentNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function creatingNodeInChildNodeWithChildNodeConstraintsThrowsException()
     {
         $this->expectException(NodeConstraintException::class);
@@ -117,9 +111,7 @@ class NodeConstraintsTest extends FunctionalTestCase
         $childNode->createNode('document', $documentNodeType);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childNodeWithChildNodeConstraintsAndNodeTypeConstraintsWorks()
     {
         $nodeTypeWithChildNodeAndConstraints = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:NodeTypeWithSubnodesAndConstraints');
@@ -131,9 +123,7 @@ class NodeConstraintsTest extends FunctionalTestCase
         self::assertCount(1, $childNode->getChildNodes());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childNodeWithChildNodeConstraintsAndNodeTypeConstraintsThrowsException()
     {
         $this->expectException(NodeConstraintException::class);
@@ -145,9 +135,7 @@ class NodeConstraintsTest extends FunctionalTestCase
         $childNode->createNode('text', $textNodeType);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function inheritanceBasedConstraintsWork()
     {
         $testingNodeTypeWithSubnodes = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:NodeTypeWithSubnodes');

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeDataExportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeDataExportServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -73,9 +73,7 @@ class NodeDataExportServiceTest extends FunctionalTestCase
         $this->setUpRootNodeAndRepository();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aSingleNodeExportedWithNodeDataExportCanBeImportedWithNodeDataImport()
     {
         $originalNode = $this->rootNode->createNode('foo', $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:ImportExport'));

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeDataTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * source code.
  */
 
+use Neos\ContentRepository\Tests\Functional\Domain\Fixtures\RelatedEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Flow\Utility\Algorithms;
 use Neos\Neos\Domain\Service\SiteImportService;
@@ -91,7 +92,7 @@ class NodeDataTest extends FunctionalTestCase
         $template->setName('new-node');
         $template->setIdentifier($identifier);
 
-        $newEntity = new Fixtures\RelatedEntity();
+        $newEntity = new RelatedEntity();
         $newEntity->setFavoritePlace('Reykjavik');
         $template->setProperty('entity', $newEntity);
 
@@ -119,7 +120,7 @@ class NodeDataTest extends FunctionalTestCase
         $template->setName('new-node');
         $template->setIdentifier($identifier);
 
-        $newEntity = new Fixtures\RelatedEntity();
+        $newEntity = new RelatedEntity();
         $newEntity->setFavoritePlace('Reykjavik');
         $template->setProperty('entity', $newEntity);
 
@@ -159,9 +160,9 @@ class NodeDataTest extends FunctionalTestCase
         $template->setName('new-node');
         $template->setIdentifier($identifier);
 
-        $newEntity = new Fixtures\RelatedEntity();
+        $newEntity = new RelatedEntity();
         $newEntity->setFavoritePlace('Reykjavik');
-        $anotherNewEntity = new Fixtures\RelatedEntity();
+        $anotherNewEntity = new RelatedEntity();
         $anotherNewEntity->setFavoritePlace('Japan');
         $template->setProperty('entity', [$newEntity, $anotherNewEntity]);
 

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeDataTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Tests\Functional\Domain\Fixtures\RelatedEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Flow\Utility\Algorithms;
@@ -66,9 +66,7 @@ class NodeDataTest extends FunctionalTestCase
         $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeFromTemplateUsesIdentifierFromTemplate()
     {
         $identifier = Algorithms::generateUUID();
@@ -82,9 +80,7 @@ class NodeDataTest extends FunctionalTestCase
         self::assertSame($identifier, $newNode->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeWithRelatedEntityWillTakeCareOfAddingToPersistence()
     {
         $identifier = Algorithms::generateUUID();
@@ -110,9 +106,7 @@ class NodeDataTest extends FunctionalTestCase
         self::assertEquals('Reykjavik', $newNodeAgain->getProperty('entity')->getFavoritePlace());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeWithRelatedEntityWillTakeCareOfUpdatingInPersistence()
     {
         $identifier = Algorithms::generateUUID();
@@ -150,9 +144,7 @@ class NodeDataTest extends FunctionalTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeWithRelatedEntitiesWillTakeCareOfAddingToPersistence()
     {
         $identifier = Algorithms::generateUUID();
@@ -182,9 +174,7 @@ class NodeDataTest extends FunctionalTestCase
         self::assertEquals('Japan', $entityArray[1]->getFavoritePlace());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function inContextWithEmptyDimensionsNodeVariantsWithoutDimensionsArePrioritized()
     {
         $siteImportService = $this->objectManager->get(SiteImportService::class);
@@ -202,9 +192,7 @@ class NodeDataTest extends FunctionalTestCase
         self::assertEmpty($resultingNodeData->getDimensions());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsSetsDimensions()
     {
         $siteImportService = $this->objectManager->get(SiteImportService::class);
@@ -241,9 +229,7 @@ class NodeDataTest extends FunctionalTestCase
         self::assertEquals('lv', $values['language'][0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsKeepsExistingDimensions()
     {
         $siteImportService = $this->objectManager->get(SiteImportService::class);
@@ -279,9 +265,7 @@ class NodeDataTest extends FunctionalTestCase
         self::assertEquals('lv', $values['language'][1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsToEMptyArrayRemovesDimensions()
     {
         $siteImportService = $this->objectManager->get(SiteImportService::class);

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Model\Workspace;
@@ -93,9 +93,7 @@ class NodeServiceTest extends FunctionalTestCase
         $this->contentDimensionRepository->setDimensionsConfiguration($configuredDimensions);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodePathAvailableForNodeWillReturnFalseIfNodeWithGivenPathExistsAlready()
     {
         $this->workspaceRepository->add(new Workspace('live'));

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodeTemplatesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodeTemplatesTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeTemplate;
@@ -76,9 +76,7 @@ class NodeTemplatesTest extends FunctionalTestCase
         $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTemplateConverterCanConvertArray()
     {
         $nodeTemplate = $this->generateBasicNodeTemplate();
@@ -86,9 +84,7 @@ class NodeTemplatesTest extends FunctionalTestCase
         self::assertEquals('Neos rules!', $nodeTemplate->getProperty('test1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function newNodeCanBeCreatedFromNodeTemplate()
     {
         $nodeTemplate = $this->generateBasicNodeTemplate();
@@ -98,9 +94,7 @@ class NodeTemplatesTest extends FunctionalTestCase
         self::assertInstanceOf(NodeInterface::class, $node);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeFromTemplateUsesWorkspacesOfContext()
     {
         $nodeTemplate = $this->generateBasicNodeTemplate();

--- a/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/NodesTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Exception\NodeExistsException;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -109,18 +109,14 @@ class NodesTest extends FunctionalTestCase
         $this->contentDimensionRepository->setDimensionsConfiguration($configuredDimensions);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeCreationThrowsExceptionIfNodeNameContainsUppercaseCharacters()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->context->getRootNode()->createNode('fooBar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setNameWorksRecursively()
     {
         $rootNode = $this->context->getRootNode();
@@ -133,9 +129,7 @@ class NodesTest extends FunctionalTestCase
         self::assertEquals('/quux/bar/baz', $bazNode->getPath());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanBeRenamed()
     {
         $rootNode = $this->context->getRootNode();
@@ -151,9 +145,7 @@ class NodesTest extends FunctionalTestCase
         self::assertEquals('/quux/lax/baz', $bazNode->getPath());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCreatedInTheLiveWorkspacesCanBeRetrievedAgainInTheLiveContext()
     {
         $rootNode = $this->context->getRootNode();
@@ -166,9 +158,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($fooNode, $rootNode->getNode('foo'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createdNodesHaveDefaultValuesSet()
     {
         $rootNode = $this->context->getRootNode();
@@ -180,9 +170,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame('default value 1', $fooNode->getProperty('test1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function postprocessorUpdatesNodeTypesProperty()
     {
         $rootNode = $this->context->getRootNode();
@@ -194,9 +182,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame('The value of "someOption" is "someOverriddenValue", the value of "someOtherOption" is "someOtherValue"', $fooNode->getProperty('test1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createdNodesHaveSubNodesCreatedIfDefinedInNodeType()
     {
         $rootNode = $this->context->getRootNode();
@@ -209,9 +195,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame('default value 1', $firstSubnode->getProperty('test1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removedNodesCannotBeRetrievedAnymore()
     {
         $rootNode = $this->context->getRootNode();
@@ -234,9 +218,7 @@ class NodesTest extends FunctionalTestCase
         self::assertNull($bazNodeResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removedNodesAreNotCountedAsChildNodes()
     {
         $rootNode = $this->context->getRootNode();
@@ -259,9 +241,7 @@ class NodesTest extends FunctionalTestCase
         self::assertFalse($rootNode->hasChildNodes(), 'Third check.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removedChildNodesAreNotCopied()
     {
         $rootNode = $this->context->getRootNode();
@@ -287,9 +267,7 @@ class NodesTest extends FunctionalTestCase
         self::assertFalse($parentClone->hasChildNodes(), 'Copied parent node should not have any child nodes');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function creatingAChildNodeAndRetrievingItAfterPersistAllWorks()
     {
         $rootNode = $this->context->getRootNode();
@@ -309,9 +287,7 @@ class NodesTest extends FunctionalTestCase
         self::assertEquals(3, $retrievedNode->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function threeCreatedNodesCanBeRetrievedInSameOrder()
     {
         $rootNode = $this->context->getRootNode();
@@ -332,9 +308,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder([$node1, $node2, $node3], $childNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function threeChildNodesOfTheRootNodeCanBeRetrievedInSameOrder()
     {
         $rootNode = $this->context->getRootNode();
@@ -354,9 +328,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder([$node1, $node2, $node3], $childNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getChildNodesSupportsSettingALimitAndOffset()
     {
         $rootNode = $this->context->getRootNode();
@@ -377,9 +349,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder([$node3, $node4, $node5], $childNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getChildNodesWorksCaseInsensitive()
     {
         $rootNode = $this->context->getRootNode();
@@ -389,9 +359,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($node, $rootNode->getNode('nOdE'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeMovesNodesBeforeOthersWithoutPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -421,9 +389,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, array_values($actualChildNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveIntoMovesNodesIntoOthersOnDifferentLevelWithoutPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -440,9 +406,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($childNodeB1, $childNodeA->getNode('child-node-b')->getNode('child-node-b1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeMovesNodesBeforeOthersOnDifferentLevelWithoutPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -465,9 +429,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, array_values($actualChildNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterMovesNodesAfterOthersOnDifferentLevelWithoutPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -490,9 +452,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, array_values($actualChildNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeNodesWithLowerIndexMovesNodesBeforeOthersWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -527,9 +487,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeNodesWithHigherIndexMovesNodesBeforeOthersWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -564,9 +522,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeNodesWithHigherIndexMovesNodesBeforeOthersWithoutPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -597,9 +553,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterNodesWithLowerIndexMovesNodesAfterOthersWithoutPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -630,9 +584,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveIntoMovesNodesIntoOthersOnDifferentLevelWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -653,9 +605,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($childNodeB1, $childNodeA->getNode('child-node-b')->getNode('child-node-b1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeMovesNodesBeforeOthersOnDifferentLevelWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -682,9 +632,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, array_values($actualChildNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterMovesNodesAfterOthersOnDifferentLevelWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -711,9 +659,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, array_values($actualChildNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterNodesWithLowerIndexMovesNodesAfterOthersWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -748,9 +694,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterNodesWithHigherIndexMovesNodesAfterOthersWithPersistAll()
     {
         $rootNode = $this->context->getRootNode();
@@ -785,9 +729,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterNodesWithHigherIndexMovesNodesAfterOthersWithoutPersistAll()
     {
         $rootNode = $this->context->getNode('/');
@@ -817,9 +759,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeInASeparateWorkspaceLeadsToCorrectSortingAcrossWorkspaces()
     {
         $rootNode = $this->context->getNode('/');
@@ -858,9 +798,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($expectedChildNodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeThrowsExceptionIfTargetExists()
     {
         $this->expectException(NodeExistsException::class);
@@ -872,9 +810,7 @@ class NodesTest extends FunctionalTestCase
         $alfaChildNode->moveBefore($alfaNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterThrowsExceptionIfTargetExists()
     {
         $this->expectException(NodeExistsException::class);
@@ -886,9 +822,7 @@ class NodesTest extends FunctionalTestCase
         $alfaChildNode->moveAfter($alfaNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveIntoThrowsExceptionIfTargetExists()
     {
         $this->expectException(NodeExistsException::class);
@@ -900,9 +834,7 @@ class NodesTest extends FunctionalTestCase
         $alfaChildNode->moveInto($rootNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAndRenameAtTheSameTime()
     {
         $rootNode = $this->context->getRootNode();
@@ -935,9 +867,8 @@ class NodesTest extends FunctionalTestCase
      *
      * The bug tested by this testcase led to wrong orderings on the floworg website in
      * the documentation part under some circumstances.
-     *
-     * @test
      */
+    #[Test]
     public function renumberingTakesUnpersistedNodeOrderChangesIntoAccount()
     {
         $rootNode = $this->context->getRootNode();
@@ -971,9 +902,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($newNodeOrder, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeDataRepositoryRenumbersNodesIfNoFreeSortingIndexesAreAvailable()
     {
         $rootNode = $this->context->getRootNode();
@@ -996,9 +925,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSameOrder($nodes, $actualChildNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeDataRepositoryRenumbersNodesIfNoFreeSortingIndexesAreAvailableAcrossDimensions()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([
@@ -1078,9 +1005,7 @@ class NodesTest extends FunctionalTestCase
         self::assertTrue(true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLabelUsesFallbackExpression()
     {
         $node = $this->context->getNode('/');
@@ -1088,9 +1013,7 @@ class NodesTest extends FunctionalTestCase
         self::assertEquals('unstructured ()', $node->getLabel());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLabelReturnsParsedEelExpressionOrFallback()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1105,9 +1028,7 @@ class NodesTest extends FunctionalTestCase
         self::assertEquals('Test nodetype', $nodeWithEelExpressionLabel->getLabel());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getChildNodeLabelReturnsParsedEelExpressionOrFallback()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1122,9 +1043,7 @@ class NodesTest extends FunctionalTestCase
         self::assertEquals('Test child node', $nodeWithEelExpressionLabelInChildNode->getNode('child')->getLabel());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanBeCopiedAfterAndBeforeAndKeepProperties()
     {
         $rootNode = $this->context->getNode('/');
@@ -1145,9 +1064,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($flussNode, $rootNode->getNode('fluss'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanBeCopiedBefore()
     {
         $rootNode = $this->context->getNode('/');
@@ -1166,9 +1083,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame(['fluss', 'baz', 'flux'], $names->names);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanBeCopiedAfter()
     {
         $rootNode = $this->context->getNode('/');
@@ -1187,9 +1102,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame(['baz', 'fluss', 'flux'], $names->names);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanBeCopiedInto()
     {
         $rootNode = $this->context->getNode('/');
@@ -1203,9 +1116,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame(true, $alfaNode->getNode('charlie')->getProperty('test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanBeCopiedIntoThemselves()
     {
         $rootNode = $this->context->getNode('/');
@@ -1219,9 +1130,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($bravoNode, $alfaNode->getNode('bravo'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesAreCopiedBeforeRecursively()
     {
         $rootNode = $this->context->getNode('/');
@@ -1242,9 +1151,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame(['capacitor', 'second', 'third'], $names->names);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesAreCopiedAfterRecursively()
     {
         $rootNode = $this->context->getNode('/');
@@ -1265,9 +1172,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame(['capacitor', 'second', 'third'], $names->names);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesAreCopiedIntoRecursively()
     {
         $rootNode = $this->context->getNode('/');
@@ -1285,9 +1190,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($alfaNode->getNode('delta')->getNode('charlie')->getProperty('test2'), true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesAreCopiedIntoThemselvesRecursively()
     {
         $rootNode = $this->context->getNode('/');
@@ -1302,9 +1205,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($alfaNode->getNode('charlie')->getNode('bravo')->getProperty('test'), true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function copyBeforeThrowsExceptionIfTargetExists()
     {
         $this->expectException(NodeExistsException::class);
@@ -1317,9 +1218,7 @@ class NodesTest extends FunctionalTestCase
         $fluxNode->copyBefore($bazNode, 'exists');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function copyAfterThrowsExceptionIfTargetExists()
     {
         $this->expectException(NodeExistsException::class);
@@ -1332,9 +1231,7 @@ class NodesTest extends FunctionalTestCase
         $fluxNode->copyAfter($bazNode, 'exists');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function copyIntoThrowsExceptionIfTargetExists()
     {
         $this->expectException(NodeExistsException::class);
@@ -1346,9 +1243,7 @@ class NodesTest extends FunctionalTestCase
         $alfaNode->copyInto($rootNode, 'exists');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setPropertyAcceptsAndConvertsIdentifierIfTargetTypeIsReference()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1365,9 +1260,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($nodeB, $nodeA->getProperty('property2'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setPropertyAcceptsAndConvertsIdentifiersIfTargetTypeIsReferences()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1390,9 +1283,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($expectedNodes, $nodeA->getProperty('property3'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertiesReturnsReferencePropertiesAsNodeObjects()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1416,9 +1307,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($expectedNodes, $actualProperties['property3']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertyDoesNotReturnNodeReferencesIfTheyAreNotVisibleAccordingToTheContentContext()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1445,9 +1334,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($nodeC, reset($property3));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertyReturnsReferencedNodesInCorrectWorkspace()
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1476,8 +1363,8 @@ class NodesTest extends FunctionalTestCase
 
     /**
      * @see https://github.com/neos/neos-development-collection/issues/3624
-     * @test
      */
+    #[Test]
     public function getPropertyReturnsReferencedNodesWithoutHolesInArrayKeys(): void
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
@@ -1502,9 +1389,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($expectedNodes, $actualProperties['property3']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFactoryCachesCreatedNodesBasedOnIdentifierAndDimensions()
     {
         /** @var NodeFactory $nodeFactory */
@@ -1521,9 +1406,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($variantNodeA1, $variantNodeB);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createVariantForContextMatchesTargetContextDimensions()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([
@@ -1549,9 +1432,7 @@ class NodesTest extends FunctionalTestCase
         }, $variantContextB->getTargetDimensions()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createVariantForContextAlsoWorksIfTheTargetWorkspaceDiffersFromTheSourceWorkspace()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([
@@ -1579,9 +1460,7 @@ class NodesTest extends FunctionalTestCase
         }, $variantContextB->getTargetDimensions()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function adoptNodeReturnsExistingNodeWithMatchingDimensionsIfPossible()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([
@@ -1609,9 +1488,7 @@ class NodesTest extends FunctionalTestCase
         self::assertNotSame($variantContextB->adoptNode($variantNodeA)->getDimensions(), $variantNodeA->getDimensions(), 'Dimensions of $variantNodeA should change when adopted in $variantContextB');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function adoptNodeMatchesTargetContextDimensions()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([
@@ -1635,9 +1512,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($variantNodeB->getDimensions(), $variantContextB->getTargetDimensionValues());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function adoptNodeWithExistingNodeMatchingTargetDimensionValuesWillReuseNode()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([
@@ -1669,9 +1544,7 @@ class NodesTest extends FunctionalTestCase
         self::assertSame($variantNodeA->getDimensions(), $variantNodeB->getDimensions());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCanHaveCustomImplementationClass()
     {
         $rootNode = $this->context->getRootNode();
@@ -1691,9 +1564,7 @@ class NodesTest extends FunctionalTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getChildNodesWithNodeTypeFilterWorks()
     {
         $documentNodeType = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Document');
@@ -1706,9 +1577,7 @@ class NodesTest extends FunctionalTestCase
         self::assertCount(1, $node->getChildNodes('Neos.ContentRepository.Testing:Headline'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesInPathAreHiddenIfBetterVariantInOtherPathExists()
     {
         $this->contentDimensionRepository->setDimensionsConfiguration([

--- a/Neos.ContentRepository/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\Image;
@@ -88,9 +88,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findNodesByRelatedEntitiesFindsExistingNodeWithMatchingEntityProperty()
     {
         $rootNode = $this->context->getRootNode();
@@ -112,9 +110,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         self::assertCount(1, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findNodesByRelatedEntitiesFindsExistingNodeWithMatchingAssetLink()
     {
         $databasePlatform = $this->objectManager->get(Connection::class)->getDatabasePlatform();
@@ -157,9 +153,8 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
     /**
      * Tests findByProperties, see https://jira.neos.io/browse/NEOS-1849
-     *
-     * @test
      */
+    #[Test]
     public function findByPropertiesLimitsToStartingPointCorrectly()
     {
         $this->setUpNodes();
@@ -172,9 +167,8 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
     /**
      * Tests findByProperties, see https://jira.neos.io/browse/NEOS-1849
-     *
-     * @test
      */
+    #[Test]
     public function findByPropertiesLimitsToRootNodeCorrectly()
     {
         $this->setUpNodes();
@@ -187,9 +181,8 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
     /**
      * Tests addParentPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
-     *
-     * @test
      */
+    #[Test]
     public function findByParentAndNodeTypeLimitsToStartingPointCorrectly()
     {
         $this->setUpNodes();
@@ -202,9 +195,8 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
     /**
      * Tests addParentPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
-     *
-     * @test
      */
+    #[Test]
     public function findByParentAndNodeTypeLimitsToRootNodeCorrectly()
     {
         $this->setUpNodes();
@@ -217,9 +209,8 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
     /**
      * Tests addPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
-     *
-     * @test
      */
+    #[Test]
     public function findByPathWithoutReduceLimitsToStartingPointCorrectly()
     {
         $this->setUpNodes();
@@ -232,9 +223,8 @@ class NodeDataRepositoryTest extends FunctionalTestCase
 
     /**
      * Tests addPathConstraintToQueryBuilder, see https://jira.neos.io/browse/NEOS-1849
-     *
-     * @test
      */
+    #[Test]
     public function findByPathWithoutReduceLimitsToRootNodeCorrectly()
     {
         $this->setUpNodes();
@@ -245,9 +235,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         self::assertCount(7, $foundNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findNodeByPropertySearch()
     {
         $this->createNodesForNodeSearchTest();
@@ -257,9 +245,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         $this->assertResultConsistsOfNodes($result, ['test-node-1', 'test-node-2']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findNodesByPropertyKeyAndValue()
     {
         $this->createNodesForNodeSearchTest();

--- a/Neos.ContentRepository/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/Repository/NodeDataRepositoryTest.php
@@ -104,7 +104,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $relationMap = [
-            Fixtures\Image::class => [$this->persistenceManager->getIdentifierByObject($testImage)]
+            Image::class => [$this->persistenceManager->getIdentifierByObject($testImage)]
         ];
 
         $result = $this->nodeDataRepository->findNodesByRelatedEntities($relationMap);
@@ -137,7 +137,7 @@ class NodeDataRepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $relationMap = [
-            Fixtures\Image::class => [$testImageIdentifier]
+            Image::class => [$testImageIdentifier]
         ];
 
         $result = $this->nodeDataRepository->findNodesByRelatedEntities($relationMap);

--- a/Neos.ContentRepository/Tests/Functional/Domain/WorkspacesTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Domain/WorkspacesTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -118,9 +118,7 @@ class WorkspacesTest extends FunctionalTestCase
         $this->rootNode = null;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCreatedInAPersonalWorkspacesCanBeRetrievedAgainInThePersonalContext()
     {
         $fooNode = $this->rootNode->createNode('foo');
@@ -131,9 +129,7 @@ class WorkspacesTest extends FunctionalTestCase
         self::assertSame($fooNode, $this->rootNode->getNode('foo'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodesCreatedInAPersonalWorkspaceAreNotVisibleInTheLiveWorkspace()
     {
         $this->rootNode->createNode('homepage')->createNode('about');
@@ -147,9 +143,7 @@ class WorkspacesTest extends FunctionalTestCase
         self::assertNull($liveRootNode->getNode('/homepage/about'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evenWithoutPersistAllNodesCreatedInAPersonalWorkspaceAreNotVisibleInTheLiveWorkspace()
     {
         $this->rootNode->createNode('homepage')->createNode('imprint');
@@ -173,9 +167,8 @@ class WorkspacesTest extends FunctionalTestCase
      *
      * We then move child-node-b UNDERNEATH child-node-a and check that it does not shine through
      * when directly asking parentNode for child-node-b.
-     *
-     * @test
      */
+    #[Test]
     public function nodesWhichAreMovedAcrossLevelsAndWorkspacesShouldBeRemovedFromOriginalLocation()
     {
         $parentNode = $this->rootNode->createNode('parent-node');
@@ -208,9 +201,8 @@ class WorkspacesTest extends FunctionalTestCase
 
     /**
      * For test setup / node structure, see nodesWhichAreMovedAcrossLevelsAndWorkspacesShouldBeRemovedFromOriginalLocation
-     *
-     * @test
      */
+    #[Test]
     public function nodesWhichAreMovedAcrossLevelsAndWorkspacesShouldBeRemovedFromOriginalLocationWhileIteratingOverIt()
     {
         $rootNode = $this->rootNode;
@@ -251,9 +243,8 @@ class WorkspacesTest extends FunctionalTestCase
      * For test setup / node structure, see nodesWhichAreMovedAcrossLevelsAndWorkspacesShouldBeRemovedFromOriginalLocation
      *
      * Here, we move child-node-c underneath child-node-a.
-     *
-     * @test
      */
+    #[Test]
     public function nodesWhichAreMovedAcrossLevelsAndWorkspacesShouldWorkWhenUsingPrimaryChildNode()
     {
         $parentNode = $this->rootNode->createNode('parent-node');
@@ -279,9 +270,7 @@ class WorkspacesTest extends FunctionalTestCase
         self::assertNotNull($childNodeC3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function changedNodeCanBePublishedFromPersonalToLiveWorkspace()
     {
         $liveContext = $this->contextFactory->create(['workspaceName' => 'live']);
@@ -306,9 +295,7 @@ class WorkspacesTest extends FunctionalTestCase
         self::assertInstanceOf(NodeInterface::class, $teaserNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removedNodeWithoutExistingTargetNodeDataWillBeRemovedWhenPublished()
     {
         $homepageNode = $this->rootNode->createNode('homepage');

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ChildrenOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ChildrenOperationTest.php
@@ -12,12 +12,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  */
 
 use Neos\Eel\FlowQuery\FlowQuery;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery ChildrenOperation
  */
-class ChildrenOperationTest extends AbstractNodeTest
+class ChildrenOperationTest extends AbstractNodeTestCase
 {
     /**
      * @test

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ChildrenOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ChildrenOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
@@ -19,9 +19,7 @@ use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
  */
 class ChildrenOperationTest extends AbstractNodeTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function noFilterReturnsAllChildNodes()
     {
         $q = new FlowQuery([$this->node]);
@@ -29,9 +27,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(5, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertyNameFilterIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -41,9 +37,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multiplePropertyNameFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -57,9 +51,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pathFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -67,9 +59,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(2, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributeFilterIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -79,9 +69,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleAttributeFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -91,9 +79,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(1, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function instanceofFilterIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -103,9 +89,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(3, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function twoInstanceofFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -113,9 +97,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(2, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleInstanceofFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -123,9 +105,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(5, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function negatedInstanceofFilterIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -135,9 +115,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(3, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function twoNegatedInstanceofFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -145,9 +123,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function combinedFilterIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -161,9 +137,7 @@ class ChildrenOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleCombinedFiltersIsSupported()
     {
         $q = new FlowQuery([$this->node]);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ClosestOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ClosestOperationTest.php
@@ -13,12 +13,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
 
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery ClosestOperation
  */
-class ClosestOperationTest extends AbstractNodeTest
+class ClosestOperationTest extends AbstractNodeTestCase
 {
     /**
      * @return array

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ClosestOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ClosestOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
@@ -72,10 +73,9 @@ class ClosestOperationTest extends AbstractNodeTestCase
      *   b3 (TestingNodeTypeWithSubnodes)
      *     b3a (TestingNodeType)
      *     b3b
-     *
-     * @test
-     * @dataProvider closestOperationDataProvider
      */
+    #[DataProvider('closestOperationDataProvider')]
+    #[Test]
     public function closestOperationTests($currentNodePath, $nodeTypeFilter, $expectedNodePath)
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ClosestOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ClosestOperationTest.php
@@ -24,7 +24,7 @@ class ClosestOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function closestOperationDataProvider()
+    public static function closestOperationDataProvider()
     {
         return [
             [

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
@@ -19,9 +19,7 @@ use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
  */
 class FilterOperationTest extends AbstractNodeTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function noFilterReturnsAllNodesInContext()
     {
         $q = new FlowQuery([$this->node, $this->node->getNode('products')]);
@@ -29,9 +27,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(2, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filterByNodeObjectIsSupported()
     {
         $q = new FlowQuery([$this->node, $this->node->getNode('products')]);
@@ -40,9 +36,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(1, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertyNameFilterIsSupported()
     {
         $q = new FlowQuery([$this->node, $this->node->getNode('products')]);
@@ -53,9 +47,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multiplePropertyNameFiltersIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -74,9 +66,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function identityFilterIsSupported()
     {
         $q = new FlowQuery([$this->node, $this->node->getNode('products')]);
@@ -87,9 +77,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleIdentityFiltersIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -108,9 +96,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributeFilterUsingPropertyIsSupported()
     {
         $q = new FlowQuery([$this->node]);
@@ -120,9 +106,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributeFilterUsingInternalPropertyIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -137,9 +121,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function instanceofFilterUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -158,9 +140,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function notInstanceofFilterUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -183,9 +163,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(5, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function twoInstanceofFiltersUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -200,9 +178,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(0, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleInstanceofFiltersUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -217,9 +193,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(4, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function negatedInstanceofFilterUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');
@@ -238,9 +212,7 @@ class FilterOperationTest extends AbstractNodeTestCase
         self::assertEquals(4, count($foundNodes));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doubleNegatedInstanceofFilterUsingNodeTypeIsSupported()
     {
         $productsNode = $this->node->getNode('products');

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FilterOperationTest.php
@@ -12,12 +12,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  */
 
 use Neos\Eel\FlowQuery\FlowQuery;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery FilterOperation
  */
-class FilterOperationTest extends AbstractNodeTest
+class FilterOperationTest extends AbstractNodeTestCase
 {
     /**
      * @test

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
@@ -21,9 +22,7 @@ use Neos\Eel\FlowQuery\FlowQueryException;
  */
 class FindOperationTest extends AbstractNodeTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeIdentifierThrowsExceptionOnInvalidIdentifier()
     {
         $this->expectException(FlowQueryException::class);
@@ -44,12 +43,11 @@ class FindOperationTest extends AbstractNodeTestCase
     }
 
     /**
-     * @test
-     * @dataProvider identifierFilterExamples
-
      * @param string $filter
      * @param array $expectedNodePaths
      */
+    #[DataProvider('identifierFilterExamples')]
+    #[Test]
     public function identifierFilterIsSupported($filter, array $expectedNodePaths)
     {
         $q = new FlowQuery([$this->node]);
@@ -75,12 +73,11 @@ class FindOperationTest extends AbstractNodeTestCase
     }
 
     /**
-     * @test
-     * @dataProvider pathAndPropertyNameFilterExamples
-
      * @param string $filter
      * @param array $expectedNodePaths
      */
+    #[DataProvider('pathAndPropertyNameFilterExamples')]
+    #[Test]
     public function pathAndPropertyNameFilterIsSupported($filter, array $expectedNodePaths)
     {
         $q = new FlowQuery([$this->node]);
@@ -125,9 +122,7 @@ class FindOperationTest extends AbstractNodeTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findWithNonInstanceofAttributeFilterAsFirstPartThrowsException()
     {
         $this->expectException(FlowQueryException::class);
@@ -136,12 +131,11 @@ class FindOperationTest extends AbstractNodeTestCase
     }
 
     /**
-     * @test
-     * @dataProvider attributeFilterExamples
-
      * @param string $filter
      * @param array $expectedNodePaths
      */
+    #[DataProvider('attributeFilterExamples')]
+    #[Test]
     public function attributeFilterIsSupported($filter, array $expectedNodePaths)
     {
         $q = new FlowQuery([$this->node]);
@@ -152,9 +146,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertSame($expectedNodePaths, $foundNodePaths);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeIdentifierReturnsCorrectNodeInContext()
     {
         $this->authenticateRoles(['Neos.ContentRepository:TestingAdministrator']);
@@ -172,9 +164,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertNotSame($foundNode, $testFoundNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithInstanceofFilterReturnsMatchingNodesRecursively()
     {
         $q = new FlowQuery([$this->node]);
@@ -185,9 +175,7 @@ class FindOperationTest extends AbstractNodeTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithInstanceofFilterExcludeNodesWithADisabledCorrespondingSuperType()
     {
         $q = new FlowQuery([$this->node]);
@@ -198,9 +186,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertNotContains('Neos.ContentRepository.Testing:ThreeColumn', $foundNodeTypeNames);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithMultipleInstanceofFilterReturnsMatchingNodesRecursively()
     {
         $q = new FlowQuery([$this->node]);
@@ -217,9 +203,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertSame($foundNodeTypes, ['Neos.ContentRepository.Testing:Page', 'Neos.ContentRepository.Testing:Text']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithAbsolutePathReturnsCorrectNode()
     {
         $q = new FlowQuery([$this->node]);
@@ -229,9 +213,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertSame('b1e0e78d-04f3-8fc3-e3d1-e2399f831312', $foundNode->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithPathReturnsEmptyArrayIfNotFound()
     {
         $q = new FlowQuery([$this->node]);
@@ -239,9 +221,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertEmpty($foundNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOperationEvaluatesWithEmptyContext()
     {
         $q = new FlowQuery([]);
@@ -249,9 +229,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertEmpty($foundNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOperationThrowsExceptionOnAtLeastOneInvalidContext()
     {
         $this->expectException(FlowQueryException::class);
@@ -259,9 +237,7 @@ class FindOperationTest extends AbstractNodeTestCase
         $q->find('/sites/example/home/main/limbo')->get();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithNodeNameReturnsCorrectNode()
     {
         $q = new FlowQuery([$this->node]);
@@ -271,9 +247,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertSame('f66b3871-515f-7f54-fb1d-1c108040b2c0', $foundNode->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithRelativePathReturnsCorrectNode()
     {
         $q = new FlowQuery([$this->node]);
@@ -283,9 +257,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertSame('b1e0e78d-04f3-8fc3-e3d1-e2399f831312', $foundNode->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByMultipleNodesReturnsMatchingNodesForAllNodes()
     {
         $this->authenticateRoles(['Neos.ContentRepository:TestingAdministrator']);
@@ -311,9 +283,7 @@ class FindOperationTest extends AbstractNodeTestCase
         self::assertTrue($foundChildrenOfB);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByNodeWithInstanceofFilterAppliesAdditionalAttributeFilter()
     {
         $q = new FlowQuery([$this->node]);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
@@ -13,13 +13,13 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
 
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 use Neos\Eel\FlowQuery\FlowQueryException;
 
 /**
  * Functional test case which tests FlowQuery FindOperation
  */
-class FindOperationTest extends AbstractNodeTest
+class FindOperationTest extends AbstractNodeTestCase
 {
     /**
      * @test

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/FindOperationTest.php
@@ -33,7 +33,7 @@ class FindOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function identifierFilterExamples()
+    public static function identifierFilterExamples()
     {
         return [
             'Single identifier' => ['#30e893c1-caef-0ca5-b53d-e5699bb8e506', ['/sites/example/home/about-us']],
@@ -61,7 +61,7 @@ class FindOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function pathAndPropertyNameFilterExamples()
+    public static function pathAndPropertyNameFilterExamples()
     {
         return [
             'Absolute path' => ['/sites/example/home', ['/sites/example/home']],
@@ -91,7 +91,7 @@ class FindOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function attributeFilterExamples()
+    public static function attributeFilterExamples()
     {
         return [
             'Single instanceof' => [

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/HasOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/HasOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
@@ -83,10 +84,9 @@ class HasOperationTest extends AbstractNodeTestCase
      *   b1 (TestingNodeType)
      *     b1a
      * c
-     *
-     * @test
-     * @dataProvider hasOperationDataProvider()
      */
+    #[DataProvider('hasOperationDataProvider')]
+    #[Test]
     public function hasOperationTests(array $currentNodePaths, $subject, array $expectedNodePaths)
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/HasOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/HasOperationTest.php
@@ -24,7 +24,7 @@ class HasOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function hasOperationDataProvider()
+    public static function hasOperationDataProvider()
     {
         return [
             [

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/HasOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/HasOperationTest.php
@@ -13,12 +13,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
 
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery HasOperation
  */
-class HasOperationTest extends AbstractNodeTest
+class HasOperationTest extends AbstractNodeTestCase
 {
     /**
      * @return array

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/NextUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/NextUntilOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
@@ -73,10 +74,9 @@ class NextUntilOperationTest extends AbstractNodeTestCase
      *   b2
      *   b3 (testNodeType3)
      *   b4
-     *
-     * @test
-     * @dataProvider nextUntilOperationDataProvider()
      */
+    #[DataProvider('nextUntilOperationDataProvider')]
+    #[Test]
     public function nextUntilOperationTests(array $currentNodePaths, $subject, array $expectedNodePaths, array $unexpectedNodePaths)
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/NextUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/NextUntilOperationTest.php
@@ -24,7 +24,7 @@ class NextUntilOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function nextUntilOperationDataProvider()
+    public static function nextUntilOperationDataProvider()
     {
         return [
             [

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/NextUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/NextUntilOperationTest.php
@@ -13,12 +13,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
 
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery NextUntilOperation
  */
-class NextUntilOperationTest extends AbstractNodeTest
+class NextUntilOperationTest extends AbstractNodeTestCase
 {
     /**
      * @return array

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
@@ -19,9 +19,7 @@ use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
  */
 class ParentsOperationTest extends AbstractNodeTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function parentsFollowedByFirstMatchesInnermostNodeOnRootline()
     {
         $teaserText = $this->node->getNode('teaser/dummy42');

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsOperationTest.php
@@ -12,12 +12,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  */
 
 use Neos\Eel\FlowQuery\FlowQuery;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery ParentsOperation
  */
-class ParentsOperationTest extends AbstractNodeTest
+class ParentsOperationTest extends AbstractNodeTestCase
 {
     /**
      * @test

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
@@ -86,10 +87,9 @@ class ParentsUntilOperationTest extends AbstractNodeTestCase
      *       b4ba (Testing:NodeType)
      *       b4bb
      *         b4bba
-     *
-     * @test
-     * @dataProvider parentsUntilOperationDataProvider()
      */
+    #[DataProvider('parentsUntilOperationDataProvider')]
+    #[Test]
     public function parentsUntilOperationTests(array $currentNodePaths, $subject, array $expectedNodePaths, array $unexpectedNodePaths)
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
@@ -24,7 +24,7 @@ class ParentsUntilOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function parentsUntilOperationDataProvider()
+    public static function parentsUntilOperationDataProvider()
     {
         return [
             [

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/ParentsUntilOperationTest.php
@@ -13,12 +13,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
 
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery ParentsUntilOperation
  */
-class ParentsUntilOperationTest extends AbstractNodeTest
+class ParentsUntilOperationTest extends AbstractNodeTestCase
 {
     /**
      * @return array

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/PrevUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/PrevUntilOperationTest.php
@@ -13,12 +13,12 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
 
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Functional test case which tests FlowQuery PrevUntilOperation
  */
-class PrevUntilOperationTest extends AbstractNodeTest
+class PrevUntilOperationTest extends AbstractNodeTestCase
 {
     /**
      * @return array

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/PrevUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/PrevUntilOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Eel\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
@@ -73,10 +74,9 @@ class PrevUntilOperationTest extends AbstractNodeTestCase
      *   b2 (testNodeType3)
      *   b3
      *   b4
-     *
-     * @test
-     * @dataProvider prevUntilOperationDataProvider()
      */
+    #[DataProvider('prevUntilOperationDataProvider')]
+    #[Test]
     public function prevUntilOperationTests(array $currentNodePaths, $subject, array $expectedNodePaths, array $unexpectedNodePaths)
     {
         $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);

--- a/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/PrevUntilOperationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Eel/FlowQueryOperations/PrevUntilOperationTest.php
@@ -24,7 +24,7 @@ class PrevUntilOperationTest extends AbstractNodeTestCase
     /**
      * @return array
      */
-    public function prevUntilOperationDataProvider()
+    public static function prevUntilOperationDataProvider()
     {
         return [
             [

--- a/Neos.ContentRepository/Tests/Functional/Migration/Domain/Repository/MigrationStatusRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/Domain/Repository/MigrationStatusRepositoryTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\Migration\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\ContentRepository\Migration\Domain\Model\MigrationStatus;
 use Neos\ContentRepository\Migration\Domain\Repository\MigrationStatusRepository;
@@ -38,9 +38,7 @@ class MigrationStatusRepositoryTest extends FunctionalTestCase
         $this->repository = $this->objectManager->get(MigrationStatusRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findAllReturnsResultsInAscendingVersionOrder()
     {
         $this->repository->add(new MigrationStatus('zyx', MigrationStatus::DIRECTION_DOWN, new \DateTime()));

--- a/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
@@ -50,7 +50,7 @@ class NodeTypeTest extends FunctionalTestCase
         $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
     }
 
-    public function getFilterExpressionsDataprovider(): array
+    public static function getFilterExpressionsDataprovider(): array
     {
         return [
             'nodeTypeOnly' => [

--- a/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/Filters/NodeTypeTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Migration\Filters;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Doctrine\ORM\Query\Expr;
 use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\Flow\Persistence\Doctrine\Query;
@@ -80,14 +81,14 @@ class NodeTypeTest extends FunctionalTestCase
     }
 
     /**
-     * @test
-     * @dataProvider getFilterExpressionsDataprovider
      * @param string $nodeType
      * @param bool $withSubTypes
      * @param bool $exclude
      * @param string $expected
      * @throws \Neos\Flow\Persistence\Exception\InvalidQueryException
      */
+    #[DataProvider('getFilterExpressionsDataprovider')]
+    #[Test]
     public function getFilterExpressions(string $nodeType, bool $withSubTypes, bool $exclude, string $expected)
     {
         $nodeTypeFilter = new NodeTypeFilter();

--- a/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
@@ -33,7 +33,7 @@ class MigrationTest extends AbstractNodeTestCase
         $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
     }
 
-    public function migrationDataprovider(): array
+    public static function migrationDataprovider(): array
     {
         return [
             'nodeTypeNoSubTypesShouldMatchType' => [

--- a/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
@@ -17,9 +17,9 @@ use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\Migration\Domain\Model\Migration;
 use Neos\ContentRepository\Migration\Service\NodeMigration;
-use Neos\ContentRepository\Tests\Functional\AbstractNodeTest;
+use Neos\ContentRepository\Tests\Functional\AbstractNodeTestCase;
 
-class MigrationTest extends AbstractNodeTest
+class MigrationTest extends AbstractNodeTestCase
 {
     /**
      * @var NodeTypeManager

--- a/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
+++ b/Neos.ContentRepository/Tests/Functional/Migration/MigrationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Functional\Migration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
@@ -232,8 +233,6 @@ class MigrationTest extends AbstractNodeTestCase
     }
 
     /**
-     * @test
-     * @dataProvider migrationDataprovider
      * @param $migrationConfiguration
      * @param $migratedNodeIdentifier
      * @param $propertyName
@@ -245,6 +244,8 @@ class MigrationTest extends AbstractNodeTestCase
      * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      * @throws \Neos\Flow\Persistence\Exception\UnknownObjectException
      */
+    #[DataProvider('migrationDataprovider')]
+    #[Test]
     public function migration($migrationConfiguration, $migratedNodeIdentifier, $propertyName, $expectedBefore, $expectedAfter)
     {
         /** @var NodeDataRepository $nodeDataRepository */

--- a/Neos.ContentRepository/Tests/Functional/TypeConverter/NodeConverterTest.php
+++ b/Neos.ContentRepository/Tests/Functional/TypeConverter/NodeConverterTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Functional\TypeConverter;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Error\Messages\Error;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Property\Exception\TypeConverterException;
@@ -149,9 +149,7 @@ class NodeConverterTest extends FunctionalTestCase
         $this->flushNodeChanges();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromLiveWorkspaceCanBeRetrievedAgainUsingNodeConverter()
     {
         $this->setupNodeWithShadowNodeInPersonalWorkspace();
@@ -160,9 +158,7 @@ class NodeConverterTest extends FunctionalTestCase
         self::assertSame('Hello World', $headlineNode->getProperty('title'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromPersonalWorkspaceCanBeRetrievedAgainUsingNodeConverter()
     {
         $this->setupNodeWithShadowNodeInPersonalWorkspace();
@@ -173,9 +169,7 @@ class NodeConverterTest extends FunctionalTestCase
         self::assertSame('Brave new world', $headlineNode->getProperty('subtitle'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeFromGermanDimensionIsFetchedCorrectly()
     {
         $this->setupNodeWithShadowNodeInPersonalWorkspace();
@@ -184,9 +178,7 @@ class NodeConverterTest extends FunctionalTestCase
         self::assertSame('Hallo Welt', $headlineNode->getProperty('title'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodePropertiesAreSetWhenConverterIsCalledWithInputArray()
     {
         $this->setupNodeWithShadowNodeInPersonalWorkspace();
@@ -200,9 +192,7 @@ class NodeConverterTest extends FunctionalTestCase
         self::assertSame('Brave new world', $headlineNode->getProperty('subtitle'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settingUnknownNodePropertiesThrowsException()
     {
         $this->expectException(TypeConverterException::class);
@@ -215,9 +205,7 @@ class NodeConverterTest extends FunctionalTestCase
         $this->convert($input);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unknownNodePropertiesAreSkippedIfTypeConverterIsConfiguredLikeThis()
     {
         $this->setupNodeWithShadowNodeInPersonalWorkspace();

--- a/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Configuration/NodeTypesLoaderTest.php
@@ -11,7 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Configuration\NodeTypesLoader;
 use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Core\ApplicationContext;
@@ -62,9 +62,7 @@ class NodeTypesLoaderTest extends UnitTestCase
         return $mockPackage;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyPackageList(): void
     {
         $actualResult = $this->nodeTypesLoader->load([], $this->mockApplicationContext);
@@ -108,9 +106,7 @@ class NodeTypesLoaderTest extends UnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function firstPackage(): void
     {
         $actualResult = $this->nodeTypesLoader->load([$this->mockPackage1], $this->mockApplicationContext);
@@ -178,9 +174,7 @@ class NodeTypesLoaderTest extends UnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function secondPackage(): void
     {
         $actualResult = $this->nodeTypesLoader->load([$this->mockPackage2], $this->mockApplicationContext);
@@ -236,9 +230,7 @@ class NodeTypesLoaderTest extends UnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bothPackages(): void
     {
         $actualResult = $this->nodeTypesLoader->load([$this->mockPackage1, $this->mockPackage2], $this->mockApplicationContext);
@@ -318,9 +310,7 @@ class NodeTypesLoaderTest extends UnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bothPackagesReversedOrder(): void
     {
         $actualResult = $this->nodeTypesLoader->load([$this->mockPackage2, $this->mockPackage1], $this->mockApplicationContext);
@@ -402,9 +392,8 @@ class NodeTypesLoaderTest extends UnitTestCase
 
     /**
      * This is a test case for the issue https://github.com/neos/neos-development-collection/issues/3449
-     *
-     * @test
      */
+    #[Test]
     public function nodeTypeCanBeOverriddenFromNodeTypesFolder(): void
     {
         $mockSeoPackage = $this->mockPackage('Neos.Seo');

--- a/Neos.ContentRepository/Tests/Unit/Domain/Factory/NodeFactoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Factory/NodeFactoryTest.php
@@ -50,7 +50,7 @@ class NodeFactoryTest extends UnitTestCase
      */
     public function setUp(): void
     {
-        $this->nodeFactory = $this->getMockBuilder(NodeFactory::class)->setMethods(['filterNodeByContext'])->getMock();
+        $this->nodeFactory = $this->getMockBuilder(NodeFactory::class)->onlyMethods(['filterNodeByContext'])->getMock();
 
         $this->nodeFactory->expects(self::any())->method('filterNodeByContext')->willReturnArgument(0);
 
@@ -91,7 +91,7 @@ class NodeFactoryTest extends UnitTestCase
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
         $mockWorkspace = $this->getMockBuilder(Workspace::class)->setMockClassName('MockWorkspace')->disableOriginalConstructor()->getMock();
-        $mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue($workspaceName));
+        $mockWorkspace->expects(self::any())->method('getName')->willReturn($workspaceName);
 
         $mockContextFactory = $this->createMock(ContextFactoryInterface::class);
         $mockContextFactory->expects(self::once())->method('create')->with([
@@ -105,7 +105,7 @@ class NodeFactoryTest extends UnitTestCase
         $this->inject($this->nodeFactory, 'contextFactory', $mockContextFactory);
 
         $mockNodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $mockNodeData->expects(self::any())->method('getWorkspace')->will(self::returnValue($mockWorkspace));
+        $mockNodeData->expects(self::any())->method('getWorkspace')->willReturn($mockWorkspace);
         $mockNodeData->expects(self::any())->method('getDimensionValues')->willReturn($dimensionValues);
 
         $context = $this->nodeFactory->createContextMatchingNodeData($mockNodeData);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Factory/NodeFactoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Factory/NodeFactoryTest.php
@@ -10,6 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Factory;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
@@ -63,9 +64,7 @@ class NodeFactoryTest extends UnitTestCase
         $this->inject($this->nodeFactory, 'objectManager', $this->objectManagerMock);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createFromNodeDataCreatesANodeWithTheGivenContextAndNodeData()
     {
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
@@ -83,9 +82,7 @@ class NodeFactoryTest extends UnitTestCase
         self::assertEquals('0068371a-c108-99cb-3aa5-81b8852a2d12', $node->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createContextMatchingNodeDataCreatesMatchingContext()
     {
         $dimensionValues = ['language' => ['is']];

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
@@ -59,45 +59,45 @@ class ContextualizedNodeTest extends UnitTestCase
         $userWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $liveWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeType->expects(self::any())->method('getPropertyType')->will(self::returnValue('string'));
+        $nodeType->expects(self::any())->method('getPropertyType')->willReturn('string');
 
         $originalNode = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $originalNode->expects(self::any())->method('getWorkspace')->will(self::returnValue($liveWorkspace));
-        $originalNode->expects(self::any())->method('getNodeType')->will(self::returnValue($nodeType));
+        $originalNode->expects(self::any())->method('getWorkspace')->willReturn($liveWorkspace);
+        $originalNode->expects(self::any())->method('getNodeType')->willReturn($nodeType);
         if ($methodName === 'hasProperty') {
             if ($argument1 === null) {
-                $originalNode->expects(self::any())->method($methodName)->will(self::returnValue(true));
+                $originalNode->expects(self::any())->method($methodName)->willReturn(true);
             } else {
-                $originalNode->expects(self::any())->method($methodName)->with($argument1)->will(self::returnValue(true));
+                $originalNode->expects(self::any())->method($methodName)->with($argument1)->willReturn(true);
             }
         } else {
             if ($argument1 === null) {
-                $originalNode->expects(self::any())->method($methodName)->will(self::returnValue('originalNodeResult'));
+                $originalNode->expects(self::any())->method($methodName)->willReturn('originalNodeResult');
             } else {
-                $originalNode->expects(self::any())->method($methodName)->with($argument1)->will(self::returnValue('originalNodeResult'));
+                $originalNode->expects(self::any())->method($methodName)->with($argument1)->willReturn('originalNodeResult');
             }
         }
 
 
         $newNode = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $newNode->expects(self::any())->method('getWorkspace')->will(self::returnValue($userWorkspace));
-        $newNode->expects(self::any())->method('getNodeType')->will(self::returnValue($nodeType));
+        $newNode->expects(self::any())->method('getWorkspace')->willReturn($userWorkspace);
+        $newNode->expects(self::any())->method('getNodeType')->willReturn($nodeType);
         if ($methodName === 'hasProperty') {
             if ($argument1 === null) {
-                $newNode->expects(self::any())->method($methodName)->will(self::returnValue(false));
+                $newNode->expects(self::any())->method($methodName)->willReturn(false);
             } else {
-                $newNode->expects(self::any())->method($methodName)->with($argument1)->will(self::returnValue(false));
+                $newNode->expects(self::any())->method($methodName)->with($argument1)->willReturn(false);
             }
         } else {
             if ($argument1 === null) {
-                $newNode->expects(self::any())->method($methodName)->will(self::returnValue('newNodeResult'));
+                $newNode->expects(self::any())->method($methodName)->willReturn('newNodeResult');
             } else {
-                $newNode->expects(self::any())->method($methodName)->with($argument1)->will(self::returnValue('newNodeResult'));
+                $newNode->expects(self::any())->method($methodName)->with($argument1)->willReturn('newNodeResult');
             }
         }
 
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $context->expects(self::any())->method('getWorkspace')->will(self::returnValue($userWorkspace));
+        $context->expects(self::any())->method('getWorkspace')->willReturn($userWorkspace);
 
         $contextualizedNode = new Node($originalNode, $context);
         $this->inject($contextualizedNode, 'propertyMapper', $propertyMapper);
@@ -140,7 +140,7 @@ class ContextualizedNodeTest extends UnitTestCase
     public function getIdentifierReturnsTheIdentifier()
     {
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::once())->method('getIdentifier')->will(self::returnValue('theidentifier'));
+        $nodeData->expects(self::once())->method('getIdentifier')->willReturn('theidentifier');
 
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
@@ -227,7 +227,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node = $this->setUpNodeWithNonMatchingContext();
         $node->expects(self::once())->method('materializeNodeDataAsNeeded');
 
-        $node->getNodeData()->expects(self::once())->method('getContentObject')->will(self::returnValue(new \stdClass()));
+        $node->getNodeData()->expects(self::once())->method('getContentObject')->willReturn(new \stdClass());
         $node->getNodeData()->expects(self::once())->method('unsetContentObject');
 
         $node->unsetContentObject();
@@ -251,7 +251,7 @@ class ContextualizedNodeTest extends UnitTestCase
     {
         $node = $this->setUpNodeWithNonMatchingContext(['getChildNodes']);
 
-        $node->expects(self::once())->method('getChildNodes')->will(self::returnValue([]));
+        $node->expects(self::once())->method('getChildNodes')->willReturn([]);
         $node->getNodeData()->expects(self::once())->method('setRemoved');
 
         $node->remove();
@@ -265,13 +265,13 @@ class ContextualizedNodeTest extends UnitTestCase
         $nodeData = $node->getNodeData();
         $context = $node->getContext();
 
-        $subNode1 = $this->getMockBuilder(Node::class)->setMethods(['setRemoved'])->setConstructorArgs([$nodeData, $context])->getMock();
+        $subNode1 = $this->getMockBuilder(Node::class)->onlyMethods(['setRemoved'])->setConstructorArgs([$nodeData, $context])->getMock();
         $subNode1->expects(self::once())->method('setRemoved');
 
-        $subNode2 = $this->getMockBuilder(Node::class)->setMethods(['setRemoved'])->setConstructorArgs([$nodeData, $context])->getMock();
+        $subNode2 = $this->getMockBuilder(Node::class)->onlyMethods(['setRemoved'])->setConstructorArgs([$nodeData, $context])->getMock();
         $subNode2->expects(self::once())->method('setRemoved');
 
-        $node->expects(self::once())->method('getChildNodes')->will(self::returnValue([$subNode1, $subNode2]));
+        $node->expects(self::once())->method('getChildNodes')->willReturn([$subNode1, $subNode2]);
         $node->remove();
     }
 
@@ -283,18 +283,18 @@ class ContextualizedNodeTest extends UnitTestCase
         $mockFirstLevelNodeCache = $this->getFirstLevelNodeCache();
 
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $context->expects(self::any())->method('getWorkspace')->will(self::returnValue($currentNodeWorkspace));
-        $context->expects(self::any())->method('getFirstLevelNodeCache')->will(self::returnValue($mockFirstLevelNodeCache));
+        $context->expects(self::any())->method('getWorkspace')->willReturn($currentNodeWorkspace);
+        $context->expects(self::any())->method('getFirstLevelNodeCache')->willReturn($mockFirstLevelNodeCache);
 
         $expectedParentNodeData = new NodeData('/foo', $currentNodeWorkspace);
         $expectedContextualizedParentNode = new Node($expectedParentNodeData, $context);
 
-        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['findOneByPathInContext'])->getMock();
-        $nodeDataRepository->expects(self::once())->method('findOneByPathInContext')->with('/foo', $context)->will(self::returnValue($expectedContextualizedParentNode));
+        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['findOneByPathInContext'])->getMock();
+        $nodeDataRepository->expects(self::once())->method('findOneByPathInContext')->with('/foo', $context)->willReturn($expectedContextualizedParentNode);
 
         $currentNodeData = $this->getMockBuilder(NodeData::class)->setConstructorArgs(['/foo/baz', $currentNodeWorkspace])->getMock();
         $currentContextualizedNode = $this->getAccessibleMock(Node::class, ['getParentPath'], [$currentNodeData, $context]);
-        $currentContextualizedNode->expects(self::once())->method('getParentPath')->will(self::returnValue('/foo'));
+        $currentContextualizedNode->expects(self::once())->method('getParentPath')->willReturn('/foo');
         $currentContextualizedNode->_set('nodeDataRepository', $nodeDataRepository);
 
         $actualParentNode = $currentContextualizedNode->getParent();
@@ -309,18 +309,18 @@ class ContextualizedNodeTest extends UnitTestCase
         $mockFirstLevelNodeCache = $this->getFirstLevelNodeCache();
 
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $context->expects(self::any())->method('getWorkspace')->will(self::returnValue($currentNodeWorkspace));
-        $context->expects(self::any())->method('getFirstLevelNodeCache')->will(self::returnValue($mockFirstLevelNodeCache));
+        $context->expects(self::any())->method('getWorkspace')->willReturn($currentNodeWorkspace);
+        $context->expects(self::any())->method('getFirstLevelNodeCache')->willReturn($mockFirstLevelNodeCache);
 
         $expectedNodeData = $this->getMockBuilder(NodeData::class)->setConstructorArgs(['/foo/bar', $currentNodeWorkspace])->getMock();
         $expectedContextualizedNode = new Node($expectedNodeData, $context);
 
-        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['findOneByPathInContext'])->getMock();
-        $nodeDataRepository->expects(self::once())->method('findOneByPathInContext')->with('/foo/bar', $context)->will(self::returnValue($expectedContextualizedNode));
+        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['findOneByPathInContext'])->getMock();
+        $nodeDataRepository->expects(self::once())->method('findOneByPathInContext')->with('/foo/bar', $context)->willReturn($expectedContextualizedNode);
 
-        $currentNodeData = $this->getMockBuilder(NodeData::class)->setMethods(['dummy'])->setConstructorArgs(['/foo/baz', $currentNodeWorkspace])->getMock();
+        $currentNodeData = $this->getMockBuilder(NodeData::class)->addMethods(['dummy'])->setConstructorArgs(['/foo/baz', $currentNodeWorkspace])->getMock();
         $nodeService = $this->getMockBuilder(NodeService::class)->disableOriginalConstructor()->getMock();
-        $nodeService->expects(self::once())->method('normalizePath')->with('../bar', '/foo/baz')->will(self::returnValue('/foo/bar'));
+        $nodeService->expects(self::once())->method('normalizePath')->with('../bar', '/foo/baz')->willReturn('/foo/bar');
         $currentContextualizedNode = $this->getAccessibleMock(Node::class, ['dummy'], [$currentNodeData, $context]);
         $currentContextualizedNode->_set('nodeDataRepository', $nodeDataRepository);
         $currentContextualizedNode->_set('nodeService', $nodeService);
@@ -336,24 +336,24 @@ class ContextualizedNodeTest extends UnitTestCase
     protected function setUpNodeWithNonMatchingContext(array $configurableMethods = [])
     {
         $userWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $userWorkspace->expects(self::any())->method('getName')->will(self::returnValue('user'));
+        $userWorkspace->expects(self::any())->method('getName')->willReturn('user');
         $liveWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $liveWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
-        $liveWorkspace->expects(self::any())->method('getBaseWorkspace')->will(self::returnValue(null));
+        $liveWorkspace->expects(self::any())->method('getName')->willReturn('live');
+        $liveWorkspace->expects(self::any())->method('getBaseWorkspace')->willReturn(null);
 
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::any())->method('getWorkspace')->will(self::returnValue($liveWorkspace));
-        $nodeData->expects(self::any())->method('hasProperty')->will(self::returnValue(true));
+        $nodeData->expects(self::any())->method('getWorkspace')->willReturn($liveWorkspace);
+        $nodeData->expects(self::any())->method('hasProperty')->willReturn(true);
 
         $mockFirstLevelNodeCache = $this->createMock(FirstLevelNodeCache::class);
 
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $context->expects(self::any())->method('getWorkspace')->will(self::returnValue($userWorkspace));
-        $context->expects(self::any())->method('getTargetDimensions')->will(self::returnValue([]));
-        $context->expects(self::any())->method('getFirstLevelNodeCache')->will(self::returnValue($mockFirstLevelNodeCache));
+        $context->expects(self::any())->method('getWorkspace')->willReturn($userWorkspace);
+        $context->expects(self::any())->method('getTargetDimensions')->willReturn([]);
+        $context->expects(self::any())->method('getFirstLevelNodeCache')->willReturn($mockFirstLevelNodeCache);
 
         /** @var Node|MockObject $node */
-        $node = $this->getMockBuilder(Node::class)->setMethods(array_merge(['materializeNodeData', 'materializeNodeDataAsNeeded', 'getNodeType'], $configurableMethods))->setConstructorArgs([$nodeData, $context])->getMock();
+        $node = $this->getMockBuilder(Node::class)->onlyMethods(array_merge(['materializeNodeData', 'materializeNodeDataAsNeeded', 'getNodeType'], $configurableMethods))->setConstructorArgs([$nodeData, $context])->getMock();
         return $node;
     }
 
@@ -363,9 +363,9 @@ class ContextualizedNodeTest extends UnitTestCase
     protected function getFirstLevelNodeCache()
     {
         $mockFirstLevelNodeCache = $this->createMock(FirstLevelNodeCache::class);
-        $mockFirstLevelNodeCache->expects(self::any())->method('getByPath')->will(self::returnValue(false));
-        $mockFirstLevelNodeCache->expects(self::any())->method('getByIdentifier')->will(self::returnValue(false));
-        $mockFirstLevelNodeCache->expects(self::any())->method('getChildNodesByPathAndNodeTypeFilter')->will(self::returnValue(false));
+        $mockFirstLevelNodeCache->expects(self::any())->method('getByPath')->willReturn(false);
+        $mockFirstLevelNodeCache->expects(self::any())->method('getByIdentifier')->willReturn(false);
+        $mockFirstLevelNodeCache->expects(self::any())->method('getChildNodesByPathAndNodeTypeFilter')->willReturn(false);
         return $mockFirstLevelNodeCache;
     }
 }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/ContextualizedNodeTest.php
@@ -10,6 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -37,9 +38,7 @@ class ContextualizedNodeTest extends UnitTestCase
      */
     protected $newNode;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aContextualizedNodeIsRelatedToNodeData()
     {
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
@@ -119,33 +118,25 @@ class ContextualizedNodeTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPathRetrievesThePathFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getPath');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getDepthRetrievesTheDepthFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getDepth');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNameRetrievesTheNameFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getName');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierReturnsTheIdentifier()
     {
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
@@ -158,26 +149,20 @@ class ContextualizedNodeTest extends UnitTestCase
         self::assertEquals('theidentifier', $contextualizedNode->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIndexRetrievesTheIndexFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getIndex');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getParentRetrievesTheParentNodeFromTheOriginalOrNewNode()
     {
         $this->markTestSkipped();
         $this->assertThatOriginalOrNewNodeIsCalled('getParent');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setIndexOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
@@ -188,9 +173,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->setIndex(5);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setPropertyOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
@@ -201,33 +184,25 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->setProperty('propertyName', 'value');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasPropertyCallsHasPropertyOnTheParentNodeFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('hasProperty', 'myProperty');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertyCallsGetPropertyOnTheParentNodeFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getProperty', 'myProperty');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertyNamesCallsGetPropertyNamesOnTheParentNodeFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getPropertyNames');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setContentObjectOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $contentObject = new \stdClass();
@@ -240,17 +215,13 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->setContentObject($contentObject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getContentObjectCallsGetContentObjectOnTheParentNodeFromTheOriginalOrNewNode()
     {
         $this->assertThatOriginalOrNewNodeIsCalled('getContentObject');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unsetContentObjectOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext();
@@ -262,9 +233,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->unsetContentObject();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setNodeTypeOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
@@ -277,9 +246,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->setNodeType($nodeType);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeCallsOnNodeWithNonMatchingContextMaterializesNodeData()
     {
         $node = $this->setUpNodeWithNonMatchingContext(['getChildNodes']);
@@ -290,9 +257,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->remove();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeRemovesAllChildNodesAndTheNodeItself()
     {
         $node = $this->setUpNodeWithNonMatchingContext(['getChildNodes']);
@@ -310,9 +275,7 @@ class ContextualizedNodeTest extends UnitTestCase
         $node->remove();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getParentReturnsParentNodeInCurrentNodesContext()
     {
         $currentNodeWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
@@ -338,9 +301,7 @@ class ContextualizedNodeTest extends UnitTestCase
         self::assertSame($expectedContextualizedParentNode, $actualParentNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeReturnsTheSpecifiedNodeInTheCurrentNodesContext()
     {
         $currentNodeWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
@@ -397,7 +358,7 @@ class ContextualizedNodeTest extends UnitTestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      */
     protected function getFirstLevelNodeCache()
     {

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/InterDimensionalFallbackGraphTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/InterDimensionalFallbackGraphTest.php
@@ -11,6 +11,12 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\InterDimension;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\InterDimension\InterDimensionalFallbackGraph;
+use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimensionValue;
+use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimension;
+use Neos\ContentRepository\Domain\Model\InterDimension\ContentSubgraph;
+use Neos\ContentRepository\Domain\Model\IntraDimension\IntraDimensionalFallbackGraph;
+use Neos\ContentRepository\Domain\Model\InterDimension\VariationEdge;
 use Neos\ContentRepository\Domain\Model\InterDimension;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
@@ -26,9 +32,9 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function createContentSubgraphRegistersSubgraph()
     {
-        $graph = new InterDimension\InterDimensionalFallbackGraph([]);
+        $graph = new InterDimensionalFallbackGraph([]);
 
-        $contentSubgraph = $graph->createContentSubgraph(['test' => new IntraDimension\ContentDimensionValue('a')]);
+        $contentSubgraph = $graph->createContentSubgraph(['test' => new ContentDimensionValue('a')]);
 
         self::assertSame($contentSubgraph, $graph->getSubgraph($contentSubgraph->getIdentityHash()));
     }
@@ -38,13 +44,13 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function connectSubgraphsAddsFallbackToVariant()
     {
-        $contentDimension = new IntraDimension\ContentDimension('test');
+        $contentDimension = new ContentDimension('test');
         $fallbackValue = $contentDimension->createValue('a');
         $variantValue = $contentDimension->createValue('b', $fallbackValue);
-        $graph = new InterDimension\InterDimensionalFallbackGraph([$contentDimension]);
+        $graph = new InterDimensionalFallbackGraph([$contentDimension]);
 
-        $fallback = new InterDimension\ContentSubgraph(['test' => $fallbackValue]);
-        $variant = new InterDimension\ContentSubgraph(['test' => $variantValue]);
+        $fallback = new ContentSubgraph(['test' => $fallbackValue]);
+        $variant = new ContentSubgraph(['test' => $variantValue]);
 
         $graph->connectSubgraphs($variant, $fallback);
 
@@ -56,13 +62,13 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function connectSubgraphsAddsVariantToFallback()
     {
-        $contentDimension = new IntraDimension\ContentDimension('test');
+        $contentDimension = new ContentDimension('test');
         $fallbackValue = $contentDimension->createValue('a');
         $variantValue = $contentDimension->createValue('b', $fallbackValue);
-        $graph = new InterDimension\InterDimensionalFallbackGraph([$contentDimension]);
+        $graph = new InterDimensionalFallbackGraph([$contentDimension]);
 
-        $fallback = new InterDimension\ContentSubgraph(['test' => $fallbackValue]);
-        $variant = new InterDimension\ContentSubgraph(['test' => $variantValue]);
+        $fallback = new ContentSubgraph(['test' => $fallbackValue]);
+        $variant = new ContentSubgraph(['test' => $variantValue]);
 
         $graph->connectSubgraphs($variant, $fallback);
 
@@ -78,7 +84,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function calculateFallbackWeightAggregatesCorrectWeightPerDimension(array $variantDimensionCombination, array $fallbackDimensionCombination, array $expectedWeight)
     {
-        $intraGraph = new IntraDimension\IntraDimensionalFallbackGraph();
+        $intraGraph = new IntraDimensionalFallbackGraph();
 
         $availableDimensionValues = [];
 
@@ -96,17 +102,17 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         $availableDimensionValues['tertiary1a'] = $tertiaryDimension->createValue('1a', $availableDimensionValues['tertiary0']);
         $availableDimensionValues['tertiary1b'] = $tertiaryDimension->createValue('1b', $availableDimensionValues['tertiary0']);
 
-        $interGraph = new InterDimension\InterDimensionalFallbackGraph([$primaryDimension, $secondaryDimension, $tertiaryDimension]);
+        $interGraph = new InterDimensionalFallbackGraph([$primaryDimension, $secondaryDimension, $tertiaryDimension]);
 
         array_walk($variantDimensionCombination, function (&$value) use ($availableDimensionValues) {
             $value = $availableDimensionValues[$value];
         });
-        $variantContentSubgraph = new InterDimension\ContentSubgraph($variantDimensionCombination);
+        $variantContentSubgraph = new ContentSubgraph($variantDimensionCombination);
 
         array_walk($fallbackDimensionCombination, function (&$value) use ($availableDimensionValues) {
             $value = $availableDimensionValues[$value];
         });
-        $fallbackContentSubgraph = new InterDimension\ContentSubgraph($fallbackDimensionCombination);
+        $fallbackContentSubgraph = new ContentSubgraph($fallbackDimensionCombination);
 
         self::assertSame($expectedWeight, $interGraph->calculateFallbackWeight($variantContentSubgraph, $fallbackContentSubgraph));
     }
@@ -137,15 +143,15 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function determineWeightNormalizationBaseEvaluatesToMaximumDimensionDepthPlusOne()
     {
-        $firstDimension = new IntraDimension\ContentDimension('first');
+        $firstDimension = new ContentDimension('first');
         $firstDepth = random_int(0, 100);
         ObjectAccess::setProperty($firstDimension, 'depth', $firstDepth, true);
 
-        $secondDimension = new IntraDimension\ContentDimension('second');
+        $secondDimension = new ContentDimension('second');
         $secondDepth = random_int(0, 100);
         ObjectAccess::setProperty($secondDimension, 'depth', $secondDepth, true);
 
-        $graph = new InterDimension\InterDimensionalFallbackGraph([$firstDimension, $secondDimension]);
+        $graph = new InterDimensionalFallbackGraph([$firstDimension, $secondDimension]);
         self::assertSame(max($firstDepth, $secondDepth) + 1, $graph->determineWeightNormalizationBase());
     }
 
@@ -159,18 +165,18 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function normalizeWeightCorrectlyCalculatesNormalizedWeight(int $dimensionDepth, array $weight, int $expectedNormalizedWeight)
     {
-        $primaryDimension = new IntraDimension\ContentDimension('primary');
+        $primaryDimension = new ContentDimension('primary');
         ObjectAccess::setProperty($primaryDimension, 'depth', $dimensionDepth, true);
-        $secondaryDimension = new IntraDimension\ContentDimension('secondary');
+        $secondaryDimension = new ContentDimension('secondary');
         ObjectAccess::setProperty($secondaryDimension, 'depth', $dimensionDepth, true);
-        $tertiaryDimension = new IntraDimension\ContentDimension('tertiary');
+        $tertiaryDimension = new ContentDimension('tertiary');
         ObjectAccess::setProperty($tertiaryDimension, 'depth', $dimensionDepth, true);
 
-        $graph = new InterDimension\InterDimensionalFallbackGraph([$primaryDimension, $secondaryDimension, $tertiaryDimension]);
+        $graph = new InterDimensionalFallbackGraph([$primaryDimension, $secondaryDimension, $tertiaryDimension]);
 
-        $variant = new InterDimension\ContentSubgraph([]);
-        $fallback = new InterDimension\ContentSubgraph([]);
-        $variationEdge = new InterDimension\VariationEdge($variant, $fallback, $weight);
+        $variant = new ContentSubgraph([]);
+        $fallback = new ContentSubgraph([]);
+        $variationEdge = new VariationEdge($variant, $fallback, $weight);
 
         self::assertSame($expectedNormalizedWeight, $graph->normalizeWeight($variationEdge->getWeight()));
     }
@@ -192,37 +198,37 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function getPrimaryFallbackReturnsFallbackWithLowestNormalizedWeight($primaryFallbackWeight, $secondaryFallbackWeight)
     {
-        $primaryDimension = new IntraDimension\ContentDimension('primary');
+        $primaryDimension = new ContentDimension('primary');
         $primaryVariantValue = $primaryDimension->createValue('variant');
         $primaryDummyValue1 = $primaryDimension->createValue('dummy1');
         $primaryDummyValue2 = $primaryDimension->createValue('dummy2');
         ObjectAccess::setProperty($primaryDimension, 'depth', 5, true);
-        $secondaryDimension = new IntraDimension\ContentDimension('secondary');
+        $secondaryDimension = new ContentDimension('secondary');
         $secondaryDummyValue = $secondaryDimension->createValue('dummy');
         ObjectAccess::setProperty($secondaryDimension, 'depth', 5, true);
-        $tertiaryDimension = new IntraDimension\ContentDimension('tertiary');
+        $tertiaryDimension = new ContentDimension('tertiary');
         $tertiaryDummyValue = $tertiaryDimension->createValue('dummy');
         ObjectAccess::setProperty($tertiaryDimension, 'depth', 5, true);
 
-        $graph = new InterDimension\InterDimensionalFallbackGraph([$primaryDimension, $secondaryDimension, $tertiaryDimension]);
+        $graph = new InterDimensionalFallbackGraph([$primaryDimension, $secondaryDimension, $tertiaryDimension]);
 
-        $variant = new InterDimension\ContentSubgraph([
+        $variant = new ContentSubgraph([
             'primary' => $primaryVariantValue,
             'secondary' => $secondaryDummyValue,
             'tertiary' => $tertiaryDummyValue
         ]);
-        $primaryFallback = new InterDimension\ContentSubgraph([
+        $primaryFallback = new ContentSubgraph([
             'primary' => $primaryDummyValue1,
             'secondary' => $secondaryDummyValue,
             'tertiary' => $tertiaryDummyValue
         ]);
-        $secondaryFallback = new InterDimension\ContentSubgraph([
+        $secondaryFallback = new ContentSubgraph([
             'primary' => $primaryDummyValue2,
             'secondary' => $secondaryDummyValue,
             'tertiary' => $tertiaryDummyValue
         ]);
-        new InterDimension\VariationEdge($variant, $primaryFallback, $primaryFallbackWeight);
-        new InterDimension\VariationEdge($variant, $secondaryFallback, $secondaryFallbackWeight);
+        new VariationEdge($variant, $primaryFallback, $primaryFallbackWeight);
+        new VariationEdge($variant, $secondaryFallback, $secondaryFallbackWeight);
 
         self::assertSame($primaryFallback, $graph->getPrimaryFallback($variant));
     }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/InterDimensionalFallbackGraphTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/InterDimensionalFallbackGraphTest.php
@@ -10,11 +10,12 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\InterDimension;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\InterDimension\InterDimensionalFallbackGraph;
 use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimensionValue;
 use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimension;
 use Neos\ContentRepository\Domain\Model\InterDimension\ContentSubgraph;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Domain\Model\IntraDimension\IntraDimensionalFallbackGraph;
 use Neos\ContentRepository\Domain\Model\InterDimension\VariationEdge;
 use Neos\ContentRepository\Domain\Model\InterDimension;
@@ -27,9 +28,7 @@ use Neos\Utility\ObjectAccess;
  */
 class InterDimensionalFallbackGraphTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createContentSubgraphRegistersSubgraph()
     {
         $graph = new InterDimensionalFallbackGraph([]);
@@ -39,9 +38,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         self::assertSame($contentSubgraph, $graph->getSubgraph($contentSubgraph->getIdentityHash()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function connectSubgraphsAddsFallbackToVariant()
     {
         $contentDimension = new ContentDimension('test');
@@ -57,9 +54,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         self::assertContains($fallback, $variant->getFallback());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function connectSubgraphsAddsVariantToFallback()
     {
         $contentDimension = new ContentDimension('test');
@@ -76,12 +71,12 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider dimensionValueCombinationProvider
      * @param array $variantDimensionCombination
      * @param array $fallbackDimensionCombination
      * @param array $expectedWeight
      */
+    #[DataProvider('dimensionValueCombinationProvider')]
+    #[Test]
     public function calculateFallbackWeightAggregatesCorrectWeightPerDimension(array $variantDimensionCombination, array $fallbackDimensionCombination, array $expectedWeight)
     {
         $intraGraph = new IntraDimensionalFallbackGraph();
@@ -138,9 +133,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function determineWeightNormalizationBaseEvaluatesToMaximumDimensionDepthPlusOne()
     {
         $firstDimension = new ContentDimension('first');
@@ -157,12 +150,12 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
 
 
     /**
-     * @test
-     * @dataProvider variationEdgeWeightNormalizationProvider
      * @param int $dimensionDepth
      * @param array $weight
      * @param int $expectedNormalizedWeight
      */
+    #[DataProvider('variationEdgeWeightNormalizationProvider')]
+    #[Test]
     public function normalizeWeightCorrectlyCalculatesNormalizedWeight(int $dimensionDepth, array $weight, int $expectedNormalizedWeight)
     {
         $primaryDimension = new ContentDimension('primary');
@@ -191,11 +184,11 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider fallbackPrioritizationProvider
      * @param array $primaryFallbackWeight
      * @param array $secondaryFallbackWeight
      */
+    #[DataProvider('fallbackPrioritizationProvider')]
+    #[Test]
     public function getPrimaryFallbackReturnsFallbackWithLowestNormalizedWeight($primaryFallbackWeight, $secondaryFallbackWeight)
     {
         $primaryDimension = new ContentDimension('primary');

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/InterDimensionalFallbackGraphTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/InterDimensionalFallbackGraphTest.php
@@ -112,7 +112,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         self::assertSame($expectedWeight, $interGraph->calculateFallbackWeight($variantContentSubgraph, $fallbackContentSubgraph));
     }
 
-    public function dimensionValueCombinationProvider()
+    public static function dimensionValueCombinationProvider()
     {
         return [
             [
@@ -174,7 +174,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         self::assertSame($expectedNormalizedWeight, $graph->normalizeWeight($variationEdge->getWeight()));
     }
 
-    public function variationEdgeWeightNormalizationProvider()
+    public static function variationEdgeWeightNormalizationProvider()
     {
         return [
             [5, ['primary' => 5, 'secondary' => 4, 'tertiary' => 0], 204],
@@ -226,7 +226,7 @@ class InterDimensionalFallbackGraphTest extends UnitTestCase
         self::assertSame($primaryFallback, $graph->getPrimaryFallback($variant));
     }
 
-    public function fallbackPrioritizationProvider()
+    public static function fallbackPrioritizationProvider()
     {
         return [
             [

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/VariationEdgeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/VariationEdgeTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\InterDimension;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\InterDimension\ContentSubgraph;
 use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimensionValue;
 use Neos\ContentRepository\Domain\Model\InterDimension\VariationEdge;
@@ -23,9 +23,7 @@ use Neos\Flow\Tests\UnitTestCase;
  */
 class VariationEdgeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function variationEdgesAreRegisteredInFallbackAndVariantUponCreation()
     {
         $variant = new ContentSubgraph(['test' => new ContentDimensionValue('a')]);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/VariationEdgeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/InterDimension/VariationEdgeTest.php
@@ -11,6 +11,9 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\InterDimension;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\InterDimension\ContentSubgraph;
+use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimensionValue;
+use Neos\ContentRepository\Domain\Model\InterDimension\VariationEdge;
 use Neos\ContentRepository\Domain\Model\InterDimension;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
@@ -25,10 +28,10 @@ class VariationEdgeTest extends UnitTestCase
      */
     public function variationEdgesAreRegisteredInFallbackAndVariantUponCreation()
     {
-        $variant = new InterDimension\ContentSubgraph(['test' => new IntraDimension\ContentDimensionValue('a')]);
-        $fallback = new InterDimension\ContentSubgraph(['test' => new IntraDimension\ContentDimensionValue('b')]);
+        $variant = new ContentSubgraph(['test' => new ContentDimensionValue('a')]);
+        $fallback = new ContentSubgraph(['test' => new ContentDimensionValue('b')]);
 
-        $variationEdge = new InterDimension\VariationEdge($variant, $fallback, [1]);
+        $variationEdge = new VariationEdge($variant, $fallback, [1]);
 
         self::assertContains($variationEdge, $variant->getFallbackEdges());
         self::assertContains($variationEdge, $fallback->getVariantEdges());

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\IntraDimension;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimension;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Utility\ObjectAccess;
@@ -25,7 +26,7 @@ class ContentDimensionTest extends UnitTestCase
      */
     public function createValueRegistersCreatedValue()
     {
-        $dimension = new IntraDimension\ContentDimension('test');
+        $dimension = new ContentDimension('test');
         $testValue = $dimension->createValue('test');
 
         self::assertSame($testValue, $dimension->getValue('test'));
@@ -36,7 +37,7 @@ class ContentDimensionTest extends UnitTestCase
      */
     public function createValueWithoutFallbackDoesNotIncreaseDepth()
     {
-        $dimension = new IntraDimension\ContentDimension('test');
+        $dimension = new ContentDimension('test');
         $dimension->createValue('test');
 
         self::assertSame(0, $dimension->getDepth());
@@ -48,7 +49,7 @@ class ContentDimensionTest extends UnitTestCase
     public function createValueWithFallbackDoesNotDecreaseDepth()
     {
         $testDepth = random_int(1, 100);
-        $dimension = new IntraDimension\ContentDimension('test');
+        $dimension = new ContentDimension('test');
         ObjectAccess::setProperty($dimension, 'depth', $testDepth, true);
         $fallbackValue = $dimension->createValue('fallback');
         $dimension->createValue('test', $fallbackValue);
@@ -62,7 +63,7 @@ class ContentDimensionTest extends UnitTestCase
     public function createValueWithFallbackIncreasesDepthIfFallbackHasCurrentMaximumDepth()
     {
         $testDepth = random_int(0, 100);
-        $dimension = new IntraDimension\ContentDimension('test');
+        $dimension = new ContentDimension('test');
         ObjectAccess::setProperty($dimension, 'depth', $testDepth, true);
         $fallbackValue = $dimension->createValue('fallback');
         ObjectAccess::setProperty($fallbackValue, 'depth', $testDepth, true);
@@ -77,7 +78,7 @@ class ContentDimensionTest extends UnitTestCase
     public function getRootValuesOnlyReturnsValuesOfDepthZero()
     {
         $testDepth = random_int(1, 100);
-        $dimension = new IntraDimension\ContentDimension('test');
+        $dimension = new ContentDimension('test');
         $depthZeroValue = $dimension->createValue('depthZero');
         $depthGreaterZeroValue = $dimension->createValue('depthGreaterZero');
         ObjectAccess::setProperty($depthGreaterZeroValue, 'depth', $testDepth, true);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\IntraDimension;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimension;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
@@ -21,9 +21,7 @@ use Neos\Utility\ObjectAccess;
  */
 class ContentDimensionTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createValueRegistersCreatedValue()
     {
         $dimension = new ContentDimension('test');
@@ -32,9 +30,7 @@ class ContentDimensionTest extends UnitTestCase
         self::assertSame($testValue, $dimension->getValue('test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createValueWithoutFallbackDoesNotIncreaseDepth()
     {
         $dimension = new ContentDimension('test');
@@ -43,9 +39,7 @@ class ContentDimensionTest extends UnitTestCase
         self::assertSame(0, $dimension->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createValueWithFallbackDoesNotDecreaseDepth()
     {
         $testDepth = random_int(1, 100);
@@ -57,9 +51,7 @@ class ContentDimensionTest extends UnitTestCase
         self::assertSame($testDepth, $dimension->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createValueWithFallbackIncreasesDepthIfFallbackHasCurrentMaximumDepth()
     {
         $testDepth = random_int(0, 100);
@@ -72,9 +64,7 @@ class ContentDimensionTest extends UnitTestCase
         self::assertSame($testDepth + 1, $dimension->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRootValuesOnlyReturnsValuesOfDepthZero()
     {
         $testDepth = random_int(1, 100);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionValueTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionValueTest.php
@@ -11,6 +11,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\IntraDimension;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimensionValue;
+use Neos\ContentRepository\Domain\Model\IntraDimension\Exception\InvalidFallbackException;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Utility\ObjectAccess;
@@ -25,7 +27,7 @@ class ContentDimensionValueTest extends UnitTestCase
      */
     public function valueWithoutFallbackHasDepthZero()
     {
-        $value = new IntraDimension\ContentDimensionValue('test');
+        $value = new ContentDimensionValue('test');
 
         self::assertSame(0, $value->getDepth());
     }
@@ -36,9 +38,9 @@ class ContentDimensionValueTest extends UnitTestCase
     public function valueWithFallbackHasDepthOneGreaterThanFallback()
     {
         $testDepth = random_int(0, 100);
-        $fallbackValue = new IntraDimension\ContentDimensionValue('fallback');
+        $fallbackValue = new ContentDimensionValue('fallback');
         ObjectAccess::setProperty($fallbackValue, 'depth', $testDepth, true);
-        $value = new IntraDimension\ContentDimensionValue('test', $fallbackValue);
+        $value = new ContentDimensionValue('test', $fallbackValue);
 
         self::assertSame($testDepth + 1, $value->getDepth());
     }
@@ -48,7 +50,7 @@ class ContentDimensionValueTest extends UnitTestCase
      */
     public function calculateFallbackDepthReturnsZeroRelativeToSelf()
     {
-        $value = new IntraDimension\ContentDimensionValue('fallback');
+        $value = new ContentDimensionValue('fallback');
 
         self::assertSame(0, $value->calculateFallbackDepth($value));
     }
@@ -60,12 +62,12 @@ class ContentDimensionValueTest extends UnitTestCase
     {
         $testLevel = random_int(1, 10);
 
-        $rootFallback = new IntraDimension\ContentDimensionValue('fallback-level0');
+        $rootFallback = new ContentDimensionValue('fallback-level0');
         $currentLevel = 1;
         $previousFallback = $rootFallback;
         $currentFallback = null;
         while ($currentLevel <= $testLevel) {
-            $currentFallback = new IntraDimension\ContentDimensionValue('fallback-level' . $currentLevel, $previousFallback);
+            $currentFallback = new ContentDimensionValue('fallback-level' . $currentLevel, $previousFallback);
             $currentLevel++;
             $previousFallback = $currentFallback;
         }
@@ -78,9 +80,9 @@ class ContentDimensionValueTest extends UnitTestCase
      */
     public function calculateFallbackDepthThrowsExceptionForDisconnectedValue()
     {
-        $this->expectException(IntraDimension\Exception\InvalidFallbackException::class);
-        $testValue = new IntraDimension\ContentDimensionValue('test');
-        $disconnectedValue = new IntraDimension\ContentDimensionValue('test2');
+        $this->expectException(InvalidFallbackException::class);
+        $testValue = new ContentDimensionValue('test');
+        $disconnectedValue = new ContentDimensionValue('test2');
 
         $testValue->calculateFallbackDepth($disconnectedValue);
     }
@@ -90,9 +92,9 @@ class ContentDimensionValueTest extends UnitTestCase
      */
     public function calculateFallbackDepthThrowsExceptionForVariant()
     {
-        $this->expectException(IntraDimension\Exception\InvalidFallbackException::class);
-        $fallback = new IntraDimension\ContentDimensionValue('fallback');
-        $variant = new IntraDimension\ContentDimensionValue('variant', $fallback);
+        $this->expectException(InvalidFallbackException::class);
+        $fallback = new ContentDimensionValue('fallback');
+        $variant = new ContentDimensionValue('variant', $fallback);
 
         $fallback->calculateFallbackDepth($variant);
     }
@@ -102,10 +104,10 @@ class ContentDimensionValueTest extends UnitTestCase
      */
     public function calculateFallbackDepthThrowsExceptionForConnectedButUnreachableValue()
     {
-        $this->expectException(IntraDimension\Exception\InvalidFallbackException::class);
-        $fallback = new IntraDimension\ContentDimensionValue('fallback');
-        $variant1 = new IntraDimension\ContentDimensionValue('variant1', $fallback);
-        $variant2 = new IntraDimension\ContentDimensionValue('variant2', $fallback);
+        $this->expectException(InvalidFallbackException::class);
+        $fallback = new ContentDimensionValue('fallback');
+        $variant1 = new ContentDimensionValue('variant1', $fallback);
+        $variant2 = new ContentDimensionValue('variant2', $fallback);
 
         $variant1->calculateFallbackDepth($variant2);
     }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionValueTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/ContentDimensionValueTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\IntraDimension;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\IntraDimension\ContentDimensionValue;
 use Neos\ContentRepository\Domain\Model\IntraDimension\Exception\InvalidFallbackException;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
@@ -22,9 +22,7 @@ use Neos\Utility\ObjectAccess;
  */
 class ContentDimensionValueTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithoutFallbackHasDepthZero()
     {
         $value = new ContentDimensionValue('test');
@@ -32,9 +30,7 @@ class ContentDimensionValueTest extends UnitTestCase
         self::assertSame(0, $value->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithFallbackHasDepthOneGreaterThanFallback()
     {
         $testDepth = random_int(0, 100);
@@ -45,9 +41,7 @@ class ContentDimensionValueTest extends UnitTestCase
         self::assertSame($testDepth + 1, $value->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function calculateFallbackDepthReturnsZeroRelativeToSelf()
     {
         $value = new ContentDimensionValue('fallback');
@@ -55,9 +49,7 @@ class ContentDimensionValueTest extends UnitTestCase
         self::assertSame(0, $value->calculateFallbackDepth($value));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function calculateFallbackDepthReturnsLevelOfAncestryForValidFallback()
     {
         $testLevel = random_int(1, 10);
@@ -75,9 +67,7 @@ class ContentDimensionValueTest extends UnitTestCase
         self::assertSame($testLevel, $currentFallback->calculateFallbackDepth($rootFallback));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function calculateFallbackDepthThrowsExceptionForDisconnectedValue()
     {
         $this->expectException(InvalidFallbackException::class);
@@ -87,9 +77,7 @@ class ContentDimensionValueTest extends UnitTestCase
         $testValue->calculateFallbackDepth($disconnectedValue);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function calculateFallbackDepthThrowsExceptionForVariant()
     {
         $this->expectException(InvalidFallbackException::class);
@@ -99,9 +87,7 @@ class ContentDimensionValueTest extends UnitTestCase
         $fallback->calculateFallbackDepth($variant);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function calculateFallbackDepthThrowsExceptionForConnectedButUnreachableValue()
     {
         $this->expectException(InvalidFallbackException::class);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/IntraDimensionalFallbackGraphTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/IntraDimensionalFallbackGraphTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\IntraDimension;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\IntraDimension\IntraDimensionalFallbackGraph;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -24,7 +25,7 @@ class IntraDimensionalFallbackGraphTest extends UnitTestCase
      */
     public function createDimensionRegistersDimension()
     {
-        $graph = new IntraDimension\IntraDimensionalFallbackGraph();
+        $graph = new IntraDimensionalFallbackGraph();
         $dimension = $graph->createDimension('test');
 
         self::assertSame($dimension, $graph->getDimension('test'));

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/IntraDimensionalFallbackGraphTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/IntraDimension/IntraDimensionalFallbackGraphTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model\IntraDimension;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\IntraDimension\IntraDimensionalFallbackGraph;
 use Neos\ContentRepository\Domain\Model\IntraDimension;
 use Neos\Flow\Tests\UnitTestCase;
@@ -20,9 +20,7 @@ use Neos\Flow\Tests\UnitTestCase;
  */
 class IntraDimensionalFallbackGraphTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createDimensionRegistersDimension()
     {
         $graph = new IntraDimensionalFallbackGraph();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
@@ -71,9 +72,7 @@ class NodeDataTest extends UnitTestCase
         $this->inject($this->nodeData, 'nodeDataRepository', $this->mockNodeDataRepository);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function constructorSetsPathWorkspaceAndIdentifier()
     {
         $node = new NodeData('/foo/bar', $this->mockWorkspace, '12345abcde');
@@ -83,10 +82,8 @@ class NodeDataTest extends UnitTestCase
         self::assertSame('12345abcde', $node->getIdentifier());
     }
 
-    /**
-     * @test
-     * @dataProvider invalidPaths()
-     */
+    #[DataProvider('invalidPaths')]
+    #[Test]
     public function setPathThrowsAnExceptionIfAnInvalidPathIsPassed($path)
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -108,10 +105,8 @@ class NodeDataTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider validPaths()
-     */
+    #[DataProvider('validPaths')]
+    #[Test]
     public function setPathAcceptsAValidPath($path)
     {
         $this->nodeData->_call('setPath', $path, false);
@@ -135,9 +130,7 @@ class NodeDataTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getDepthReturnsThePathDepthOfTheNode()
     {
         $node = new NodeData('/', $this->mockWorkspace);
@@ -153,9 +146,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals(4, $node->getDepth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setWorkspacesAllowsForSettingTheWorkspaceForInternalPurposes()
     {
         /** @var Workspace|MockObject $newWorkspace */
@@ -167,27 +158,21 @@ class NodeDataTest extends UnitTestCase
         self::assertSame($newWorkspace, $this->nodeData->getWorkspace());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function theIndexCanBeSetAndRetrieved()
     {
         $this->nodeData->setIndex(2);
         self::assertEquals(2, $this->nodeData->getIndex());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getParentReturnsNullForARootNode()
     {
         $node = new NodeData('/', $this->mockWorkspace);
         self::assertNull($node->getParent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aContentObjectCanBeSetRetrievedAndUnset()
     {
         $contentObject = new \stdClass();
@@ -199,18 +184,14 @@ class NodeDataTest extends UnitTestCase
         self::assertNull($this->nodeData->getContentObject());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aContentObjectMustBeAnObject()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->nodeData->setContentObject('not an object');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertiesCanBeSetAndRetrieved()
     {
         $this->nodeData->setProperty('title', 'My Title');
@@ -229,9 +210,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals(['body', 'title'], $actualPropertyNames);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertiesCanBeRemoved()
     {
         $this->nodeData->setProperty('title', 'My Title');
@@ -246,9 +225,7 @@ class NodeDataTest extends UnitTestCase
         self::assertArrayNotHasKey('title', $this->nodeData->getProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertiesHandlesNullValuesCorrectly()
     {
         $this->nodeData->setProperty('value', null);
@@ -270,18 +247,14 @@ class NodeDataTest extends UnitTestCase
         self::assertArrayNotHasKey('value', $this->nodeData->getProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removePropertyThrowsExceptionIfPropertyDoesNotExist()
     {
         $this->expectException(NodeException::class);
         $this->nodeData->removeProperty('nada');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removePropertyDoesNotTouchAContentObject()
     {
         $this->inject($this->nodeData, 'persistenceManager', $this->createMock(PersistenceManagerInterface::class));
@@ -299,9 +272,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals('My Title', $this->nodeData->getProperty('title'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertyFunctionsUseAContentObjectIfOneHasBeenDefined()
     {
         $this->inject($this->nodeData, 'persistenceManager', $this->createMock(PersistenceManagerInterface::class));
@@ -336,9 +307,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals('My Other Title', $this->nodeData->getProperty('title'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertyThrowsAnExceptionIfTheSpecifiedPropertyDoesNotExistInTheContentObject()
     {
         $this->expectException(NodeException::class);
@@ -354,9 +323,7 @@ class NodeDataTest extends UnitTestCase
         $this->nodeData->getProperty('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function theNodeTypeCanBeSetAndRetrieved()
     {
         /** @var NodeTypeManager|MockObject $mockNodeTypeManager */
@@ -377,9 +344,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals($myNodeType, $this->nodeData->getNodeType());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeReturnsFallbackNodeTypeForUnknownNodeType()
     {
         $mockFallbackNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
@@ -396,9 +361,7 @@ class NodeDataTest extends UnitTestCase
         self::assertSame($mockFallbackNodeType, $this->nodeData->getNodeType());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeCreatesAChildNodeOfTheCurrentNodeInTheContextWorkspace()
     {
         $this->marktestIncomplete('Should be refactored to a contextualized node test.');
@@ -424,9 +387,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals('mynodetype', $newNode->getNodeType()->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeThrowsNodeExceptionIfPathAlreadyExists()
     {
         $this->expectException(NodeException::class);
@@ -461,9 +422,7 @@ class NodeDataTest extends UnitTestCase
         self::assertNull($currentNode->getNode('/foo/quux'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getChildNodeDataFindsUnreducedNodeDataChildren()
     {
         $childNodeData = $this->getMockBuilder(NodeData::class)->setConstructorArgs(['/foo/bar', $this->mockWorkspace])->getMock();
@@ -484,9 +443,7 @@ class NodeDataTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeFlagsTheNodeAsRemoved()
     {
         $mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);
@@ -507,9 +464,7 @@ class NodeDataTest extends UnitTestCase
         self::assertTrue($currentNode->isRemoved());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeRemovesTheNodeFromRepositoryIfItsWorkspaceHasNoOtherBaseWorkspace()
     {
         $mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);
@@ -549,9 +504,9 @@ class NodeDataTest extends UnitTestCase
     /**
      * @param array $accessRoles
      * @param boolean $expectedResult
-     * @test
-     * @dataProvider hasAccessRestrictionsDataProvider
      */
+    #[DataProvider('hasAccessRestrictionsDataProvider')]
+    #[Test]
     public function hasAccessRestrictionsTests($accessRoles, $expectedResult)
     {
         $this->nodeData->_set('accessRoles', $accessRoles);
@@ -562,17 +517,13 @@ class NodeDataTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAccessibleReturnsTrueIfAccessRolesIsNotSet()
     {
         self::assertTrue($this->nodeData->isAccessible());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAccessibleReturnsTrueIfSecurityContextCannotBeInitialized()
     {
         /** @var SecurityContext|MockObject $mockSecurityContext */
@@ -585,9 +536,7 @@ class NodeDataTest extends UnitTestCase
         self::assertTrue($this->nodeData->isAccessible());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAccessibleReturnsFalseIfAccessRolesIsSetAndSecurityContextHasNoRoles()
     {
         /** @var SecurityContext|MockObject $mockSecurityContext */
@@ -600,9 +549,7 @@ class NodeDataTest extends UnitTestCase
         self::assertFalse($this->nodeData->isAccessible());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAccessibleReturnsTrueIfAccessRolesIsSetAndSecurityContextHasOneOfTheRequiredRoles()
     {
         /** @var SecurityContext|MockObject $mockSecurityContext */
@@ -615,9 +562,7 @@ class NodeDataTest extends UnitTestCase
         self::assertTrue($this->nodeData->isAccessible());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAccessibleReturnsTrueIfRoleIsEveryone()
     {
         /** @var SecurityContext|MockObject $mockSecurityContext */
@@ -630,9 +575,7 @@ class NodeDataTest extends UnitTestCase
         self::assertTrue($this->nodeData->isAccessible());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeCreatesNodeDataWithExplicitWorkspaceIfGiven()
     {
         /** @var NodeDataRepository|MockObject $nodeDataRepository */
@@ -644,9 +587,7 @@ class NodeDataTest extends UnitTestCase
         $this->nodeData->createNodeData('foo', null, null, $this->mockWorkspace);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function similarizeClearsPropertiesBeforeAddingNewOnes()
     {
         /** @var $sourceNode NodeData */
@@ -668,9 +609,7 @@ class NodeDataTest extends UnitTestCase
         self::assertEquals($expectedProperties, $this->nodeData->getProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function similarizeCopiesCreationAndLastModificationDateTimes()
     {
         $creationDateTime = \DateTime::createFromFormat('Y-m-d', '2000-01-01 12:00:00');
@@ -686,9 +625,7 @@ class NodeDataTest extends UnitTestCase
         self::assertSame($creationDateTime, $this->nodeData->getCreationDateTime());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchesWorkspaceAndDimensionsWithDifferentWorkspaceReturnsFalse()
     {
         $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
@@ -701,9 +638,7 @@ class NodeDataTest extends UnitTestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchesWorkspaceAndDimensionsWithDifferentDimensionReturnsFalse()
     {
         $this->nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['language' => ['en_US']]);
@@ -714,9 +649,7 @@ class NodeDataTest extends UnitTestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchesWorkspaceAndDimensionsWithMatchingWorkspaceAndDimensionsReturnsTrue()
     {
         $this->nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['language' => ['mul_ZZ']]);
@@ -727,9 +660,7 @@ class NodeDataTest extends UnitTestCase
         self::assertTrue($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getDimensionValuesReturnsDimensionsSortedByKey()
     {
         $nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['c' => ['c1', 'c2'], 'a' => ['a1']]);
@@ -738,9 +669,7 @@ class NodeDataTest extends UnitTestCase
         self::assertSame(['a' => ['a1'], 'c' => ['c1', 'c2']], $dimensionValues);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dimensionsHashIsOrderIndependent()
     {
         $nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['c' => ['c1', 'c2'], 'a' => ['a1']]);
@@ -754,9 +683,7 @@ class NodeDataTest extends UnitTestCase
         self::assertSame('955c716a191a0957f205ea9376600e72', $dimensionsHash);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsAddsDimensionValues()
     {
         $nodeData = new NodeData('/foo/bar', $this->mockWorkspace);
@@ -779,9 +706,7 @@ class NodeDataTest extends UnitTestCase
         self::assertSame($expectedDimensionValues, $setDimensionValues);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsAddsNewDimensionValues()
     {
         $nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['c' => ['c1', 'c2'], 'a' => ['a1']]);
@@ -804,9 +729,7 @@ class NodeDataTest extends UnitTestCase
         self::assertSame($expectedDimensionValues, $setDimensionValues);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsRemovesDimensionValuesNotGiven()
     {
         $nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['c' => ['c1', 'c2'], 'a' => ['a1']]);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -92,7 +92,7 @@ class NodeDataTest extends UnitTestCase
 
     /**
      */
-    public function invalidPaths()
+    public static function invalidPaths()
     {
         return [
             ['foo'],
@@ -116,7 +116,7 @@ class NodeDataTest extends UnitTestCase
 
     /**
      */
-    public function validPaths()
+    public static function validPaths()
     {
         return [
             ['/foo'],
@@ -489,7 +489,7 @@ class NodeDataTest extends UnitTestCase
     /**
      * @return array
      */
-    public function hasAccessRestrictionsDataProvider()
+    public static function hasAccessRestrictionsDataProvider()
     {
         return [
             ['accessRoles' => null, 'expectedResult' => false],

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * source code.
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Persistence\RepositoryInterface;
@@ -30,12 +31,12 @@ use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 class NodeDataTest extends UnitTestCase
 {
     /**
-     * @var Workspace|\PHPUnit\Framework\MockObject\MockObject
+     * @var Workspace|MockObject
      */
     protected $mockWorkspace;
 
     /**
-     * @var NodeTypeManager|\PHPUnit\Framework\MockObject\MockObject
+     * @var NodeTypeManager|MockObject
      */
     protected $mockNodeTypeManager;
 
@@ -45,12 +46,12 @@ class NodeDataTest extends UnitTestCase
     protected $mockNodeType;
 
     /**
-     * @var NodeDataRepository|\PHPUnit\Framework\MockObject\MockObject
+     * @var NodeDataRepository|MockObject
      */
     protected $mockNodeDataRepository;
 
     /**
-     * @var NodeData|\PHPUnit\Framework\MockObject\MockObject
+     * @var NodeData|MockObject
      */
     protected $nodeData;
 
@@ -157,7 +158,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function setWorkspacesAllowsForSettingTheWorkspaceForInternalPurposes()
     {
-        /** @var Workspace|\PHPUnit\Framework\MockObject\MockObject $newWorkspace */
+        /** @var Workspace|MockObject $newWorkspace */
         $newWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         self::assertSame($this->mockWorkspace, $this->nodeData->getWorkspace());
@@ -358,7 +359,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function theNodeTypeCanBeSetAndRetrieved()
     {
-        /** @var NodeTypeManager|\PHPUnit\Framework\MockObject\MockObject $mockNodeTypeManager */
+        /** @var NodeTypeManager|MockObject $mockNodeTypeManager */
         $mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
         $mockNodeTypeManager->expects(self::any())->method('hasNodeType')->will(self::returnValue(true));
         $mockNodeTypeManager->expects(self::any())->method('getNodeType')->will(self::returnCallback(
@@ -386,7 +387,7 @@ class NodeDataTest extends UnitTestCase
         $mockNonExistingNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNonExistingNodeType->expects(self::atLeastOnce())->method('getName')->willReturn('definitelyNotAvailableNodeType');
 
-        /** @var NodeTypeManager|\PHPUnit\Framework\MockObject\MockObject $mockNodeTypeManager */
+        /** @var NodeTypeManager|MockObject $mockNodeTypeManager */
         $mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
         $mockNodeTypeManager->expects(self::atLeastOnce())->method('getNodeType')->with('definitelyNotAvailableNodeType')->will(self::returnValue($mockFallbackNodeType));
         $this->inject($this->nodeData, 'nodeTypeManager', $mockNodeTypeManager);
@@ -437,7 +438,7 @@ class NodeDataTest extends UnitTestCase
         $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['findOneByPath', 'getContext'])->getMock();
         $nodeDataRepository->expects(self::any())->method('findOneByPath')->with('/foo', $this->mockWorkspace)->will(self::returnValue($oldNode));
 
-        /** @var NodeData|\PHPUnit\Framework\MockObject\MockObject $currentNode */
+        /** @var NodeData|MockObject $currentNode */
         $currentNode = $this->getAccessibleMock(NodeData::class, ['getNode'], ['/', $this->mockWorkspace]);
         $this->inject($currentNode, 'nodeDataRepository', $nodeDataRepository);
         $currentNode->_set('context', $mockContext);
@@ -574,7 +575,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function isAccessibleReturnsTrueIfSecurityContextCannotBeInitialized()
     {
-        /** @var SecurityContext|\PHPUnit\Framework\MockObject\MockObject $mockSecurityContext */
+        /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
         $mockSecurityContext->expects($this->once(0))->method('canBeInitialized')->will(self::returnValue(false));
         $mockSecurityContext->expects(self::never())->method('hasRole');
@@ -589,7 +590,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function isAccessibleReturnsFalseIfAccessRolesIsSetAndSecurityContextHasNoRoles()
     {
-        /** @var SecurityContext|\PHPUnit\Framework\MockObject\MockObject $mockSecurityContext */
+        /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
         $mockSecurityContext->expects(self::any())->method('isInitialized')->will(self::returnValue(true));
         $mockSecurityContext->expects(self::any())->method('hasRole')->will(self::returnValue(false));
@@ -604,7 +605,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function isAccessibleReturnsTrueIfAccessRolesIsSetAndSecurityContextHasOneOfTheRequiredRoles()
     {
-        /** @var SecurityContext|\PHPUnit\Framework\MockObject\MockObject $mockSecurityContext */
+        /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
         $mockSecurityContext->method('canBeInitialized')->willReturn(true);
         $mockSecurityContext->expects(self::atLeast(2))->method('hasRole')->withConsecutive(['SomeRole'], ['SomeOtherRole'])->willReturnOnConsecutiveCalls(false, true);
@@ -619,7 +620,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function isAccessibleReturnsTrueIfRoleIsEveryone()
     {
-        /** @var SecurityContext|\PHPUnit\Framework\MockObject\MockObject $mockSecurityContext */
+        /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
         $mockSecurityContext->method('canBeInitialized')->willReturn(true);
         $mockSecurityContext->expects(self::atLeast(2))->method('hasRole')->withConsecutive(['SomeRole'], ['Everyone'])->willReturnOnConsecutiveCalls(false, true);
@@ -634,7 +635,7 @@ class NodeDataTest extends UnitTestCase
      */
     public function createNodeCreatesNodeDataWithExplicitWorkspaceIfGiven()
     {
-        /** @var NodeDataRepository|\PHPUnit\Framework\MockObject\MockObject $nodeDataRepository */
+        /** @var NodeDataRepository|MockObject $nodeDataRepository */
         $nodeDataRepository = $this->createMock(NodeDataRepository::class);
         $this->inject($this->nodeData, 'nodeDataRepository', $nodeDataRepository);
 
@@ -692,7 +693,7 @@ class NodeDataTest extends UnitTestCase
     {
         $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
 
-        /** @var Workspace|\PHPUnit\Framework\MockObject\MockObject $otherWorkspace */
+        /** @var Workspace|MockObject $otherWorkspace */
         $otherWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $otherWorkspace->expects(self::any())->method('getName')->will(self::returnValue('other'));
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeDataTest.php
@@ -64,8 +64,8 @@ class NodeDataTest extends UnitTestCase
         $this->mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
 
         $this->mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
-        $this->mockNodeTypeManager->expects(self::any())->method('getNodeType')->will(self::returnValue($this->mockNodeType));
-        $this->mockNodeTypeManager->expects(self::any())->method('hasNodeType')->will(self::returnValue(true));
+        $this->mockNodeTypeManager->expects(self::any())->method('getNodeType')->willReturn($this->mockNodeType);
+        $this->mockNodeTypeManager->expects(self::any())->method('hasNodeType')->willReturn(true);
         $this->inject($this->nodeData, 'nodeTypeManager', $this->mockNodeTypeManager);
 
         $this->mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->getMock();
@@ -328,12 +328,10 @@ class NodeDataTest extends UnitTestCase
     {
         /** @var NodeTypeManager|MockObject $mockNodeTypeManager */
         $mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
-        $mockNodeTypeManager->expects(self::any())->method('hasNodeType')->will(self::returnValue(true));
-        $mockNodeTypeManager->expects(self::any())->method('getNodeType')->will(self::returnCallback(
-            function ($name) {
-                return new NodeType($name, [], []) ;
-            }
-        ));
+        $mockNodeTypeManager->expects(self::any())->method('hasNodeType')->willReturn(true);
+        $mockNodeTypeManager->expects(self::any())->method('getNodeType')->willReturnCallback(function ($name) {
+            return new NodeType($name, [], []) ;
+        });
 
         $this->inject($this->nodeData, 'nodeTypeManager', $mockNodeTypeManager);
 
@@ -354,7 +352,7 @@ class NodeDataTest extends UnitTestCase
 
         /** @var NodeTypeManager|MockObject $mockNodeTypeManager */
         $mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
-        $mockNodeTypeManager->expects(self::atLeastOnce())->method('getNodeType')->with('definitelyNotAvailableNodeType')->will(self::returnValue($mockFallbackNodeType));
+        $mockNodeTypeManager->expects(self::atLeastOnce())->method('getNodeType')->with('definitelyNotAvailableNodeType')->willReturn($mockFallbackNodeType);
         $this->inject($this->nodeData, 'nodeTypeManager', $mockNodeTypeManager);
         $this->inject($this->nodeData, 'nodeType', $mockNonExistingNodeType);
 
@@ -367,19 +365,19 @@ class NodeDataTest extends UnitTestCase
         $this->marktestIncomplete('Should be refactored to a contextualized node test.');
 
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $context->expects(self::once())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
+        $context->expects(self::once())->method('getWorkspace')->willReturn($this->mockWorkspace);
 
-        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['countByParentAndNodeType', 'add'])->getMock();
-        $nodeDataRepository->expects(self::once())->method('countByParentAndNodeType')->with('/', null, $this->mockWorkspace)->will(self::returnValue(0));
+        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['countByParentAndNodeType', 'add'])->getMock();
+        $nodeDataRepository->expects(self::once())->method('countByParentAndNodeType')->with('/', null, $this->mockWorkspace)->willReturn(0);
         $nodeDataRepository->expects(self::once())->method('add');
-        $nodeDataRepository->expects(self::any())->method('getContext')->will(self::returnValue($context));
+        $nodeDataRepository->expects(self::any())->method('getContext')->willReturn($context);
 
-        /** @var NodeData|\PHPUnit\Framework\MockObject\MockObject $currentNode */
+        /** @var NodeData|MockObject $currentNode */
         $currentNode = $this->getAccessibleMock(NodeData::class, ['getNode'], ['/', $this->mockWorkspace]);
         $this->inject($currentNode, 'nodeDataRepository', $nodeDataRepository);
 
-        $currentNode->expects(self::once())->method('createProxyForContextIfNeeded')->will($this->returnArgument(0));
-        $currentNode->expects(self::once())->method('filterNodeByContext')->will($this->returnArgument(0));
+        $currentNode->expects(self::once())->method('createProxyForContextIfNeeded')->willReturnArgument(0);
+        $currentNode->expects(self::once())->method('filterNodeByContext')->willReturnArgument(0);
 
         $newNode = $currentNode->createNode('foo', 'mynodetype');
         self::assertSame($currentNode, $newNode->getParent());
@@ -392,12 +390,12 @@ class NodeDataTest extends UnitTestCase
     {
         $this->expectException(NodeException::class);
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $mockContext->expects(self::any())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
+        $mockContext->expects(self::any())->method('getWorkspace')->willReturn($this->mockWorkspace);
 
         $oldNode = $this->getAccessibleMock(NodeData::class, [], ['/foo', $this->mockWorkspace]);
 
-        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['findOneByPath', 'getContext'])->getMock();
-        $nodeDataRepository->expects(self::any())->method('findOneByPath')->with('/foo', $this->mockWorkspace)->will(self::returnValue($oldNode));
+        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['findOneByPath'])->addMethods(['getContext'])->getMock();
+        $nodeDataRepository->expects(self::any())->method('findOneByPath')->with('/foo', $this->mockWorkspace)->willReturn($oldNode);
 
         /** @var NodeData|MockObject $currentNode */
         $currentNode = $this->getAccessibleMock(NodeData::class, ['getNode'], ['/', $this->mockWorkspace]);
@@ -412,12 +410,12 @@ class NodeDataTest extends UnitTestCase
      */
     public function getNodeReturnsNullIfTheSpecifiedNodeDoesNotExist()
     {
-        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['findOneByPath', 'getContext'])->getMock();
-        $nodeDataRepository->expects(self::once())->method('findOneByPath')->with('/foo/quux', $this->mockWorkspace)->will(self::returnValue(null));
+        $nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['findOneByPath'])->addMethods(['getContext'])->getMock();
+        $nodeDataRepository->expects(self::once())->method('findOneByPath')->with('/foo/quux', $this->mockWorkspace)->willReturn(null);
 
         $currentNode = $this->getAccessibleMock(NodeData::class, ['normalizePath', 'getContext'], ['/foo/baz', $this->mockWorkspace]);
         $this->inject($currentNode, 'nodeDataRepository', $nodeDataRepository);
-        $currentNode->expects(self::once())->method('normalizePath')->with('/foo/quux')->will(self::returnValue('/foo/quux'));
+        $currentNode->expects(self::once())->method('normalizePath')->with('/foo/quux')->willReturn('/foo/quux');
 
         self::assertNull($currentNode->getNode('/foo/quux'));
     }
@@ -470,13 +468,13 @@ class NodeDataTest extends UnitTestCase
         $mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);
 
         $workspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $workspace->expects(self::once())->method('getBaseWorkspace')->will(self::returnValue(null));
+        $workspace->expects(self::once())->method('getBaseWorkspace')->willReturn(null);
 
         $nodeDataRepository = $this->getAccessibleMock(NodeDataRepository::class, ['remove', 'update'], [], '', false);
         $this->inject($nodeDataRepository, 'entityClassName', NodeData::class);
         $this->inject($nodeDataRepository, 'persistenceManager', $mockPersistenceManager);
 
-        $currentNode = $this->getAccessibleMock(NodeData::class, null, ['/foo', $workspace]);
+        $currentNode = $this->getAccessibleMock(NodeData::class, [], ['/foo', $workspace]);
         $this->inject($currentNode, 'persistenceManager', $mockPersistenceManager);
         $this->inject($currentNode, 'nodeDataRepository', $nodeDataRepository);
 
@@ -528,7 +526,7 @@ class NodeDataTest extends UnitTestCase
     {
         /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
-        $mockSecurityContext->expects($this->once(0))->method('canBeInitialized')->will(self::returnValue(false));
+        $mockSecurityContext->expects($this->once(0))->method('canBeInitialized')->willReturn(false);
         $mockSecurityContext->expects(self::never())->method('hasRole');
         $this->inject($this->nodeData, 'securityContext', $mockSecurityContext);
 
@@ -541,8 +539,8 @@ class NodeDataTest extends UnitTestCase
     {
         /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
-        $mockSecurityContext->expects(self::any())->method('isInitialized')->will(self::returnValue(true));
-        $mockSecurityContext->expects(self::any())->method('hasRole')->will(self::returnValue(false));
+        $mockSecurityContext->expects(self::any())->method('isInitialized')->willReturn(true);
+        $mockSecurityContext->expects(self::any())->method('hasRole')->willReturn(false);
         $this->inject($this->nodeData, 'securityContext', $mockSecurityContext);
 
         $this->nodeData->setAccessRoles(['SomeRole']);
@@ -555,7 +553,17 @@ class NodeDataTest extends UnitTestCase
         /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
         $mockSecurityContext->method('canBeInitialized')->willReturn(true);
-        $mockSecurityContext->expects(self::atLeast(2))->method('hasRole')->withConsecutive(['SomeRole'], ['SomeOtherRole'])->willReturnOnConsecutiveCalls(false, true);
+        $matcher = self::atLeast(2);
+        $mockSecurityContext->expects($matcher)->method('hasRole')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('SomeRole', $parameters[0]);
+                return false;
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('SomeOtherRole', $parameters[0]);
+                return true;
+            }
+        });
         $this->inject($this->nodeData, 'securityContext', $mockSecurityContext);
 
         $this->nodeData->setAccessRoles(['SomeRole', 'SomeOtherRole']);
@@ -568,7 +576,17 @@ class NodeDataTest extends UnitTestCase
         /** @var SecurityContext|MockObject $mockSecurityContext */
         $mockSecurityContext = $this->createMock(SecurityContext::class);
         $mockSecurityContext->method('canBeInitialized')->willReturn(true);
-        $mockSecurityContext->expects(self::atLeast(2))->method('hasRole')->withConsecutive(['SomeRole'], ['Everyone'])->willReturnOnConsecutiveCalls(false, true);
+        $matcher = self::atLeast(2);
+        $mockSecurityContext->expects($matcher)->method('hasRole')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('SomeRole', $parameters[0]);
+                return false;
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('Everyone', $parameters[0]);
+                return true;
+            }
+        });
         $this->inject($this->nodeData, 'securityContext', $mockSecurityContext);
 
         $this->nodeData->setAccessRoles(['SomeRole', 'Everyone', 'SomeOtherRole']);
@@ -628,11 +646,11 @@ class NodeDataTest extends UnitTestCase
     #[Test]
     public function matchesWorkspaceAndDimensionsWithDifferentWorkspaceReturnsFalse()
     {
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         /** @var Workspace|MockObject $otherWorkspace */
         $otherWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $otherWorkspace->expects(self::any())->method('getName')->will(self::returnValue('other'));
+        $otherWorkspace->expects(self::any())->method('getName')->willReturn('other');
 
         $result = $this->nodeData->matchesWorkspaceAndDimensions($otherWorkspace, null);
         self::assertFalse($result);
@@ -643,7 +661,7 @@ class NodeDataTest extends UnitTestCase
     {
         $this->nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['language' => ['en_US']]);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $result = $this->nodeData->matchesWorkspaceAndDimensions($this->mockWorkspace, ['language' => ['de_DE', 'mul_ZZ']]);
         self::assertFalse($result);
@@ -654,7 +672,7 @@ class NodeDataTest extends UnitTestCase
     {
         $this->nodeData = new NodeData('/foo/bar', $this->mockWorkspace, null, ['language' => ['mul_ZZ']]);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $result = $this->nodeData->matchesWorkspaceAndDimensions($this->mockWorkspace, ['language' => ['de_DE', 'mul_ZZ']]);
         self::assertTrue($result);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTemplateTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTemplateTest.php
@@ -10,6 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\NodeTemplate;
 
@@ -18,9 +19,7 @@ use Neos\ContentRepository\Domain\Model\NodeTemplate;
  */
 class NodeTemplateTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function setNameWithValidNameUpdatesName()
     {
         $nodeTemplate = new NodeTemplate();
@@ -29,9 +28,7 @@ class NodeTemplateTest extends UnitTestCase
         self::assertEquals('valid-node-name', $nodeTemplate->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setNameWithInvalidNameThrowsException()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTest.php
@@ -42,10 +42,10 @@ class NodeTest extends UnitTestCase
         $mockFirstLevelNodeCache = $this->createMock(FirstLevelNodeCache::class);
         $newNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $context->expects(self::any())->method('getFirstLevelNodeCache')->will(self::returnValue($mockFirstLevelNodeCache));
+        $context->expects(self::any())->method('getFirstLevelNodeCache')->willReturn($mockFirstLevelNodeCache);
         $nodeTemplate = new NodeTemplate();
 
-        $context->expects(self::any())->method('getWorkspace')->will(self::returnValue($workspace));
+        $context->expects(self::any())->method('getWorkspace')->willReturn($workspace);
 
         $nodeFactory = $this->createMock(NodeFactory::class);
 
@@ -53,8 +53,8 @@ class NodeTest extends UnitTestCase
 
         $this->inject($parentNode, 'nodeFactory', $nodeFactory);
 
-        $parentNodeData->expects(self::atLeastOnce())->method('createNodeDataFromTemplate')->with($nodeTemplate, 'bar', $workspace)->will(self::returnValue($newNodeData));
-        $nodeFactory->expects(self::atLeastOnce())->method('createFromNodeData')->with($newNodeData, $context)->will(self::returnValue($newNode));
+        $parentNodeData->expects(self::atLeastOnce())->method('createNodeDataFromTemplate')->with($nodeTemplate, 'bar', $workspace)->willReturn($newNodeData);
+        $nodeFactory->expects(self::atLeastOnce())->method('createFromNodeData')->with($newNodeData, $context)->willReturn($newNode);
 
         $parentNode->createNodeFromTemplate($nodeTemplate, 'bar');
     }
@@ -64,7 +64,7 @@ class NodeTest extends UnitTestCase
     public function getPrimaryChildNodeReturnsTheFirstChildNode()
     {
         $mockNodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $mockNodeData->expects(self::any())->method('getPath')->will(self::returnValue('/foo/bar'));
+        $mockNodeData->expects(self::any())->method('getPath')->willReturn('/foo/bar');
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
 
@@ -74,7 +74,7 @@ class NodeTest extends UnitTestCase
         $this->inject($node, 'nodeDataRepository', $mockNodeDataRepository);
 
         $expectedNode = $this->createMock(NodeInterface::class);
-        $mockNodeDataRepository->expects(self::once())->method('findFirstByParentAndNodeTypeInContext')->with('/foo/bar', null, $mockContext)->will(self::returnValue($expectedNode));
+        $mockNodeDataRepository->expects(self::once())->method('findFirstByParentAndNodeTypeInContext')->with('/foo/bar', null, $mockContext)->willReturn($expectedNode);
 
         $primaryChildNode = $node->getPrimaryChildNode();
 
@@ -184,25 +184,25 @@ class NodeTest extends UnitTestCase
     public function createNodeWithAutoCreatedChildNodesAndNoIdentifierUsesGeneratedIdentifierOfNodeForChildNodes()
     {
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $mockContext->expects(self::any())->method('getTargetDimensions')->will(self::returnValue(['language' => 'mul_ZZ']));
+        $mockContext->expects(self::any())->method('getTargetDimensions')->willReturn(['language' => 'mul_ZZ']);
         $mockFirstLevelNodeCache = $this->createMock(FirstLevelNodeCache::class);
-        $mockContext->expects(self::any())->method('getFirstLevelNodeCache')->will(self::returnValue($mockFirstLevelNodeCache));
+        $mockContext->expects(self::any())->method('getFirstLevelNodeCache')->willReturn($mockFirstLevelNodeCache);
 
         $mockNodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockSubNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
 
-        $mockNodeType->expects(self::any())->method('getDefaultValuesForProperties')->will(self::returnValue([]));
-        $mockNodeType->expects(self::any())->method('getAutoCreatedChildNodes')->will(self::returnValue([
+        $mockNodeType->expects(self::any())->method('getDefaultValuesForProperties')->willReturn([]);
+        $mockNodeType->expects(self::any())->method('getAutoCreatedChildNodes')->willReturn([
             'subnode1' => $mockSubNodeType
-        ]));
+        ]);
 
         $i = 0;
         $generatedIdentifiers = [];
-        $node = $this->getMockBuilder(Node::class)->setMethods(['createSingleNode'])->setConstructorArgs([$mockNodeData, $mockContext])->getMock();
-        $node->expects(self::any())->method('createSingleNode')->will(self::returnCallback(function () use (&$i, &$generatedIdentifiers, $mockSubNodeType) {
+        $node = $this->getMockBuilder(Node::class)->onlyMethods(['createSingleNode'])->setConstructorArgs([$mockNodeData, $mockContext])->getMock();
+        $node->expects(self::any())->method('createSingleNode')->willReturnCallback(function () use (&$i, &$generatedIdentifiers, $mockSubNodeType) {
             $newNode = $this->createMock(NodeInterface::class);
-            $newNode->expects(self::any())->method('getIdentifier')->will(self::returnValue('node-' . $i++));
+            $newNode->expects(self::any())->method('getIdentifier')->willReturn('node-' . $i++);
 
             $newNode->expects(self::once())->method('createNode')->with('subnode1', $mockSubNodeType, $this->callback(function ($identifier) use (&$generatedIdentifiers, $i) {
                 $generatedIdentifiers[$i] = $identifier;
@@ -210,7 +210,7 @@ class NodeTest extends UnitTestCase
             }));
 
             return $newNode;
-        }));
+        });
 
         $node->createNode('foo', $mockNodeType);
         $node->createNode('bar', $mockNodeType);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Exception\NodeException;
 use Neos\Flow\Property\Exception as PropertyException;
 use Neos\Flow\Property\PropertyMapper;
@@ -31,9 +32,7 @@ use Neos\ContentRepository\Domain\Service\Context;
  */
 class NodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeFromTemplateUsesWorkspaceFromContextForNodeData()
     {
         $workspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
@@ -61,9 +60,7 @@ class NodeTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPrimaryChildNodeReturnsTheFirstChildNode()
     {
         $mockNodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
@@ -150,10 +147,8 @@ class NodeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSourceForContextPathPattern
-     */
+    #[DataProvider('dataSourceForContextPathPattern')]
+    #[Test]
     public function contextPathPatternShouldWorkWithContexts($path, $expected)
     {
         $matches = [];
@@ -177,19 +172,15 @@ class NodeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSourceForInvalidContextPaths
-     */
+    #[DataProvider('dataSourceForInvalidContextPaths')]
+    #[Test]
     public function contextPathPatternShouldNotMatchOnInvalidPaths($path)
     {
         $result = preg_match(NodeInterface::MATCH_PATTERN_CONTEXTPATH, $path, $matches);
         self::assertEquals(0, $result, 'The invalid context path yielded matches: ' . print_r($matches, true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeWithAutoCreatedChildNodesAndNoIdentifierUsesGeneratedIdentifierOfNodeForChildNodes()
     {
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
@@ -227,9 +218,7 @@ class NodeTest extends UnitTestCase
         self::assertNotSame($generatedIdentifiers[1], $generatedIdentifiers[2], 'Child nodes should have distinct identifiers');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPropertyThrowsMeaningfulExceptionWhenPropertyCantBeConverted()
     {
         $mockNodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTest.php
@@ -86,7 +86,7 @@ class NodeTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataSourceForContextPathPattern()
+    public static function dataSourceForContextPathPattern()
     {
         return [
             'empty node path' => [
@@ -160,7 +160,7 @@ class NodeTest extends UnitTestCase
     /**
      * @return array
      */
-    public function dataSourceForInvalidContextPaths()
+    public static function dataSourceForInvalidContextPaths()
     {
         return [
             'invalid dimension values' => [

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\NodeType;
@@ -123,36 +124,28 @@ class NodeTypeTest extends UnitTestCase
         ]
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aNodeTypeHasAName()
     {
         $nodeType = new NodeType('Neos.ContentRepository.Testing:Text', [], []);
         self::assertSame('Neos.ContentRepository.Testing:Text', $nodeType->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDeclaredSuperTypesExpectsAnArrayOfNodeTypesAsKeys()
     {
         $this->expectException(\InvalidArgumentException::class);
         new NodeType('ContentRepository:Folder', ['foo' => true], []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDeclaredSuperTypesAcceptsAnArrayOfNodeTypes()
     {
         $this->expectException(\InvalidArgumentException::class);
         new NodeType('ContentRepository:Folder', ['foo'], []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTypesCanHaveAnyNumberOfSuperTypes()
     {
         $baseType = new NodeType('Neos.ContentRepository:Base', [], []);
@@ -195,27 +188,21 @@ class NodeTypeTest extends UnitTestCase
         self::assertFalse($pageType->isOfType('Neos.ContentRepository.Testing:TimeableContent'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function labelIsEmptyStringByDefault()
     {
         $baseType = new NodeType('Neos.ContentRepository:Base', [], []);
         self::assertSame('', $baseType->getLabel());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propertiesAreEmptyArrayByDefault()
     {
         $baseType = new NodeType('Neos.ContentRepository:Base', [], []);
         self::assertSame([], $baseType->getProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasConfigurationInitializesTheNodeType()
     {
         $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(['initialize'])->getMock();
@@ -223,9 +210,7 @@ class NodeTypeTest extends UnitTestCase
         $nodeType->hasConfiguration('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasConfigurationReturnsTrueIfSpecifiedConfigurationPathExists()
     {
         $nodeType = new NodeType('Neos.ContentRepository:Base', [], [
@@ -236,18 +221,14 @@ class NodeTypeTest extends UnitTestCase
         self::assertTrue($nodeType->hasConfiguration('someKey.someSubKey'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasConfigurationReturnsFalseIfSpecifiedConfigurationPathDoesNotExist()
     {
         $nodeType = new NodeType('Neos.ContentRepository:Base', [], []);
         self::assertFalse($nodeType->hasConfiguration('some.nonExisting.path'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getConfigurationInitializesTheNodeType()
     {
         $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(['initialize'])->getMock();
@@ -255,9 +236,7 @@ class NodeTypeTest extends UnitTestCase
         $nodeType->getConfiguration('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getConfigurationReturnsTheConfigurationWithTheSpecifiedPath()
     {
         $nodeType = new NodeType('Neos.ContentRepository:Base', [], [
@@ -268,9 +247,7 @@ class NodeTypeTest extends UnitTestCase
         self::assertSame('someValue', $nodeType->getConfiguration('someKey.someSubKey'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getConfigurationReturnsNullIfTheSpecifiedPathDoesNotExist()
     {
         $nodeType = new NodeType('Neos.ContentRepository:Base', [], []);
@@ -294,9 +271,9 @@ class NodeTypeTest extends UnitTestCase
 
     /**
      * @param string  $getter
-     * @test
-     * @dataProvider gettersThatRequiresInitialization
      */
+    #[DataProvider('gettersThatRequiresInitialization')]
+    #[Test]
     public function accessingConfigurationOptionsInitializesTheNodeType($getter)
     {
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
@@ -306,9 +283,7 @@ class NodeTypeTest extends UnitTestCase
         $nodeType->$getter();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function defaultValuesForPropertiesHandlesDateTypes()
     {
         $nodeType = new NodeType('Neos.ContentRepository:Base', [], [
@@ -323,9 +298,7 @@ class NodeTypeTest extends UnitTestCase
         self::assertEquals($nodeType->getDefaultValuesForProperties(), ['date' => new \DateTime('2014-09-23')]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTypeConfigurationIsMergedTogether()
     {
         $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:Text');
@@ -352,8 +325,8 @@ class NodeTypeTest extends UnitTestCase
 
     /**
      * This test asserts that a supertype that has been inherited can be removed on a specific type again.
-     * @test
      */
+    #[Test]
     public function inheritedSuperTypesCanBeRemoved()
     {
         $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:Shortcut');
@@ -367,18 +340,14 @@ class NodeTypeTest extends UnitTestCase
         self::assertSame($expectedProperties, $nodeType->getProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isOfTypeReturnsFalseForDirectlyDisabledSuperTypes()
     {
         $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:Shortcut');
         self::assertFalse($nodeType->isOfType('Neos.ContentRepository.Testing:SomeMixin'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isOfTypeReturnsFalseForIndirectlyDisabledSuperTypes()
     {
         $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:SubShortcut');
@@ -387,8 +356,8 @@ class NodeTypeTest extends UnitTestCase
 
     /**
      * This test asserts that a supertype that has been inherited can be removed by a supertype again.
-     * @test
      */
+    #[Test]
     public function inheritedSuperSuperTypesCanBeRemoved()
     {
         $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:SubShortcut');
@@ -404,8 +373,8 @@ class NodeTypeTest extends UnitTestCase
 
     /**
      * This test asserts that a supertype that has been inherited can be removed by a supertype again.
-     * @test
      */
+    #[Test]
     public function superTypesRemovedByInheritanceCanBeAddedAgain()
     {
         $nodeType = $this->getNodeType('Neos.ContentRepository.Testing:SubSubSubShortcut');
@@ -446,9 +415,7 @@ class NodeTypeTest extends UnitTestCase
         return new NodeType($nodeTypeName, $declaredSuperTypes, $configuration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAutoCreatedChildNodesReturnsLowercasePaths()
     {
         $childNodeConfiguration = ['type' => 'Neos.ContentRepository:Base'];

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -257,7 +257,7 @@ class NodeTypeTest extends UnitTestCase
     /**
      * data source for accessingConfigurationOptionsInitializesTheNodeType()
      */
-    public function gettersThatRequiresInitialization()
+    public static function gettersThatRequiresInitialization()
     {
         return [
             ['getFullConfiguration'],

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/NodeTypeTest.php
@@ -205,7 +205,7 @@ class NodeTypeTest extends UnitTestCase
     #[Test]
     public function hasConfigurationInitializesTheNodeType()
     {
-        $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(['initialize'])->getMock();
+        $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->onlyMethods(['initialize'])->getMock();
         $nodeType->expects(self::once())->method('initialize');
         $nodeType->hasConfiguration('foo');
     }
@@ -231,7 +231,7 @@ class NodeTypeTest extends UnitTestCase
     #[Test]
     public function getConfigurationInitializesTheNodeType()
     {
-        $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(['initialize'])->getMock();
+        $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->onlyMethods(['initialize'])->getMock();
         $nodeType->expects(self::once())->method('initialize');
         $nodeType->getConfiguration('foo');
     }
@@ -423,7 +423,7 @@ class NodeTypeTest extends UnitTestCase
             'childNodes' => ['nodeName' => $childNodeConfiguration]
         ]);
         $mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
-        $mockNodeTypeManager->expects(self::any())->method('getNodeType')->will(self::returnValue($baseType));
+        $mockNodeTypeManager->expects(self::any())->method('getNodeType')->willReturn($baseType);
         $this->inject($baseType, 'nodeTypeManager', $mockNodeTypeManager);
 
         $autoCreatedChildNodes = $mockNodeTypeManager->getNodeType('Neos.ContentRepository:Base')->getAutoCreatedChildNodes();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Exception\WorkspaceException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
@@ -25,9 +26,7 @@ use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
  */
 class WorkspaceTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function aWorkspaceCanBeBasedOnAnotherWorkspace()
     {
         $baseWorkspace = new Workspace('BaseWorkspace');
@@ -37,9 +36,7 @@ class WorkspaceTest extends UnitTestCase
         self::assertSame($baseWorkspace, $workspace->getBaseWorkspace());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function onInitializationANewlyCreatedWorkspaceCreatesItsOwnRootNode()
     {
         $workspace = $this->getAccessibleMock(Workspace::class, ['dummy'], [], '', false);
@@ -54,9 +51,7 @@ class WorkspaceTest extends UnitTestCase
         self::assertInstanceOf(NodeData::class, $workspace->getRootNodeData());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeCountCallsRepositoryFunction()
     {
         $mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['countByWorkspace'])->getMock();
@@ -69,9 +64,7 @@ class WorkspaceTest extends UnitTestCase
         self::assertSame(42, $workspace->getNodeCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publishNodeReturnsIfTheCurrentWorkspaceHasNoBaseWorkspace()
     {
         $targetWorkspace = new Workspace('live');
@@ -88,9 +81,8 @@ class WorkspaceTest extends UnitTestCase
      * Bug NEOS-1769: Content Collections disappear when publishing to other workspace than "live"
      *
      * Under certain circumstances, content collection nodes will be deleted when publishing a document to a workspace which is based on another workspace.
-     *
-     * @test
      */
+    #[Test]
     public function publishNodeReturnsIfTheTargetWorkspaceIsTheSameAsTheSourceWorkspace()
     {
         $liveWorkspace = new Workspace('live');
@@ -105,9 +97,7 @@ class WorkspaceTest extends UnitTestCase
         $workspace->publishNode($mockNode, $workspace);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function verifyPublishingTargetWorkspaceDoesNotThrowAnExceptionIfTargetWorkspaceIsABaseWorkspace()
     {
         $someBaseWorkspace = new Workspace('live');
@@ -119,9 +109,7 @@ class WorkspaceTest extends UnitTestCase
         self::assertTrue(true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function verifyPublishingTargetWorkspaceThrowsAnExceptionIfWorkspaceIsNotBasedOnTheSpecifiedWorkspace()
     {
         $this->expectException(WorkspaceException::class);
@@ -145,10 +133,8 @@ class WorkspaceTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider validContextNodePaths
-     */
+    #[DataProvider('validContextNodePaths')]
+    #[Test]
     public function contextNodePathMatchPatternMatchesNodeContextPaths($contextNodePath)
     {
         preg_match(NodeInterface::MATCH_PATTERN_CONTEXTPATH, $contextNodePath, $matches);
@@ -166,19 +152,15 @@ class WorkspaceTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider invalidContextNodePaths
-     */
+    #[DataProvider('invalidContextNodePaths')]
+    #[Test]
     public function contextNodePathMatchPatternDoesNotMatchInvalidNodeContextPaths($contextNodePath)
     {
         preg_match(NodeInterface::MATCH_PATTERN_CONTEXTPATH, $contextNodePath, $matches);
         self::assertArrayNotHasKey('WorkspaceName', $matches);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publishNodeWithANodeInTheTargetWorkspaceShouldDoNothing()
     {
         $liveWorkspace = new Workspace('live');
@@ -195,9 +177,7 @@ class WorkspaceTest extends UnitTestCase
         $personalWorkspace->publishNode($node, $liveWorkspace);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isPersonalWorkspaceChecksIfTheWorkspaceNameStartsWithUser()
     {
         $liveWorkspace = new Workspace('live');

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -41,7 +41,7 @@ class WorkspaceTest extends UnitTestCase
     {
         $workspace = $this->getAccessibleMock(Workspace::class, ['dummy'], [], '', false);
 
-        $mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['add'])->getMock();
+        $mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['add'])->getMock();
         $mockNodeDataRepository->expects(self::once())->method('add');
 
         $workspace->_set('nodeDataRepository', $mockNodeDataRepository);
@@ -54,12 +54,12 @@ class WorkspaceTest extends UnitTestCase
     #[Test]
     public function getNodeCountCallsRepositoryFunction()
     {
-        $mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['countByWorkspace'])->getMock();
+        $mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['countByWorkspace'])->getMock();
 
         $workspace = $this->getAccessibleMock(Workspace::class, ['dummy'], [], '', false);
         $workspace->_set('nodeDataRepository', $mockNodeDataRepository);
 
-        $mockNodeDataRepository->expects(self::once())->method('countByWorkspace')->with($workspace)->will(self::returnValue(42));
+        $mockNodeDataRepository->expects(self::once())->method('countByWorkspace')->with($workspace)->willReturn(42);
 
         self::assertSame(42, $workspace->getNodeCount());
     }
@@ -86,11 +86,11 @@ class WorkspaceTest extends UnitTestCase
     public function publishNodeReturnsIfTheTargetWorkspaceIsTheSameAsTheSourceWorkspace()
     {
         $liveWorkspace = new Workspace('live');
-        $workspace = $this->getMockBuilder(Workspace::class)->setMethods(['emitBeforeNodePublishing'])->setConstructorArgs(['some-campaign'])->getMock();
+        $workspace = $this->getMockBuilder(Workspace::class)->onlyMethods(['emitBeforeNodePublishing'])->setConstructorArgs(['some-campaign'])->getMock();
         $workspace->setBaseWorkspace($liveWorkspace);
 
         $mockNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $mockNode->expects(self::any())->method('getWorkspace')->will(self::returnValue($workspace));
+        $mockNode->expects(self::any())->method('getWorkspace')->willReturn($workspace);
 
         $workspace->expects(self::never())->method('emitBeforeNodePublishing');
 
@@ -170,7 +170,7 @@ class WorkspaceTest extends UnitTestCase
         $this->inject($liveWorkspace, 'nodeDataRepository', $nodeDataRepository);
 
         $node = $this->createMock(NodeInterface::class);
-        $node->expects(self::any())->method('getWorkspace')->will(self::returnValue($liveWorkspace));
+        $node->expects(self::any())->method('getWorkspace')->willReturn($liveWorkspace);
 
         $nodeDataRepository->expects(self::never())->method('findOneByIdentifier');
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Model/WorkspaceTest.php
@@ -123,7 +123,7 @@ class WorkspaceTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validContextNodePaths()
+    public static function validContextNodePaths()
     {
         return [
             ['foo@user-bar'],
@@ -144,7 +144,7 @@ class WorkspaceTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidContextNodePaths()
+    public static function invalidContextNodePaths()
     {
         return [
             ['foo@user-bar.html'],

--- a/Neos.ContentRepository/Tests/Unit/Domain/Projection/Content/TraversableNodesTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Projection/Content/TraversableNodesTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Projection\Content;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
@@ -52,18 +53,14 @@ class TraversableNodesTest extends UnitTestCase
         return $mockNode;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromArrayThrowsAnExceptionIfGetsPassedAString()
     {
         $this->expectException(\InvalidArgumentException::class);
         TraversableNodes::fromArray(['foo']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromArrayThrowsAnExceptionIfGetsPassedAnInvalidObject()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -87,12 +84,12 @@ class TraversableNodesTest extends UnitTestCase
     }
 
     /**
-     * @param array $nodes1
-     * @param array $nodes2
-     * @param array $expectedResult
-     * @test
-     * @dataProvider mergeDataProvider
+     * @param int[] $nodes1
+     * @param int[] $nodes2
+     * @param int[] $expectedResult
      */
+    #[DataProvider('mergeDataProvider')]
+    #[Test]
     public function mergeTests(array $nodes1, array $nodes2, array $expectedResult)
     {
         $nodes1 = TraversableNodes::fromArray($nodes1);
@@ -101,45 +98,35 @@ class TraversableNodesTest extends UnitTestCase
         self::assertSame($expectedResult, $mergeResult->toArray());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEmptyIsTrueIfTraversableNodesDoesNotContainAnyNodes()
     {
         $nodes = TraversableNodes::fromArray([]);
         self::assertTrue($nodes->isEmpty());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEmptyIsFalseIfTraversableNodesContainNodes()
     {
         $nodes = TraversableNodes::fromArray([$this->mockNode1]);
         self::assertFalse($nodes->isEmpty());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function countReturnsZeroIfTraversableNodesIsEmpty()
     {
         $nodes = TraversableNodes::fromArray([]);
         self::assertSame(0, $nodes->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function countReturnsNumberOfNodes()
     {
         $nodes = TraversableNodes::fromArray([$this->mockNode1, $this->mockNode2]);
         self::assertSame(2, $nodes->count());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function previousThrowsExceptionIfReferenceNodeIsNotFoundInTheSet()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -148,9 +135,7 @@ class TraversableNodesTest extends UnitTestCase
         $nodes->previous($this->mockNode3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function previousThrowsExceptionIfReferenceNodeIsTheFirstNodeInTheSet()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -159,9 +144,7 @@ class TraversableNodesTest extends UnitTestCase
         $nodes->previous($this->mockNode1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function previousReturnsThePreviousNode()
     {
         $nodes = TraversableNodes::fromArray([$this->mockNode1, $this->mockNode2, $this->mockNode3]);
@@ -170,9 +153,7 @@ class TraversableNodesTest extends UnitTestCase
         self::assertSame($this->mockNode1, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function previousAllThrowsExceptionIfReferenceNodeIsNotFoundInTheSet()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -198,9 +179,9 @@ class TraversableNodesTest extends UnitTestCase
      * @param array $nodes
      * @param TraversableNodeInterface $reference
      * @param array $expectedResult
-     * @test
-     * @dataProvider previousAllDataProvider
      */
+    #[DataProvider('previousAllDataProvider')]
+    #[Test]
     public function previousAllTests(array $nodes, TraversableNodeInterface $reference, array $expectedResult)
     {
         $traversableNodes = TraversableNodes::fromArray($nodes);
@@ -209,9 +190,7 @@ class TraversableNodesTest extends UnitTestCase
         self::assertSame($expectedResult, $result->toArray());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextThrowsExceptionIfReferenceNodeIsNotFoundInTheSet()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -220,9 +199,7 @@ class TraversableNodesTest extends UnitTestCase
         $nodes->next($this->mockNode3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextThrowsExceptionIfReferenceNodeIsTheLastNodeInTheSet()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -231,9 +208,7 @@ class TraversableNodesTest extends UnitTestCase
         $nodes->next($this->mockNode3);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextReturnsTheNextNode()
     {
         $nodes = TraversableNodes::fromArray([$this->mockNode1, $this->mockNode2, $this->mockNode3]);
@@ -242,9 +217,7 @@ class TraversableNodesTest extends UnitTestCase
         self::assertSame($this->mockNode3, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextAllThrowsExceptionIfReferenceNodeIsNotFoundInTheSet()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -270,9 +243,9 @@ class TraversableNodesTest extends UnitTestCase
      * @param array $nodes
      * @param TraversableNodeInterface $reference
      * @param array $expectedResult
-     * @test
-     * @dataProvider nextAllDataProvider
      */
+    #[DataProvider('nextAllDataProvider')]
+    #[Test]
     public function nextAllTests(array $nodes, TraversableNodeInterface $reference, array $expectedResult)
     {
         $traversableNodes = TraversableNodes::fromArray($nodes);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Projection/Content/TraversableNodesTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Projection/Content/TraversableNodesTest.php
@@ -42,6 +42,23 @@ class TraversableNodesTest extends UnitTestCase
         $this->mockNode3 = $this->mockNode();
     }
 
+    /**
+     * Data providers have to be static, so they cannot build mocks. Instead they refer to
+     * nodes by index and this helper resolves those indices to the mocks built in setUp().
+     *
+     * @param int[] $nodeIndices
+     * @return TraversableNodeInterface[]
+     */
+    private function resolveNodes(array $nodeIndices): array
+    {
+        return array_map(fn (int $nodeIndex) => $this->resolveNode($nodeIndex), $nodeIndices);
+    }
+
+    private function resolveNode(int $nodeIndex): TraversableNodeInterface
+    {
+        return [$this->mockNode1, $this->mockNode2, $this->mockNode3][$nodeIndex];
+    }
+
     private function mockNode(): TraversableNodeInterface
     {
         /** @var TraversableNodeInterface|MockObject $mockNode */
@@ -67,19 +84,16 @@ class TraversableNodesTest extends UnitTestCase
         TraversableNodes::fromArray([new \stdClass()]);
     }
 
-    public function mergeDataProvider()
+    public static function mergeDataProvider(): array
     {
-        $mockNode1 = $this->mockNode();
-        $mockNode2 = $this->mockNode();
-        $mockNode3 = $this->mockNode();
         return [
             ['nodes1' => [], 'nodes2' => [], 'expectedResult' => []],
-            ['nodes1' => [$mockNode1], 'nodes2' => [$mockNode2], 'expectedResult' => [$mockNode1, $mockNode2]],
-            ['nodes1' => [$mockNode1, $mockNode2], 'nodes2' => [$mockNode3], 'expectedResult' => [$mockNode1, $mockNode2, $mockNode3]],
-            ['nodes1' => [$mockNode1], 'nodes2' => [$mockNode2, $mockNode3], 'expectedResult' => [$mockNode1, $mockNode2, $mockNode3]],
+            ['nodes1' => [0], 'nodes2' => [1], 'expectedResult' => [0, 1]],
+            ['nodes1' => [0, 1], 'nodes2' => [2], 'expectedResult' => [0, 1, 2]],
+            ['nodes1' => [0], 'nodes2' => [1, 2], 'expectedResult' => [0, 1, 2]],
 
             // TODO is the following expected or should TraversableNodes deduplicate nodes?
-            ['nodes1' => [$mockNode1], 'nodes2' => [$mockNode1], 'expectedResult' => [$mockNode1, $mockNode1]],
+            ['nodes1' => [0], 'nodes2' => [0], 'expectedResult' => [0, 0]],
         ];
     }
 
@@ -92,10 +106,10 @@ class TraversableNodesTest extends UnitTestCase
     #[Test]
     public function mergeTests(array $nodes1, array $nodes2, array $expectedResult)
     {
-        $nodes1 = TraversableNodes::fromArray($nodes1);
-        $nodes2 = TraversableNodes::fromArray($nodes2);
+        $nodes1 = TraversableNodes::fromArray($this->resolveNodes($nodes1));
+        $nodes2 = TraversableNodes::fromArray($this->resolveNodes($nodes2));
         $mergeResult = $nodes1->merge($nodes2);
-        self::assertSame($expectedResult, $mergeResult->toArray());
+        self::assertSame($this->resolveNodes($expectedResult), $mergeResult->toArray());
     }
 
     #[Test]
@@ -162,32 +176,28 @@ class TraversableNodesTest extends UnitTestCase
         $nodes->previousAll($this->mockNode3);
     }
 
-    public function previousAllDataProvider()
+    public static function previousAllDataProvider(): array
     {
-        $mockNode1 = $this->mockNode();
-        $mockNode2 = $this->mockNode();
-        $mockNode3 = $this->mockNode();
         return [
-            ['nodes' => [$mockNode1, $mockNode2, $mockNode3], 'reference' => $mockNode1, 'expectedResult' => []],
-            ['nodes' => [$mockNode1, $mockNode2, $mockNode3], 'reference' => $mockNode2, 'expectedResult' => [$mockNode1]],
-            ['nodes' => [$mockNode1, $mockNode2, $mockNode3], 'reference' => $mockNode3, 'expectedResult' => [$mockNode1, $mockNode2]],
-            ['nodes' => [$mockNode1], 'reference' => $mockNode1, 'expectedResult' => []],
+            ['nodes' => [0, 1, 2], 'reference' => 0, 'expectedResult' => []],
+            ['nodes' => [0, 1, 2], 'reference' => 1, 'expectedResult' => [0]],
+            ['nodes' => [0, 1, 2], 'reference' => 2, 'expectedResult' => [0, 1]],
+            ['nodes' => [0], 'reference' => 0, 'expectedResult' => []],
         ];
     }
 
     /**
-     * @param array $nodes
-     * @param TraversableNodeInterface $reference
-     * @param array $expectedResult
+     * @param int[] $nodes
+     * @param int[] $expectedResult
      */
     #[DataProvider('previousAllDataProvider')]
     #[Test]
-    public function previousAllTests(array $nodes, TraversableNodeInterface $reference, array $expectedResult)
+    public function previousAllTests(array $nodes, int $reference, array $expectedResult)
     {
-        $traversableNodes = TraversableNodes::fromArray($nodes);
-        $result = $traversableNodes->previousAll($reference);
+        $traversableNodes = TraversableNodes::fromArray($this->resolveNodes($nodes));
+        $result = $traversableNodes->previousAll($this->resolveNode($reference));
 
-        self::assertSame($expectedResult, $result->toArray());
+        self::assertSame($this->resolveNodes($expectedResult), $result->toArray());
     }
 
     #[Test]
@@ -226,31 +236,27 @@ class TraversableNodesTest extends UnitTestCase
         $nodes->nextAll($this->mockNode3);
     }
 
-    public function nextAllDataProvider()
+    public static function nextAllDataProvider(): array
     {
-        $mockNode1 = $this->mockNode();
-        $mockNode2 = $this->mockNode();
-        $mockNode3 = $this->mockNode();
         return [
-            ['nodes' => [$mockNode1, $mockNode2, $mockNode3], 'reference' => $mockNode3, 'expectedResult' => []],
-            ['nodes' => [$mockNode1, $mockNode2, $mockNode3], 'reference' => $mockNode1, 'expectedResult' => [$mockNode2, $mockNode3]],
-            ['nodes' => [$mockNode1, $mockNode2, $mockNode3], 'reference' => $mockNode2, 'expectedResult' => [$mockNode3]],
-            ['nodes' => [$mockNode1], 'reference' => $mockNode1, 'expectedResult' => []],
+            ['nodes' => [0, 1, 2], 'reference' => 2, 'expectedResult' => []],
+            ['nodes' => [0, 1, 2], 'reference' => 0, 'expectedResult' => [1, 2]],
+            ['nodes' => [0, 1, 2], 'reference' => 1, 'expectedResult' => [2]],
+            ['nodes' => [0], 'reference' => 0, 'expectedResult' => []],
         ];
     }
 
     /**
-     * @param array $nodes
-     * @param TraversableNodeInterface $reference
-     * @param array $expectedResult
+     * @param int[] $nodes
+     * @param int[] $expectedResult
      */
     #[DataProvider('nextAllDataProvider')]
     #[Test]
-    public function nextAllTests(array $nodes, TraversableNodeInterface $reference, array $expectedResult)
+    public function nextAllTests(array $nodes, int $reference, array $expectedResult)
     {
-        $traversableNodes = TraversableNodes::fromArray($nodes);
-        $result = $traversableNodes->nextAll($reference);
+        $traversableNodes = TraversableNodes::fromArray($this->resolveNodes($nodes));
+        $result = $traversableNodes->nextAll($this->resolveNode($reference));
 
-        self::assertSame($expectedResult, $result->toArray());
+        self::assertSame($this->resolveNodes($expectedResult), $result->toArray());
     }
 }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Repository;
  * source code.
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Doctrine\ORM\QueryBuilder;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
@@ -22,19 +23,19 @@ use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 class NodeDataRepositoryTest extends UnitTestCase
 {
     /**
-     * @var \Neos\ContentRepository\Domain\Repository\NodeDataRepository|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Neos\ContentRepository\Domain\Repository\NodeDataRepository|MockObject
      */
     protected $nodeDataRepository;
 
     /**
      * Mocks the getResult method of \Doctrine\ORM\Query, which cannot be mocked for real, since it is final.
      *
-     * @var \PHPUnit\Framework\MockObject\MockObject
+     * @var MockObject
      */
     protected $mockQuery;
 
     /**
-     * @var QueryBuilder|\PHPUnit\Framework\MockObject\MockObject
+     * @var QueryBuilder|MockObject
      */
     protected $mockQueryBuilder;
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
@@ -46,14 +46,14 @@ class NodeDataRepositoryTest extends UnitTestCase
         $this->mockQuery = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->getMock();
 
         $this->mockQueryBuilder = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
-        $this->mockQueryBuilder->expects(self::any())->method('getQuery')->will(self::returnValue($this->mockQuery));
+        $this->mockQueryBuilder->expects(self::any())->method('getQuery')->willReturn($this->mockQuery);
 
-        $this->nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->setMethods(['getNodeDataForParentAndNodeType', 'filterNodesOverlaidInBaseWorkspace', 'getNodeTypeFilterConstraintsForDql', 'createQueryBuilder', 'addPathConstraintToQueryBuilder', 'filterNodeDataByBestMatchInContext'])->getMock();
-        $this->nodeDataRepository->expects(self::any())->method('filterNodesOverlaidInBaseWorkspace')->will(self::returnCallback(function (array $foundNodes, Workspace $baseWorkspace, $dimensions) {
+        $this->nodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->addMethods(['filterNodesOverlaidInBaseWorkspace'])->onlyMethods(['getNodeDataForParentAndNodeType', 'getNodeTypeFilterConstraintsForDql', 'createQueryBuilder', 'addPathConstraintToQueryBuilder', 'filterNodeDataByBestMatchInContext'])->getMock();
+        $this->nodeDataRepository->expects(self::any())->method('filterNodesOverlaidInBaseWorkspace')->willReturnCallback(function (array $foundNodes, Workspace $baseWorkspace, $dimensions) {
             return $foundNodes;
-        }));
-        $this->nodeDataRepository->expects(self::any())->method('createQueryBuilder')->will(self::returnValue($this->mockQueryBuilder));
-        $this->nodeDataRepository->expects(self::any())->method('filterNodeDataByBestMatchInContext')->will($this->returnArgument(0));
+        });
+        $this->nodeDataRepository->expects(self::any())->method('createQueryBuilder')->willReturn($this->mockQueryBuilder);
+        $this->nodeDataRepository->expects(self::any())->method('filterNodeDataByBestMatchInContext')->willReturnArgument(0);
 
         // The repository needs an explicit entity class name because of the generated mock class name
         $this->inject($this->nodeDataRepository, 'entityClassName', NodeData::class);
@@ -67,12 +67,12 @@ class NodeDataRepositoryTest extends UnitTestCase
         $dimensions = ['persona' => ['everybody'], 'language' => ['de_DE', 'mul_ZZ']];
 
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::any())->method('getPath')->will(self::returnValue('/foo'));
-        $nodeData->expects(self::any())->method('getWorkspace')->will(self::returnValue($liveWorkspace));
-        $nodeData->expects(self::any())->method('getDimensionValues')->will(self::returnValue($dimensions));
-        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->will(self::returnValue(true));
+        $nodeData->expects(self::any())->method('getPath')->willReturn('/foo');
+        $nodeData->expects(self::any())->method('getWorkspace')->willReturn($liveWorkspace);
+        $nodeData->expects(self::any())->method('getDimensionValues')->willReturn($dimensions);
+        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->willReturn(true);
 
-        $this->mockQuery->expects(self::any())->method('getResult')->will(self::returnValue([]));
+        $this->mockQuery->expects(self::any())->method('getResult')->willReturn([]);
 
         $this->nodeDataRepository->add($nodeData);
 
@@ -87,13 +87,13 @@ class NodeDataRepositoryTest extends UnitTestCase
         $liveWorkspace = new Workspace('live');
 
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::any())->method('getIdentifier')->will(self::returnValue('abcd-efgh-ijkl-mnop'));
+        $nodeData->expects(self::any())->method('getIdentifier')->willReturn('abcd-efgh-ijkl-mnop');
 
         $this->nodeDataRepository->add($nodeData);
 
         $dimensions = ['persona' => ['everybody'], 'language' => ['de_DE', 'mul_ZZ']];
 
-        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->will(self::returnValue(true));
+        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->willReturn(true);
 
         $result = $this->nodeDataRepository->findOneByIdentifier('abcd-efgh-ijkl-mnop', $liveWorkspace, $dimensions);
 
@@ -106,13 +106,13 @@ class NodeDataRepositoryTest extends UnitTestCase
         $liveWorkspace = new Workspace('live');
 
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::any())->method('getIdentifier')->will(self::returnValue('abcd-efgh-ijkl-mnop'));
+        $nodeData->expects(self::any())->method('getIdentifier')->willReturn('abcd-efgh-ijkl-mnop');
 
         $this->nodeDataRepository->remove($nodeData);
 
         $dimensions = ['persona' => ['everybody'], 'language' => ['de_DE', 'mul_ZZ']];
 
-        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->will(self::returnValue(true));
+        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->willReturn(true);
 
         $result = $this->nodeDataRepository->findOneByIdentifier('abcd-efgh-ijkl-mnop', $liveWorkspace, $dimensions);
 
@@ -129,8 +129,8 @@ class NodeDataRepositoryTest extends UnitTestCase
         $removedNodesFlag = true;
         $recursiveFlag = true;
 
-        $this->nodeDataRepository->expects(self::once())->method('getNodeDataForParentAndNodeType')->with($parentPath, $nodeTypeFilter, $mockWorkspace, $dimensions, $removedNodesFlag, $recursiveFlag)->will(self::returnValue([]));
-        $this->nodeDataRepository->expects(self::once())->method('getNodeTypeFilterConstraintsForDql')->with($nodeTypeFilter)->will(self::returnValue(['excludeNodeTypes' => [], 'includeNodeTypes' => [$nodeTypeFilter]]));
+        $this->nodeDataRepository->expects(self::once())->method('getNodeDataForParentAndNodeType')->with($parentPath, $nodeTypeFilter, $mockWorkspace, $dimensions, $removedNodesFlag, $recursiveFlag)->willReturn([]);
+        $this->nodeDataRepository->expects(self::once())->method('getNodeTypeFilterConstraintsForDql')->with($nodeTypeFilter)->willReturn(['excludeNodeTypes' => [], 'includeNodeTypes' => [$nodeTypeFilter]]);
 
         $this->nodeDataRepository->findByParentAndNodeTypeRecursively($parentPath, $nodeTypeFilter, $mockWorkspace, $dimensions, true);
     }
@@ -141,18 +141,18 @@ class NodeDataRepositoryTest extends UnitTestCase
         $liveWorkspace = new Workspace('live');
 
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::any())->method('getIdentifier')->will(self::returnValue('abcd-efgh-ijkl-mnop'));
-        $nodeData->expects(self::any())->method('getPath')->will(self::returnValue('/foo/bar'));
-        $nodeData->expects(self::any())->method('getDepth')->will(self::returnValue(2));
+        $nodeData->expects(self::any())->method('getIdentifier')->willReturn('abcd-efgh-ijkl-mnop');
+        $nodeData->expects(self::any())->method('getPath')->willReturn('/foo/bar');
+        $nodeData->expects(self::any())->method('getDepth')->willReturn(2);
 
         $this->nodeDataRepository->add($nodeData);
 
         $dimensions = ['persona' => ['everybody'], 'language' => ['de_DE', 'mul_ZZ']];
 
-        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->will(self::returnValue(true));
+        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->willReturn(true);
 
-        $this->nodeDataRepository->expects(self::any())->method('getNodeDataForParentAndNodeType')->will(self::returnValue([]));
-        $this->nodeDataRepository->expects(self::once())->method('getNodeTypeFilterConstraintsForDql')->will(self::returnValue(['excludeNodeTypes' => [], 'includeNodeTypes' => []]));
+        $this->nodeDataRepository->expects(self::any())->method('getNodeDataForParentAndNodeType')->willReturn([]);
+        $this->nodeDataRepository->expects(self::once())->method('getNodeTypeFilterConstraintsForDql')->willReturn(['excludeNodeTypes' => [], 'includeNodeTypes' => []]);
 
         $result = $this->nodeDataRepository->findByParentAndNodeType('/foo', null, $liveWorkspace, $dimensions);
 
@@ -169,19 +169,19 @@ class NodeDataRepositoryTest extends UnitTestCase
         $liveWorkspace = new Workspace('live');
 
         $nodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $nodeData->expects(self::any())->method('getIdentifier')->will(self::returnValue('abcd-efgh-ijkl-mnop'));
-        $nodeData->expects(self::any())->method('getPath')->will(self::returnValue('/foo/bar'));
-        $nodeData->expects(self::any())->method('getDepth')->will(self::returnValue(2));
+        $nodeData->expects(self::any())->method('getIdentifier')->willReturn('abcd-efgh-ijkl-mnop');
+        $nodeData->expects(self::any())->method('getPath')->willReturn('/foo/bar');
+        $nodeData->expects(self::any())->method('getDepth')->willReturn(2);
 
         $this->nodeDataRepository->remove($nodeData);
 
         $dimensions = ['persona' => ['everybody'], 'language' => ['de_DE', 'mul_ZZ']];
 
-        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->will(self::returnValue(true));
+        $nodeData->expects(self::atLeastOnce())->method('matchesWorkspaceAndDimensions')->with($liveWorkspace, $dimensions)->willReturn(true);
 
-        $this->nodeDataRepository->expects(self::any())->method('getNodeDataForParentAndNodeType')->will(self::returnValue([
+        $this->nodeDataRepository->expects(self::any())->method('getNodeDataForParentAndNodeType')->willReturn([
             'abcd-efgh-ijkl-mnop' => $nodeData
-        ]));
+        ]);
 
         $result = $this->nodeDataRepository->findByParentAndNodeType('/foo', null, $liveWorkspace, $dimensions);
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Repository/NodeDataRepositoryTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Doctrine\ORM\QueryBuilder;
 use Neos\Flow\Persistence\Doctrine\Query;
@@ -60,9 +60,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         $this->inject($this->nodeDataRepository, 'persistenceManager', $mockPersistenceManager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOneByPathFindsAddedNodeInRepositoryAndRespectsWorkspaceAndDimensions()
     {
         $liveWorkspace = new Workspace('live');
@@ -83,9 +81,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         self::assertSame($nodeData, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOneByIdentifierFindsAddedNodeInRepositoryAndRespectsWorkspaceAndDimensions()
     {
         $liveWorkspace = new Workspace('live');
@@ -104,9 +100,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         self::assertSame($nodeData, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOneByIdentifierFindsRemovedNodeInRepositoryAndRespectsWorkspaceAndDimensions()
     {
         $liveWorkspace = new Workspace('live');
@@ -125,9 +119,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         self::assertNull($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByParentAndNodeTypeRecursivelyCallsGetNodeDataForParentAndNodeTypeWithRecursiveFlag()
     {
         $parentPath = 'some/parent/path';
@@ -143,9 +135,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         $this->nodeDataRepository->findByParentAndNodeTypeRecursively($parentPath, $nodeTypeFilter, $mockWorkspace, $dimensions, true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByParentAndNodeTypeIncludesAddedNodeInRepositoryAndRespectsWorkspaceAndDimensions()
     {
         $liveWorkspace = new Workspace('live');
@@ -173,9 +163,7 @@ class NodeDataRepositoryTest extends UnitTestCase
         self::assertSame($nodeData, $fetchedNodeData);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByParentAndNodeTypeRemovesRemovedNodeInRepositoryAndRespectsWorkspaceAndDimensions()
     {
         $liveWorkspace = new Workspace('live');

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/Cache/FirstLevelNodeCacheTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/Cache/FirstLevelNodeCacheTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Service\Cache\FirstLevelNodeCache;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -19,9 +19,7 @@ use Neos\Flow\Tests\UnitTestCase;
  */
 class FirstLevelNodeCacheTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function returnNullForCachedNullValue()
     {
         $nodeIdA = 'node-id-a';
@@ -38,9 +36,7 @@ class FirstLevelNodeCacheTest extends UnitTestCase
         self::assertFalse($valueForNodeIdB);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resetCacheWorksProperly()
     {
         $nodeIdA = 'node-id-a';

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ConfigurationContentDimensionPresetSourceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ConfigurationContentDimensionPresetSourceTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Exception;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Service\ConfigurationContentDimensionPresetSource;
@@ -126,9 +126,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findPresetByDimensionValuesWithExistingValuesReturnsPreset()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -139,9 +137,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllPresetsReturnsDimensionsOrderedByPosition()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -150,9 +146,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertEquals(['targetGroups', 'language'], array_keys($presets));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllPresetsReturnsDimensionPresetsOrderedByPosition()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -162,9 +156,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertEquals(['de_DE', 'all'], array_keys($presets['language']['presets']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getDefaultPresetWithExistingDimensionReturnsDefaultPresetWithIdentifier()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -174,9 +166,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertEquals('all', $preset['identifier']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setConfigurationThrowsExceptionIfSpecifiedDefaultPresetDoesNotExist()
     {
         $this->expectException(Exception::class);
@@ -187,9 +177,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         $source->setConfiguration($configuration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isPresetCombinationAllowedByConstraintsReturnsTrueIfNoConstraintsHaveBeenDefined()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -198,9 +186,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertTrue($source->isPresetCombinationAllowedByConstraints(['language' => 'de', 'country' => 'DE']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isPresetCombinationAllowedByConstraintsReturnsFalseIfAnyOfThePresetsDoesNotExist()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -211,9 +197,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertFalse($source->isPresetCombinationAllowedByConstraints(['language' => 'de', 'country' => 'DEXX']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isPresetCombinationAllowedByConstraintsReturnsFalseIfConstraintExplicitlyDoesNotAllowTheCombination()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -225,9 +209,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertFalse($source->isPresetCombinationAllowedByConstraints(['language' => 'de', 'country' => 'US']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isPresetCombinationAllowedByConstraintsReturnsFalseIfWildCardConstraintIsSetToFalse()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -239,9 +221,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertFalse($source->isPresetCombinationAllowedByConstraints(['language' => 'de', 'country' => 'US']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isPresetCombinationAllowedByConstraintsCorrectlyEvaluatesCombinationsOfWildcardAndExplicitConstraints()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -263,9 +243,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertFalse($source->isPresetCombinationAllowedByConstraints(['language' => 'fr', 'country' => 'US']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllowedDimensionPresetsAccordingToPreselectionReturnsAllowedPresetsOfSecondDimensionIfPresetOfFirstDimensionIsGiven()
     {
         $source = new ConfigurationContentDimensionPresetSource();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextFactoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextFactoryTest.php
@@ -30,7 +30,7 @@ class ContextFactoryTest extends UnitTestCase
         $this->inject($contextFactory, 'now', new Now());
 
         $mockContentDimensionRepository = $this->createMock(ContentDimensionRepository::class);
-        $mockContentDimensionRepository->expects(self::any())->method('findAll')->will(self::returnValue([]));
+        $mockContentDimensionRepository->expects(self::any())->method('findAll')->willReturn([]);
         $this->inject($contextFactory, 'contentDimensionRepository', $mockContentDimensionRepository);
         $this->inject($contextFactory, 'securityContext', $this->createMock(Context::class));
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextFactoryTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextFactoryTest.php
@@ -10,6 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Utility\Now;
@@ -22,9 +23,7 @@ use Neos\ContentRepository\Domain\Service\ContextFactory;
  */
 class ContextFactoryTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createMergesDefaultPropertiesBeforeSettingAnInstanceByIdentifier()
     {
         $contextFactory = new ContextFactory();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * source code.
  */
 use Neos\Flow\Utility\Now;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Repository\ContentDimensionRepository;
@@ -38,9 +39,7 @@ class ContextTest extends UnitTestCase
         $this->inject($this->contextFactory, 'contentDimensionRepository', $mockContentDimensionRepository);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCurrentDateTimeReturnsACurrentDateAndTime()
     {
         $now = new \DateTime();
@@ -52,9 +51,7 @@ class ContextTest extends UnitTestCase
         self::assertEquals($now->getTimestamp(), $currentTime->getTimestamp(), 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDateTimeAllowsForMockingTheCurrentTime()
     {
         $simulatedCurrentTime = new \DateTime();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextTest.php
@@ -35,7 +35,7 @@ class ContextTest extends UnitTestCase
         $this->inject($this->contextFactory, 'securityContext', $this->createMock(Context::class));
 
         $mockContentDimensionRepository = $this->createMock(ContentDimensionRepository::class);
-        $mockContentDimensionRepository->expects(self::any())->method('findAll')->will(self::returnValue([]));
+        $mockContentDimensionRepository->expects(self::any())->method('findAll')->willReturn([]);
         $this->inject($this->contextFactory, 'contentDimensionRepository', $mockContentDimensionRepository);
     }
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ContextTest.php
@@ -10,6 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use Neos\Flow\Utility\Now;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Repository\ContentDimensionRepository;
@@ -29,7 +30,7 @@ class ContextTest extends UnitTestCase
     public function setUp(): void
     {
         $this->contextFactory = new ContextFactory();
-        $this->inject($this->contextFactory, 'now', new \Neos\Flow\Utility\Now());
+        $this->inject($this->contextFactory, 'now', new Now());
         $this->inject($this->contextFactory, 'securityContext', $this->createMock(Context::class));
 
         $mockContentDimensionRepository = $this->createMock(ContentDimensionRepository::class);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeExportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeExportServiceTest.php
@@ -31,20 +31,20 @@ class NodeExportServiceTest extends UnitTestCase
     public function setUp(): void
     {
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $this->mockSecurityContext->expects(self::any())->method('withoutAuthorizationChecks')->will(self::returnCallback(function ($callback) {
+        $this->mockSecurityContext->expects(self::any())->method('withoutAuthorizationChecks')->willReturnCallback(function ($callback) {
             return $callback->__invoke();
-        }));
+        });
     }
 
     #[Test]
     public function exportEmptyListOfNodesCreatesEmptyXml()
     {
         /** @var NodeExportService|MockObject $nodeExportService */
-        $nodeExportService = $this->getMockBuilder(NodeExportService::class)->setMethods(['findNodeDataListToExport'])->getMock();
+        $nodeExportService = $this->getMockBuilder(NodeExportService::class)->onlyMethods(['findNodeDataListToExport'])->getMock();
         $this->inject($nodeExportService, 'securityContext', $this->mockSecurityContext);
 
         $nodeDataList = [];
-        $nodeExportService->expects(self::any())->method('findNodeDataListToExport')->will(self::returnValue($nodeDataList));
+        $nodeExportService->expects(self::any())->method('findNodeDataListToExport')->willReturn($nodeDataList);
 
         $xmlWriter = $nodeExportService->export();
         $output = $xmlWriter->outputMemory();
@@ -58,7 +58,7 @@ class NodeExportServiceTest extends UnitTestCase
     public function exportRootNodeCreatesSingleNode()
     {
         /** @var NodeExportService|MockObject $nodeExportService */
-        $nodeExportService = $this->getMockBuilder(NodeExportService::class)->setMethods(['findNodeDataListToExport'])->getMock();
+        $nodeExportService = $this->getMockBuilder(NodeExportService::class)->onlyMethods(['findNodeDataListToExport'])->getMock();
         $this->inject($nodeExportService, 'securityContext', $this->mockSecurityContext);
         $nodeTypeManager = $this->createMock(NodeTypeManager::class);
         $this->inject($nodeExportService, 'nodeTypeManager', $nodeTypeManager);
@@ -73,7 +73,7 @@ class NodeExportServiceTest extends UnitTestCase
         );
 
         $nodeDataList = [$nodeData];
-        $nodeExportService->expects(self::any())->method('findNodeDataListToExport')->will(self::returnValue($nodeDataList));
+        $nodeExportService->expects(self::any())->method('findNodeDataListToExport')->willReturn($nodeDataList);
 
         $xmlWriter = $nodeExportService->export();
         $output = $xmlWriter->outputMemory();
@@ -95,7 +95,7 @@ class NodeExportServiceTest extends UnitTestCase
     public function exportNodeWithoutParentSkipsBrokenNode()
     {
         /** @var NodeExportService|MockObject $nodeExportService */
-        $nodeExportService = $this->getMockBuilder(NodeExportService::class)->setMethods(['findNodeDataListToExport'])->getMock();
+        $nodeExportService = $this->getMockBuilder(NodeExportService::class)->onlyMethods(['findNodeDataListToExport'])->getMock();
         $this->inject($nodeExportService, 'securityContext', $this->mockSecurityContext);
         $nodeTypeManager = $this->createMock(NodeTypeManager::class);
         $this->inject($nodeExportService, 'nodeTypeManager', $nodeTypeManager);
@@ -122,12 +122,12 @@ class NodeExportServiceTest extends UnitTestCase
         );
 
         $nodeDataList = [$nodeData1, $nodeData2];
-        $nodeExportService->expects(self::any())->method('findNodeDataListToExport')->will(self::returnValue($nodeDataList));
+        $nodeExportService->expects(self::any())->method('findNodeDataListToExport')->willReturn($nodeDataList);
 
-        $mockPropertyMapper = $this->createMock(\Neos\Flow\Property\PropertyMapper::class);
-        $mockPropertyMapper->expects(self::any())->method('convert')->will(self::returnCallback(function ($source) {
+        $mockPropertyMapper = $this->createMock(PropertyMapper::class);
+        $mockPropertyMapper->expects(self::any())->method('convert')->willReturnCallback(function ($source) {
             return $source;
-        }));
+        });
         $this->inject($nodeExportService, 'propertyMapper', $mockPropertyMapper);
 
         $xmlWriter = $nodeExportService->export('/sites/foo');

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeExportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeExportServiceTest.php
@@ -11,6 +11,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service\ImportExport;
  * source code.
  */
 
+use Neos\Flow\Property\PropertyMapper;
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Service\ImportExport\NodeExportService;
@@ -22,7 +24,7 @@ use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 class NodeExportServiceTest extends UnitTestCase
 {
     /**
-     * @var Context|\PHPUnit\Framework\MockObject\MockObject
+     * @var Context|MockObject
      */
     protected $mockSecurityContext;
 
@@ -39,7 +41,7 @@ class NodeExportServiceTest extends UnitTestCase
      */
     public function exportEmptyListOfNodesCreatesEmptyXml()
     {
-        /** @var NodeExportService|\PHPUnit\Framework\MockObject\MockObject $nodeExportService */
+        /** @var NodeExportService|MockObject $nodeExportService */
         $nodeExportService = $this->getMockBuilder(NodeExportService::class)->setMethods(['findNodeDataListToExport'])->getMock();
         $this->inject($nodeExportService, 'securityContext', $this->mockSecurityContext);
 
@@ -59,7 +61,7 @@ class NodeExportServiceTest extends UnitTestCase
      */
     public function exportRootNodeCreatesSingleNode()
     {
-        /** @var NodeExportService|\PHPUnit\Framework\MockObject\MockObject $nodeExportService */
+        /** @var NodeExportService|MockObject $nodeExportService */
         $nodeExportService = $this->getMockBuilder(NodeExportService::class)->setMethods(['findNodeDataListToExport'])->getMock();
         $this->inject($nodeExportService, 'securityContext', $this->mockSecurityContext);
         $nodeTypeManager = $this->createMock(NodeTypeManager::class);
@@ -98,7 +100,7 @@ class NodeExportServiceTest extends UnitTestCase
      */
     public function exportNodeWithoutParentSkipsBrokenNode()
     {
-        /** @var NodeExportService|\PHPUnit\Framework\MockObject\MockObject $nodeExportService */
+        /** @var NodeExportService|MockObject $nodeExportService */
         $nodeExportService = $this->getMockBuilder(NodeExportService::class)->setMethods(['findNodeDataListToExport'])->getMock();
         $this->inject($nodeExportService, 'securityContext', $this->mockSecurityContext);
         $nodeTypeManager = $this->createMock(NodeTypeManager::class);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeExportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeExportServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service\ImportExport;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Property\PropertyMapper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Security\Context;
@@ -36,9 +36,7 @@ class NodeExportServiceTest extends UnitTestCase
         }));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exportEmptyListOfNodesCreatesEmptyXml()
     {
         /** @var NodeExportService|MockObject $nodeExportService */
@@ -56,9 +54,7 @@ class NodeExportServiceTest extends UnitTestCase
 		', $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exportRootNodeCreatesSingleNode()
     {
         /** @var NodeExportService|MockObject $nodeExportService */
@@ -95,9 +91,7 @@ class NodeExportServiceTest extends UnitTestCase
 		', $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exportNodeWithoutParentSkipsBrokenNode()
     {
         /** @var NodeExportService|MockObject $nodeExportService */

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -38,9 +38,9 @@ class NodeImportServiceTest extends UnitTestCase
         $this->mockPropertyMapper = $this->getMockBuilder(PropertyMapper::class)->disableOriginalConstructor()->getMock();
 
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $this->mockSecurityContext->expects(self::any())->method('withoutAuthorizationChecks')->will(self::returnCallback(function ($callback) {
+        $this->mockSecurityContext->expects(self::any())->method('withoutAuthorizationChecks')->willReturnCallback(function ($callback) {
             return $callback->__invoke();
-        }));
+        });
     }
 
     #[Test]
@@ -52,7 +52,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertTrue($result);
 
         /** @var NodeImportService $nodeImportService */
-        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->setMethods(['persistNodeData'])->getMock();
+        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->onlyMethods(['persistNodeData'])->getMock();
         $this->inject($nodeImportService, 'propertyMapper', $this->mockPropertyMapper);
         $this->inject($nodeImportService, 'securityContext', $this->mockSecurityContext);
 
@@ -86,18 +86,18 @@ class NodeImportServiceTest extends UnitTestCase
                 ]
             ]
         ];
-        $nodeImportService->expects(self::once())->method('persistNodeData')->will(self::returnCallback(function ($nodeData) use (&$actualNodeData) {
+        $nodeImportService->expects(self::once())->method('persistNodeData')->willReturnCallback(function ($nodeData) use (&$actualNodeData) {
             unset($nodeData['Persistence_Object_Identifier']);
             $actualNodeData = $nodeData;
             return true;
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('convert')->will(self::returnCallback(function ($source, $targetType) {
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('convert')->willReturnCallback(function ($source, $targetType) {
             if ($targetType === 'DateTimeImmutable') {
                 return new \DateTimeImmutable($source);
             }
             throw new \Exception('Target type ' . $targetType . ' not supported in property mapper mock');
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('getMessages')->willReturn(new \Neos\Error\Messages\Result());
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('getMessages')->willReturn(new Result());
 
         $nodeImportService->import($xmlReader, '/');
 
@@ -118,7 +118,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertTrue($result);
 
         /** @var NodeImportService $nodeImportService */
-        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->setMethods(['persistNodeData'])->getMock();
+        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->onlyMethods(['persistNodeData'])->getMock();
         $this->inject($nodeImportService, 'propertyMapper', $this->mockPropertyMapper);
         $this->inject($nodeImportService, 'securityContext', $this->mockSecurityContext);
 
@@ -141,13 +141,13 @@ class NodeImportServiceTest extends UnitTestCase
             ]
         ];
         $actualIdentifier = null;
-        $nodeImportService->expects(self::once())->method('persistNodeData')->will(self::returnCallback(function ($nodeData) use (&$actualNodeData, &$actualIdentifier) {
+        $nodeImportService->expects(self::once())->method('persistNodeData')->willReturnCallback(function ($nodeData) use (&$actualNodeData, &$actualIdentifier) {
             unset($nodeData['Persistence_Object_Identifier']);
             $actualIdentifier = $nodeData['identifier'];
             unset($nodeData['identifier']);
             $actualNodeData = $nodeData;
             return true;
-        }));
+        });
 
         $nodeImportService->import($xmlReader, '/');
 
@@ -169,7 +169,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertTrue($result);
 
         /** @var NodeImportService $nodeImportService */
-        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->setMethods(['persistNodeData'])->getMock();
+        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->onlyMethods(['persistNodeData'])->getMock();
         $this->inject($nodeImportService, 'propertyMapper', $this->mockPropertyMapper);
         $this->inject($nodeImportService, 'securityContext', $this->mockSecurityContext);
 
@@ -300,18 +300,18 @@ class NodeImportServiceTest extends UnitTestCase
                 ]
             ]
         ];
-        $nodeImportService->expects(self::atLeastOnce())->method('persistNodeData')->will(self::returnCallback(function ($nodeData) use (&$actualNodeDatas) {
+        $nodeImportService->expects(self::atLeastOnce())->method('persistNodeData')->willReturnCallback(function ($nodeData) use (&$actualNodeDatas) {
             unset($nodeData['Persistence_Object_Identifier']);
             $actualNodeDatas[] = $nodeData;
             return true;
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('convert')->will(self::returnCallback(function ($source, $targetType) {
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('convert')->willReturnCallback(function ($source, $targetType) {
             return [
                 'targetType' => $targetType,
                 'source' => $source
             ];
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('getMessages')->willReturn(new \Neos\Error\Messages\Result());
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('getMessages')->willReturn(new Result());
 
         $nodeImportService->import($xmlReader, '/');
 
@@ -336,7 +336,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertTrue($result);
 
         /** @var NodeImportService $nodeImportService */
-        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->setMethods(['persistNodeData'])->getMock();
+        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->onlyMethods(['persistNodeData'])->getMock();
         $this->inject($nodeImportService, 'propertyMapper', $this->mockPropertyMapper);
         $this->inject($nodeImportService, 'securityContext', $this->mockSecurityContext);
 
@@ -369,17 +369,17 @@ class NodeImportServiceTest extends UnitTestCase
                 ]
             ]
         ];
-        $nodeImportService->expects(self::atLeastOnce())->method('persistNodeData')->will(self::returnCallback(function ($nodeData) use (&$actualNodeDatas) {
+        $nodeImportService->expects(self::atLeastOnce())->method('persistNodeData')->willReturnCallback(function ($nodeData) use (&$actualNodeDatas) {
             unset($nodeData['Persistence_Object_Identifier']);
             $actualNodeDatas[] = $nodeData;
             return true;
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('convert')->will(self::returnCallback(function ($source, $targetType) {
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('convert')->willReturnCallback(function ($source, $targetType) {
             return [
                 'targetType' => $targetType,
                 'source' => $source
             ];
-        }));
+        });
 
         $nodeImportService->import($xmlReader, '/');
 
@@ -400,7 +400,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertTrue($result);
 
         /** @var \Neos\ContentRepository\Domain\Service\ImportExport\NodeImportService $nodeImportService */
-        $nodeImportService = $this->getMockBuilder(\Neos\ContentRepository\Domain\Service\ImportExport\NodeImportService::class)->setMethods(['persistNodeData'])->getMock();
+        $nodeImportService = $this->getMockBuilder(NodeImportService::class)->onlyMethods(['persistNodeData'])->getMock();
         $this->inject($nodeImportService, 'propertyMapper', $this->mockPropertyMapper);
         $this->inject($nodeImportService, 'securityContext', $this->mockSecurityContext);
 
@@ -411,18 +411,18 @@ class NodeImportServiceTest extends UnitTestCase
                 ]
             ]
         ];
-        $nodeImportService->expects(self::atLeastOnce())->method('persistNodeData')->will(self::returnCallback(function ($nodeData) use (&$actualNodeDatas) {
+        $nodeImportService->expects(self::atLeastOnce())->method('persistNodeData')->willReturnCallback(function ($nodeData) use (&$actualNodeDatas) {
             unset($nodeData['Persistence_Object_Identifier']);
             $actualNodeDatas[] = $nodeData;
             return true;
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('convert')->will(self::returnCallback(function ($source, $targetType) {
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('convert')->willReturnCallback(function ($source, $targetType) {
             return [
                 'targetType' => $targetType,
                 'source' => $source
             ];
-        }));
-        $this->mockPropertyMapper->expects(self::any())->method('getMessages')->willReturn(new \Neos\Error\Messages\Result());
+        });
+        $this->mockPropertyMapper->expects(self::any())->method('getMessages')->willReturn(new Result());
 
         $nodeImportService->import($xmlReader, '/');
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -11,6 +11,11 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service\ImportExport;
  * source code.
  */
 
+use Neos\Error\Messages\Result;
+use Neos\Media\Domain\Model\ImageVariant;
+use Neos\Media\Domain\Model\Image;
+use Neos\Media\Domain\Model\Asset;
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
@@ -19,12 +24,12 @@ use Neos\ContentRepository\Domain\Service\ImportExport\NodeImportService;
 class NodeImportServiceTest extends UnitTestCase
 {
     /**
-     * @var PropertyMapper|\PHPUnit\Framework\MockObject\MockObject
+     * @var PropertyMapper|MockObject
      */
     protected $mockPropertyMapper;
 
     /**
-     * @var Context|\PHPUnit\Framework\MockObject\MockObject
+     * @var Context|MockObject
      */
     protected $mockSecurityContext;
 
@@ -195,7 +200,7 @@ class NodeImportServiceTest extends UnitTestCase
                     'relatedDocuments' => [],
                     'image' =>
                         [
-                            'targetType' => \Neos\Media\Domain\Model\ImageVariant::class,
+                            'targetType' => ImageVariant::class,
                             'source' =>
                                 [
                                     'originalImage' =>
@@ -267,7 +272,7 @@ class NodeImportServiceTest extends UnitTestCase
                 'properties' => [
                     'assets' => [
                         0 => [
-                            'targetType' => \Neos\Media\Domain\Model\Image::class,
+                            'targetType' => Image::class,
                             'source' =>
                                 [
                                     'title' => '',
@@ -280,7 +285,7 @@ class NodeImportServiceTest extends UnitTestCase
                                 ],
                         ],
                         1 => [
-                            'targetType' => \Neos\Media\Domain\Model\Asset::class,
+                            'targetType' => Asset::class,
                             'source' =>
                                 [
                                     'title' => '',

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/ImportExport/NodeImportServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service\ImportExport;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Error\Messages\Result;
 use Neos\Media\Domain\Model\ImageVariant;
 use Neos\Media\Domain\Model\Image;
@@ -43,9 +43,7 @@ class NodeImportServiceTest extends UnitTestCase
         }));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function importSingleNode()
     {
         $xmlReader = new \XMLReader();
@@ -111,9 +109,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertEquals($expectedNodeData, $actualNodeData);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function importSingleNodeWithoutIdentifier()
     {
         $xmlReader = new \XMLReader();
@@ -164,9 +160,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertEquals($expectedNodeData, $actualNodeData);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function importWithEmptyPropertyImportsAllProperties()
     {
         $xmlReader = new \XMLReader();
@@ -333,9 +327,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertEquals($expectedNodeDatas, $actualNodeDatas);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function importWithArrayPropertiesImportsCorrectly()
     {
         $xmlReader = new \XMLReader();
@@ -399,9 +391,7 @@ class NodeImportServiceTest extends UnitTestCase
         self::assertEquals($expectedNodeDatas, $actualNodeDatas);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function importWithLinebreakInDateTimeImportsCorrectly()
     {
         $xmlReader = new \XMLReader();

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
@@ -11,9 +11,11 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\ArrayPropertyCollection;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeService;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
@@ -231,7 +233,7 @@ class NodeServiceTest extends UnitTestCase
         $nodeService = $this->createNodeService();
 
         $mockNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
-        $mockNodeData = $this->getMockBuilder(\Neos\ContentRepository\Domain\Model\NodeData::class)->disableOriginalConstructor()->getMock();
+        $mockNodeData = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
         $mockNodeType = $this->mockNodeType('Neos.ContentRepository.Testing:Content');
 
         $mockNodeData->expects(self::once())

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
@@ -414,7 +414,7 @@ class NodeServiceTest extends UnitTestCase
     /**
      * @return array
      */
-    public function abnormalPaths()
+    public static function abnormalPaths()
     {
         return [
             ['/', '/', '/'],

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
@@ -66,12 +66,12 @@ class NodeServiceTest extends UnitTestCase
         $mockNodeTypeManager = $this->getMockBuilder(NodeTypeManager::class)->disableOriginalConstructor()->getMock();
         $mockNodeTypeManager->expects(self::any())
             ->method('getSubNodeTypes')
-            ->will(self::returnValue($this->subNodeTypesFixture));
+            ->willReturn($this->subNodeTypesFixture);
         $mockNodeTypeManager->expects(self::any())
             ->method('getNodeType')
-            ->will(self::returnCallback(function ($nodeTypeName) {
+            ->willReturnCallback(function ($nodeTypeName) {
                 return new NodeType($nodeTypeName, [], []);
-            }));
+            });
 
         $this->inject($nodeService, 'nodeTypeManager', $mockNodeTypeManager);
 
@@ -87,10 +87,10 @@ class NodeServiceTest extends UnitTestCase
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
         $mockNodeType->expects(self::any())
             ->method('getName')
-            ->will(self::returnValue($nodeTypeName));
+            ->willReturn($nodeTypeName);
         $mockNodeType->expects(self::any())
             ->method('__toString')
-            ->will(self::returnValue($nodeTypeName));
+            ->willReturn($nodeTypeName);
 
         return $mockNodeType;
     }
@@ -106,12 +106,12 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNode->expects(self::once())
             ->method('getProperty')
             ->with('title')
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         $mockNode->expects(self::once())
             ->method('setProperty')
@@ -119,9 +119,9 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNodeType->expects(self::once())
             ->method('getDefaultValuesForProperties')
-            ->will(self::returnValue([
+            ->willReturn([
                 'title' => 'hello'
-            ]));
+            ]);
 
         $nodeService->setDefaultValues($mockNode);
     }
@@ -137,12 +137,12 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNode->expects(self::once())
             ->method('getProperty')
             ->with('date')
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         $mockNode->expects(self::once())
             ->method('setProperty')
@@ -150,9 +150,9 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNodeType->expects(self::once())
             ->method('getDefaultValuesForProperties')
-            ->will(self::returnValue([
+            ->willReturn([
                 'date' => new \DateTime('2014-09-03')
-            ]));
+            ]);
 
         $nodeService->setDefaultValues($mockNode);
     }
@@ -168,21 +168,21 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNode->expects(self::once())
             ->method('getProperty')
             ->with('title')
-            ->will(self::returnValue('Existing value'));
+            ->willReturn('Existing value');
 
         $mockNode->expects(self::never())
             ->method('setProperty');
 
         $mockNodeType->expects(self::once())
             ->method('getDefaultValuesForProperties')
-            ->will(self::returnValue([
+            ->willReturn([
                 'title' => 'hello'
-            ]));
+            ]);
 
         $nodeService->setDefaultValues($mockNode);
     }
@@ -200,20 +200,30 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNodeType->expects(self::once())
             ->method('getAutoCreatedChildNodes')
-            ->will(self::returnValue([
+            ->willReturn([
                 'first-child-node-name' => $firstChildNodeType,
                 'second-child-node-name' => $secondChildNodeType
-            ]));
+            ]);
 
         $mockNode->method('getIdentifier')->willReturn(Algorithms::generateUUID());
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
+        $matcher = self::atLeast(2);
 
-        $mockNode->expects(self::atLeast(2))
-            ->method('createNode')
-            ->withConsecutive(['first-child-node-name', $firstChildNodeType], ['second-child-node-name', $secondChildNodeType]);
+        $mockNode->expects($matcher)
+            ->method('createNode')->willReturnCallback(function (...$parameters) use ($matcher, $firstChildNodeType, $secondChildNodeType) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('first-child-node-name', $parameters[0]);
+                $this->assertSame($firstChildNodeType, $parameters[1]);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('second-child-node-name', $parameters[0]);
+                $this->assertSame($secondChildNodeType, $parameters[1]);
+            }
+            return $this->createMock(NodeInterface::class);
+        });
 
         $nodeService->createChildNodes($mockNode);
     }
@@ -233,30 +243,30 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNodeType->expects(self::once())
             ->method('getProperties')
-            ->will(self::returnValue([
+            ->willReturn([
                 'title' => [],
                 'description' => []
-            ]));
+            ]);
 
         $mockNode->expects(self::once())
             ->method('isRemoved')
-            ->will(self::returnValue(false));
+            ->willReturn(false);
 
         $mockNode->expects(self::once())
             ->method('getNodeData')
-            ->will(self::returnValue($mockNodeData));
+            ->willReturn($mockNodeData);
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNode->expects(self::once())
             ->method('getProperties')
-            ->will(self::returnValue(new ArrayPropertyCollection([
+            ->willReturn(new ArrayPropertyCollection([
                 'title' => 'hello',
                 'description' => 'world',
                 'invalidProperty' => 'world'
-            ])));
+            ]));
 
         $nodeService->cleanUpProperties($mockNode);
     }
@@ -280,30 +290,30 @@ class NodeServiceTest extends UnitTestCase
         $mockFirstChildNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
         $mockFirstChildNode->expects(self::any())
             ->method('getNodeType')
-            ->will(self::returnValue($mockContentNodeType));
+            ->willReturn($mockContentNodeType);
         $mockFirstChildNode->expects(self::any())
             ->method('getName')
-            ->will(self::returnValue('main'));
+            ->willReturn('main');
         $mockFirstChildNode->expects(self::never())
             ->method('remove');
 
         $mockSecondChildNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
         $mockSecondChildNode->expects(self::any())
             ->method('getNodeType')
-            ->will(self::returnValue($mockContentNodeType));
+            ->willReturn($mockContentNodeType);
         $mockSecondChildNode->expects(self::any())
             ->method('getName')
-            ->will(self::returnValue('sidebar'));
+            ->willReturn('sidebar');
         $mockSecondChildNode->expects(self::never())
             ->method('remove');
 
         $mockThirdChildNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
         $mockThirdChildNode->expects(self::any())
             ->method('getNodeType')
-            ->will(self::returnValue($mockContentNodeType));
+            ->willReturn($mockContentNodeType);
         $mockThirdChildNode->expects(self::any())
             ->method('getName')
-            ->will(self::returnValue('footer'));
+            ->willReturn('footer');
         $mockThirdChildNode->expects(self::once())
             ->method('remove');
 
@@ -311,22 +321,22 @@ class NodeServiceTest extends UnitTestCase
         $mockSidebarChildNodeType = $this->mockNodeType('Neos.ContentRepository.Testing:ContentCollection');
         $mockNodeType->expects(self::once())
             ->method('getAutoCreatedChildNodes')
-            ->will(self::returnValue([
+            ->willReturn([
                 'main' => $mockMainChildNodeType,
                 'sidebar' => $mockSidebarChildNodeType
-            ]));
+            ]);
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNode->expects(self::once())
             ->method('getChildNodes')
-            ->will(self::returnValue([
+            ->willReturn([
                 $mockFirstChildNode,
                 $mockSecondChildNode,
                 $mockThirdChildNode
-            ]));
+            ]);
 
         $nodeService->cleanUpChildNodes($mockNode);
     }
@@ -350,29 +360,29 @@ class NodeServiceTest extends UnitTestCase
         $mockFirstChildNode = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
         $mockFirstChildNode->expects(self::any())
             ->method('getNodeType')
-            ->will(self::returnValue($mockContentNodeType));
+            ->willReturn($mockContentNodeType);
         $mockFirstChildNode->expects(self::any())
             ->method('getName')
-            ->will(self::returnValue('sidebar'));
+            ->willReturn('sidebar');
         $mockFirstChildNode->expects(self::never())
             ->method('remove');
 
         $mockMainChildNodeType = $this->mockNodeType('Neos.ContentRepository.Testing:ContentCollection');
         $mockNodeType->expects(self::once())
             ->method('getAutoCreatedChildNodes')
-            ->will(self::returnValue([
+            ->willReturn([
                 'main' => $mockMainChildNodeType
-            ]));
+            ]);
 
         $mockNode->expects(self::once())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNode->expects(self::once())
             ->method('getChildNodes')
-            ->will(self::returnValue([
+            ->willReturn([
                 $mockFirstChildNode,
-            ]));
+            ]);
 
         $nodeService->cleanUpChildNodes($mockNode);
     }
@@ -388,7 +398,7 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNode->expects(self::atLeastOnce())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         $mockNodeType = $this->mockNodeType('Neos.ContentRepository.Testing:ContentObject');
         self::assertTrue($nodeService->isNodeOfType($mockNode, $mockNodeType));
@@ -405,7 +415,7 @@ class NodeServiceTest extends UnitTestCase
 
         $mockNode->expects(self::atLeastOnce())
             ->method('getNodeType')
-            ->will(self::returnValue($mockNodeType));
+            ->willReturn($mockNodeType);
 
         self::assertTrue($nodeService->isNodeOfType($mockNode, $mockNodeType));
     }

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeServiceTest.php
@@ -10,8 +10,9 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeData;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Domain\Model\ArrayPropertyCollection;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\Node;
@@ -94,9 +95,7 @@ class NodeServiceTest extends UnitTestCase
         return $mockNodeType;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDefaultValueOnlyIfTheCurrentPropertyIsNull()
     {
         $nodeService = $this->createNodeService();
@@ -127,9 +126,7 @@ class NodeServiceTest extends UnitTestCase
         $nodeService->setDefaultValues($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDefaultDateValueOnlyIfTheCurrentPropertyIsNull()
     {
         $nodeService = $this->createNodeService();
@@ -160,9 +157,7 @@ class NodeServiceTest extends UnitTestCase
         $nodeService->setDefaultValues($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDefaultValueNeverReplaceExistingValue()
     {
         $nodeService = $this->createNodeService();
@@ -192,9 +187,7 @@ class NodeServiceTest extends UnitTestCase
         $nodeService->setDefaultValues($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createChildNodesTryToCreateAllConfiguredChildNodes()
     {
         $nodeService = $this->createNodeService();
@@ -225,9 +218,7 @@ class NodeServiceTest extends UnitTestCase
         $nodeService->createChildNodes($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cleanUpPropertiesRemoveAllUndeclaredProperties()
     {
         $nodeService = $this->createNodeService();
@@ -271,10 +262,9 @@ class NodeServiceTest extends UnitTestCase
     }
 
     /**
-     * @test
-     *
      * TODO: Adjust after the removal of child nodes is implemented again.
      */
+    #[Test]
     public function cleanUpChildNodesRemoveAllUndeclaredChildNodes()
     {
         $this->markTestSkipped('Currently this functionality is disabled. We will introduce it again at a later point and then reenable this test.');
@@ -342,10 +332,9 @@ class NodeServiceTest extends UnitTestCase
     }
 
     /**
-     * @test
-     *
      * TODO: Adjust after the removal of child nodes is implemented again.
      */
+    #[Test]
     public function cleanUpChildNodesNeverRemoveDocumentNode()
     {
         $this->markTestSkipped('Currently this functionality is disabled. We will introduce it again at a later point and then reenable this test.');
@@ -388,9 +377,7 @@ class NodeServiceTest extends UnitTestCase
         $nodeService->cleanUpChildNodes($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isNodeOfTypeReturnTrueIsTheGivenNodeIsSubNodeOfTheGivenType()
     {
         $nodeService = $this->createNodeService();
@@ -407,9 +394,7 @@ class NodeServiceTest extends UnitTestCase
         self::assertTrue($nodeService->isNodeOfType($mockNode, $mockNodeType));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isNodeOfTypeReturnTrueIsTheGivenNodeHasTheSameTypeOfTheGivenType()
     {
         $nodeService = $this->createNodeService();
@@ -453,18 +438,16 @@ class NodeServiceTest extends UnitTestCase
      * @param string $currentPath
      * @param string $relativePath
      * @param string $normalizedPath
-     * @test
-     * @dataProvider abnormalPaths
      */
+    #[DataProvider('abnormalPaths')]
+    #[Test]
     public function normalizePathReturnsANormalizedAbsolutePath($currentPath, $relativePath, $normalizedPath)
     {
         $nodeService = $this->createNodeService();
         self::assertSame($normalizedPath, $nodeService->normalizePath($relativePath, $currentPath));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function normalizePathThrowsInvalidArgumentExceptionOnPathContainingDoubleSlash()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
@@ -50,7 +50,7 @@ class NodeTypeManagerTest extends UnitTestCase
 
         $this->mockConfigurationManager = $this->getMockBuilder(ConfigurationManager::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('NodeTypes')->will(self::returnValue($nodeTypesFixtureData));
+        $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('NodeTypes')->willReturn($nodeTypesFixtureData);
         $this->inject($this->nodeTypeManager, 'configurationManager', $this->mockConfigurationManager);
     }
 

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Exception\NodeTypeIsFinalException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\ContentRepository\Exception;
@@ -144,9 +144,7 @@ class NodeTypeManagerTest extends UnitTestCase
         'Neos.ContentRepository:FallbackNode' => []
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTypeConfigurationIsMergedTogether()
     {
         $nodeType = $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Text');
@@ -171,27 +169,21 @@ class NodeTypeManagerTest extends UnitTestCase
         self::assertSame($expectedProperties, $nodeType->getProperties());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeThrowsExceptionForUnknownNodeType()
     {
         $this->expectException(NodeTypeNotFoundException::class);
         $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:TextFooBarNotHere');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeThrowsExceptionIfNoFallbackNodeTypeIsConfigured()
     {
         $this->expectException(NodeTypeNotFoundException::class);
         $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:TextFooBarNotHere');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeThrowsExceptionIfConfiguredFallbackNodeTypeCantBeFound()
     {
         $this->expectException(NodeTypeNotFoundException::class);
@@ -199,9 +191,7 @@ class NodeTypeManagerTest extends UnitTestCase
         $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:TextFooBarNotHere');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeReturnsFallbackNodeTypeIfConfigured()
     {
         $this->inject($this->nodeTypeManager, 'fallbackNodeTypeName', 'Neos.ContentRepository:FallbackNode');
@@ -211,42 +201,32 @@ class NodeTypeManagerTest extends UnitTestCase
         self::assertSame($expectedNodeType, $fallbackNodeType);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createNodeTypeAlwaysThrowsAnException()
     {
         $this->expectException(Exception::class);
         $this->nodeTypeManager->createNodeType('Neos.ContentRepository.Testing:ContentObject');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasNodeTypeReturnsTrueIfTheGivenNodeTypeIsFound()
     {
         self::assertTrue($this->nodeTypeManager->hasNodeType('Neos.ContentRepository.Testing:TextWithImage'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasNodeTypeReturnsFalseIfTheGivenNodeTypeIsNotFound()
     {
         self::assertFalse($this->nodeTypeManager->hasNodeType('Neos.ContentRepository.Testing:TextFooBarNotHere'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasNodeTypeReturnsTrueForAbstractNodeTypes()
     {
         self::assertTrue($this->nodeTypeManager->hasNodeType('Neos.ContentRepository.Testing:ContentObject'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypesReturnsRegisteredNodeTypes()
     {
         $expectedNodeTypes = [
@@ -265,79 +245,61 @@ class NodeTypeManagerTest extends UnitTestCase
         self::assertEquals($expectedNodeTypes, array_keys($this->nodeTypeManager->getNodeTypes()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypesContainsAbstractNodeTypes()
     {
         $nodeTypes = $this->nodeTypeManager->getNodeTypes();
         self::assertArrayHasKey('Neos.ContentRepository.Testing:ContentObject', $nodeTypes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypesWithoutIncludeAbstractContainsNoAbstractNodeTypes()
     {
         $nodeTypes = $this->nodeTypeManager->getNodeTypes(false);
         self::assertArrayNotHasKey('Neos.ContentRepository.Testing:ContentObject', $nodeTypes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubNodeTypesReturnsInheritedNodeTypes()
     {
         $nodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject');
         self::assertArrayHasKey('Neos.ContentRepository.Testing:TextWithImage', $nodeTypes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubNodeTypesContainsAbstractNodeTypes()
     {
         $nodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject');
         self::assertArrayHasKey('Neos.ContentRepository.Testing:AbstractType', $nodeTypes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubNodeTypesWithoutIncludeAbstractContainsNoAbstractNodeTypes()
     {
         $nodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject', false);
         self::assertArrayNotHasKey('Neos.ContentRepository.Testing:AbstractType', $nodeTypes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeAllowsToRetrieveFinalNodeTypes()
     {
         self::assertTrue($this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:MyFinalType')->isFinal());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aggregateNodeTypeFlagIsFalseByDefault()
     {
         self::assertFalse($this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Text')->isAggregate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aggregateNodeTypeFlagIsInherited()
     {
         self::assertTrue($this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Document')->isAggregate());
         self::assertTrue($this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Page')->isAggregate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNodeTypeThrowsExceptionIfFinalNodeTypeIsSubclassed()
     {
         $this->expectException(NodeTypeIsFinalException::class);
@@ -354,9 +316,7 @@ class NodeTypeManagerTest extends UnitTestCase
         $this->nodeTypeManager->getNodeType('Neos.ContentRepository.Testing:Sub');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubNodeTypesWithDifferentIncludeFlagValuesReturnsCorrectValues()
     {
         $subNodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.ContentRepository.Testing:ContentObject', true);

--- a/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Domain/Service/NodeTypeManagerTest.php
@@ -11,6 +11,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Service;
  * source code.
  */
 
+use Neos\ContentRepository\Exception\NodeTypeIsFinalException;
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\ContentRepository\Exception;
 use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
 use Neos\Flow\Configuration\ConfigurationManager;
@@ -28,7 +30,7 @@ class NodeTypeManagerTest extends UnitTestCase
     protected $nodeTypeManager;
 
     /**
-     * @var ConfigurationManager|\PHPUnit\Framework\MockObject\MockObject
+     * @var ConfigurationManager|MockObject
      */
     protected $mockConfigurationManager;
 
@@ -338,7 +340,7 @@ class NodeTypeManagerTest extends UnitTestCase
      */
     public function getNodeTypeThrowsExceptionIfFinalNodeTypeIsSubclassed()
     {
-        $this->expectException(Exception\NodeTypeIsFinalException::class);
+        $this->expectException(NodeTypeIsFinalException::class);
         $nodeTypesFixture = [
             'Neos.ContentRepository.Testing:Base' => [
                 'final' => true

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/AbstractQueryOperationsTestCase.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/AbstractQueryOperationsTestCase.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Abstract base class for the Query Operation tests
  */
-abstract class AbstractQueryOperationsTest extends UnitTestCase
+abstract class AbstractQueryOperationsTestCase extends UnitTestCase
 {
     protected function mockNode(string $nodeAggregateIdentifier): TraversableNodeInterface
     {

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Eel\FlowQueryOperations\CacheLifetimeOperation;
 use Neos\Eel\FlowQuery\FlowQuery;
@@ -56,9 +57,7 @@ class CacheLifetimeOperationTest extends AbstractQueryOperationsTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canEvaluateReturnsTrueIfNodeIsInContext()
     {
         $mockNode = $this->mockNode('node');
@@ -124,10 +123,8 @@ class CacheLifetimeOperationTest extends AbstractQueryOperationsTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider nodePropertiesAndLifetime
-     */
+    #[DataProvider('nodePropertiesAndLifetime')]
+    #[Test]
     public function evaluateReturnsMinimumOfFutureHiddenDates($nodes, $expectedLifetime)
     {
         $mockFlowQuery = $this->buildFlowQueryWithNodesInContext($nodes);

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
@@ -18,7 +18,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the ContentRepository FlowQuery CacheLifetimeOperation
  */
-class CacheLifetimeOperationTest extends AbstractQueryOperationsTest
+class CacheLifetimeOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var CacheLifetimeOperation

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
@@ -146,14 +146,14 @@ class CacheLifetimeOperationTest extends AbstractQueryOperationsTestCase
         $contextValues = [];
         foreach ($nodes as $nodeProperties) {
             $mockNode = $this->createMock(NodeInterface::class);
-            $mockNode->expects(self::any())->method('getHiddenBeforeDateTime')->will(self::returnValue($nodeProperties['hiddenBeforeDateTime'] !== null ? $this->dateFixtures[$nodeProperties['hiddenBeforeDateTime']] : null));
-            $mockNode->expects(self::any())->method('getHiddenAfterDateTime')->will(self::returnValue($nodeProperties['hiddenAfterDateTime'] !== null ? $this->dateFixtures[$nodeProperties['hiddenAfterDateTime']] : null));
+            $mockNode->expects(self::any())->method('getHiddenBeforeDateTime')->willReturn($nodeProperties['hiddenBeforeDateTime'] !== null ? $this->dateFixtures[$nodeProperties['hiddenBeforeDateTime']] : null);
+            $mockNode->expects(self::any())->method('getHiddenAfterDateTime')->willReturn($nodeProperties['hiddenAfterDateTime'] !== null ? $this->dateFixtures[$nodeProperties['hiddenAfterDateTime']] : null);
 
             $contextValues[] = $mockNode;
         }
 
         $mockFlowQuery = $this->getMockBuilder(FlowQuery::class)->disableOriginalConstructor()->getMock();
-        $mockFlowQuery->expects(self::any())->method('getContext')->will(self::returnValue($contextValues));
+        $mockFlowQuery->expects(self::any())->method('getContext')->willReturn($contextValues);
         return $mockFlowQuery;
     }
 }

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/CacheLifetimeOperationTest.php
@@ -66,7 +66,7 @@ class CacheLifetimeOperationTest extends AbstractQueryOperationsTestCase
         self::assertTrue($result);
     }
 
-    public function nodePropertiesAndLifetime()
+    public static function nodePropertiesAndLifetime()
     {
         return [
             'Minimum in hiddenBeforeDateTime' => [

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
@@ -20,7 +20,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery ContextOperation
  */
-class ContextOperationTest extends AbstractQueryOperationsTest
+class ContextOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var ContextOperation

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
@@ -39,9 +39,7 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
         $this->inject($this->operation, 'contextFactory', $this->mockContextFactory);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canEvaluateReturnsTrueIfNodeIsInContext()
     {
         $mockNode = $this->createMock(NodeInterface::class);
@@ -50,9 +48,7 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
         self::assertTrue($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateCreatesModifiedContextFromFactoryUsingMergedProperties()
     {
         $suppliedContextProperties = ['infiniteImprobabilityDrive' => true];
@@ -69,9 +65,7 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
         $this->operation->evaluate($mockFlowQuery, [$suppliedContextProperties]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateGetsAndSetsNodesInContextFromModifiedContextByIdentifier()
     {
         $suppliedContextProperties = ['infiniteImprobabilityDrive' => true];
@@ -93,9 +87,7 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
         $this->operation->evaluate($mockFlowQuery, [$suppliedContextProperties]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateSkipsNodesNotAvailableInModifiedContext()
     {
         $suppliedContextProperties = ['infiniteImprobabilityDrive' => true];

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ContextOperationTest.php
@@ -60,7 +60,7 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
 
         $modifiedNodeContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockContextFactory->expects(self::atLeastOnce())->method('create')->with($expectedModifiedContextProperties)->will(self::returnValue($modifiedNodeContext));
+        $this->mockContextFactory->expects(self::atLeastOnce())->method('create')->with($expectedModifiedContextProperties)->willReturn($modifiedNodeContext);
 
         $this->operation->evaluate($mockFlowQuery, [$suppliedContextProperties]);
     }
@@ -73,15 +73,15 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
         $nodeIdentifier = 'c575c430-c971-11e3-a6e7-14109fd7a2dd';
 
         $mockNode = $this->createMock(NodeInterface::class);
-        $mockNode->expects(self::any())->method('getIdentifier')->will(self::returnValue($nodeIdentifier));
+        $mockNode->expects(self::any())->method('getIdentifier')->willReturn($nodeIdentifier);
         $mockFlowQuery = $this->buildFlowQueryWithNodeInContext($mockNode, $nodeContextProperties);
 
         $modifiedNodeContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
         $nodeInModifiedContext = $this->createMock(NodeInterface::class);
-        $nodeInModifiedContext->expects(self::any())->method('getPath')->will(self::returnValue('/foo/bar'));
-        $this->mockContextFactory->expects(self::any())->method('create')->will(self::returnValue($modifiedNodeContext));
+        $nodeInModifiedContext->expects(self::any())->method('getPath')->willReturn('/foo/bar');
+        $this->mockContextFactory->expects(self::any())->method('create')->willReturn($modifiedNodeContext);
 
-        $modifiedNodeContext->expects(self::once())->method('getNodeByIdentifier')->with($nodeIdentifier)->will(self::returnValue($nodeInModifiedContext));
+        $modifiedNodeContext->expects(self::once())->method('getNodeByIdentifier')->with($nodeIdentifier)->willReturn($nodeInModifiedContext);
         $mockFlowQuery->expects(self::atLeastOnce())->method('setContext')->with([$nodeInModifiedContext]);
 
         $this->operation->evaluate($mockFlowQuery, [$suppliedContextProperties]);
@@ -95,13 +95,13 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
         $nodeIdentifier = 'c575c430-c971-11e3-a6e7-14109fd7a2dd';
 
         $mockNode = $this->createMock(NodeInterface::class);
-        $mockNode->expects(self::any())->method('getIdentifier')->will(self::returnValue($nodeIdentifier));
+        $mockNode->expects(self::any())->method('getIdentifier')->willReturn($nodeIdentifier);
         $mockFlowQuery = $this->buildFlowQueryWithNodeInContext($mockNode, $nodeContextProperties);
 
         $modifiedNodeContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $this->mockContextFactory->expects(self::any())->method('create')->will(self::returnValue($modifiedNodeContext));
+        $this->mockContextFactory->expects(self::any())->method('create')->willReturn($modifiedNodeContext);
 
-        $modifiedNodeContext->expects(self::once())->method('getNodeByIdentifier')->with($nodeIdentifier)->will(self::returnValue(null));
+        $modifiedNodeContext->expects(self::once())->method('getNodeByIdentifier')->with($nodeIdentifier)->willReturn(null);
         $mockFlowQuery->expects(self::atLeastOnce())->method('setContext')->with([]);
 
         $this->operation->evaluate($mockFlowQuery, [$suppliedContextProperties]);
@@ -115,12 +115,12 @@ class ContextOperationTest extends AbstractQueryOperationsTestCase
     protected function buildFlowQueryWithNodeInContext($mockNode, $nodeContextProperties)
     {
         $mockNodeContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $mockNodeContext->expects(self::any())->method('getProperties')->will(self::returnValue($nodeContextProperties));
+        $mockNodeContext->expects(self::any())->method('getProperties')->willReturn($nodeContextProperties);
 
-        $mockNode->expects(self::any())->method('getContext')->will(self::returnValue($mockNodeContext));
+        $mockNode->expects(self::any())->method('getContext')->willReturn($mockNodeContext);
 
         $mockFlowQuery = $this->getMockBuilder(FlowQuery::class)->disableOriginalConstructor()->getMock();
-        $mockFlowQuery->expects(self::any())->method('getContext')->will(self::returnValue([$mockNode]));
+        $mockFlowQuery->expects(self::any())->method('getContext')->willReturn([$mockNode]);
         return $mockFlowQuery;
     }
 }

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/FilterOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/FilterOperationTest.php
@@ -17,7 +17,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery FilterOperation
  */
-class FilterOperationTest extends AbstractQueryOperationsTest
+class FilterOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @test

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/FilterOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/FilterOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Eel\FlowQueryOperations\FilterOperation;
 use Neos\Eel\FlowQuery\FlowQuery;
 
@@ -19,9 +19,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
  */
 class FilterOperationTest extends AbstractQueryOperationsTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function filterWithIdentifierUsesNodeAggregateIdentifier()
     {
         $node1 = $this->mockNode('node1-identifier-uuid');
@@ -36,9 +34,7 @@ class FilterOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$node2], $q->getContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function filterWithNodeInstanceIsSupported()
     {
         $node1 = $this->mockNode('node1');

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery NextAllOperation
  */
-class NextAllOperationTest extends AbstractQueryOperationsTest
+class NextAllOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var Context

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
@@ -55,20 +55,20 @@ class NextAllOperationTest extends AbstractQueryOperationsTestCase
         $this->secondNodeInLevel = $this->mockNode('node2');
         $this->thirdNodeInLevel = $this->mockNode('node3');
 
-        $this->siteNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site')));
-        $this->siteNode->expects(self::any())->method('findChildNodes')->will(self::returnValue(TraversableNodes::fromArray([
+        $this->siteNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site'));
+        $this->siteNode->expects(self::any())->method('findChildNodes')->willReturn(TraversableNodes::fromArray([
             $this->firstNodeInLevel,
             $this->secondNodeInLevel,
             $this->thirdNodeInLevel
-        ])));
+        ]));
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->firstNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/first')));
-        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->secondNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/second')));
-        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->thirdNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/third')));
+        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->firstNodeInLevel->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/first'));
+        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->secondNodeInLevel->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/second'));
+        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->thirdNodeInLevel->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/third'));
     }
 
     #[Test]

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextAllOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
@@ -71,9 +71,7 @@ class NextAllOperationTest extends AbstractQueryOperationsTestCase
         $this->thirdNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/third')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextAllWillReturnEmptyResultForLastNodeInLevel()
     {
         $context = [$this->thirdNodeInLevel];
@@ -86,9 +84,7 @@ class NextAllOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextAllWillReturnSecondNodeAndThirdNodeInLevelForFirstNodeInLevel()
     {
         $context = [$this->firstNodeInLevel];
@@ -101,9 +97,7 @@ class NextAllOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->secondNodeInLevel, $this->thirdNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextAllWillReturnThirdNodeInLevelForSecondNodeInLevel()
     {
         $context = [$this->secondNodeInLevel];
@@ -116,9 +110,7 @@ class NextAllOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->thirdNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextAllWillReturnSecondNodeAndThirdNodeInLevelForFirstAndSecondNodeInLevel()
     {
         $context = [$this->firstNodeInLevel, $this->secondNodeInLevel];

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextOperationTest.php
@@ -55,20 +55,20 @@ class NextOperationTest extends AbstractQueryOperationsTestCase
         $this->secondNodeInLevel = $this->mockNode('node2');
         $this->thirdNodeInLevel = $this->mockNode('node3');
 
-        $this->siteNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site')));
-        $this->siteNode->expects(self::any())->method('findChildNodes')->will(self::returnValue(TraversableNodes::fromArray([
+        $this->siteNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site'));
+        $this->siteNode->expects(self::any())->method('findChildNodes')->willReturn(TraversableNodes::fromArray([
             $this->firstNodeInLevel,
             $this->secondNodeInLevel,
             $this->thirdNodeInLevel
-        ])));
+        ]));
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->firstNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/first')));
-        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->secondNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/second')));
-        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->thirdNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/third')));
+        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->firstNodeInLevel->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/first'));
+        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->secondNodeInLevel->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/second'));
+        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->thirdNodeInLevel->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/third'));
     }
 
     #[Test]

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
@@ -71,9 +71,7 @@ class NextOperationTest extends AbstractQueryOperationsTestCase
         $this->thirdNodeInLevel->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/third')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextWillReturnEmptyResultForLastNodeInLevel()
     {
         $context = [$this->thirdNodeInLevel];
@@ -86,9 +84,7 @@ class NextOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextWillReturnSecondNodeInLevelForFirstNodeInLevel()
     {
         $context = [$this->firstNodeInLevel];
@@ -101,9 +97,7 @@ class NextOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->secondNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nextWillReturnSecondNodeAndThirdNodeInLevelForFirstAndSecondNodeInLevel()
     {
         $context = [$this->firstNodeInLevel, $this->secondNodeInLevel];

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/NextOperationTest.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery NextOperation
  */
-class NextOperationTest extends AbstractQueryOperationsTest
+class NextOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var Context

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
@@ -13,6 +13,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
 use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\ContentRepository\Eel\FlowQueryOperations\ParentOperation;
 use Neos\ContentRepository\Exception\NodeException;
@@ -49,15 +50,15 @@ class ParentOperationTest extends AbstractQueryOperationsTestCase
         $this->firstLevelNode = $this->mockNode('node1');
         $this->secondLevelNode = $this->mockNode('node2');
 
-        $this->siteNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site')));
-        $this->siteNode->expects(self::any())->method('findChildNodes')->will(self::returnValue([$this->firstLevelNode]));
+        $this->siteNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site'));
+        $this->siteNode->expects(self::any())->method('findChildNodes')->willReturn(TraversableNodes::fromArray([$this->firstLevelNode]));
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->siteNode->expects(self::any())->method('findParentNode')->will(self::throwException(new NodeException('No parent')));
-        $this->firstLevelNode->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->firstLevelNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/first')));
-        $this->secondLevelNode->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->secondLevelNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/first/second')));
+        $this->siteNode->expects(self::any())->method('findParentNode')->willThrowException(new NodeException('No parent'));
+        $this->firstLevelNode->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->firstLevelNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/first'));
+        $this->secondLevelNode->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->secondLevelNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site/first/second'));
     }
 
     #[Test]

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery ParentsOperation
  */
-class ParentOperationTest extends AbstractQueryOperationsTest
+class ParentOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var Context

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/ParentOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Service\Context;
@@ -60,9 +60,7 @@ class ParentOperationTest extends AbstractQueryOperationsTestCase
         $this->secondLevelNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site/first/second')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parentWillReturnEmptyResultForTheSiteNode()
     {
         $context = [$this->siteNode];
@@ -75,9 +73,7 @@ class ParentOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parentWillReturnFirstLevelNodeForSecondLevelNode()
     {
         $context = [$this->secondLevelNode];

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery PrevAllOperation
  */
-class PrevAllOperationTest extends AbstractQueryOperationsTest
+class PrevAllOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var Context

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
@@ -72,9 +72,7 @@ class PrevAllOperationTest extends AbstractQueryOperationsTestCase
         $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevAllWillReturnEmptyResultForFirstNodeInLevel()
     {
         $context = [$this->firstNodeInLevel];
@@ -87,9 +85,7 @@ class PrevAllOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevAllWillReturnFirstNodeInLevelForSecondNodeInLevel()
     {
         $context = [$this->secondNodeInLevel];
@@ -102,9 +98,7 @@ class PrevAllOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->firstNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevAllWillReturnFirstNodeAndSecondNodeInLevelForSecondAndThirdNodeInLevel()
     {
         $context = [$this->secondNodeInLevel, $this->thirdNodeInLevel];
@@ -117,9 +111,7 @@ class PrevAllOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->firstNodeInLevel, $this->secondNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevAllWillReturnFirstNodeAndSecondNodeInLevelForThirdNodeInLevel()
     {
         $context = [$this->thirdNodeInLevel];

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevAllOperationTest.php
@@ -59,17 +59,17 @@ class PrevAllOperationTest extends AbstractQueryOperationsTestCase
         $this->secondNodeInLevel = $this->mockNode('node2');
         $this->thirdNodeInLevel = $this->mockNode('node3');
 
-        $this->siteNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site')));
-        $this->siteNode->expects(self::any())->method('findChildNodes')->will(self::returnValue(TraversableNodes::fromArray([
+        $this->siteNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site'));
+        $this->siteNode->expects(self::any())->method('findChildNodes')->willReturn(TraversableNodes::fromArray([
             $this->firstNodeInLevel,
             $this->secondNodeInLevel,
             $this->thirdNodeInLevel
-        ])));
+        ]));
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
+        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
     }
 
     #[Test]

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
@@ -59,17 +59,17 @@ class PrevOperationTest extends AbstractQueryOperationsTestCase
         $this->secondNodeInLevel = $this->mockNode('second-node');
         $this->thirdNodeInLevel = $this->mockNode('third-node');
 
-        $this->siteNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/site')));
-        $this->siteNode->expects(self::any())->method('findChildNodes')->will(self::returnValue(TraversableNodes::fromArray([
+        $this->siteNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/site'));
+        $this->siteNode->expects(self::any())->method('findChildNodes')->willReturn(TraversableNodes::fromArray([
             $this->firstNodeInLevel,
             $this->secondNodeInLevel,
             $this->thirdNodeInLevel
-        ])));
+        ]));
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
+        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
     }
 
     #[Test]

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery PrevOperation
  */
-class PrevOperationTest extends AbstractQueryOperationsTest
+class PrevOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var Context

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/PrevOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
@@ -72,9 +72,7 @@ class PrevOperationTest extends AbstractQueryOperationsTestCase
         $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevWillReturnEmptyResultForFirstNodeInLevel()
     {
         $context = [$this->firstNodeInLevel];
@@ -87,9 +85,7 @@ class PrevOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevWillReturnFirstNodeInLevelForSecondNodeInLevel()
     {
         $context = [$this->secondNodeInLevel];
@@ -102,9 +98,7 @@ class PrevOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->firstNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prevWillReturnFirstNodeAndSecondNodeInLevelForSecondAndThirdNodeInLevel()
     {
         $context = [$this->secondNodeInLevel, $this->thirdNodeInLevel];

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
@@ -21,7 +21,7 @@ use Neos\Eel\FlowQuery\FlowQuery;
 /**
  * Testcase for the FlowQuery SiblingsOperation
  */
-class SiblingsOperationTest extends AbstractQueryOperationsTest
+class SiblingsOperationTest extends AbstractQueryOperationsTestCase
 {
     /**
      * @var Context

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
@@ -59,17 +59,17 @@ class SiblingsOperationTest extends AbstractQueryOperationsTestCase
         $this->secondNodeInLevel = $this->mockNode('second-node');
         $this->thirdNodeInLevel = $this->mockNode('third-node');
 
-        $this->siteNode->expects(self::any())->method('findChildNodes')->will(self::returnValue(TraversableNodes::fromArray([
+        $this->siteNode->expects(self::any())->method('findChildNodes')->willReturn(TraversableNodes::fromArray([
             $this->firstNodeInLevel,
             $this->secondNodeInLevel,
             $this->thirdNodeInLevel
-        ])));
+        ]));
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->siteNode->expects(self::any())->method('findParentNode')->will(self::throwException(new NodeException('No parent')));
-        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
-        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
+        $this->siteNode->expects(self::any())->method('findParentNode')->willThrowException(new NodeException('No parent'));
+        $this->firstNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->secondNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
+        $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->willReturn($this->siteNode);
     }
 
     #[Test]

--- a/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
+++ b/Neos.ContentRepository/Tests/Unit/FlowQueryOperations/SiblingsOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
 use Neos\ContentRepository\Domain\Service\Context;
@@ -72,9 +72,7 @@ class SiblingsOperationTest extends AbstractQueryOperationsTestCase
         $this->thirdNodeInLevel->expects(self::any())->method('findParentNode')->will(self::returnValue($this->siteNode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function siblingsWillReturnEmptyResultForAllNodesInLevel()
     {
         $context = [$this->firstNodeInLevel, $this->secondNodeInLevel, $this->thirdNodeInLevel];
@@ -87,9 +85,7 @@ class SiblingsOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function siblingsWillReturnFirstAndThirdNodeInLevelForSecondNodeInLevel()
     {
         $context = [$this->secondNodeInLevel];
@@ -102,9 +98,7 @@ class SiblingsOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->firstNodeInLevel, $this->thirdNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function siblingsWillReturnFirstNodeForSecondAndThirdNodeInLevel()
     {
         $context = [$this->secondNodeInLevel, $this->thirdNodeInLevel];
@@ -117,9 +111,7 @@ class SiblingsOperationTest extends AbstractQueryOperationsTestCase
         self::assertEquals([$this->firstNodeInLevel], $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function siblingsWillReturnEmptyArrayForSiteNode()
     {
         $context = [$this->siteNode];

--- a/Neos.ContentRepository/Tests/Unit/Service/Utility/NodePublishingDependencySolverTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Service/Utility/NodePublishingDependencySolverTest.php
@@ -83,13 +83,13 @@ class NodePublishingDependencySolverTest extends UnitTestCase
     protected function buildNodeMock($path, $movedTo = null)
     {
         $mockNodeData = $this->getMockBuilder(NodeData::class)->setConstructorArgs([$path, $this->mockWorkspace])->getMock();
-        $mockNodeData->expects(self::any())->method('getMovedTo')->will(self::returnValue($movedTo));
-        $mockNodeData->expects(self::any())->method('getPath')->will(self::returnValue($path));
+        $mockNodeData->expects(self::any())->method('getMovedTo')->willReturn($movedTo);
+        $mockNodeData->expects(self::any())->method('getPath')->willReturn($path);
         $mockNode = $this->getMockBuilder(Node::class)->setConstructorArgs([$mockNodeData, $this->mockContext])->getMock();
-        $mockNode->expects(self::any())->method('getNodeData')->will(self::returnValue($mockNodeData));
-        $mockNode->expects(self::any())->method('getPath')->will(self::returnValue($path));
+        $mockNode->expects(self::any())->method('getNodeData')->willReturn($mockNodeData);
+        $mockNode->expects(self::any())->method('getPath')->willReturn($path);
         $parentPath = substr($path, 0, strrpos($path, '/'));
-        $mockNode->expects(self::any())->method('getParentPath')->will(self::returnValue($parentPath));
+        $mockNode->expects(self::any())->method('getParentPath')->willReturn($parentPath);
 
         return $mockNode;
     }

--- a/Neos.ContentRepository/Tests/Unit/Service/Utility/NodePublishingDependencySolverTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Service/Utility/NodePublishingDependencySolverTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\Service\Utility;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeData;
@@ -36,9 +36,7 @@ class NodePublishingDependencySolverTest extends UnitTestCase
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortNodesWithParentRelations()
     {
         $nodeService = $this->buildNodeMock('/sites/typo3cr/service');
@@ -53,9 +51,7 @@ class NodePublishingDependencySolverTest extends UnitTestCase
         $this->assertBeforeInArray($nodeCompany, $nodeAboutUs, $sortedNodes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortNodesWithMovedToRelations()
     {
         $nodeEnterprise = $this->buildNodeMock('/sites/typo3cr/enterprise');

--- a/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Transformations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\ContentDimension;
 use Neos\ContentRepository\Domain\Model\NodeData;
@@ -75,12 +76,12 @@ class SetDimensionsTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider setDimensionsInput
-     * @test
      * @param array $setValues The values passed to the transformation
      * @param array $expectedValues The values that are expected to be set on the node
      * @param array $configuredDimensions Optional set of dimensions "configured in the system"
      */
+    #[DataProvider('setDimensionsInput')]
+    #[Test]
     public function setDimensionsWorksAsExpected(array $setValues, array $expectedValues, ?array $configuredDimensions = null)
     {
         $transformation = new SetDimensions();
@@ -125,9 +126,7 @@ class SetDimensionsTest extends UnitTestCase
         $transformation->execute($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setDimensionsFillsInDefaultDimensionsAndValues()
     {
         $dimensionsToBeSet = [

--- a/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
@@ -96,7 +96,7 @@ class SetDimensionsTest extends UnitTestCase
             }
 
             $mockContentDimensionRepository = $this->getMockBuilder(ContentDimensionRepository::class)->getMock();
-            $mockContentDimensionRepository->expects(self::atLeastOnce())->method('findAll')->will(self::returnValue($configuredDimensionObjects));
+            $mockContentDimensionRepository->expects(self::atLeastOnce())->method('findAll')->willReturn($configuredDimensionObjects);
             $this->inject($transformation, 'contentDimensionRepository', $mockContentDimensionRepository);
         }
 

--- a/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Transformations/SetDimensionsTest.php
@@ -27,7 +27,7 @@ class SetDimensionsTest extends UnitTestCase
     /**
      * @return array
      */
-    public function setDimensionsInput()
+    public static function setDimensionsInput()
     {
         return [
             // single dimension, single value

--- a/Neos.ContentRepository/Tests/Unit/TypeConverter/NodeConverterTest.php
+++ b/Neos.ContentRepository/Tests/Unit/TypeConverter/NodeConverterTest.php
@@ -10,7 +10,7 @@ namespace Neos\ContentRepository\Tests\Unit\TypeConverter;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
@@ -88,9 +88,7 @@ class NodeConverterTest extends UnitTestCase
         $this->mockConverterConfiguration = $this->getMockBuilder(PropertyMappingConfigurationInterface::class)->disableOriginalConstructor()->getMock();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertFromSetsRemovedContentShownContextPropertyFromConfigurationForContextPathSource()
     {
         $contextPath = '/foo/bar@user-demo';
@@ -111,9 +109,7 @@ class NodeConverterTest extends UnitTestCase
         self::assertTrue($contextProperties['removedContentShown'], 'removedContentShown context property should be true');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertFromUsesPropertyMapperToConvertNodePropertyOfReferenceType()
     {
         $contextPath = '/foo/bar@user-demo';
@@ -140,9 +136,7 @@ class NodeConverterTest extends UnitTestCase
         $this->nodeConverter->convertFrom($source, null, [], $this->mockConverterConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertFromUsesPropertyMapperToConvertNodePropertyOfReferencesType()
     {
         $contextPath = '/foo/bar@user-demo';
@@ -174,9 +168,7 @@ class NodeConverterTest extends UnitTestCase
         $this->nodeConverter->convertFrom($source, null, [], $this->mockConverterConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertFromUsesPropertyMapperToConvertNodePropertyOfArrayType()
     {
         $contextPath = '/foo/bar@user-demo';
@@ -204,9 +196,7 @@ class NodeConverterTest extends UnitTestCase
         $this->nodeConverter->convertFrom($source, null, [], $this->mockConverterConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertFromDecodesJsonEncodedArraysAsAssociative()
     {
         $contextPath = '/foo/bar@user-demo';

--- a/Neos.ContentRepository/Tests/Unit/TypeConverter/NodeConverterTest.php
+++ b/Neos.ContentRepository/Tests/Unit/TypeConverter/NodeConverterTest.php
@@ -95,11 +95,20 @@ class NodeConverterTest extends UnitTestCase
         $nodePath = '/foo/bar';
 
         $mockNode = $this->setUpNodeWithNodeType($nodePath);
+        $matcher = self::atLeast(2);
 
-        $this->mockConverterConfiguration->expects(self::atLeast(2))
-            ->method('getConfigurationValue')
-            ->withConsecutive([NodeConverter::class, NodeConverter::INVISIBLE_CONTENT_SHOWN], [NodeConverter::class, NodeConverter::REMOVED_CONTENT_SHOWN])
-            ->willReturn(true);
+        $this->mockConverterConfiguration->expects($matcher)
+            ->method('getConfigurationValue')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame(NodeConverter::class, $parameters[0]);
+                $this->assertSame(NodeConverter::INVISIBLE_CONTENT_SHOWN, $parameters[1]);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame(NodeConverter::class, $parameters[0]);
+                $this->assertSame(NodeConverter::REMOVED_CONTENT_SHOWN, $parameters[1]);
+            }
+            return true;
+        });
 
         $result = $this->nodeConverter->convertFrom($contextPath, null, [], $this->mockConverterConfiguration);
         self::assertSame($mockNode, $result);
@@ -129,7 +138,7 @@ class NodeConverterTest extends UnitTestCase
 
         $mockNode = $this->setUpNodeWithNodeType($nodePath, $nodeTypeProperties);
 
-        $mockNode->getContext()->expects(self::once())->method('getNodeByIdentifier')->with($propertyValue)->will(self::returnValue($convertedPropertyValue));
+        $mockNode->getContext()->expects(self::once())->method('getNodeByIdentifier')->with($propertyValue)->willReturn($convertedPropertyValue);
 
         $mockNode->expects(self::once())->method('setProperty')->with('reference', $convertedPropertyValue);
 
@@ -158,10 +167,18 @@ class NodeConverterTest extends UnitTestCase
 
         /** @var Context|MockObject $mockContext */
         $mockContext = $mockNode->getContext();
-        $mockContext->expects(self::atLeast(2))
-            ->method('getNodeByIdentifier')
-            ->withConsecutive([current($decodedPropertyValue)], [end($decodedPropertyValue)])
-            ->willReturnOnConsecutiveCalls(current($convertedPropertyValue), end($convertedPropertyValue));
+        $matcher = self::atLeast(2);
+        $mockContext->expects($matcher)
+            ->method('getNodeByIdentifier')->willReturnCallback(function (...$parameters) use ($matcher, $decodedPropertyValue, $convertedPropertyValue) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame(current($decodedPropertyValue), $parameters[0]);
+                return current($convertedPropertyValue);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame(end($decodedPropertyValue), $parameters[0]);
+                return end($convertedPropertyValue);
+            }
+        });
 
         $mockNode->expects(self::once())->method('setProperty')->with('references', $convertedPropertyValue);
 
@@ -188,9 +205,9 @@ class NodeConverterTest extends UnitTestCase
 
         $mockNode = $this->setUpNodeWithNodeType($nodePath, $nodeTypeProperties);
 
-        $this->mockObjectManager->expects(self::any())->method('isRegistered')->with(Asset::class)->will(self::returnValue(true));
+        $this->mockObjectManager->expects(self::any())->method('isRegistered')->with(Asset::class)->willReturn(true);
 
-        $this->mockPropertyMapper->expects(self::once())->method('convert')->with($decodedPropertyValue, $nodeTypeProperties['assets']['type'])->will(self::returnValue($convertedPropertyValue));
+        $this->mockPropertyMapper->expects(self::once())->method('convert')->with($decodedPropertyValue, $nodeTypeProperties['assets']['type'])->willReturn($convertedPropertyValue);
         $mockNode->expects(self::once())->method('setProperty')->with('assets', $convertedPropertyValue);
 
         $this->nodeConverter->convertFrom($source, null, [], $this->mockConverterConfiguration);
@@ -230,20 +247,20 @@ class NodeConverterTest extends UnitTestCase
 
         $mockNode = $this->createMock(NodeInterface::class);
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $mockNodeType->expects(self::any())->method('getProperties')->will(self::returnValue($nodeTypeProperties));
-        $mockNode->expects(self::any())->method('getNodeType')->will(self::returnValue($mockNodeType));
+        $mockNodeType->expects(self::any())->method('getProperties')->willReturn($nodeTypeProperties);
+        $mockNode->expects(self::any())->method('getNodeType')->willReturn($mockNodeType);
 
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $mockContext->expects(self::any())->method('getWorkspace')->will(self::returnValue($mockLiveWorkspace));
-        $mockContext->expects(self::any())->method('getNode')->with($nodePath)->will(self::returnValue($mockNode));
+        $mockContext->expects(self::any())->method('getWorkspace')->willReturn($mockLiveWorkspace);
+        $mockContext->expects(self::any())->method('getNode')->with($nodePath)->willReturn($mockNode);
 
-        $mockNode->expects(self::any())->method('getContext')->will(self::returnValue($mockContext));
+        $mockNode->expects(self::any())->method('getContext')->willReturn($mockContext);
 
         // Simulate context properties by returning the same properties that were given to the ContextFactory
-        $this->mockContextFactory->expects(self::any())->method('create')->will(self::returnCallback(function ($contextProperties) use ($mockContext) {
-            $mockContext->expects(self::any())->method('getProperties')->will(self::returnValue($contextProperties));
+        $this->mockContextFactory->expects(self::any())->method('create')->willReturnCallback(function ($contextProperties) use ($mockContext) {
+            $mockContext->expects(self::any())->method('getProperties')->willReturn($contextProperties);
             return $mockContext;
-        }));
+        });
 
         return $mockNode;
     }

--- a/Neos.ContentRepository/Tests/Unit/Utility/NodePathsTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Utility/NodePathsTest.php
@@ -11,6 +11,7 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Utility;
  * source code.
  */
 
+use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 
@@ -18,7 +19,7 @@ use Neos\ContentRepository\Domain\Utility\NodePaths;
  * Testcase for the NodeService
  *
  */
-class NodePathsTest extends \Neos\Flow\Tests\UnitTestCase
+class NodePathsTest extends UnitTestCase
 {
     /**
      * @test

--- a/Neos.ContentRepository/Tests/Unit/Utility/NodePathsTest.php
+++ b/Neos.ContentRepository/Tests/Unit/Utility/NodePathsTest.php
@@ -10,8 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit\Domain\Utility;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 
@@ -21,9 +21,7 @@ use Neos\ContentRepository\Domain\Utility\NodePaths;
  */
 class NodePathsTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function generateRandomNodeNameReturnsValidNodeName()
     {
         for ($i=0; $i<25; $i++) {

--- a/Neos.ContentRepository/Tests/Unit/UtilityTest.php
+++ b/Neos.ContentRepository/Tests/Unit/UtilityTest.php
@@ -10,7 +10,8 @@ namespace Neos\ContentRepository\Tests\Unit;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\ContentRepository\Utility;
 
@@ -23,7 +24,7 @@ class UtilityTest extends UnitTestCase
      *
      * @return array
      */
-    public function sourcesAndNodeNames()
+    public static function sourcesAndNodeNames()
     {
         return [
             ['Überlandstraßen; adé', 'uberlandstrassen-ade'],
@@ -45,10 +46,8 @@ class UtilityTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider sourcesAndNodeNames
-     */
+    #[DataProvider('sourcesAndNodeNames')]
+    #[Test]
     public function renderValidNodeNameWorks($source, $expectedNodeName)
     {
         self::assertEquals($expectedNodeName, Utility::renderValidNodeName($source));

--- a/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/AfxServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Neos\Fusion\Afx\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Afx\Exception\AfxException;
 use Neos\Fusion\Afx\Parser\AfxParserException;
 use Neos\Fusion\Afx\Service\AfxService;
@@ -8,9 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class AfxServiceTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyCodeConvertedToEmptyFusion(): void
     {
         $afxCode = '';
@@ -20,9 +19,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function whitepaceCodeIsConvertedToEmptyFusion(): void
     {
         $afxCode = '   ';
@@ -32,9 +29,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function htmlTagsAreConvertedToFusionTags(): void
     {
         $afxCode = '<h1></h1>';
@@ -46,9 +41,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function htmlTagsWithSpaceContentAreConvertedToFusionTags(): void
     {
         $afxCode = '<h1>   </h1>';
@@ -61,9 +54,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function htmlTagsWithIgnoredContentAreConvertedToFusionTags(): void
     {
         $afxCode = <<<'EOF'
@@ -81,9 +72,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleHtmlTagsAreConvertedToFusionArray(): void
     {
         $afxCode = '<h1></h1><p></p><p></p>';
@@ -103,9 +92,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleHtmlTagsAndTextsAreConvertedToFusionArray(): void
     {
         $afxCode = 'Foo<h1></h1>Bar<p></p>Baz';
@@ -125,9 +112,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function whitepaceAroundAfxIsIgnored(): void
     {
         $afxCode = '  <h1></h1><p></p>  ';
@@ -144,9 +129,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleHtmlTagsAreConvertedToFusionTags(): void
     {
         $afxCode = '<h1></h1><p></p><p></p>';
@@ -166,9 +149,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function whitespacesAndNewlinesAroundAfxCodeAreIgnored(): void
     {
         $afxCode = '
@@ -182,9 +163,7 @@ class AfxServiceTest extends TestCase
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function newlinesInsideStringsAreCollapsedToSpaces(): void
     {
         $afxCode = '
@@ -204,9 +183,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function htmlTagsAreConvertedToSelfClosingFusionTags(): void
     {
         $afxCode = '<h1/>';
@@ -219,9 +196,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributesInHtmlTagsAreConvertedToTagAttributes(): void
     {
         $afxCode = '<h1 content="bar" class="fooo" />';
@@ -236,9 +211,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function zeroAndSpaceInAttributesInHtmlTagsAreConvertedToTagAttributes(): void
     {
         $afxCode = '<h1 content="0" class=" " />';
@@ -254,9 +227,7 @@ EOF;
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sindgleQuotesAreEscapedInAttributesAndChildren(): void
     {
         $afxCode = '<h1 class="foo\'bar" >foo\'bar</h1>';
@@ -270,9 +241,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionTagsAreConvertedToFusionObjects(): void
     {
         $afxCode = '<Vendor.Site:Prototype/>';
@@ -283,9 +252,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributesInFusionTagsAreConvertedToFusionPropertiesOrEelExpressions(): void
     {
         $afxCode = '<Vendor.Site:Prototype foo="bar" baz="bam" />';
@@ -298,9 +265,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function metaAttributesOfFusionObjectTagsAreConvertedToFusionProperties(): void
     {
         $afxCode = '<Vendor.Site:Prototype @position="start" @if.hasTitle={title} />';
@@ -313,9 +278,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function metaAttributesOfHtmlTagsAreConvertedToFusionProperties(): void
     {
         $afxCode = '<div @position="start" @if.hasTitle={title} ></div>';
@@ -329,9 +292,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shorthandDirectMetaAttributesHaveAutoGeneratedPaths(): void
     {
         $afxCode = '<Vendor.Site:Prototype @if={eel1} @if={eel2} @process={eel3} @process={eel4} />';
@@ -346,9 +307,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shorthandNestedMetaAttributesOfFusionObjectHaveAutoGeneratedPaths(): void
     {
         $afxCode = '<Vendor.Site:Prototype image.@if={eel1} image.@if={eel2} text.@if={eel3} data.@process={eel4} />';
@@ -363,9 +322,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shorthandNestedMetaAttributesOfTagHaveAutoGeneratedPaths(): void
     {
         $afxCode = '<h1 class.@if={eel1} style.@if={eel2} class.@if={eel3} data.@process={eel4} ></h1>';
@@ -381,9 +338,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function contentOfHtmlTagsIsRenderedAsFusionContent(): void
     {
         $afxCode = '<h1>Fooo</h1>';
@@ -396,9 +351,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function zeroInContentOfHtmlTagsIsRenderedAsFusionContent(): void
     {
         $afxCode = '<h1>0</h1>';
@@ -411,9 +364,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spaceInContentOfHtmlTagsIsRenderedAsFusionContent(): void
     {
         $afxCode = '<h1> </h1>';
@@ -426,9 +377,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function contentOfFusionTagsIsRenderedAsFusionRenderer(): void
     {
         $afxCode = '<Vendor.Site:Prototype>Fooo</Vendor.Site:Prototype>';
@@ -440,9 +389,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function textContentOfHtmlTagsIsRenderedAsConfiguredChildrenProperty(): void
     {
         $afxCode = '<Vendor.Site:Prototype @children="children">Fooo</Vendor.Site:Prototype>';
@@ -454,9 +401,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelContentOfHtmlTagsIsRenderedAsConfiguredChildrenProperty(): void
     {
         $afxCode = '<Vendor.Site:Prototype @children="children">{eelExpression()}</Vendor.Site:Prototype>';
@@ -468,9 +413,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexChildrenAreRenderedAsArray(): void
     {
         $afxCode = '<h1><strong>foo</strong><i>bar</i></h1>';
@@ -492,9 +435,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexChildrenAreRenderedAsArrayIgnoringWhitespaceInBetween(): void
     {
         $afxCode = <<<'EOF'
@@ -525,9 +466,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexChildrenAreRenderedAsArrayWithOptionalKeys(): void
     {
         $afxCode = '<h1><strong @key="key_one">foo</strong><i @key="key_two">bar</i></h1>';
@@ -549,9 +488,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexChildrenAreCanContainTagsAnsValues(): void
     {
         $afxCode = '<h1>a string<strong>a tag</strong>{eelExpression()}</h1>';
@@ -571,9 +508,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childrenWithPathesAreRendered(): void
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="namedProp">foo</strong></Vendor.Site:Prototype>';
@@ -588,9 +523,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleChildrenWithPathesAreRendered(): void
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="propOne">foo</strong><Vendor.Site:Prototype @path="propTwo">bar</Vendor.Site:Prototype></Vendor.Site:Prototype>';
@@ -608,9 +541,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childrenWithPathesAreCompatibleWithContentChildren(): void
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="propOne">foo</strong><Vendor.Site:Prototype @path="propTwo">bar</Vendor.Site:Prototype><div>a tag</div><div>another tag</div></Vendor.Site:Prototype>';
@@ -638,9 +569,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childrenWithDeepPathsAreSupported(): void
     {
         $afxCode = '<Vendor.Site:Prototype><strong @path="a.fusion.path">foo</strong><Vendor.Site:Prototype @path="another.fusion.path">bar</Vendor.Site:Prototype></Vendor.Site:Prototype>';
@@ -658,9 +587,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spacesNewLinesAndSpacesAroundAreIgnored(): void
     {
         $afxCode = '<h1>
@@ -682,9 +609,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spacesInsideALineArePreserved(): void
     {
         $afxCode = '<h1>
@@ -704,9 +629,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spacesInsideALineArePreservedAlsoForStrings(): void
     {
         $afxCode = '<h1>
@@ -726,9 +649,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spreadsAreEvaluatedForFusionObjectTags(): void
     {
         $afxCode = '<Vendor.Site:Prototype {...spreadExpression} />';
@@ -741,9 +662,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spreadsCanMixWithPropsForFusionObjectTags(): void
     {
         $afxCode = '<Vendor.Site:Prototype stringBefore="string" expressionBefore={expression} {...spreadExpression} stringAfter="string" expressionAfter={expression} />';
@@ -763,9 +682,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spreadsAreEvaluetedForHtmlTags(): void
     {
         $afxCode = '<h1 {...spreadExpression} />';
@@ -780,9 +697,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function spreadsCanMixWithPropsForHtmlTags(): void
     {
         $afxCode = '<h1 stringBefore="string" expressionBefore={expression} {...spreadExpression} stringAfter="string" expressionAfter={expression} />';
@@ -803,9 +718,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function slashesInTextNodesArePreserved(): void
     {
         $afxCode = '<h1>\o/</h1>';
@@ -819,9 +732,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function textsAreEscaped(): void
     {
         $afxCode = <<<'EOF'
@@ -837,9 +748,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function commentsAreIgnored(): void
     {
         $afxCode = <<<'EOF'
@@ -860,9 +769,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function standaloneCommentsAreIgnored(): void
     {
         $afxCode = <<<'EOF'
@@ -875,9 +782,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function standaloneCommentsChildrenAreIgnored(): void
     {
         $afxCode = <<<'EOF'
@@ -893,9 +798,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multilineCommentsAreIgnored(): void
     {
         $afxCode = <<<'EOF'
@@ -918,9 +821,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function slashesInStringNodesArePreserved()
     {
         $afxCode = <<<'EOF'
@@ -937,9 +838,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function stringsAreEscaped()
     {
         $afxCode = <<<'EOF'
@@ -956,9 +855,7 @@ EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unclosedTagsRaisesException(): void
     {
         $this->expectException(AfxParserException::class);
@@ -966,9 +863,7 @@ EOF;
         AfxService::convertAfxToFusion($afxCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unclosedAttributeRaisesException(): void
     {
         $this->expectException(AfxParserException::class);
@@ -976,9 +871,7 @@ EOF;
         AfxService::convertAfxToFusion($afxCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unclosedExpressionRaisesException(): void
     {
         $this->expectException(AfxParserException::class);
@@ -986,9 +879,7 @@ EOF;
         AfxService::convertAfxToFusion($afxCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unclosedSpreadRaisesException(): void
     {
         $this->expectException(AfxParserException::class);
@@ -996,9 +887,7 @@ EOF;
         AfxService::convertAfxToFusion($afxCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childPathAnnotationWithExpressionRaisesException(): void
     {
         $this->expectException(AfxException::class);
@@ -1006,9 +895,7 @@ EOF;
         AfxService::convertAfxToFusion($afxCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function keyAnnotationWithExpressionRaisesException(): void
     {
         $this->expectException(AfxException::class);
@@ -1016,9 +903,7 @@ EOF;
         AfxService::convertAfxToFusion($afxCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childrenAnnotationWithExpressionRaisesException(): void
     {
         $this->expectException(AfxException::class);

--- a/Neos.Fusion.Afx/Tests/Functional/ParserTest.php
+++ b/Neos.Fusion.Afx/Tests/Functional/ParserTest.php
@@ -1,15 +1,14 @@
 <?php
 namespace Neos\Fusion\Afx\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Afx\Parser\AfxParserException;
 use Neos\Fusion\Afx\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 
 class ParserTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseEmptyCode(): void
     {
         $parser = new Parser('');
@@ -20,9 +19,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseBlankCode(): void
     {
         $parser = new Parser('    ');
@@ -38,9 +35,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseASingleExpression(): void
     {
         $parser = new Parser('{String.uppercase("test")}');
@@ -58,9 +53,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTag(): void
     {
         $parser = new Parser('<div></div>');
@@ -81,9 +74,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTagWithContent(): void
     {
         $parser = new Parser('<div>test</div>');
@@ -109,9 +100,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTagWithContentExpression(): void
     {
         $parser = new Parser('<div>{String.uppercase("test")}</div>');
@@ -139,9 +128,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTagWithZeroAsContent(): void
     {
         $parser = new Parser('<div>0</div>');
@@ -167,9 +154,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTag(): void
     {
         $parser = new Parser('<div/>');
@@ -190,9 +175,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTagWithWhitespaces(): void
     {
         $parser = new Parser('<div   />');
@@ -213,9 +196,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTagWithWhitespaces(): void
     {
         $parser = new Parser('<div   ></div>');
@@ -236,9 +217,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTagWithSingleAttribute(): void
     {
         $parser = new Parser('<div prop="value"/>');
@@ -268,9 +247,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTagWithSingleAttributeExpression(): void
     {
         $parser = new Parser('<div prop={"value" + "a"}/>');
@@ -302,9 +279,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTagWithEmptyAttribute(): void
     {
         $parser = new Parser('<div prop/>');
@@ -334,9 +309,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTagWithMultipleAttributes(): void
     {
         $parser = new Parser('<div prop="value" anotherProp="Another Value"/>');
@@ -374,9 +347,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleSelfClosingTagWithMultipleAttributesWrappedByMultipleWhitespaces(): void
     {
         $parser = new Parser('<div   prop="value"    anotherProp="Another Value"  />');
@@ -414,9 +385,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseTagWithSingleOrDoubleQuoteEscapedAttributeIdentifier(): void
     {
         $parser = new Parser('<div "@click.blah.blih.blub"="value" \'@click.blah.blih.blub\'="value"/>');
@@ -454,9 +423,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseTagWithEscapedAttributeIdentifierWithQuoteEscapesInside(): void
     {
         $parser = new Parser('<div "@click.escaped\"escaped"="value" \'escaped\\\'escaped\' />');
@@ -494,9 +461,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSpreads(): void
     {
         $parser = new Parser('<div {...item} />');
@@ -527,9 +492,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSpreadsAndPropsInOrder(): void
     {
         $parser = new Parser('<div foo="string" {...item} bar={expression} />');
@@ -578,9 +541,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseListOfTags(): void
     {
         $parser = new Parser('<div></div><span></span><h1></h1>');
@@ -619,9 +580,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseListOfTagsAndTextsWithTextOutside(): void
     {
         $parser = new Parser('foo<div></div>bar');
@@ -650,9 +609,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseListOfTagsAndTextsWithTagsOutside(): void
     {
         $parser = new Parser('<div></div>foobar<span></span>');
@@ -686,9 +643,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseListOfTagsAndTextsWithWhitepaceOutside(): void
     {
         $parser = new Parser('    <div></div>    ');
@@ -717,9 +672,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function propsCanHaveDashesInTheirName(): void
     {
         $parser = new Parser('<div prop-1="value" prop-2="Another Value"/>');
@@ -757,9 +710,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTagWithSeparateClosingTag(): void
     {
         $parser = new Parser('<div></div>');
@@ -780,9 +731,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseSingleTagWithSeparateClosingTagAndOneChild(): void
     {
         $parser = new Parser('<div>Hello World!</div>');
@@ -808,9 +757,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseNestedSelfClosingTag(): void
     {
         $parser = new Parser('<div><input/></div>');
@@ -841,9 +788,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseNestedTags(): void
     {
         $parser = new Parser('<article><header><div>Header</div></header><div>Content</div><footer><div>Footer</div></footer></article>');
@@ -927,9 +872,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldHandleWhitespace(): void
     {
         $parser = new Parser('   <div>
@@ -1004,9 +947,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseComments(): void
     {
         $parser = new Parser('<!-- lorem ipsum -->');
@@ -1021,9 +962,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldIgnoreTagsAndExpressionsInComments(): void
     {
         $parser = new Parser('<!-- <foo>{bar}</foo> -->');
@@ -1038,9 +977,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseCommentsBeforeContent(): void
     {
         $parser = new Parser('<!--lorem ipsum--><div />');
@@ -1064,9 +1001,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseCommentsAfterContent(): void
     {
         $parser = new Parser('<div/><!--lorem ipsum-->');
@@ -1090,9 +1025,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldParseCommentsInsideContent(): void
     {
         $parser = new Parser('<div><!--lorem ipsum--></div>');
@@ -1117,9 +1050,7 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForUnclosedTag(): void
     {
         $this->expectException(AfxParserException::class);
@@ -1127,9 +1058,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForUnclosedTagWithContent(): void
     {
         $this->expectException(AfxParserException::class);
@@ -1137,9 +1066,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForUnclosedStringAttribute(): void
     {
         $this->expectException(AfxParserException::class);
@@ -1147,9 +1074,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForUnclosedAttributeExpression(): void
     {
         $this->expectException(AfxParserException::class);
@@ -1157,9 +1082,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForUnclosedContentExpression(): void
     {
         $this->expectException(AfxParserException::class);
@@ -1167,9 +1090,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForUnclosedSpreadExpression(): void
     {
         $this->expectException(AfxParserException::class);
@@ -1177,9 +1098,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForWronglyStartedComment()
     {
         $this->expectException(AfxParserException::class);
@@ -1187,9 +1106,7 @@ class ParserTest extends TestCase
         $parser->parse();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionForCommentWithoutProperEnd()
     {
         $this->expectException(AfxParserException::class);

--- a/Neos.Fusion.Afx/composer.json
+++ b/Neos.Fusion.Afx/composer.json
@@ -16,7 +16,7 @@
     "neos/fusion": "self.version"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0"
+    "phpunit/phpunit": "~11.5"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Fusion/Tests/Benchmark/RuntimeBench.php
+++ b/Neos.Fusion/Tests/Benchmark/RuntimeBench.php
@@ -11,6 +11,11 @@ namespace Neos\Fusion\Tests\Benchmark;
  * source code.
  */
 
+use Neos\Fusion\FusionObjects\ValueImplementation;
+use Neos\Fusion\Core\RuntimeFactory;
+use Neos\Utility\ObjectAccess;
+use Neos\Cache\Backend\TransientMemoryBackend;
+use Neos\Cache\Frontend\StringFrontend;
 use Neos\Eel\CompilingEvaluator;
 
 /**
@@ -87,17 +92,17 @@ class RuntimeBench
             '__prototypes' => [
                 'Neos.Fusion:Value' => [
                     '__meta' => [
-                        'class' => \Neos\Fusion\FusionObjects\ValueImplementation::class
+                        'class' => ValueImplementation::class
                     ]
                 ]
             ]
         ];
-        $runtimeFactory = new \Neos\Fusion\Core\RuntimeFactory();
+        $runtimeFactory = new RuntimeFactory();
         $this->runtime = $runtimeFactory->create($fusionConfiguration);
 
         // Build an EEL evaluator suitable for benchmarking
         $evaluator = $this->buildEelEvaluator();
-        \Neos\Utility\ObjectAccess::setProperty($this->runtime, 'eelEvaluator', $evaluator, true);
+        ObjectAccess::setProperty($this->runtime, 'eelEvaluator', $evaluator, true);
 
         $this->runtime->pushContextArray([
             'foo' => 'Hello expression!'
@@ -164,8 +169,8 @@ class RuntimeBench
     {
         $evaluator = new CompilingEvaluator();
 
-        $backend = new \Neos\Cache\Backend\TransientMemoryBackend();
-        $frontend = new \Neos\Cache\Frontend\StringFrontend('expressions', $backend);
+        $backend = new TransientMemoryBackend();
+        $frontend = new StringFrontend('expressions', $backend);
         $backend->setCache($frontend);
 
         $evaluator->injectExpressionCache($frontend);

--- a/Neos.Fusion/Tests/Functional/FusionObjects/AbstractFusionObjectTestCase.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/AbstractFusionObjectTestCase.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\ServerRequestFactoryInterface;
  * Testcase for the Fusion View
  *
  */
-abstract class AbstractFusionObjectTest extends FunctionalTestCase
+abstract class AbstractFusionObjectTestCase extends FunctionalTestCase
 {
     /**
      * @var ControllerContext

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ActionUriTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ActionUriTest.php
@@ -10,11 +10,10 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the UriBuilder object
  */
-class ActionUriTest extends AbstractFusionObjectTest
+class ActionUriTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ActionUriTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ActionUriTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -15,9 +17,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ActionUriTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function buildRelativeUriToAction()
     {
         $this->registerRoute(

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ApplyTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueRendering()
     {
         $view = $this->buildView();
@@ -26,9 +26,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('original eel expression', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithSingleSpreadRendering()
     {
         $view = $this->buildView();
@@ -36,9 +34,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('altered eel expression', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithInvalidFusionObjectSpreadRendering()
     {
         $view = $this->buildView();
@@ -46,9 +42,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('original eel expression', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithInvalidExpressionSpreadRendering()
     {
         $view = $this->buildView();
@@ -56,9 +50,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('original eel expression', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueInvalidCyclicExpressionSpreadRendering()
     {
         $view = $this->buildView();
@@ -66,9 +58,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals(null, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithFusionObjectSpreadRendering()
     {
         $view = $this->buildView();
@@ -76,9 +66,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('altered eel expression', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithMultipleSpreadRendering()
     {
         $view = $this->buildView();
@@ -86,9 +74,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('altered eel expression 3', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithMultipleOrderedSpreadRendering()
     {
         $view = $this->buildView();
@@ -96,9 +82,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('altered eel expression to be evaluated last', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithProcessorRendering()
     {
         $view = $this->buildView();
@@ -106,9 +90,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('foo:original eel expression:bar', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelValueWithProcessorAndSingleSpreadRendering()
     {
         $view = $this->buildView();
@@ -116,9 +98,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('foo:altered eel expression:bar', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithNonMatchingIfConditionRendering()
     {
         $view = $this->buildView();
@@ -126,9 +106,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals(null, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithNonMatchingIfConditionThatUseSpreadValuesRendering()
     {
         $view = $this->buildView();
@@ -136,9 +114,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals(null, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithNonMatchingIfConditionIfSpreadAltersValueRendering()
     {
         $view = $this->buildView();
@@ -146,9 +122,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals(null, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithNonMatchingIfConditionIfSpreadAltersValueAndEnabledConditionRendering()
     {
         $view = $this->buildView();
@@ -156,9 +130,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('altered value', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valueWithMatchingIfConditionThatUseSpreadValuesRendering()
     {
         $view = $this->buildView();
@@ -166,9 +138,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('enabled value', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prototypeWithNonMatchingIfConditionRendering()
     {
         $view = $this->buildView();
@@ -176,9 +146,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals(null, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prototypeWithNonMatchingIfConditionThatUseSpreadValuesRendering()
     {
         $view = $this->buildView();
@@ -186,9 +154,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals(null, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prototypeWithMatchingIfConditionThatUseSpreadValuesRendering()
     {
         $view = $this->buildView();
@@ -196,9 +162,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('enabled value', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedPrototypeRendering()
     {
         $view = $this->buildView();
@@ -206,9 +170,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('expression from nested prototypes', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedPrototypeOverriddenWithSpreadsRendering()
     {
         $view = $this->buildView();
@@ -216,9 +178,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('i can change this', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function loopWithoutSpreadRendering()
     {
         $view = $this->buildView();
@@ -226,9 +186,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('X1X2X2X3', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function loopWithSpreadRendering()
     {
         $view = $this->buildView();
@@ -236,9 +194,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('X1X2X2X3', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWithTypeAndElementSpreadRendering()
     {
         $view = $this->buildView();
@@ -246,9 +202,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('XValueAppliedViaElementSpread', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dataStructureWithSpreadRendering()
     {
         $view = $this->buildView();
@@ -263,9 +217,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function joinWithPositionAndSpreadRendering()
     {
         $view = $this->buildView();
@@ -276,9 +228,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWithNestedPropsInApply()
     {
         $view = $this->buildView();
@@ -286,9 +236,7 @@ class ApplyTest extends AbstractFusionObjectTestCase
         self::assertEquals('::example::', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateLazyPropsWithLastOneSkipped()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ApplyTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for basic Fusion spread rendering
  *
  */
-class ApplyTest extends AbstractFusionObjectTest
+class ApplyTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/BasicRenderingTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/BasicRenderingTest.php
@@ -17,7 +17,7 @@ use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
  * Testcase for basic Fusion rendering
  *
  */
-class BasicRenderingTest extends AbstractFusionObjectTest
+class BasicRenderingTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/BasicRenderingTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/BasicRenderingTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
 
 /**
@@ -19,9 +19,7 @@ use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
  */
 class BasicRenderingTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicRendering()
     {
         $view = $this->buildView();
@@ -29,9 +27,7 @@ class BasicRenderingTest extends AbstractFusionObjectTestCase
         self::assertEquals('XHello World', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicRenderingReusingFusionVariables()
     {
         $view = $this->buildView();
@@ -46,9 +42,8 @@ class BasicRenderingTest extends AbstractFusionObjectTestCase
      *
      * The default handler for the tests rethrows the exception
      * TODO: test different exception handlers
-     *
-     * @test
      */
+    #[Test]
     public function basicRenderingCrashing()
     {
         $this->expectException(InvalidTemplateResourceException::class);
@@ -57,9 +52,7 @@ class BasicRenderingTest extends AbstractFusionObjectTestCase
         self::assertEquals('XHello World', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicRenderingReusingFusionVariablesWithEel()
     {
         $view = $this->buildView();
@@ -67,9 +60,7 @@ class BasicRenderingTest extends AbstractFusionObjectTestCase
         self::assertEquals('XHello World', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexExample()
     {
         $view = $this->buildView();
@@ -77,9 +68,7 @@ class BasicRenderingTest extends AbstractFusionObjectTestCase
         self::assertEquals('Static string post', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexExample2()
     {
         $view = $this->buildView();
@@ -87,33 +76,25 @@ class BasicRenderingTest extends AbstractFusionObjectTestCase
         self::assertEquals('Static string post', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function plainValueCanBeOverridden()
     {
         $this->assertMultipleFusionPaths('overridden', 'basicRendering/overridePlainValueWith');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function eelExpressionCanBeOverridden()
     {
         $this->assertMultipleFusionPaths('overridden', 'basicRendering/overrideEelWith');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionCanBeOverridden()
     {
         $this->assertMultipleFusionPaths('overridden', 'basicRendering/overrideFusionWith');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function contentIsNotTrimmed()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/CaseTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/CaseTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -27,17 +29,13 @@ class CaseTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xtestconditionfalse', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function numericMatchingWorks()
     {
         $this->assertMatchingWorks('case/numericMatching');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchingWithDebugModeWorks()
     {
         $view = $this->buildView();
@@ -52,73 +50,55 @@ class CaseTest extends AbstractFusionObjectTestCase
         self::assertStringContainsString('Xtestconditionfalse', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function positionalMatchingWorks()
     {
         $this->assertMatchingWorks('case/positionalMatching');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderPathWillRenderAbsolutePath()
     {
         $this->assertMatchingWorks('case/renderPath');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderPathWillWinOverType()
     {
         $this->assertMatchingWorks('case/renderPathWillWin');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ignorePropertiesWorks()
     {
         $this->assertMatchingWorks('case/ignoredPropertiesAreIgnored');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function usingRendererWorks()
     {
         $this->assertMatchingWorks('case/renderer');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWinsOverType()
     {
         $this->assertMatchingWorks('case/rendererWithType');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWinsOverRenderPath()
     {
         $this->assertMatchingWorks('case/rendererWithRenderPath');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWorksWithEelAndSimpleTypes()
     {
         $this->assertMatchingWorks('case/rendererWorksWithEelAndSimpleTypes');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererHasAccessToThis()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/CaseTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/CaseTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Case Fusion object
  *
  */
-class CaseTest extends AbstractFusionObjectTest
+class CaseTest extends AbstractFusionObjectTestCase
 {
     public function assertMatchingWorks($path)
     {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/CollectionTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/CollectionTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Collection Fusion object
  *
  */
-class CollectionTest extends AbstractFusionObjectTest
+class CollectionTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/CollectionTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/CollectionTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class CollectionTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicCollectionWorks()
     {
         $view = $this->buildView();
@@ -27,9 +27,7 @@ class CollectionTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1Xelement2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicCollectionWorksAndStillContainsOtherContextVariables()
     {
         $view = $this->buildView();
@@ -39,9 +37,7 @@ class CollectionTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1varXelement2var', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyCollectionReturnsEmptyString()
     {
         $view = $this->buildView();
@@ -50,9 +46,7 @@ class CollectionTest extends AbstractFusionObjectTestCase
         self::assertEquals('', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function iterationInformationIsAddedToCollection()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Component Fusion object
  *
  */
-class ComponentTest extends AbstractFusionObjectTest
+class ComponentTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ComponentTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ComponentTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function componentBasicRenderer()
     {
         $view = $this->buildView();
@@ -26,9 +26,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Hello World', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentNestedRenderer()
     {
         $view = $this->buildView();
@@ -36,9 +34,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Hello World', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentStaticRenderer()
     {
         $view = $this->buildView();
@@ -46,9 +42,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Hello World', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentSandboxRenderer()
     {
         $view = $this->buildView();
@@ -56,9 +50,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Hello ', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentLazyRenderer()
     {
         $view = $this->buildView();
@@ -66,9 +58,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Hello', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentWrapperRenderer()
     {
         $view = $this->buildView();
@@ -76,9 +66,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Default content', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivate()
     {
         $view = $this->buildView();
@@ -86,9 +74,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('MoinMoin!<div>Moin</div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateLazy()
     {
         $view = $this->buildView();
@@ -96,9 +82,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('MoinMoin!', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateSelfReferencing()
     {
         $view = $this->buildView();
@@ -106,9 +90,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Moin!Moin!', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateNotDefined()
     {
         $this->expectException(\RuntimeException::class);
@@ -119,9 +101,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateSelfReferencingInfiniteLoop()
     {
         $this->expectException(\RuntimeException::class);
@@ -131,9 +111,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateSelfReferencingInfiniteLoopComplex()
     {
         $this->expectException(\RuntimeException::class);
@@ -143,9 +121,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateCannotBeApplied()
     {
         $view = $this->buildView();
@@ -153,9 +129,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateCannotBeLooped()
     {
         $this->expectException(\TypeError::class);
@@ -164,9 +138,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateScopeIsIsolatedFromOtherPrivate()
     {
         $this->expectException(\RuntimeException::class);
@@ -177,9 +149,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateScopeIsIsolatedInRenderer()
     {
         $this->expectException(\RuntimeException::class);
@@ -190,9 +160,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateScopeIsReachableInProps()
     {
         $view = $this->buildView();
@@ -200,9 +168,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals("Moin", $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateLegacyPatternWorks()
     {
         $view = $this->buildView();
@@ -210,9 +176,7 @@ class ComponentTest extends AbstractFusionObjectTestCase
         self::assertEquals('Moin', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function componentPrivateOuterContextIsOverridden()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Attributes\Test;
  */
 class ConditionsTest extends AbstractFusionObjectTestCase
 {
-    public function conditionExamples()
+    public static function conditionExamples()
     {
         return [
             ['conditions/simpleValueTrue', 'Foo'],
@@ -53,7 +53,7 @@ class ConditionsTest extends AbstractFusionObjectTestCase
         self::assertSame($expected, $view->render());
     }
 
-    public function valuesForCondition()
+    public static function valuesForCondition()
     {
         return [
             [false, null],

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
@@ -10,11 +10,10 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for conditional rendering (if)
  */
-class ConditionsTest extends AbstractFusionObjectTest
+class ConditionsTest extends AbstractFusionObjectTestCase
 {
     public function conditionExamples()
     {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ConditionsTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -40,10 +43,8 @@ class ConditionsTest extends AbstractFusionObjectTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider conditionExamples
-     */
+    #[DataProvider('conditionExamples')]
+    #[Test]
     public function conditionsWork($path, $expected)
     {
         $view = $this->buildView();
@@ -69,10 +70,8 @@ class ConditionsTest extends AbstractFusionObjectTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider valuesForCondition
-     */
+    #[DataProvider('valuesForCondition')]
+    #[Test]
     public function everythingButFalseIsEvaluated($conditionValue, $expected)
     {
         $view = $this->buildView();
@@ -81,9 +80,7 @@ class ConditionsTest extends AbstractFusionObjectTestCase
         self::assertSame($expected, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function conditionsInFusionObjectsWithSubEvaluationUsedInProcessorRenderCorrectly()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -375,16 +375,16 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         $mockCache = $this->createMock(FrontendInterface::class);
         $this->inject($this->contentCache, 'cache', $mockCache);
 
-        $mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
-        $mockCache->expects(self::any())->method('has')->will(self::returnValue(false));
+        $mockCache->expects(self::any())->method('get')->willReturn(false);
+        $mockCache->expects(self::any())->method('has')->willReturn(false);
 
         $entriesWritten = [];
 
-        $mockCache->expects(self::atLeastOnce())->method('set')->will(self::returnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
+        $mockCache->expects(self::atLeastOnce())->method('set')->willReturnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
             $entriesWritten[$entryIdentifier] = [
                 'lifetime' => $lifetime
             ];
-        }));
+        });
 
         $firstRenderResult = $view->render();
         self::assertEquals('Foo|Bar|Baz|Qux', $firstRenderResult);
@@ -415,13 +415,13 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
     {
         $entriesWritten = [];
         $mockCache = $this->createMock(FrontendInterface::class);
-        $mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
-        $mockCache->expects(self::any())->method('has')->will(self::returnValue(false));
-        $mockCache->expects(self::atLeastOnce())->method('set')->will(self::returnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
+        $mockCache->expects(self::any())->method('get')->willReturn(false);
+        $mockCache->expects(self::any())->method('has')->willReturn(false);
+        $mockCache->expects(self::atLeastOnce())->method('set')->willReturnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
             $entriesWritten[$entryIdentifier] = [
                 'tags' => $tags
             ];
-        }));
+        });
         $this->inject($this->contentCache, 'cache', $mockCache);
 
         $object = new TestModel(42, 'Object value 1');
@@ -457,13 +457,13 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
     {
         $entriesWritten = [];
         $mockCache = $this->createMock(FrontendInterface::class);
-        $mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
-        $mockCache->expects(self::any())->method('has')->will(self::returnValue(false));
-        $mockCache->expects(self::atLeastOnce())->method('set')->will(self::returnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
+        $mockCache->expects(self::any())->method('get')->willReturn(false);
+        $mockCache->expects(self::any())->method('has')->willReturn(false);
+        $mockCache->expects(self::atLeastOnce())->method('set')->willReturnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
             $entriesWritten[$entryIdentifier] = [
                 'tags' => $tags
             ];
-        }));
+        });
         $this->inject($this->contentCache, 'cache', $mockCache);
 
         $view = $this->buildView();
@@ -493,28 +493,28 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
     {
         $entriesWritten = [];
         $mockCache = $this->createMock(FrontendInterface::class);
-        $mockCache->expects(self::any())->method('get')->will(self::returnCallback(function ($entryIdentifier) use ($entriesWritten) {
+        $mockCache->expects(self::any())->method('get')->willReturnCallback(function ($entryIdentifier) use ($entriesWritten) {
             if (isset($entriesWritten[$entryIdentifier])) {
                 return $entriesWritten[$entryIdentifier]['data'];
             } else {
                 return false;
             }
-        }));
-        $mockCache->expects(self::any())->method('has')->will(self::returnCallback(function ($entryIdentifier) use ($entriesWritten) {
+        });
+        $mockCache->expects(self::any())->method('has')->willReturnCallback(function ($entryIdentifier) use ($entriesWritten) {
             if (isset($entriesWritten[$entryIdentifier])) {
                 return true;
             } else {
                 return false;
             }
-        }));
-        $mockCache->expects(self::atLeastOnce())->method('set')->will(self::returnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
+        });
+        $mockCache->expects(self::atLeastOnce())->method('set')->willReturnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
             if (!isset($entriesWritten[$entryIdentifier])) {
                 $entriesWritten[$entryIdentifier] = [
                     'tags' => $tags,
                     'data' => $data
                 ];
             }
-        }));
+        });
         $this->inject($this->contentCache, 'cache', $mockCache);
 
         $object = new TestModel(42, 'Object value 1');

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -20,7 +20,7 @@ use Neos\Fusion\Tests\Functional\FusionObjects\Fixtures\Model\TestModel;
 /**
  * Test case for the Fusion ContentCache
  */
-class ContentCacheTest extends AbstractFusionObjectTest
+class ContentCacheTest extends AbstractFusionObjectTestCase
 {
     /**
      * @var ContentCache

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -402,7 +402,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         $view->setOption('enableContentCache', true);
         $view->setFusionPath('contentCache/maximumLifetimeInNestedEmbedAndCachedSegments');
 
-        $mockCache = $this->createMock(\Neos\Cache\Frontend\FrontendInterface::class);
+        $mockCache = $this->createMock(FrontendInterface::class);
         $this->inject($this->contentCache, 'cache', $mockCache);
 
         $mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
@@ -446,7 +446,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
     public function cacheUsesGlobalCacheIdentifiersAsDefaultPrototypeForEntryIdentifier()
     {
         $entriesWritten = [];
-        $mockCache = $this->createMock(\Neos\Cache\Frontend\FrontendInterface::class);
+        $mockCache = $this->createMock(FrontendInterface::class);
         $mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
         $mockCache->expects(self::any())->method('has')->will(self::returnValue(false));
         $mockCache->expects(self::atLeastOnce())->method('set')->will(self::returnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {
@@ -490,7 +490,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
     public function globalIdentifiersAreUsedWithBlankEntryIdentifiers()
     {
         $entriesWritten = [];
-        $mockCache = $this->createMock(\Neos\Cache\Frontend\FrontendInterface::class);
+        $mockCache = $this->createMock(FrontendInterface::class);
         $mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
         $mockCache->expects(self::any())->method('has')->will(self::returnValue(false));
         $mockCache->expects(self::atLeastOnce())->method('set')->will(self::returnCallback(function ($entryIdentifier, $data, $tags, $lifetime) use (&$entriesWritten) {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContentCacheTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Flow\Mvc\ActionRequest;
@@ -42,9 +42,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         $this->inject($this->contentCache, 'cache', $cacheFrontend);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderCachedSegmentTwiceYieldsSameResult()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -66,9 +64,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame($firstRenderResult, $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedCacheSegmentsAreFetchedFromCache()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -92,9 +88,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Outer segment|site=site2|Inner segment|object=Object value 1|End inner|End outer', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function uncachedSegmentOnTopLevelIsProcessedWithoutChanges()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -112,9 +106,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Uncached segment|counter=2|End uncached', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function uncachedSegmentWithWrongContextConfigurationWillTriggerErrorOnFirstHit()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -134,9 +126,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Uncached segment|counter=|End uncached', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function uncachedSegmentInCachedSegmentIsEvaluatedFromSerializedContext()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -157,9 +147,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Outer segment|object=Object value 1|Uncached segment|counter=2|End uncached|End outer', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function uncachedSegmentInUpdatedCachedSegmentIsEvaluatedFromContextValue()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -184,9 +172,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Outer segment|object=New object value|Uncached segment|counter=2|End uncached|End outer', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flushByTagFlushesCacheEntriesWithSpecificEntryTagsAndRerenderCreatesOuterSegment()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -214,9 +200,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Outer segment|counter=2|Inner segment 1|object=Object value 2|End innerInner segment 2|object=Object value 1|End inner|End outer', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function entryTagsUseSanitizedTagValue()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -248,9 +232,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Outer segment|counter=3|Inner segment 1|object=Object value 2|End innerInner segment 2|object=Object value 2|End inner|End outer', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processorsAreAppliedBeforeCachingASegment()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -268,9 +250,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame($firstRenderResult, $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processorsAreAppliedAfterUncachedSegments()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -288,9 +268,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Cached segment|Processor start|counter=2|Uncached segment|object=Object value 1|End cached|Processor end|End segment', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function conditionsAreAppliedAfterGettingCachedSegment()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -316,9 +294,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('', $updatedRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function conditionsAreAppliedForUncachedSegment()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -349,9 +325,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Cached segment||End segment', $updatedRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function handlingInnerRenderingExceptionsDisablesTheContentCache()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -369,9 +343,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertStringStartsWith('Cached segment|counter=2|Exception', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionInAlreadyCachedSegmentShouldNotLeaveSegmentMarkersInOutput()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -393,9 +365,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertStringStartsWith('Cached segment|counter=1|Exception', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function maximumLifetimeForCachedSegmentWillBeMinimumOfNestedEmbedSegmentsAndSelf()
     {
         $view = $this->buildView();
@@ -440,9 +410,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         ], $entriesWritten);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cacheUsesGlobalCacheIdentifiersAsDefaultPrototypeForEntryIdentifier()
     {
         $entriesWritten = [];
@@ -484,9 +452,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         ], $entriesWritten);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function globalIdentifiersAreUsedWithBlankEntryIdentifiers()
     {
         $entriesWritten = [];
@@ -522,9 +488,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         ], $entriesWritten);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cacheIdentifierPrototypeCanBeOverwritten()
     {
         $entriesWritten = [];
@@ -580,9 +544,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function uncachedSegmentInCachedSegmentCanOverrideContextVariables()
     {
         $object = new TestModel(42, 'Object value 1');
@@ -603,9 +565,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Outer segment|object=Object value 1|Uncached segment|counter=2|End uncached|End outer', $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dynamicSegmentIsCachedIfDiscriminatorIsNotChanged()
     {
         $renderObject = new TestModel(42, 'Render object');
@@ -627,9 +587,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame($firstRenderResult, $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dynamicSegmentCacheIsFlushedIfDiscriminatorIsChanged()
     {
         $renderObject = new TestModel(42, 'Render object');
@@ -651,9 +609,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertNotSame($firstRenderResult, $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dynamicSegmentCacheBehavesLikeUncachedIfDiscriminatorIsDisabled()
     {
         $renderObject = new TestModel(42, 'Render object');
@@ -679,9 +635,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('Dynamic segment|counter=3', $fourthRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cachedSegmentsCanBeNestedWithinDynamicSegments()
     {
         $renderObject = new TestModel(42, 'Render object');
@@ -698,9 +652,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame($firstRenderResult, $secondRenderResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cachedSegmentWithNestedDynamicSegmentCanReRenderWithCacheEntryFlushTest()
     {
         $view = $this->buildView();
@@ -719,9 +671,7 @@ class ContentCacheTest extends AbstractFusionObjectTestCase
         self::assertSame('prettyUnused', $secondRenderResult);
         self::assertSame('prettyUnused', $thirdRenderResult);
     }
-    /**
-     * @test
-     */
+    #[Test]
     public function contextIsCorrectlyEvaluated()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContextOverrideTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContextOverrideTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ContextOverrideTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicContextOverrides()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ContextOverrideTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ContextOverrideTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion View
  *
  */
-class ContextOverrideTest extends AbstractFusionObjectTest
+class ContextOverrideTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -17,7 +17,7 @@ use Neos\Utility\PositionalArraySorter;
 /**
  * Testcase for the Fusion Dictionary
  */
-class DataStructureTest extends AbstractFusionObjectTest
+class DataStructureTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DataStructureTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Exception\MissingFusionImplementationException;
 use Neos\Utility\PositionalArraySorter;
 
@@ -19,9 +19,7 @@ use Neos\Utility\PositionalArraySorter;
  */
 class DataStructureTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicOrderingWorks()
     {
         $view = $this->buildView();
@@ -30,9 +28,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals([10 => 'Xtest10', 100 => 'Xtest100'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function positionalOrderingWorks()
     {
         $view = $this->buildView();
@@ -41,9 +37,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['c' => 'Xbefore', 'f' => 'Xmiddle', 'a' => 'Xafter'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function startEndOrderingWorks()
     {
         $view = $this->buildView();
@@ -52,9 +46,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['c' => 'Xbefore', 'f' => 'Xmiddle', 'a' => 'Xafter'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advancedStartEndOrderingWorks()
     {
         $view = $this->buildView();
@@ -63,9 +55,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['e' => 'Xe', 'd' => 'Xd', 'foobar' => 'Xfoobar', 'f' => 'Xf', 'g' => 'Xg', 100 => 'X100', 'b' => 'Xb', 'a' => 'Xa', 'c' => 'Xc'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ignoredPropertiesWork()
     {
         $view = $this->buildView();
@@ -74,9 +64,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['c' => 'Xbefore', 'a' => 'Xafter'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedKeysWithoutObjectTypesRenderAsDataStructure(): void
     {
         $view = $this->buildView();
@@ -84,9 +72,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['keyWithoutType' => ['bar' => ['baz' => 123 ]], 'keyWithType' => 456, 'keyWithValue' => 789], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestingWithNonExistingChildObjectThrowsException(): void
     {
         $view = $this->buildView();
@@ -97,9 +83,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function untypedChildKeysWorkWithFusionIf(): void
     {
         $view = $this->buildView();
@@ -107,9 +91,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['keyWithoutType' => ['foo' => 123]], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function untypedChildKeysWorkWithFusionProcess(): void
     {
         $view = $this->buildView();
@@ -117,9 +99,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['keyWithoutType' => ['foo' => 123, 0 => 'baz']], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function untypedChildKeysWorkWithFusionEelThisContext(): void
     {
         $view = $this->buildView();
@@ -127,9 +107,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['keyWithoutType' => ['foo' => 123, 'thisFoo' => 123]], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function untypedChildKeysWorkWithFusionPositionSorting(): void
     {
         $view = $this->buildView();
@@ -137,9 +115,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['keyWithoutTypeLast' => ['baz' => 456], 'keyWithoutTypeFirst' => ['foo' => 123]], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unsetUntypedChildKeysWillRenderAsDataStructure(): void
     {
         $view = $this->buildView();
@@ -147,9 +123,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['buz' => 456, 'keyWithUnsetType' => ['bat' => 123]], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unsetChildKeyWillNotRender(): void
     {
         $view = $this->buildView();
@@ -158,9 +132,9 @@ class DataStructureTest extends AbstractFusionObjectTestCase
     }
 
     /**
-     * @test
      * NOTE: This test mainly documents the current behavior. "null1" is removed by the {@see PositionalArraySorter} currently
      */
+    #[Test]
     public function nulledChildKeyWillRenderAsNull(): void
     {
         $view = $this->buildView();
@@ -168,9 +142,7 @@ class DataStructureTest extends AbstractFusionObjectTestCase
         self::assertEquals(['foo' => 'bar', 'null2' => null], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function appliedNullValueWillRenderAsNull(): void
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugConsoleTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugConsoleTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class DebugConsoleTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function debugEmptyValue()
     {
         $view = $this->buildView();
@@ -27,9 +27,7 @@ class DebugConsoleTest extends AbstractFusionObjectTestCase
         self::assertEquals('<script>console.log("")</script>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugNull()
     {
         $view = $this->buildView();
@@ -38,9 +36,7 @@ class DebugConsoleTest extends AbstractFusionObjectTestCase
         self::assertEquals('<script>console.log("")</script>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugNullWithTitle()
     {
         $view = $this->buildView();
@@ -49,9 +45,7 @@ class DebugConsoleTest extends AbstractFusionObjectTestCase
         self::assertEquals('<script>console.log("", "Title")</script>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugObject()
     {
         $view = $this->buildView();
@@ -60,9 +54,7 @@ class DebugConsoleTest extends AbstractFusionObjectTestCase
         self::assertEquals('<script>console.log({"foo":"bar"})</script>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugMultipleValues()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugConsoleTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugConsoleTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the DebugConsole object
  *
  */
-class DebugConsoleTest extends AbstractFusionObjectTest
+class DebugConsoleTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
@@ -17,7 +17,7 @@ use Neos\Fusion\Service\DebugStack;
  * Testcase for the Debug object
  *
  */
-class DebugTest extends AbstractFusionObjectTest
+class DebugTest extends AbstractFusionObjectTestCase
 {
     /**
      * @var DebugStack

--- a/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/DebugTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Service\DebugStack;
 
 /**
@@ -31,9 +31,7 @@ class DebugTest extends AbstractFusionObjectTestCase
         $this->debugStack->flush();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugEmptyValue()
     {
         $view = $this->buildView();
@@ -44,9 +42,7 @@ class DebugTest extends AbstractFusionObjectTestCase
         self::assertEquals('NULL', $lines[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugNullValue()
     {
         $view = $this->buildView();
@@ -57,9 +53,7 @@ class DebugTest extends AbstractFusionObjectTestCase
         self::assertEquals('NULL', $lines[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugNullValueWithTitle()
     {
         $view = $this->buildView();
@@ -71,9 +65,7 @@ class DebugTest extends AbstractFusionObjectTestCase
         self::assertEquals('NULL', $lines[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugEelExpression()
     {
         $view = $this->buildView();
@@ -84,9 +76,7 @@ class DebugTest extends AbstractFusionObjectTestCase
         self::assertEquals('string "hello world" (11)', $lines[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugFusionObjectExpression()
     {
         $view = $this->buildView();
@@ -97,9 +87,7 @@ class DebugTest extends AbstractFusionObjectTestCase
         self::assertEquals('string "hello world" (11)', $lines[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugMultipleValues()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExceptionHandlerTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExceptionHandlerTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion exception handling
  *
  */
-class ExceptionHandlerTest extends AbstractFusionObjectTest
+class ExceptionHandlerTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExceptionHandlerTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExceptionHandlerTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ExceptionHandlerTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionalEelExpressionInPropertyIsHandledCorrectly()
     {
         $view = $this->buildView();
@@ -27,9 +27,7 @@ class ExceptionHandlerTest extends AbstractFusionObjectTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionalEelExpressionInOverrideIsHandledCorrectly()
     {
         $view = $this->buildView();
@@ -43,9 +41,8 @@ class ExceptionHandlerTest extends AbstractFusionObjectTestCase
      * We trigger rendering of a Fusion object with a nested Fusion object being "evaluated". If an exception happens there,
      * the configured exceptionHandler needs to be triggered as well, even though the object has been rendered with "evaluate()"
      * and not with "render()"
-     *
-     * @test
      */
+    #[Test]
     public function exceptionHandlerIsEvaluatedForNestedFusionObjects()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
@@ -19,7 +19,7 @@ use Neos\Fusion\Core\Runtime;
 /**
  * Testcase for Eel expressions in Fusion
  */
-class ExpressionsTest extends AbstractFusionObjectTest
+class ExpressionsTest extends AbstractFusionObjectTestCase
 {
     public function expressionExamples()
     {
@@ -46,7 +46,7 @@ class ExpressionsTest extends AbstractFusionObjectTest
     }
 
     /**
-     * The view and runtime of the AbstractFusionObjectTest
+     * The view and runtime of the AbstractFusionObjectTestCase
      * is not used to make sure the runtime context is empty.
      *
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
@@ -22,7 +22,7 @@ use Neos\Fusion\Core\Runtime;
  */
 class ExpressionsTest extends AbstractFusionObjectTestCase
 {
-    public function expressionExamples()
+    public static function expressionExamples()
     {
         return [
             ['expressions/calculus', 42],

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ExpressionsTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Core\Parser;
@@ -33,10 +34,8 @@ class ExpressionsTest extends AbstractFusionObjectTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider expressionExamples
-     */
+    #[DataProvider('expressionExamples')]
+    #[Test]
     public function expressionsWork($path, $expected)
     {
         $view = $this->buildView();
@@ -48,9 +47,8 @@ class ExpressionsTest extends AbstractFusionObjectTestCase
     /**
      * The view and runtime of the AbstractFusionObjectTestCase
      * is not used to make sure the runtime context is empty.
-     *
-     * @test
      */
+    #[Test]
     public function usingEelWorksWithoutSetCurrentContextInRuntime()
     {
         $fusionAst = (new Parser())->parseFromSource(FusionSourceCodeCollection::fromString('root = ${"foo"}'))->toArray();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/FusionObjects/ThrowingImplementation.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/FusionObjects/ThrowingImplementation.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects\Fixtures\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use Neos\Fusion\Exception;
 use Neos\Fusion;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 
@@ -30,7 +30,7 @@ class ThrowingImplementation extends AbstractFusionObject
     public function evaluate()
     {
         if ($this->getShouldThrow()) {
-            throw new Fusion\Exception('Just testing an exception', 1396557841);
+            throw new Exception('Just testing an exception', 1396557841);
         }
         return 'It depends';
     }

--- a/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Helper/UtilityHelper.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/Fixtures/Helper/UtilityHelper.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects\Fixtures\Helper;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use Neos\Fusion\Exception;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Fusion;
 
@@ -22,7 +22,7 @@ class UtilityHelper implements ProtectedContextAwareInterface
      */
     public function throwException()
     {
-        throw new Fusion\Exception('Just testing an exception', 1397118532);
+        throw new Exception('Just testing an exception', 1397118532);
     }
 
     /**

--- a/Neos.Fusion/Tests/Functional/FusionObjects/FusionArrayTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/FusionArrayTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion Array
  *
  */
-class FusionArrayTest extends AbstractFusionObjectTest
+class FusionArrayTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/FusionArrayTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/FusionArrayTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class FusionArrayTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicOrderingWorks()
     {
         $view = $this->buildView();
@@ -27,9 +27,7 @@ class FusionArrayTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xtest10Xtest100', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function positionalOrderingWorks()
     {
         $view = $this->buildView();
@@ -38,9 +36,7 @@ class FusionArrayTest extends AbstractFusionObjectTestCase
         self::assertEquals('XbeforeXmiddleXafter', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function startEndOrderingWorks()
     {
         $view = $this->buildView();
@@ -49,9 +45,7 @@ class FusionArrayTest extends AbstractFusionObjectTestCase
         self::assertEquals('XbeforeXmiddleXafter', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advancedStartEndOrderingWorks()
     {
         $view = $this->buildView();
@@ -60,9 +54,7 @@ class FusionArrayTest extends AbstractFusionObjectTestCase
         self::assertEquals('XeXdXfoobarXfXgX100XbXaXc', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ignoredPropertiesWork()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/JoinTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/JoinTest.php
@@ -10,11 +10,10 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion Concat
  */
-class JoinTest extends AbstractFusionObjectTest
+class JoinTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/JoinTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/JoinTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -15,9 +17,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class JoinTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicOrderingWorks()
     {
         $view = $this->buildView();
@@ -26,9 +26,7 @@ class JoinTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xtest10Xtest100', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function positionalOrderingWorks()
     {
         $view = $this->buildView();
@@ -37,9 +35,7 @@ class JoinTest extends AbstractFusionObjectTestCase
         self::assertEquals('XbeforeXmiddleXafter', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function startEndOrderingWorks()
     {
         $view = $this->buildView();
@@ -48,9 +44,7 @@ class JoinTest extends AbstractFusionObjectTestCase
         self::assertEquals('XbeforeXmiddleXafter', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advancedStartEndOrderingWorks()
     {
         $view = $this->buildView();
@@ -59,9 +53,7 @@ class JoinTest extends AbstractFusionObjectTestCase
         self::assertEquals('XeXdXfoobarXfXgX100XbXaXc', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ignoredPropertiesWork()
     {
         $view = $this->buildView();
@@ -70,9 +62,7 @@ class JoinTest extends AbstractFusionObjectTestCase
         self::assertEquals('XbeforeXafter', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function glueWorks()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class LoopTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicLoopWorks()
     {
         $view = $this->buildView();
@@ -27,9 +27,7 @@ class LoopTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1Xelement2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicLoopWorksWithIterator()
     {
         $view = $this->buildView();
@@ -38,9 +36,7 @@ class LoopTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1Xelement2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicLoopWorksWithIteratorThatDoesNotImplementCount()
     {
         $view = $this->buildView();
@@ -49,9 +45,7 @@ class LoopTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1Xelement2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicLoopWorksWithGlue()
     {
         $view = $this->buildView();
@@ -60,9 +54,7 @@ class LoopTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1, Xelement2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicLoopWorksAndStillContainsOtherContextVariables()
     {
         $view = $this->buildView();
@@ -72,9 +64,7 @@ class LoopTest extends AbstractFusionObjectTestCase
         self::assertEquals('Xelement1varXelement2var', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyLoopReturnsEmptyString()
     {
         $view = $this->buildView();
@@ -83,9 +73,7 @@ class LoopTest extends AbstractFusionObjectTestCase
         self::assertEquals('', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function iterationInformationIsAddedToLoop()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/LoopTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Iteration Fusion object
  *
  */
-class LoopTest extends AbstractFusionObjectTest
+class LoopTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Mapping Fusion object
  *
  */
-class MapTest extends AbstractFusionObjectTest
+class MapTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MapTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class MapTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicMapWorks()
     {
         $view = $this->buildView();
@@ -27,9 +27,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['Xelement1','Xelement2'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicMapWorksWithIterator()
     {
         $view = $this->buildView();
@@ -38,9 +36,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['Xelement1','Xelement2'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicMapWorksWithIteratorThatDoesNotImplementCount()
     {
         $view = $this->buildView();
@@ -49,9 +45,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['Xelement1','Xelement2'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicMapWorksWithContentRenderer()
     {
         $view = $this->buildView();
@@ -60,9 +54,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['Xelement1','Xelement2'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicMapWorksAndPreservesKeys()
     {
         $view = $this->buildView();
@@ -71,9 +63,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['foo' => 'Xelement1', 'bar' => 'Xelement2'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resultKeysCanBeRendered(): void
     {
         $view = $this->buildView();
@@ -82,9 +72,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['key-element1' => 'value-element1', 'key-element2' => 'value-element2'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicMapWorksAndStillContainsOtherContextVariables()
     {
         $view = $this->buildView();
@@ -94,9 +82,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals(['Xelement1var','Xelement2var'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyMapReturnsEmptyArray()
     {
         $view = $this->buildView();
@@ -105,9 +91,7 @@ class MapTest extends AbstractFusionObjectTestCase
         self::assertEquals([], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function iterationInformationIsAddedToMap()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
@@ -11,12 +11,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Debug object
  *
  */
-class MatchTest extends AbstractFusionObjectTest
+class MatchTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MatchTest.php
@@ -2,6 +2,8 @@
 
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -17,9 +19,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class MatchTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function matchEmptyValue()
     {
         $view = $this->buildView();
@@ -28,9 +28,7 @@ class MatchTest extends AbstractFusionObjectTestCase
         self::assertEquals('empty', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchSimple()
     {
         $view = $this->buildView();
@@ -39,9 +37,7 @@ class MatchTest extends AbstractFusionObjectTestCase
         self::assertEquals('module--left', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchDefault()
     {
         $view = $this->buildView();
@@ -50,9 +46,7 @@ class MatchTest extends AbstractFusionObjectTestCase
         self::assertEquals('module--centered', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function errorWithoutMatch()
     {
         $this->expectExceptionMessage('Unhandled match');
@@ -61,9 +55,7 @@ class MatchTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchDefaultDataStructure()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MemoTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MemoTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class MemoTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function returnsSameResult()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/MemoTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/MemoTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Memo object
  *
  */
-class MemoTest extends AbstractFusionObjectTest
+class MemoTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for basic Fusion rendering
  *
  */
-class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTest
+class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/NestedOverwritesAndProcessorsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function overwritingSimpleValueWithProcessorWorks()
     {
         $view = $this->buildView();
@@ -26,9 +26,7 @@ class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTestCase
         self::assertEquals('<div class="Xclass processed" tea="green"></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function applyingProcessorToExpressionWorks()
     {
         $view = $this->buildView();
@@ -36,9 +34,7 @@ class NestedOverwritesAndProcessorsTest extends AbstractFusionObjectTestCase
         self::assertEquals('<div class="Xclass" tea="green infused"></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function applyingProcessorToNonExistingValueWorks()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -51,7 +51,7 @@ class ProcessorTest extends AbstractFusionObjectTestCase
      *
      * @return array
      */
-    public function dataProviderForUnsettingProcessors()
+    public static function dataProviderForUnsettingProcessors()
     {
         return [
             ['processors/newSyntax/unset/simple'],

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,25 +19,19 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ProcessorTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicProcessorsWork()
     {
         $this->assertMultipleFusionPaths('Hello World foo', 'processors/newSyntax/basicProcessor/valueWithNested');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicProcessorsBeforeValueWork()
     {
         $this->assertMultipleFusionPaths('Hello World foo', 'processors/newSyntax/processorBeforeValue/valueWithNested');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function extendedSyntaxProcessorsWork()
     {
         $this->assertMultipleFusionPaths('Hello World foo', 'processors/newSyntax/extendedSyntaxProcessor/valueWithNested');
@@ -42,8 +39,8 @@ class ProcessorTest extends AbstractFusionObjectTestCase
 
     /**
      * https://github.com/neos/neos-development-collection/pull/3847
-     * @test
      */
+    #[Test]
     public function plainValueOverriddenByPlainValueWorks()
     {
         $this->assertFusionPath('foo', 'processors/newSyntax/basicProcessor/plainValueOverriddenByPlainValue');
@@ -64,10 +61,8 @@ class ProcessorTest extends AbstractFusionObjectTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataProviderForUnsettingProcessors
-     */
+    #[DataProvider('dataProviderForUnsettingProcessors')]
+    #[Test]
     public function processorsCanBeUnset($path)
     {
         $view = $this->buildView();
@@ -75,17 +70,13 @@ class ProcessorTest extends AbstractFusionObjectTestCase
         self::assertEquals('Foobaz', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function usingThisInProcessorWorks()
     {
         $this->assertFusionPath('my value append', 'processors/newSyntax/usingThisInProcessor');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function skippedLazyPropsInProcessor()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ProcessorTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion View
  *
  */
-class ProcessorTest extends AbstractFusionObjectTest
+class ProcessorTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/PrototypeInheritanceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/PrototypeInheritanceTest.php
@@ -10,11 +10,10 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Prototypical Inheritance Test
  */
-class PrototypeInheritanceTest extends AbstractFusionObjectTest
+class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/PrototypeInheritanceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/PrototypeInheritanceTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -15,9 +17,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function baseClassHasModifiedValue()
     {
         $view = $this->buildView();
@@ -25,9 +25,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
         self::assertEquals('BaseModified', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function subWithOverrideHasOverriddenValue()
     {
         $view = $this->buildView();
@@ -35,9 +33,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
         self::assertEquals('Sub', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function subWithoutOverrideHasModifiedBaseValue()
     {
         $view = $this->buildView();
@@ -45,9 +41,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
         self::assertEquals('BaseModified', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advancedBaseObjectHasModifiedValue()
     {
         $view = $this->buildView();
@@ -55,9 +49,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
         self::assertEquals('prepend_beforeOverride|value_from_nested_prototype|append_afterOverride', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advancedSubWithoutOverrideHasModifiedBaseValue()
     {
         $view = $this->buildView();
@@ -65,9 +57,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
         self::assertEquals('prepend_beforeOverride|value_from_nested_prototype|append_afterOverride', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advancedSubWithOverrideHasModifiedBaseValue()
     {
         $view = $this->buildView();
@@ -75,9 +65,7 @@ class PrototypeInheritanceTest extends AbstractFusionObjectTestCase
         self::assertEquals('prepend_inSub|value_from_nested_prototype|append_afterOverride', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function contextDependentPrototypesTakeInheritanceIntoAccount()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/QuotedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/QuotedKeysTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class QuotedKeysTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function mulitpleKeysWorks()
     {
         $view = $this->buildView();
@@ -31,9 +31,7 @@ class QuotedKeysTest extends AbstractFusionObjectTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function singleQuotedWorks()
     {
         $view = $this->buildView();
@@ -41,9 +39,7 @@ class QuotedKeysTest extends AbstractFusionObjectTestCase
         self::assertSame($view->render(), 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doubleQuotedWorks()
     {
         $view = $this->buildView();
@@ -51,9 +47,7 @@ class QuotedKeysTest extends AbstractFusionObjectTestCase
         self::assertSame($view->render(), 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedQuotedWorks()
     {
         $view = $this->buildView();
@@ -61,9 +55,7 @@ class QuotedKeysTest extends AbstractFusionObjectTestCase
         self::assertSame($view->render(), 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function specialCharactersWorks()
     {
         $view = $this->buildView();
@@ -71,9 +63,7 @@ class QuotedKeysTest extends AbstractFusionObjectTestCase
         self::assertSame($view->render(), 1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prototypeAndQuotedKeysWorks()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/QuotedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/QuotedKeysTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion DataStructure
  *
  */
-class QuotedKeysTest extends AbstractFusionObjectTest
+class QuotedKeysTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/RawCollectionTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/RawCollectionTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the RawCollection Fusion object
  *
  */
-class RawCollectionTest extends AbstractFusionObjectTest
+class RawCollectionTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/RawCollectionTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/RawCollectionTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class RawCollectionTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicCollectionWorks()
     {
         $view = $this->buildView();
@@ -28,9 +28,7 @@ class RawCollectionTest extends AbstractFusionObjectTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicCollectionWorksAndStillContainsOtherContextVariables()
     {
         $view = $this->buildView();
@@ -40,9 +38,7 @@ class RawCollectionTest extends AbstractFusionObjectTestCase
         self::assertEquals(['Xelement1var','Xelement2var'], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyCollectionReturnsEmptyArray()
     {
         $view = $this->buildView();
@@ -51,9 +47,7 @@ class RawCollectionTest extends AbstractFusionObjectTestCase
         self::assertEquals([], $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function iterationInformationIsAddedToCollection()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Reduction Fusion object
  *
  */
-class ReduceTest extends AbstractFusionObjectTest
+class ReduceTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReduceTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class ReduceTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicReductionWorks()
     {
         $view = $this->buildView();
@@ -28,9 +28,7 @@ class ReduceTest extends AbstractFusionObjectTestCase
         self::assertEquals('XXInitialValue::element1element2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicReductionWorksWithIterator()
     {
         $view = $this->buildView();
@@ -40,9 +38,7 @@ class ReduceTest extends AbstractFusionObjectTestCase
         self::assertEquals('XXInitialValue::element1element2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicReductionWorksWithIteratorThatDoesNotImplementCount()
     {
         $view = $this->buildView();
@@ -52,9 +48,7 @@ class ReduceTest extends AbstractFusionObjectTestCase
         self::assertEquals('XXInitialValue::element1element2', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicReductionAddsNumbers()
     {
         $view = $this->buildView();
@@ -64,9 +58,7 @@ class ReduceTest extends AbstractFusionObjectTestCase
         self::assertEquals(15, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicReductionWorksAndStillContainsOtherContextVariables()
     {
         $view = $this->buildView();
@@ -76,9 +68,7 @@ class ReduceTest extends AbstractFusionObjectTestCase
         self::assertEquals('XXelement1varelement2var', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyReductionReturnsInitialValue()
     {
         $initialValue = '::InitialValue::';
@@ -89,9 +79,7 @@ class ReduceTest extends AbstractFusionObjectTestCase
         self::assertEquals($initialValue, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function iterationInformationIsAddedToReduction()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/RendererTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/RendererTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -24,25 +26,19 @@ class RendererTest extends AbstractFusionObjectTestCase
         self::assertEquals($expectation, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function usingRendererWorks()
     {
         $this->assertRenderingWorks('renderer/default', 'result_of_renderer_prototyope');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWinsOverType()
     {
         $this->assertRenderingWorks('renderer/withType', 'result_of_type_with_override');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rendererWinsOverRenderPath()
     {
         $this->assertRenderingWorks('renderer/withRenderPath', 'result_of_path_with_override');

--- a/Neos.Fusion/Tests/Functional/FusionObjects/RendererTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/RendererTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Renderer Fusion object
  *
  */
-class RendererTest extends AbstractFusionObjectTest
+class RendererTest extends AbstractFusionObjectTestCase
 {
     public function assertRenderingWorks($path, $expectation)
     {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Exception;
 
 /**
@@ -19,9 +19,7 @@ use Neos\Fusion\Exception;
  */
 class ReservedKeysTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function usingReservedKeysThrowsException()
     {
         $this->expectException(Exception::class);
@@ -30,9 +28,7 @@ class ReservedKeysTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nonReservedKeysWorks()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/ReservedKeysTest.php
@@ -17,7 +17,7 @@ use Neos\Fusion\Exception;
  * Testcase for reserved Fusion keys
  *
  */
-class ReservedKeysTest extends AbstractFusionObjectTest
+class ReservedKeysTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/SimpleTypesTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/SimpleTypesTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Exception\MissingFusionImplementationException;
 use Neos\Fusion\Exception\MissingFusionObjectException;
 
@@ -20,25 +20,19 @@ use Neos\Fusion\Exception\MissingFusionObjectException;
  */
 class SimpleTypesTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function valuesCanBeExpressedAsSimpleValueAsEelAsTypoScropt()
     {
         $this->assertMultipleFusionPaths('A simple string value is not a Fusion object', 'simpleTypes/stringAs');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionPropertiesCanContainSimpleValueOrEelOrTypoScropt()
     {
         $this->assertMultipleFusionPaths('A simple value', 'simpleTypes/valueWithNested');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function booleanSimpleTypeWorks()
     {
         $view = $this->buildView();
@@ -48,9 +42,7 @@ class SimpleTypesTest extends AbstractFusionObjectTestCase
         self::assertTrue($view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nullSimpleTypeWorks()
     {
         $view = $this->buildView();
@@ -58,9 +50,7 @@ class SimpleTypesTest extends AbstractFusionObjectTestCase
         self::assertNull($view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processorOnSimpleTypeWorks()
     {
         $view = $this->buildView();
@@ -68,9 +58,7 @@ class SimpleTypesTest extends AbstractFusionObjectTestCase
         self::assertSame('Hello, Foo', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderingObjectWithMissingImplementationThrowsException()
     {
         $this->expectException(MissingFusionImplementationException::class);
@@ -79,9 +67,7 @@ class SimpleTypesTest extends AbstractFusionObjectTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderingNonExistingPathThrowsException()
     {
         $this->expectException(MissingFusionObjectException::class);

--- a/Neos.Fusion/Tests/Functional/FusionObjects/SimpleTypesTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/SimpleTypesTest.php
@@ -18,7 +18,7 @@ use Neos\Fusion\Exception\MissingFusionObjectException;
  * Testcase for the Fusion View
  *
  */
-class SimpleTypesTest extends AbstractFusionObjectTest
+class SimpleTypesTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Tag object
  *
  */
-class TagTest extends AbstractFusionObjectTest
+class TagTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TagTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class TagTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithAttributesFromNonFusionObjectWorks()
     {
         $view = $this->buildView();
@@ -26,9 +26,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<link rel="stylesheet" type="text/css" />', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithAttributesFromFusionObjectWorks()
     {
         $view = $this->buildView();
@@ -36,9 +34,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<test sum="4" />', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithAttributesFromArraysWorks()
     {
         $view = $this->buildView();
@@ -46,9 +42,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<div class="a b"></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithFusionAttributesWorks()
     {
         $view = $this->buildView();
@@ -56,9 +50,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<div key="value" list="foo bar"></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithAttributesFromDataStructureWorks()
     {
         $view = $this->buildView();
@@ -66,9 +58,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<div key="value" list="foo bar"></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithBooleanAttributesWorks()
     {
         $view = $this->buildView();
@@ -76,9 +66,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<div foo></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithBooleanAttributesAndForbiddenEmptyAttributesWorks()
     {
         $view = $this->buildView();
@@ -86,9 +74,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<div foo=""></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithBooleanAndAllowEmptyAttributesAttributesWorks()
     {
         $view = $this->buildView();
@@ -96,9 +82,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<div foo></div>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithContentFromNonFusionObjectWorks()
     {
         $view = $this->buildView();
@@ -106,9 +90,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<span>test</span>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithContentFromFusionObjectWorks()
     {
         $view = $this->buildView();
@@ -116,9 +98,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<span>4</span>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registeredSelfClosingTagWorks()
     {
         $view = $this->buildView();
@@ -126,9 +106,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<br />', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function omitClosingTagWorks()
     {
         $view = $this->buildView();
@@ -136,9 +114,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<test>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithEelExpressionUsingThis()
     {
         $view = $this->buildView();
@@ -146,9 +122,7 @@ class TagTest extends AbstractFusionObjectTestCase
         self::assertSame('<title databar="baz" datafoo="baz_baz">foo</title>', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagWithIgnorePropertiesInAttributes()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TemplateTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TemplateTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -16,9 +18,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class TemplateTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicFluidTemplateCanBeUsedForRendering()
     {
         $view = $this->buildView();
@@ -26,9 +26,7 @@ class TemplateTest extends AbstractFusionObjectTestCase
         self::assertEquals('Test Templatefoo', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function basicFluidTemplateContainsEelVariables()
     {
         $view = $this->buildView();
@@ -36,9 +34,7 @@ class TemplateTest extends AbstractFusionObjectTestCase
         self::assertEquals('Test Templatefoobar', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function customPartialPathCanBeSetOnRendering()
     {
         $view = $this->buildView();
@@ -46,9 +42,7 @@ class TemplateTest extends AbstractFusionObjectTestCase
         self::assertEquals('Test Template--partial contents', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function customLayoutPathCanBeSetOnRendering()
     {
         $view = $this->buildView();
@@ -56,9 +50,7 @@ class TemplateTest extends AbstractFusionObjectTestCase
         self::assertEquals('layout start -- Test Template -- layout end', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionExceptionInObjectAccessIsHandledCorrectly()
     {
         $view = $this->buildView();
@@ -66,9 +58,7 @@ class TemplateTest extends AbstractFusionObjectTestCase
         self::assertStringStartsWith('Test TemplateException while rendering template', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function expressionCanBeOverridenWithSimpleValueForTemplate()
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/TemplateTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/TemplateTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the Fusion Template Object
  *
  */
-class TemplateTest extends AbstractFusionObjectTest
+class TemplateTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
@@ -10,12 +10,11 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for unsetting Fusion paths
  *
  */
-class UnsetTest extends AbstractFusionObjectTest
+class UnsetTest extends AbstractFusionObjectTestCase
 {
     public function unsetExamples()
     {

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
  */
 class UnsetTest extends AbstractFusionObjectTestCase
 {
-    public function unsetExamples()
+    public static function unsetExamples()
     {
         return [
             ['valueUnset/inheritedPrototypePath', 'Baz'],

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UnsetTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -26,10 +29,8 @@ class UnsetTest extends AbstractFusionObjectTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider unsetExamples
-     */
+    #[DataProvider('unsetExamples')]
+    #[Test]
     public function unsetWorks($path, $expected)
     {
         $view = $this->buildView();

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UriBuilderTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UriBuilderTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Neos\Fusion\Tests\Functional\FusionObjects;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /*
  * This file is part of the Neos.Fusion package.
  *
@@ -15,9 +17,7 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  */
 class UriBuilderTest extends AbstractFusionObjectTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function buildRelativeUriToAction()
     {
         $this->registerRoute(

--- a/Neos.Fusion/Tests/Functional/FusionObjects/UriBuilderTest.php
+++ b/Neos.Fusion/Tests/Functional/FusionObjects/UriBuilderTest.php
@@ -10,11 +10,10 @@ namespace Neos\Fusion\Tests\Functional\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 /**
  * Testcase for the UriBuilder object
  */
-class UriBuilderTest extends AbstractFusionObjectTest
+class UriBuilderTest extends AbstractFusionObjectTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Functional/Parser/FusionParserTest.php
+++ b/Neos.Fusion/Tests/Functional/Parser/FusionParserTest.php
@@ -11,6 +11,8 @@ namespace Neos\Fusion\Tests\Functional\Parser;
  * source code.
  */
 
+use Neos\Fusion\Core\FusionSourceCodeCollection;
+use Neos\Fusion\Exception;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion;
@@ -26,7 +28,7 @@ class FusionParserTest extends FunctionalTestCase
     public function parserHandlesExpressionsThatReturnStrings()
     {
         $parser = new Parser();
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`"StringExpressionValue"`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`"StringExpressionValue"`'))->toArray();
         $expectedAst = [
             'value' => 'StringExpressionValue'
         ];
@@ -39,7 +41,7 @@ class FusionParserTest extends FunctionalTestCase
     public function parserHandlesExpressionsThatReturnMultilineStrings()
     {
         $parser = new Parser();
-        $actualAst = $parser->parseFromSource(Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`"String' . "\n" . 'Expression' . "\n" . 'Value"`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`"String' . "\n" . 'Expression' . "\n" . 'Value"`'))->toArray();
         $expectedAst = [
             'value' => 'String' . chr(10) . 'Expression' . chr(10) . 'Value'
         ];
@@ -53,13 +55,13 @@ class FusionParserTest extends FunctionalTestCase
     {
         $parser = new Parser();
 
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`true`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`true`'))->toArray();
         $expectedAst = [
             'value' => true
         ];
         self::assertEquals($expectedAst, $actualAst);
 
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`false`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`false`'))->toArray();
         $expectedAst = [
             'value' => false
         ];
@@ -73,19 +75,19 @@ class FusionParserTest extends FunctionalTestCase
     {
         $parser = new Parser();
 
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`1234`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`1234`'))->toArray();
         $expectedAst = [
             'value' => 1234
         ];
         self::assertEquals($expectedAst, $actualAst);
 
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`12.34`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`12.34`'))->toArray();
         $expectedAst = [
             'value' => 12.34
         ];
         self::assertEquals($expectedAst, $actualAst);
 
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`-12.34`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`-12.34`'))->toArray();
         $expectedAst = [
             'value' => -12.34
         ];
@@ -98,7 +100,7 @@ class FusionParserTest extends FunctionalTestCase
     public function parserHandlesDslExpressionThatReturnsEelExpressions()
     {
         $parser = new Parser();
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`${1234}`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`${1234}`'))->toArray();
         $expectedAst = [
             'value' => ["__eelExpression" => "1234","__value" => null, "__objectType" => null]
         ];
@@ -111,7 +113,7 @@ class FusionParserTest extends FunctionalTestCase
     public function parserHandlesDslExpressionThatReturnsFusionObjects()
     {
         $parser = new Parser();
-        $actualAst = $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestFusionObjectDsl`{"objectName": "Neos.Fusion:Value", "attributes": { "value": "foo" }}`'))->toArray();
+        $actualAst = $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestFusionObjectDsl`{"objectName": "Neos.Fusion:Value", "attributes": { "value": "foo" }}`'))->toArray();
         $expectedAst = [
             'value' => ["__eelExpression" => null,"__value" => null, "__objectType" => 'Neos.Fusion:Value', 'value' => "foo"]
         ];
@@ -124,9 +126,9 @@ class FusionParserTest extends FunctionalTestCase
     public function parserThrowsExceptionIfAnUnknownDslIsExecuted()
     {
         $parser = new Parser();
-        $this->expectException(Fusion\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionCode(1180600696);
-        $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestUnknownDsl`foobar`'))->toArray();
+        $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestUnknownDsl`foobar`'))->toArray();
     }
 
     /**
@@ -135,8 +137,8 @@ class FusionParserTest extends FunctionalTestCase
     public function parserThrowsExceptionIfAnDslExprssionIsNotClosed()
     {
         $parser = new Parser();
-        $this->expectException(Fusion\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionCode(1490714685);
-        $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`foobar'))->toArray();
+        $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestPassthroughDsl`foobar'))->toArray();
     }
 }

--- a/Neos.Fusion/Tests/Functional/Parser/FusionParserTest.php
+++ b/Neos.Fusion/Tests/Functional/Parser/FusionParserTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\Parser;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Exception;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -22,9 +22,7 @@ use Neos\Fusion;
  */
 class FusionParserTest extends FunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function parserHandlesExpressionsThatReturnStrings()
     {
         $parser = new Parser();
@@ -35,9 +33,7 @@ class FusionParserTest extends FunctionalTestCase
         self::assertEquals($expectedAst, $actualAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserHandlesExpressionsThatReturnMultilineStrings()
     {
         $parser = new Parser();
@@ -48,9 +44,7 @@ class FusionParserTest extends FunctionalTestCase
         self::assertEquals($expectedAst, $actualAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserHandlesDslExpressionThatReturnsBooleans()
     {
         $parser = new Parser();
@@ -68,9 +62,7 @@ class FusionParserTest extends FunctionalTestCase
         self::assertEquals($expectedAst, $actualAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserHandlesDslExpressionThatReturnsNumbers()
     {
         $parser = new Parser();
@@ -94,9 +86,7 @@ class FusionParserTest extends FunctionalTestCase
         self::assertEquals($expectedAst, $actualAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserHandlesDslExpressionThatReturnsEelExpressions()
     {
         $parser = new Parser();
@@ -107,9 +97,7 @@ class FusionParserTest extends FunctionalTestCase
         self::assertEquals($expectedAst, $actualAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserHandlesDslExpressionThatReturnsFusionObjects()
     {
         $parser = new Parser();
@@ -120,9 +108,7 @@ class FusionParserTest extends FunctionalTestCase
         self::assertEquals($expectedAst, $actualAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserThrowsExceptionIfAnUnknownDslIsExecuted()
     {
         $parser = new Parser();
@@ -131,9 +117,7 @@ class FusionParserTest extends FunctionalTestCase
         $parser->parseFromSource(FusionSourceCodeCollection::fromString('value = TestUnknownDsl`foobar`'))->toArray();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserThrowsExceptionIfAnDslExprssionIsNotClosed()
     {
         $parser = new Parser();

--- a/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
+++ b/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
@@ -68,9 +68,9 @@ class FusionViewTest extends FunctionalTestCase
     protected function buildView($controllerObjectName, $controllerActionName)
     {
         $request = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
-        $request->expects(self::any())->method('getControllerObjectName')->will(self::returnValue($controllerObjectName));
-        $request->expects(self::any())->method('getControllerActionName')->will(self::returnValue($controllerActionName));
-        $this->mockControllerContext->expects(self::any())->method('getRequest')->will(self::returnValue($request));
+        $request->expects(self::any())->method('getControllerObjectName')->willReturn($controllerObjectName);
+        $request->expects(self::any())->method('getControllerActionName')->willReturn($controllerActionName);
+        $this->mockControllerContext->expects(self::any())->method('getRequest')->willReturn($request);
 
         $view = new FusionView();
         $view->setControllerContext($this->mockControllerContext);

--- a/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
+++ b/Neos.Fusion/Tests/Functional/View/FusionViewTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Functional\View;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -35,18 +35,14 @@ class FusionViewTest extends FunctionalTestCase
         $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionViewIsUsedForRendering()
     {
         $view = $this->buildView('Foo\Bar\Controller\TestController', 'index');
         self::assertEquals('X', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionViewUsesGivenPathIfSet()
     {
         $view = $this->buildView('Foo\Bar\Controller\TestController', 'index');
@@ -54,9 +50,7 @@ class FusionViewTest extends FunctionalTestCase
         self::assertEquals('Xfoobar', $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fusionViewOutputsVariable()
     {
         $view = $this->buildView('Foo\Bar\Controller\TestController', 'index');

--- a/Neos.Fusion/Tests/Unit/Core/Cache/CacheSegmentParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Cache/CacheSegmentParserTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Cache;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Cache\CacheSegmentParser;
 use Neos\Fusion\Exception;
@@ -174,9 +174,7 @@ class CacheSegmentParserTest extends UnitTestCase
         ]
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOutputAfterExtractReturnsOriginalTextWithoutAnnotations()
     {
         $parser = new CacheSegmentParser($this->content);
@@ -186,9 +184,7 @@ class CacheSegmentParserTest extends UnitTestCase
         self::assertEquals($this->expectedOutput, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function extractReturnsOuterContentWithPlaceholders()
     {
         $parser = new CacheSegmentParser($this->content);
@@ -197,9 +193,7 @@ class CacheSegmentParserTest extends UnitTestCase
         self::assertEquals($this->expectedOuterContent, $outerContent);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCacheEntriesAfterExtractReturnsInnerContentWithPlaceholders()
     {
         $parser = new CacheSegmentParser($this->content);
@@ -208,9 +202,7 @@ class CacheSegmentParserTest extends UnitTestCase
         self::assertEquals($this->expectedEntries, $entries);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidContentWithMissingEndThrowsException()
     {
         $this->expectException(Exception::class);
@@ -218,9 +210,7 @@ class CacheSegmentParserTest extends UnitTestCase
         new CacheSegmentParser($this->invalidContentWithMissingEnd);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidContentWithExceedingEndThrowsException()
     {
         $this->expectException(Exception::class);
@@ -228,9 +218,7 @@ class CacheSegmentParserTest extends UnitTestCase
         new CacheSegmentParser($this->invalidContentWithExceedingEnd);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidContentWithMissingSeparatorThrowsException()
     {
         $this->expectException(Exception::class);
@@ -238,9 +226,7 @@ class CacheSegmentParserTest extends UnitTestCase
         new CacheSegmentParser($this->invalidContentWithMissingSeparator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function extractWithUncachedSegmentsReturnsOuterContentWithPlaceholders()
     {
         $parser = new CacheSegmentParser($this->contentWithUncachedSegments);
@@ -249,9 +235,7 @@ class CacheSegmentParserTest extends UnitTestCase
         self::assertEquals($this->expectedOuterContentWithUncachedSegments, $outerContent);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOutputAfterExtractWithUncachedSegmentsReturnsOriginalTextWithoutAnnotations()
     {
         $parser = new CacheSegmentParser($this->contentWithUncachedSegments);
@@ -260,9 +244,7 @@ class CacheSegmentParserTest extends UnitTestCase
         self::assertEquals($this->expectedOutputWithUncachedSegments, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCacheSegmentsAfterExtractWithUncachedSegmentsReturnsContentWithPlaceholder()
     {
         $parser = new CacheSegmentParser($this->contentWithUncachedSegments);

--- a/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\Core\Cache;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Cache\Backend\TransientMemoryBackend;
 use Neos\Cache\CacheAwareInterface;
 use Neos\Cache\EnvironmentConfiguration;
@@ -43,10 +44,8 @@ class ContentCacheTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider tags()
-     * @test
-     */
+    #[DataProvider('tags')]
+    #[Test]
     public function flushByTagSanitizesTagsForCacheFrontend($tag, $sanitizedTag)
     {
         $mockCache = $this->getMockBuilder(StringFrontend::class)->disableOriginalConstructor()->getMock();
@@ -66,10 +65,8 @@ class ContentCacheTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider invalidEntryIdentifierValues
-     */
+    #[DataProvider('invalidEntryIdentifierValues')]
+    #[Test]
     public function createCacheSegmentWithInvalidEntryIdentifierValueThrowsException($entryIdentifierValues)
     {
         $this->expectException(CacheException::class);
@@ -95,10 +92,8 @@ class ContentCacheTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider validEntryIdentifierValues
-     */
+    #[DataProvider('validEntryIdentifierValues')]
+    #[Test]
     public function createCacheSegmentWithValidEntryIdentifierValueCreatesIdentifier($entryIdentifierValues)
     {
         $contentCache = new ContentCache();
@@ -108,9 +103,7 @@ class ContentCacheTest extends UnitTestCase
         self::assertNotEmpty($segement);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createCacheSegmentWithLifetimeStoresLifetimeAfterTagsInMetadata()
     {
         $contentCache = new ContentCache();
@@ -120,9 +113,7 @@ class ContentCacheTest extends UnitTestCase
         self::assertStringContainsString('Foo,Bar;60' . ContentCache::CACHE_SEGMENT_SEPARATOR_TOKEN, $segment);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCacheSegmentsSetsLifetimeFromMetadata()
     {
         $contentCache = new ContentCache();
@@ -144,9 +135,7 @@ class ContentCacheTest extends UnitTestCase
         $contentCache->processCacheSegments($segement);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createCacheSegmentAndProcessCacheSegmentsDoesWorkWithCacheSegmentTokensInContent()
     {
         $contentCache = new ContentCache();
@@ -186,9 +175,7 @@ class ContentCacheTest extends UnitTestCase
         self::assertSame($invalidContent . $validContent, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createUncachedSegmentAndProcessCacheSegmentsDoesWorkWithCacheSegmentTokensInContent()
     {
         $contentCache = new ContentCache();
@@ -213,9 +200,7 @@ class ContentCacheTest extends UnitTestCase
         self::assertSame($invalidContent, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCachedSegmentWithExistingCacheEntryReplacesNestedCachedSegments()
     {
         $contentCache = new ContentCache();

--- a/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
@@ -167,12 +167,20 @@ class ContentCacheTest extends UnitTestCase
             ['mytag2'],
             86400
         );
-        $mockCache->expects(self::atLeast(2))
-            ->method('set')
-            ->withConsecutive(
-                [self::anything(), $invalidContent, ['mytag1', 'mytag2'], null],
-                [self::anything(), $validContent, ['mytag2'], 86400],
-            );
+        $matcher = self::atLeast(2);
+        $mockCache->expects($matcher)
+            ->method('set')->willReturnCallback(function (...$parameters) use ($matcher, $invalidContent, $validContent) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame($invalidContent, $parameters[1]);
+                $this->assertSame(['mytag1', 'mytag2'], $parameters[2]);
+                $this->assertSame(null, $parameters[3]);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame($validContent, $parameters[1]);
+                $this->assertSame(['mytag2'], $parameters[2]);
+                $this->assertSame(86400, $parameters[3]);
+            }
+        });
 
         $output = $contentCache->processCacheSegments($content);
 
@@ -185,7 +193,7 @@ class ContentCacheTest extends UnitTestCase
         $contentCache = new ContentCache();
 
         $mockPropertyMapper = $this->createMock(PropertyMapper::class);
-        $mockPropertyMapper->expects(self::any())->method('convert')->will($this->returnArgument(0));
+        $mockPropertyMapper->expects(self::any())->method('convert')->willReturnArgument(0);
         $this->inject($contentCache, 'propertyMapper', $mockPropertyMapper);
 
         $mockCache = $this->createMock(FrontendInterface::class);
@@ -213,7 +221,7 @@ class ContentCacheTest extends UnitTestCase
         $this->inject($contentCache, 'securityContext', $mockSecurityContext);
 
         $mockPropertyMapper = $this->createMock(PropertyMapper::class);
-        $mockPropertyMapper->expects(self::any())->method('convert')->will($this->returnArgument(0));
+        $mockPropertyMapper->expects(self::any())->method('convert')->willReturnArgument(0);
         $this->inject($contentCache, 'propertyMapper', $mockPropertyMapper);
 
         $mockContext = $this->getMockBuilder(EnvironmentConfiguration::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Cache/ContentCacheTest.php
@@ -31,7 +31,7 @@ class ContentCacheTest extends UnitTestCase
     /**
      * @return array
      */
-    public function tags()
+    public static function tags()
     {
         return [
             ['Everything', 'Everything'],
@@ -58,7 +58,7 @@ class ContentCacheTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidEntryIdentifierValues()
+    public static function invalidEntryIdentifierValues()
     {
         return [
             'object not implementing CacheAwareInterface' => [['foo' => new \stdClass()]]
@@ -80,14 +80,15 @@ class ContentCacheTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validEntryIdentifierValues()
+    public static function validEntryIdentifierValues()
     {
-        $mockCacheAware = $this->createMock(CacheAwareInterface::class);
         return [
             'string value' => [['foo' => 'Bar']],
             'boolean value' => [['foo' => true]],
             'integer value' => [['foo' => 42]],
-            'object implementing CacheAwareInterface' => [['foo' => $mockCacheAware]],
+            // data providers must be static and cannot build mocks, so the test method
+            // replaces this marker with a CacheAwareInterface mock
+            'object implementing CacheAwareInterface' => [['foo' => '__mock:CacheAwareInterface']],
             'null' => [['foo' => null]]
         ];
     }
@@ -96,6 +97,9 @@ class ContentCacheTest extends UnitTestCase
     #[Test]
     public function createCacheSegmentWithValidEntryIdentifierValueCreatesIdentifier($entryIdentifierValues)
     {
+        if (($entryIdentifierValues['foo'] ?? null) === '__mock:CacheAwareInterface') {
+            $entryIdentifierValues['foo'] = $this->createMock(CacheAwareInterface::class);
+        }
         $contentCache = new ContentCache();
         $mockSecurityContext = $this->createMock(Context::class);
         $this->inject($contentCache, 'securityContext', $mockSecurityContext);

--- a/Neos.Fusion/Tests/Unit/Core/ExceptionHandlers/AbstractRenderingExceptionHandlerTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ExceptionHandlers/AbstractRenderingExceptionHandlerTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\Core\ExceptionHandlers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Exception;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Tests\UnitTestCase;
@@ -44,9 +44,8 @@ class AbstractRenderingExceptionHandlerTest extends UnitTestCase
 
     /**
      * exceptions are handled and transformed to a message
-     *
-     * @test
      */
+    #[Test]
     public function handleExceptions()
     {
         $exception = new \Exception();
@@ -60,9 +59,8 @@ class AbstractRenderingExceptionHandlerTest extends UnitTestCase
 
     /**
      * exceptions are handled and transformed to a message
-     *
-     * @test
      */
+    #[Test]
     public function useReferenceCodes()
     {
         $exception = new Exception();
@@ -77,9 +75,8 @@ class AbstractRenderingExceptionHandlerTest extends UnitTestCase
     /**
      * runtime exceptions are unpacked,
      * meaning that the inner fusion path an the inner exception is used to generate the message
-     *
-     * @test
      */
+    #[Test]
     public function unpackRuntimeException()
     {
         $exception = new Exception();
@@ -93,9 +90,8 @@ class AbstractRenderingExceptionHandlerTest extends UnitTestCase
 
     /**
      * StopActionException are rethrown
-     *
-     * @test
      */
+    #[Test]
     public function neverHandleStopActionException()
     {
         $this->expectException(StopActionException::class);
@@ -105,9 +101,8 @@ class AbstractRenderingExceptionHandlerTest extends UnitTestCase
 
     /**
      * SecurityException are rethrown
-     *
-     * @test
      */
+    #[Test]
     public function neverHandleSecurityException()
     {
         $this->expectException(\Neos\Flow\Security\Exception::class);

--- a/Neos.Fusion/Tests/Unit/Core/FusionSourceCodeDtosTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/FusionSourceCodeDtosTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\FusionSourceCode;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
@@ -26,9 +26,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         return $asArray[0];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pureFactories()
     {
         $code = FusionSourceCode::fromString("a");
@@ -49,9 +47,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         self::assertCount(0, $code);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromFilePathFactories()
     {
         vfsStream::setup('fusion', null, [
@@ -72,9 +68,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         self::assertCount(0, $code);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectionIterableAndCountable()
     {
         $code = FusionSourceCode::fromString("a");
@@ -88,9 +82,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deduplication()
     {
         vfsStream::setup('fusion', null, [
@@ -114,9 +106,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         self::assertEquals($code1doubled, $asArray[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deduplication2()
     {
         vfsStream::setup('fusion', null, [
@@ -149,9 +139,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
         self::assertEquals($code4, $asArray[3]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deduplication4()
     {
         vfsStream::setup('fusion', null, [
@@ -182,9 +170,7 @@ class FusionSourceCodeDtosTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function union()
     {
         $code1 = FusionSourceCodeCollection::fromString("a");

--- a/Neos.Fusion/Tests/Unit/Core/LegacyParserApiTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/LegacyParserApiTest.php
@@ -32,8 +32,8 @@ class LegacyParserApiTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
-        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->willReturnCallback(fn ($_, $getValue) => $getValue());
+        $parserCache->method('cacheForDsl')->willReturnCallback(fn ($_, $_2, $getValue) => $getValue());
         $this->inject($parser, 'parserCache', $parserCache);
     }
 
@@ -845,14 +845,20 @@ class LegacyParserApiTest extends UnitTestCase
         $this->injectParserCacheMockIntoParser($parser);
 
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture24');
+        $matcher = $this->exactly(2);
 
         $parser
-            ->expects($this->exactly(2))
-            ->method('handleDslTranspile')
-            ->withConsecutive(
-                ['dsl1', 'example value'],
-                ['dsl2', 'another' . chr(10) . 'multiline' . chr(10) . 'value']
-            );
+            ->expects($matcher)
+            ->method('handleDslTranspile')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('dsl1', $parameters[0]);
+                $this->assertSame('example value', $parameters[1]);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('dsl2', $parameters[0]);
+                $this->assertSame('another' . chr(10) . 'multiline' . chr(10) . 'value', $parameters[1]);
+            }
+        });
 
         $parser->parse($sourceCode);
     }

--- a/Neos.Fusion/Tests/Unit/Core/LegacyParserApiTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/LegacyParserApiTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Cache\ParserCache;
@@ -39,9 +39,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 01
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture01()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture01');
@@ -70,9 +69,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if a leading slash in the namespace declaration throws an exception
-     *
-     * @test
      */
+    #[Test]
     public function parserThrowsFusionExceptionIfNamespaceDeclarationIsInvalid()
     {
         $this->expectException(Exception::class);
@@ -82,9 +80,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 02
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture02()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture02');
@@ -117,9 +114,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 03
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture03()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture03');
@@ -164,9 +160,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 04
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture04()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture04');
@@ -233,9 +228,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 05
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture05()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture05');
@@ -302,9 +296,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 07
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture07()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture07');
@@ -331,8 +324,8 @@ class LegacyParserApiTest extends UnitTestCase
      * checks if the object tree returned by the Fusion parser reflects source code fixture 08
      *
      * @todo Implement lazy rendering support for variable substitutions
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture08()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture08');
@@ -393,9 +386,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 10
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture10()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture10');
@@ -472,9 +464,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 13
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture13()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture13');
@@ -524,9 +515,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 14
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture14()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture14');
@@ -562,9 +552,7 @@ class LegacyParserApiTest extends UnitTestCase
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 14.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserCorrectlyParsesFixture15()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture15');
@@ -664,9 +652,7 @@ class LegacyParserApiTest extends UnitTestCase
         return $expectedParseTree;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserCorrectlyParsesFixture16()
     {
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture16.fusion';
@@ -678,9 +664,7 @@ class LegacyParserApiTest extends UnitTestCase
         self::assertEquals($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 16');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserThrowsExceptionOnFixture16b()
     {
         $this->expectException(Exception::class);
@@ -690,9 +674,7 @@ class LegacyParserApiTest extends UnitTestCase
         $this->parser->parse($sourceCode, $fixture);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserCorrectlyParsesFixture17()
     {
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture17.fusion';
@@ -727,9 +709,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if simple values (string, boolean, integer) are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture19()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture19');
@@ -750,9 +731,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if path with an underscore is parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture20()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture20');
@@ -774,9 +754,7 @@ class LegacyParserApiTest extends UnitTestCase
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 20.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserDetectsDirectRecursions()
     {
         $this->expectException(Exception::class);
@@ -784,9 +762,7 @@ class LegacyParserApiTest extends UnitTestCase
         $this->parser->parse($sourceCode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserDetectsIndirectRecursions()
     {
         $this->expectException(Exception::class);
@@ -796,9 +772,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if identifiers starting with digits are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture21()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture23');
@@ -820,9 +795,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if identifiers starting with digits are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture25()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture25');
@@ -840,9 +814,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if really long strings are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyLongStrings()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixtureLongString');
@@ -852,9 +825,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if comments in comments are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesComments01()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionComments01');
@@ -865,9 +837,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks if dsl value is handed over to the handleDslTranspile method
-     *
-     * @test
      */
+    #[Test]
     public function parserInvokesFusionDslParsingIfADslPatternIsDetected()
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleDslTranspile'])->getMock();
@@ -888,9 +859,8 @@ class LegacyParserApiTest extends UnitTestCase
 
     /**
      * Checks unclosed dsl-expressions are
-     *
-     * @test
      */
+    #[Test]
     public function parserThrowsFusionExceptionIfUnfinishedDslIsDetected()
     {
         $this->expectException(Exception::class);

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * source code.
  */
 
+use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Core\ObjectTreeParser\ExceptionMessage\MessageLinePart;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Cache\ParserCache;
@@ -310,7 +311,7 @@ class ParserExceptionTest extends UnitTestCase
     {
         self::expectException(ParserException::class);
         self::expectExceptionMessage($expectedMessage);
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
     /**
@@ -326,7 +327,7 @@ class ParserExceptionTest extends UnitTestCase
     public function itMatchesThePartialExceptionMessage($fusion, $expectedMessage): void
     {
         try {
-            $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+            $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
             self::fail('No exception was thrown. Expected message: ' . $expectedMessage);
         } catch (ParserException $e) {
             self::assertSame($expectedMessage, $e->getHelperMessagePart());

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -32,8 +32,8 @@ class ParserExceptionTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
-        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->willReturnCallback(fn ($_, $getValue) => $getValue());
+        $parserCache->method('cacheForDsl')->willReturnCallback(fn ($_, $_2, $getValue) => $getValue());
         $this->inject($parser, 'parserCache', $parserCache);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Core\ObjectTreeParser\ExceptionMessage\MessageLinePart;
 use Neos\Fusion\Core\Parser;
@@ -303,10 +304,8 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider fullParserExceptionMessage
-     */
+    #[DataProvider('fullParserExceptionMessage')]
+    #[Test]
     public function itMatchesTheFullExceptionMessage($fusion, $expectedMessage): void
     {
         self::expectException(ParserException::class);
@@ -314,16 +313,14 @@ class ParserExceptionTest extends UnitTestCase
         $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
-    /**
-     * @test
-     * @dataProvider advancedGuessingWhatWentWrong
-     * @dataProvider removedLanguageFeaturedAreExplained
-     * @dataProvider generalInvalidFusion
-     * @dataProvider parsingWorksButOtherLogicThrows
-     * @dataProvider privateMetaPathCanOnlyBeDeclaredInsideRootPrototypeDeclaration
-     * @dataProvider unclosedStatements
-     * @dataProvider endOfLineExpected
-     */
+    #[DataProvider('advancedGuessingWhatWentWrong')]
+    #[DataProvider('removedLanguageFeaturedAreExplained')]
+    #[DataProvider('generalInvalidFusion')]
+    #[DataProvider('parsingWorksButOtherLogicThrows')]
+    #[DataProvider('privateMetaPathCanOnlyBeDeclaredInsideRootPrototypeDeclaration')]
+    #[DataProvider('unclosedStatements')]
+    #[DataProvider('endOfLineExpected')]
+    #[Test]
     public function itMatchesThePartialExceptionMessage($fusion, $expectedMessage): void
     {
         try {
@@ -334,9 +331,7 @@ class ParserExceptionTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function messageLinePartWorks()
     {
         $part = new MessageLinePart('abcd');

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserExceptionTest.php
@@ -37,7 +37,7 @@ class ParserExceptionTest extends UnitTestCase
         $this->inject($parser, 'parserCache', $parserCache);
     }
 
-    public function fullParserExceptionMessage(): \Generator
+    public static function fullParserExceptionMessage(): \Generator
     {
         yield 'no closing brace' => [
             <<<'FUSION'
@@ -101,7 +101,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function generalInvalidFusion(): \Generator
+    public static function generalInvalidFusion(): \Generator
     {
         yield 'space in object path' => [
             'path. hello = 123',
@@ -159,7 +159,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function privateMetaPathCanOnlyBeDeclaredInsideRootPrototypeDeclaration(): \Generator
+    public static function privateMetaPathCanOnlyBeDeclaredInsideRootPrototypeDeclaration(): \Generator
     {
         yield 'simple @private meta key cannot be declared from outside' => [
             <<<'FUSION'
@@ -198,7 +198,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function parsingWorksButOtherLogicThrows(): \Generator
+    public static function parsingWorksButOtherLogicThrows(): \Generator
     {
         yield 'invalid path to object inheritance' => [
             'prototype(a:b) < path.simple',
@@ -217,7 +217,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function advancedGuessingWhatWentWrong(): \Generator
+    public static function advancedGuessingWhatWentWrong(): \Generator
     {
         yield 'misspelled prototype declaration' => [
             'prooototype(a:b)',
@@ -230,7 +230,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function unclosedStatements(): \Generator
+    public static function unclosedStatements(): \Generator
     {
         yield 'unclosed multiline comment' => [
             '/*',
@@ -278,7 +278,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function removedLanguageFeaturedAreExplained(): \Generator
+    public static function removedLanguageFeaturedAreExplained(): \Generator
     {
         yield 'unqualified object type' => [
             'a = Value',
@@ -291,7 +291,7 @@ class ParserExceptionTest extends UnitTestCase
         ];
     }
 
-    public function endOfLineExpected(): \Generator
+    public static function endOfLineExpected(): \Generator
     {
         yield 'multiple values' => [
             'a = 1 + 1',

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Core\FusionSourceCode;
 use Neos\Fusion\Exception;
@@ -194,12 +195,10 @@ class ParserIncludeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider includeSingleFile
-     * @dataProvider includeNormalGlobbing
-     * @dataProvider includeRecursiveGlobbing
-     * @test
-     */
+    #[DataProvider('includeSingleFile')]
+    #[DataProvider('includeNormalGlobbing')]
+    #[DataProvider('includeRecursiveGlobbing')]
+    #[Test]
     public function fusionParseMethodIsCalledCorrectlyWithFilesOfPattern($contextPathAndFilename, $fusionCode, $expectedFusionAst): void
     {
         $actualFusionAst = $this->parser->parseFromSource(new FusionSourceCodeCollection(
@@ -209,9 +208,7 @@ class ParserIncludeTest extends UnitTestCase
         self::assertSame($expectedFusionAst, $actualFusionAst);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function absoluteIncludePathsRaiseError(): void
     {
         self::expectException(Exception::class);
@@ -240,10 +237,8 @@ class ParserIncludeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider weirdFusionIncludeValuesAreHandedOver
-     * @test
-     */
+    #[DataProvider('weirdFusionIncludeValuesAreHandedOver')]
+    #[Test]
     public function testFusionIncludesArePassedCorrectlyToIncludeAndParseFilesByPattern($fusion, $includePattern): void
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleFileInclude'])->getMock();
@@ -275,10 +270,8 @@ class ParserIncludeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider throwsFusionIncludesWithSpaces
-     * @test
-     */
+    #[DataProvider('throwsFusionIncludesWithSpaces')]
+    #[Test]
     public function testFusionIncludesThrowExpectedEndOfStatement($fusion): void
     {
         self::expectException(Exception::class);
@@ -315,10 +308,8 @@ class ParserIncludeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider unsupportedGlobbingTechnics
-     */
+    #[DataProvider('unsupportedGlobbingTechnics')]
+    #[Test]
     public function testUnsupportedGlobbingTechnicsThrowException($pattern): void
     {
         self::expectException(Exception::class);
@@ -331,9 +322,7 @@ class ParserIncludeTest extends UnitTestCase
         $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusionCode))->toArray();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testThatInTestEnvironmentStatCanDifferentiateBetweenFilesWhoHaveTheSameSize(): void
     {
         self::assertNotSame(stat('vfs://fusion/Globbing/level1-A.fusion'), stat('vfs://fusion/Globbing/level1-B.fusion'));

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -39,8 +39,8 @@ class ParserIncludeTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
-        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->willReturnCallback(fn ($_, $getValue) => $getValue());
+        $parserCache->method('cacheForDsl')->willReturnCallback(fn ($_, $_2, $getValue) => $getValue());
         $this->inject($parser, 'parserCache', $parserCache);
     }
 
@@ -79,48 +79,48 @@ class ParserIncludeTest extends UnitTestCase
     public static function includeSingleFile(): \Generator
     {
         yield 'single file without quotes and space relative' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include:file.fusion',
-            'include' => ['file.fusion' => true]
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include:file.fusion',
+            'expectedFusionAst' => ['file.fusion' => true]
         ];
 
         yield 'single file without quotes and special chars absolute' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include: vfs://fusion/sp3z:al-CHAR_.fs ',
-            'include' => ['sp3z:al-CHAR_.fs' => true]
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include: vfs://fusion/sp3z:al-CHAR_.fs ',
+            'expectedFusionAst' => ['sp3z:al-CHAR_.fs' => true]
         ];
 
         yield 'single file without quotes and with space absolute' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include:  vfs://fusion/file.fusion  ',
-            'include' => ['file.fusion' => true]
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include:  vfs://fusion/file.fusion  ',
+            'expectedFusionAst' => ['file.fusion' => true]
         ];
 
         yield 'single file with single quotes explicit relative' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include:\'./file.fusion\'',
-            'include' => ['file.fusion' => true]
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include:\'./file.fusion\'',
+            'expectedFusionAst' => ['file.fusion' => true]
         ];
 
         yield 'single file with double quotes space explicit relative' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include:  "  ./file.fusion  "  ',
-            'include' => ['file.fusion' => true]
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include:  "  ./file.fusion  "  ',
+            'expectedFusionAst' => ['file.fusion' => true]
         ];
 
         yield 'single file context will prevent recursion' => [
-            'context' => 'vfs://fusion/file.fusion',
-            'fusion ' => 'include:./file.fusion',
-            'include' => []
+            'contextPathAndFilename' => 'vfs://fusion/file.fusion',
+            'fusionCode' => 'include:./file.fusion',
+            'expectedFusionAst' => []
         ];
     }
 
-    public function includeNormalGlobbing(): \Generator
+    public static function includeNormalGlobbing(): \Generator
     {
         yield 'simple glob relative' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include: Globbing/* ',
-            'include' => [
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include: Globbing/* ',
+            'expectedFusionAst' => [
                 'Globbing/level1-A.fusion' => true,
                 'Globbing/level1-B.fusion' => true,
                 'Globbing/level1-C.fusion' => true,
@@ -131,9 +131,9 @@ class ParserIncludeTest extends UnitTestCase
     public static function includeRecursiveGlobbing(): \Generator
     {
         yield 'recursive glob relative with specified file end' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include:Globbing/**/*.fusion',
-            'include' => [
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include:Globbing/**/*.fusion',
+            'expectedFusionAst' => [
                 'Globbing/Nested/level2-A.fusion' => true,
                 'Globbing/Nested/level2-B.fusion' => true,
                 'Globbing/Nested/Deep/level3-A.fusion' => true,
@@ -144,9 +144,9 @@ class ParserIncludeTest extends UnitTestCase
         ];
 
         yield 'recursive glob relative without recursion' => [
-            'context' => 'vfs://fusion/Globbing/level1-A.fusion',
-            'fusion ' => 'include:**/*',
-            'include' => [
+            'contextPathAndFilename' => 'vfs://fusion/Globbing/level1-A.fusion',
+            'fusionCode' => 'include:**/*',
+            'expectedFusionAst' => [
                 'Globbing/Nested/level2-A.fusion' => true,
                 'Globbing/Nested/level2-B.fusion' => true,
                 'Globbing/Nested/Deep/level3-A.fusion' => true,
@@ -158,9 +158,9 @@ class ParserIncludeTest extends UnitTestCase
         ];
 
         yield 'recursive glob absolute' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include: vfs://fusion/Globbing/**/*',
-            'include' => [
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include: vfs://fusion/Globbing/**/*',
+            'expectedFusionAst' => [
                 'Globbing/Nested/level2-A.fusion' => true,
                 'Globbing/Nested/level2-B.fusion' => true,
                 'Globbing/Nested/Deep/level3-A.fusion' => true,
@@ -171,9 +171,9 @@ class ParserIncludeTest extends UnitTestCase
         ];
 
         yield 'recursive glob relative parent' => [
-            'context' => 'vfs://fusion/Globbing/Nested/level2-A.fusion',
-            'fusion ' => 'include: ../**/*',
-            'include' => [
+            'contextPathAndFilename' => 'vfs://fusion/Globbing/Nested/level2-A.fusion',
+            'fusionCode' => 'include: ../**/*',
+            'expectedFusionAst' => [
                 // Not included because this would mean a recursion.
                 // 'Globbing/Nested/level2-A.fusion' => true,
                 'Globbing/Nested/level2-B.fusion' => true,
@@ -185,9 +185,9 @@ class ParserIncludeTest extends UnitTestCase
         ];
 
         yield 'recursive glob relative with uncommon specified file end' => [
-            'context' => 'vfs://fusion/root.fusion',
-            'fusion ' => 'include: ./Globbing/**/*-A.fusion',
-            'include' => [
+            'contextPathAndFilename' => 'vfs://fusion/root.fusion',
+            'fusionCode' => 'include: ./Globbing/**/*-A.fusion',
+            'expectedFusionAst' => [
                 'Globbing/Nested/level2-A.fusion' => true,
                 'Globbing/Nested/Deep/level3-A.fusion' => true,
                 'Globbing/level1-A.fusion' => true,
@@ -243,10 +243,15 @@ class ParserIncludeTest extends UnitTestCase
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleFileInclude'])->getMock();
         $this->injectParserCacheMockIntoParser($parser);
+        $matcher = self::once();
         $parser
-            ->expects(self::once())
+            ->expects($matcher)
             ->method('handleFileInclude')
-            ->withConsecutive([self::anything(), $includePattern]);
+            ->willReturnCallback(function (...$parameters) use ($matcher, $includePattern) {
+                if ($matcher->numberOfInvocations() === 1) {
+                    $this->assertSame($includePattern, $parameters[1]);
+                }
+            });
 
         $parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -76,7 +76,7 @@ class ParserIncludeTest extends UnitTestCase
         self::setUniqueLastModifiedTimeForEachFileRecursive($file_system);
     }
 
-    public function includeSingleFile(): \Generator
+    public static function includeSingleFile(): \Generator
     {
         yield 'single file without quotes and space relative' => [
             'context' => 'vfs://fusion/root.fusion',
@@ -128,7 +128,7 @@ class ParserIncludeTest extends UnitTestCase
         ];
     }
 
-    public function includeRecursiveGlobbing(): \Generator
+    public static function includeRecursiveGlobbing(): \Generator
     {
         yield 'recursive glob relative with specified file end' => [
             'context' => 'vfs://fusion/root.fusion',
@@ -221,7 +221,7 @@ class ParserIncludeTest extends UnitTestCase
         $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusionCode))->toArray();
     }
 
-    public function weirdFusionIncludeValuesAreHandedOver(): \Generator
+    public static function weirdFusionIncludeValuesAreHandedOver(): \Generator
     {
         yield 'pattern with direct comment' => [
             'include: pattern /* this is a comment */', 'pattern'
@@ -251,7 +251,7 @@ class ParserIncludeTest extends UnitTestCase
         $parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
-    public function throwsFusionIncludesWithSpaces(): \Generator
+    public static function throwsFusionIncludesWithSpaces(): \Generator
     {
         yield 'pattern with direct comment' => [
             'include: /* comments are here not allowed */ pattern '
@@ -289,7 +289,7 @@ class ParserIncludeTest extends UnitTestCase
     /**
      * FilePattern accept only simple File paths or /**\/* and /*
      */
-    public function unsupportedGlobbingTechnics(): array
+    public static function unsupportedGlobbingTechnics(): array
     {
         return [
             'simple glob at end without slash (that means its a file)' => ['file*'],

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserIncludeTest.php
@@ -11,6 +11,9 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * source code.
  */
 
+use Neos\Fusion\Core\FusionSourceCodeCollection;
+use Neos\Fusion\Core\FusionSourceCode;
+use Neos\Fusion\Exception;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion;
 use Neos\Fusion\Core\Cache\ParserCache;
@@ -199,8 +202,8 @@ class ParserIncludeTest extends UnitTestCase
      */
     public function fusionParseMethodIsCalledCorrectlyWithFilesOfPattern($contextPathAndFilename, $fusionCode, $expectedFusionAst): void
     {
-        $actualFusionAst = $this->parser->parseFromSource(new Fusion\Core\FusionSourceCodeCollection(
-            Fusion\Core\FusionSourceCode::fromDangerousPotentiallyDifferingSourceCodeAndFilePath($fusionCode, $contextPathAndFilename)
+        $actualFusionAst = $this->parser->parseFromSource(new FusionSourceCodeCollection(
+            FusionSourceCode::fromDangerousPotentiallyDifferingSourceCodeAndFilePath($fusionCode, $contextPathAndFilename)
         ))->toArray();
 
         self::assertSame($expectedFusionAst, $actualFusionAst);
@@ -211,14 +214,14 @@ class ParserIncludeTest extends UnitTestCase
      */
     public function absoluteIncludePathsRaiseError(): void
     {
-        self::expectException(Fusion\Exception::class);
+        self::expectException(Exception::class);
         self::expectExceptionCode(1636144292);
 
         $fusionCode = <<<Fusion
         include: /**/*
         Fusion;
 
-        $this->parser->parseFromSource(Fusion\Core\FusionSourceCodeCollection::fromString($fusionCode))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusionCode))->toArray();
     }
 
     public function weirdFusionIncludeValuesAreHandedOver(): \Generator
@@ -250,7 +253,7 @@ class ParserIncludeTest extends UnitTestCase
             ->method('handleFileInclude')
             ->withConsecutive([self::anything(), $includePattern]);
 
-        $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+        $parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
     public function throwsFusionIncludesWithSpaces(): \Generator
@@ -278,7 +281,7 @@ class ParserIncludeTest extends UnitTestCase
      */
     public function testFusionIncludesThrowExpectedEndOfStatement($fusion): void
     {
-        self::expectException(Fusion\Exception::class);
+        self::expectException(Exception::class);
         self::expectExceptionCode(1635878683);
 
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleFileInclude'])->getMock();
@@ -287,7 +290,7 @@ class ParserIncludeTest extends UnitTestCase
             ->expects(self::never())
             ->method('handleFileInclude');
 
-        $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+        $parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
     /**
@@ -318,14 +321,14 @@ class ParserIncludeTest extends UnitTestCase
      */
     public function testUnsupportedGlobbingTechnicsThrowException($pattern): void
     {
-        self::expectException(Fusion\Exception::class);
+        self::expectException(Exception::class);
         self::expectExceptionCode(1636144713);
 
         $fusionCode = <<<Fusion
         include: vfs://fusion/$pattern
         Fusion;
 
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusionCode))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusionCode))->toArray();
     }
 
     /**

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
 use Neos\Fusion\Exception;
 use Neos\Fusion\Core\Parser;
@@ -488,9 +489,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function typeConversionOnPhpArrayKeys()
     {
         // as a reminder how php arrays work ^^
@@ -1010,59 +1009,51 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider overridePaths
-     * @dataProvider simplePathToArray
-     * @dataProvider commentsTest
-     * @dataProvider unsetPathOrSetToNull
-     * @dataProvider problematicPathIdNames
-     * @dataProvider metaObjectPaths
-     * @dataProvider eelValueAssign
-     * @dataProvider simpleValueAssign
-     * @dataProvider unexpectedCopyAssigment
-     * @dataProvider unexpectedObjectPaths
-     * @dataProvider nestedObjectPaths
-     * @dataProvider pathBlockTest
-     * @dataProvider stringAndCharValueAssign
-     * @dataProvider prototypeDeclarationAndInheritance
-     * @dataProvider fusionObjectNameEdgeCases
-     */
+    #[DataProvider('overridePaths')]
+    #[DataProvider('simplePathToArray')]
+    #[DataProvider('commentsTest')]
+    #[DataProvider('unsetPathOrSetToNull')]
+    #[DataProvider('problematicPathIdNames')]
+    #[DataProvider('metaObjectPaths')]
+    #[DataProvider('eelValueAssign')]
+    #[DataProvider('simpleValueAssign')]
+    #[DataProvider('unexpectedCopyAssigment')]
+    #[DataProvider('unexpectedObjectPaths')]
+    #[DataProvider('nestedObjectPaths')]
+    #[DataProvider('pathBlockTest')]
+    #[DataProvider('stringAndCharValueAssign')]
+    #[DataProvider('prototypeDeclarationAndInheritance')]
+    #[DataProvider('fusionObjectNameEdgeCases')]
+    #[Test]
     public function itParsesToExpectedAst($fusion, $expectedAst): void
     {
         $parsedFusionAst = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
         self::assertSame($expectedAst, $parsedFusionAst);
     }
 
-    /**
-     * @test
-     * @dataProvider throwsOldNamespaceDeclaration
-     * @dataProvider throwsWrongComments
-     * @dataProvider throwsGeneralWrongSyntax
-     * @dataProvider throwsFusionObjectNamesWithoutNamespace
-     */
+    #[DataProvider('throwsOldNamespaceDeclaration')]
+    #[DataProvider('throwsWrongComments')]
+    #[DataProvider('throwsGeneralWrongSyntax')]
+    #[DataProvider('throwsFusionObjectNamesWithoutNamespace')]
+    #[Test]
     public function itThrowsWhileParsing($fusion): void
     {
         self::expectException(Exception::class);
         $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
-    /**
-     * @test
-     * @dataProvider weirdFusionObjectNamesParsesBecauseTheOldParserDidntComplain
-     * @dataProvider unexpectedBlocksWork
-     */
+    #[DataProvider('weirdFusionObjectNamesParsesBecauseTheOldParserDidntComplain')]
+    #[DataProvider('unexpectedBlocksWork')]
+    #[Test]
     public function itParsesWithoutError($fusion): void
     {
         $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
         self::assertTrue(true);
     }
 
-    /**
-     * @dataProvider weirdDslNames
-     * @dataProvider dslWithBraceOnFirstLine
-     * @test
-     */
+    #[DataProvider('weirdDslNames')]
+    #[DataProvider('dslWithBraceOnFirstLine')]
+    #[Test]
     public function dslIsRecognizedAndPassed($sourceCode, $expectedDslName, $expectedDslContent)
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleDslTranspile'])->getMock();

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -32,8 +32,8 @@ class ParserTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
-        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->willReturnCallback(fn ($_, $getValue) => $getValue());
+        $parserCache->method('cacheForDsl')->willReturnCallback(fn ($_, $_2, $getValue) => $getValue());
         $this->inject($parser, 'parserCache', $parserCache);
     }
 

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -37,7 +37,7 @@ class ParserTest extends UnitTestCase
         $this->inject($parser, 'parserCache', $parserCache);
     }
 
-    public function pathBlockTest(): array
+    public static function pathBlockTest(): array
     {
         return [
             [
@@ -97,7 +97,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function unexpectedBlocksWork(): array
+    public static function unexpectedBlocksWork(): array
     {
         // test of normal objects is already done with the fixtures
         return [
@@ -132,7 +132,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function unsetPathOrSetToNull()
+    public static function unsetPathOrSetToNull()
     {
         yield 'overwrite with boolean value' => [
             <<<'Fusion'
@@ -188,7 +188,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function simplePathToArray(): \Generator
+    public static function simplePathToArray(): \Generator
     {
         yield 'simple string "opened" with meta' => [
             <<<'Fusion'
@@ -231,7 +231,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function overridePaths(): \Generator
+    public static function overridePaths(): \Generator
     {
         yield 'eel expression is overridden by simple type' => [
             <<<'Fusion'
@@ -327,7 +327,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function commentsTest(): array
+    public static function commentsTest(): array
     {
         $obj = function (string $name): array {
             return ['__objectType' => $name, '__value' => null, '__eelExpression' => null];
@@ -386,7 +386,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function throwsWrongComments(): array
+    public static function throwsWrongComments(): array
     {
         return[
             [
@@ -430,7 +430,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function prototypeDeclarationAndInheritance(): array
+    public static function prototypeDeclarationAndInheritance(): array
     {
         return [
             [
@@ -511,7 +511,7 @@ class ParserTest extends UnitTestCase
         self::assertSame('123.456', $asArrayKey('123.456'), 'string float array keys stay strings');
     }
 
-    public function problematicPathIdNames(): \Generator
+    public static function problematicPathIdNames(): \Generator
     {
         yield 'float in quotes as path identifier' => [
             <<<'Fusion'
@@ -601,7 +601,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function throwsOldNamespaceDeclaration(): array
+    public static function throwsOldNamespaceDeclaration(): array
     {
         return [
             [
@@ -619,7 +619,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function throwsGeneralWrongSyntax(): \Generator
+    public static function throwsGeneralWrongSyntax(): \Generator
     {
         yield 'path declaration after opening' => [<<<'Fusion'
             a { b = "hello"
@@ -721,7 +721,7 @@ class ParserTest extends UnitTestCase
             Fusion];
     }
 
-    public function unexpectedCopyAssigment()
+    public static function unexpectedCopyAssigment()
     {
         yield 'copying from undefined path 1' => ['a < b', ['a' => null]];
 
@@ -760,7 +760,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function unexpectedObjectPaths(): array
+    public static function unexpectedObjectPaths(): array
     {
         return [
             ['0 = ""', [0 => '']],
@@ -789,14 +789,14 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function metaObjectPaths(): array
+    public static function metaObjectPaths(): array
     {
         return [
             ['a.@abc = 1', ['a' => ['__meta' => ['abc' => 1]]]],
         ];
     }
 
-    public function nestedObjectPaths(): array
+    public static function nestedObjectPaths(): array
     {
         return [
             ['12f:o:o.ba:r.as.ba:z = 1', ['12f:o:o' => ['ba:r' => ['as' => ['ba:z' => 1]]]]],
@@ -806,7 +806,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function simpleValueAssign(): array
+    public static function simpleValueAssign(): array
     {
         return [
             ['a="b"', ['a' => 'b']],
@@ -835,7 +835,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function eelValueAssign(): \Generator
+    public static function eelValueAssign(): \Generator
     {
         $eel = function (string $exp): array {
             return ['__eelExpression' => $exp, '__value' => null, '__objectType' => null];
@@ -895,7 +895,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function stringAndCharValueAssign(): array
+    public static function stringAndCharValueAssign(): array
     {
         return [
             [<<<'Fusion'
@@ -922,7 +922,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function fusionObjectNameEdgeCases(): array
+    public static function fusionObjectNameEdgeCases(): array
     {
         $obj = function (string $name): array {
             return ['__objectType' => $name, '__value' => null, '__eelExpression' => null];
@@ -940,7 +940,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function weirdFusionObjectNamesParsesBecauseTheOldParserDidntComplain(): array
+    public static function weirdFusionObjectNamesParsesBecauseTheOldParserDidntComplain(): array
     {
         return [
             ['a = ABC:123'],
@@ -955,7 +955,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function throwsFusionObjectNamesWithoutNamespace(): array
+    public static function throwsFusionObjectNamesWithoutNamespace(): array
     {
         return [
             ['a = Value'],
@@ -973,7 +973,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function weirdDslNames(): \Generator
+    public static function weirdDslNames(): \Generator
     {
         yield 'true as dsl key' => [
             'foo = true`code`',
@@ -1000,7 +1000,7 @@ class ParserTest extends UnitTestCase
         ];
     }
 
-    public function dslWithBraceOnFirstLine(): \Generator
+    public static function dslWithBraceOnFirstLine(): \Generator
     {
         yield 'dsl with brace on end of first line' => [
             'foo = dsl1`code {`',

--- a/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/Parser/ParserTest.php
@@ -11,6 +11,8 @@ namespace Neos\Fusion\Tests\Unit\Core\Parser;
  * source code.
  */
 
+use Neos\Fusion\Core\FusionSourceCodeCollection;
+use Neos\Fusion\Exception;
 use Neos\Fusion\Core\Parser;
 use Neos\Fusion\Core\Cache\ParserCache;
 use Neos\Fusion;
@@ -1028,7 +1030,7 @@ class ParserTest extends UnitTestCase
      */
     public function itParsesToExpectedAst($fusion, $expectedAst): void
     {
-        $parsedFusionAst = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+        $parsedFusionAst = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
         self::assertSame($expectedAst, $parsedFusionAst);
     }
 
@@ -1041,8 +1043,8 @@ class ParserTest extends UnitTestCase
      */
     public function itThrowsWhileParsing($fusion): void
     {
-        self::expectException(Fusion\Exception::class);
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+        self::expectException(Exception::class);
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
     }
 
     /**
@@ -1052,7 +1054,7 @@ class ParserTest extends UnitTestCase
      */
     public function itParsesWithoutError($fusion): void
     {
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($fusion))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($fusion))->toArray();
         self::assertTrue(true);
     }
 
@@ -1071,6 +1073,6 @@ class ParserTest extends UnitTestCase
             ->method('handleDslTranspile')
             ->with($expectedDslName, $expectedDslContent);
 
-        $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
     }
 }

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\FusionSourceCode;
 use Neos\Fusion\Core\FusionSourceCodeCollection;
@@ -41,9 +41,8 @@ class ParserTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 01
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture01()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture01');
@@ -65,28 +64,26 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
 
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 01.');
     }
 
     /**
      * Checks if a leading slash in the namespace declaration throws an exception
-     *
-     * @test
      */
+    #[Test]
     public function parserThrowsFusionExceptionIfNamespaceDeclarationIsInvalid()
     {
         $this->expectException(Exception::class);
         $sourceCode = 'namespace: cms=\-notvalid-\Fusion\Fixtures';
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 02
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture02()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture02');
@@ -113,15 +110,14 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 02.');
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 03
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture03()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture03');
@@ -160,15 +156,14 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 03.');
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 04
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture04()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture04');
@@ -229,15 +224,14 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 04.');
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 05
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture05()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture05');
@@ -298,15 +292,14 @@ class ParserTest extends UnitTestCase
             ],
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 05.');
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 07
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture07()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture07');
@@ -325,7 +318,7 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 07.');
     }
 
@@ -333,8 +326,8 @@ class ParserTest extends UnitTestCase
      * checks if the object tree returned by the Fusion parser reflects source code fixture 08
      *
      * @todo Implement lazy rendering support for variable substitutions
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture08()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture08');
@@ -395,9 +388,8 @@ class ParserTest extends UnitTestCase
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 10
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture10()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture10');
@@ -468,15 +460,14 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertEquals($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 10.');
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 13
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture13()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture13');
@@ -520,15 +511,14 @@ class ParserTest extends UnitTestCase
             ],
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 13.');
     }
 
     /**
      * checks if the object tree returned by the Fusion parser reflects source code fixture 14
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture14()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture14');
@@ -560,13 +550,11 @@ class ParserTest extends UnitTestCase
             ],
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 14.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserCorrectlyParsesFixture15()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture15');
@@ -580,7 +568,7 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 15.');
     }
 
@@ -666,9 +654,7 @@ class ParserTest extends UnitTestCase
         return $expectedParseTree;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserCorrectlyParsesFixture16()
     {
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture16.fusion';
@@ -680,9 +666,7 @@ class ParserTest extends UnitTestCase
         self::assertEquals($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 16');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserThrowsExceptionOnFixture16b()
     {
         $this->expectException(Exception::class);
@@ -692,9 +676,7 @@ class ParserTest extends UnitTestCase
         $this->parser->parseFromSource(new FusionSourceCodeCollection(FusionSourceCode::fromDangerousPotentiallyDifferingSourceCodeAndFilePath($sourceCode, $fixture)))->toArray();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserCorrectlyParsesFixture17()
     {
         $fixture = __DIR__ . '/Fixtures/ParserTestFusionFixture17.fusion';
@@ -729,9 +711,8 @@ class ParserTest extends UnitTestCase
 
     /**
      * Checks if simple values (string, boolean, integer) are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture19()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture19');
@@ -746,15 +727,14 @@ class ParserTest extends UnitTestCase
             ],
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 19.');
     }
 
     /**
      * Checks if path with an underscore is parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture20()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture20');
@@ -772,35 +752,30 @@ class ParserTest extends UnitTestCase
             ],
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 20.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserDetectsDirectRecursions()
     {
         $this->expectException(Exception::class);
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture21');
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parserDetectsIndirectRecursions()
     {
         $this->expectException(Exception::class);
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture22');
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
     }
 
     /**
      * Checks if identifiers starting with digits are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture21()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture23');
@@ -816,15 +791,14 @@ class ParserTest extends UnitTestCase
             ],
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 23.');
     }
 
     /**
      * Checks if identifiers starting with digits are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesFixture25()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture25');
@@ -836,40 +810,37 @@ class ParserTest extends UnitTestCase
             ]
         ];
 
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertSame($expectedParseTree, $actualParseTree, 'The parse tree was not as expected after parsing fixture 23.');
     }
 
     /**
      * Checks if really long strings are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyLongStrings()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixtureLongString');
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertArrayHasKey('longString', $actualParseTree);
     }
 
     /**
      * Checks if comments in comments are parsed correctly
-     *
-     * @test
      */
+    #[Test]
     public function parserCorrectlyParsesComments01()
     {
         $sourceCode = $this->readFusionFixture('ParserTestFusionComments01');
         $expected = []; // Fixture contains only comments, so expect empty parse tree
-        $actualParseTree = $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $actualParseTree = $this->parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
         self::assertEquals($expected, $actualParseTree, 'The parse tree was not as expected after parsing fixture `ParserTestFusionComments01.fusion`');
     }
 
     /**
      * Checks if dsl value is handed over to the handleDslTranspile method
-     *
-     * @test
      */
+    #[Test]
     public function parserInvokesFusionDslParsingIfADslPatternIsDetected()
     {
         $parser = $this->getMockBuilder(Parser::class)->disableOriginalConstructor()->onlyMethods(['handleDslTranspile'])->getMock();
@@ -890,14 +861,13 @@ class ParserTest extends UnitTestCase
 
     /**
      * Checks unclosed dsl-expressions are
-     *
-     * @test
      */
+    #[Test]
     public function parserThrowsFusionExceptionIfUnfinishedDslIsDetected()
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(1490714685);
-        $this->parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString('dslValue1 = dsl1`unclosed dsl expression'))->toArray();
+        $this->parser->parseFromSource(FusionSourceCodeCollection::fromString('dslValue1 = dsl1`unclosed dsl expression'))->toArray();
     }
 
     /**

--- a/Neos.Fusion/Tests/Unit/Core/ParserTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/ParserTest.php
@@ -34,8 +34,8 @@ class ParserTest extends UnitTestCase
     private function injectParserCacheMockIntoParser(Parser $parser): void
     {
         $parserCache = $this->getMockBuilder(ParserCache::class)->getMock();
-        $parserCache->method('cacheForFusionFile')->will(self::returnCallback(fn ($_, $getValue) => $getValue()));
-        $parserCache->method('cacheForDsl')->will(self::returnCallback(fn ($_, $_2, $getValue) => $getValue()));
+        $parserCache->method('cacheForFusionFile')->willReturnCallback(fn ($_, $getValue) => $getValue());
+        $parserCache->method('cacheForDsl')->willReturnCallback(fn ($_, $_2, $getValue) => $getValue());
         $this->inject($parser, 'parserCache', $parserCache);
     }
 
@@ -847,16 +847,22 @@ class ParserTest extends UnitTestCase
         $this->injectParserCacheMockIntoParser($parser);
 
         $sourceCode = $this->readFusionFixture('ParserTestFusionFixture24');
+        $matcher = $this->exactly(2);
 
         $parser
-            ->expects($this->exactly(2))
-            ->method('handleDslTranspile')
-            ->withConsecutive(
-                ['dsl1', 'example value'],
-                ['dsl2', 'another' . chr(10) . 'multiline' . chr(10) . 'value']
-            );
+            ->expects($matcher)
+            ->method('handleDslTranspile')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('dsl1', $parameters[0]);
+                $this->assertSame('example value', $parameters[1]);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('dsl2', $parameters[0]);
+                $this->assertSame('another' . chr(10) . 'multiline' . chr(10) . 'value', $parameters[1]);
+            }
+        });
 
-        $parser->parseFromSource(\Neos\Fusion\Core\FusionSourceCodeCollection::fromString($sourceCode))->toArray();
+        $parser->parseFromSource(FusionSourceCodeCollection::fromString($sourceCode))->toArray();
     }
 
     /**

--- a/Neos.Fusion/Tests/Unit/Core/RuntimeConfigurationTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/RuntimeConfigurationTest.php
@@ -12,6 +12,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
  * source code.
  */
 
+use Neos\Fusion\Core\RuntimeConfiguration;
 use Neos\Flow\Tests\UnitTestCase;
 
 class RuntimeConfigurationTest extends UnitTestCase
@@ -50,7 +51,7 @@ class RuntimeConfigurationTest extends UnitTestCase
                 ]
             ]
         ];
-        $runtimeConfiguration = new \Neos\Fusion\Core\RuntimeConfiguration($fusionConfiguration);
+        $runtimeConfiguration = new RuntimeConfiguration($fusionConfiguration);
         $configuration = $runtimeConfiguration->forPath('root/item1/renderer');
 
         $this->assertEquals([

--- a/Neos.Fusion/Tests/Unit/Core/RuntimeConfigurationTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/RuntimeConfigurationTest.php
@@ -11,15 +11,13 @@ namespace Neos\Fusion\Tests\Unit\Core;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Core\RuntimeConfiguration;
 use Neos\Flow\Tests\UnitTestCase;
 
 class RuntimeConfigurationTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function forPath_caches_paths()
     {
         $fusionConfiguration = [

--- a/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\Core;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\EelEvaluatorInterface;
 use Neos\Eel\ProtectedContext;
 use Neos\Flow\Exception;
@@ -26,9 +26,8 @@ class RuntimeTest extends UnitTestCase
     /**
      * if the rendering leads to an exception
      * the exception is transformed into 'content' by calling 'handleRenderingException'
-     *
-     * @test
      */
+    #[Test]
     public function renderHandlesExceptionDuringRendering()
     {
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
@@ -47,9 +46,8 @@ class RuntimeTest extends UnitTestCase
      * exceptions are rendered using the renderer from configuration
      *
      * if this handler throws exceptions, they are not handled
-     *
-     * @test
      */
+    #[Test]
     public function handleRenderingExceptionThrowsException()
     {
         $this->expectException(Exception::class);
@@ -67,9 +65,7 @@ class RuntimeTest extends UnitTestCase
         $runtime->handleRenderingException('/foo/bar', $runtimeException);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateProcessorForEelExpressionUsesProtectedContext()
     {
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
@@ -89,9 +85,7 @@ class RuntimeTest extends UnitTestCase
         $runtime->_call('evaluateEelExpression', 'q(node).property("title")');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateWithCacheModeUncachedAndUnspecifiedContextThrowsException()
     {
         $this->expectException(\Neos\Fusion\Exception::class);
@@ -112,9 +106,7 @@ class RuntimeTest extends UnitTestCase
         $runtime->evaluate('foo/bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderRethrowsSecurityExceptions()
     {
         $this->expectException(\Neos\Flow\Security\Exception::class);
@@ -126,9 +118,7 @@ class RuntimeTest extends UnitTestCase
         $runtime->render('/foo/bar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function runtimeCurrentContextStackWorksSimplePushPop()
     {
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
@@ -145,9 +135,7 @@ class RuntimeTest extends UnitTestCase
         self::assertSame([], $runtime->getCurrentContext(), 'Runtime context should be empty again at end.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function runtimeCurrentContextStack3PushesAndPops()
     {
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
+++ b/Neos.Fusion/Tests/Unit/Core/RuntimeTest.php
@@ -32,10 +32,10 @@ class RuntimeTest extends UnitTestCase
     {
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'));
-        $runtime = $this->getMockBuilder(Runtime::class)->setMethods(['evaluate', 'handleRenderingException'])->setConstructorArgs([[], $controllerContext])->getMock();
+        $runtime = $this->getMockBuilder(Runtime::class)->onlyMethods(['evaluate', 'handleRenderingException'])->setConstructorArgs([[], $controllerContext])->getMock();
         $runtime->injectSettings(['rendering' => ['exceptionHandler' => ThrowingHandler::class]]);
-        $runtime->expects(self::any())->method('evaluate')->will(self::throwException($runtimeException));
-        $runtime->expects(self::once())->method('handleRenderingException')->with('/foo/bar', $runtimeException)->will(self::returnValue('Exception Message'));
+        $runtime->expects(self::any())->method('evaluate')->willThrowException($runtimeException);
+        $runtime->expects(self::once())->method('handleRenderingException')->with('/foo/bar', $runtimeException)->willReturn('Exception Message');
 
         $output = $runtime->render('/foo/bar');
 
@@ -51,7 +51,7 @@ class RuntimeTest extends UnitTestCase
     public function handleRenderingExceptionThrowsException()
     {
         $this->expectException(Exception::class);
-        $objectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->setMethods(['isRegistered', 'get'])->getMock();
+        $objectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->onlyMethods(['isRegistered', 'get'])->getMock();
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $runtimeException = new RuntimeException('I am a parent exception', 123, new Exception('I am a previous exception'));
         $runtime =  new Runtime([], $controllerContext);
@@ -59,8 +59,8 @@ class RuntimeTest extends UnitTestCase
         $exceptionHandlerSetting = 'settings';
         $runtime->injectSettings(['rendering' => ['exceptionHandler' => $exceptionHandlerSetting]]);
 
-        $objectManager->expects(self::once())->method('isRegistered')->with($exceptionHandlerSetting)->will(self::returnValue(true));
-        $objectManager->expects(self::once())->method('get')->with($exceptionHandlerSetting)->will(self::returnValue(new ThrowingHandler()));
+        $objectManager->expects(self::once())->method('isRegistered')->with($exceptionHandlerSetting)->willReturn(true);
+        $objectManager->expects(self::once())->method('get')->with($exceptionHandlerSetting)->willReturn(new ThrowingHandler());
 
         $runtime->handleRenderingException('/foo/bar', $runtimeException);
     }
@@ -112,8 +112,8 @@ class RuntimeTest extends UnitTestCase
         $this->expectException(\Neos\Flow\Security\Exception::class);
         $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
         $securityException = new \Neos\Flow\Security\Exception();
-        $runtime = $this->getMockBuilder(Runtime::class)->setMethods(['evaluate', 'handleRenderingException'])->setConstructorArgs([[], $controllerContext])->getMock();
-        $runtime->expects(self::any())->method('evaluate')->will(self::throwException($securityException));
+        $runtime = $this->getMockBuilder(Runtime::class)->onlyMethods(['evaluate', 'handleRenderingException'])->setConstructorArgs([[], $controllerContext])->getMock();
+        $runtime->expects(self::any())->method('evaluate')->willThrowException($securityException);
 
         $runtime->render('/foo/bar');
     }

--- a/Neos.Fusion/Tests/Unit/FusionObjects/AttributesImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/AttributesImplementationTest.php
@@ -33,7 +33,7 @@ class AttributesImplementationTest extends UnitTestCase
         $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
-    public function attributeExamples()
+    public static function attributeExamples()
     {
         return [
             'null' => [null, ''],

--- a/Neos.Fusion/Tests/Unit/FusionObjects/AttributesImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/AttributesImplementationTest.php
@@ -53,10 +53,10 @@ class AttributesImplementationTest extends UnitTestCase
     public function evaluateTests($properties, $expectedOutput)
     {
         $path = 'attributes/test';
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) use ($path, $properties) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) use ($path, $properties) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             return ObjectAccess::getPropertyPath($properties, str_replace('/', '.', $relativePath));
-        }));
+        });
 
         $fusionObjectName = 'Neos.Fusion:Attributes';
         $renderer = new AttributesImplementation($this->mockRuntime, $path, $fusionObjectName);

--- a/Neos.Fusion/Tests/Unit/FusionObjects/AttributesImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/AttributesImplementationTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
@@ -47,10 +48,8 @@ class AttributesImplementationTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider attributeExamples
-     */
+    #[DataProvider('attributeExamples')]
+    #[Test]
     public function evaluateTests($properties, $expectedOutput)
     {
         $path = 'attributes/test';

--- a/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
@@ -11,6 +11,7 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * source code.
  */
 
+use Neos\Flow\Tests\UnitTestCase;
 use Neos\Utility\ObjectAccess;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\CaseImplementation;
@@ -18,7 +19,7 @@ use Neos\Fusion\FusionObjects\CaseImplementation;
 /**
  * Testcase for the Case object
  */
-class CaseImplementationTest extends \Neos\Flow\Tests\UnitTestCase
+class CaseImplementationTest extends UnitTestCase
 {
     /**
      * @test

--- a/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
@@ -10,8 +10,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Utility\ObjectAccess;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\CaseImplementation;
@@ -21,9 +21,7 @@ use Neos\Fusion\FusionObjects\CaseImplementation;
  */
 class CaseImplementationTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function ignoredPropertiesShouldNotBeUsedAsMatcher()
     {
         $path = 'page/body/content/main';

--- a/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/CaseImplementationTest.php
@@ -28,7 +28,7 @@ class CaseImplementationTest extends UnitTestCase
         $ignoredProperties = ['nodePath'];
 
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) use ($path, $ignoredProperties) {
+        $mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) use ($path, $ignoredProperties) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             switch ($relativePath) {
                 case '__meta/ignoreProperties':
@@ -37,7 +37,7 @@ class CaseImplementationTest extends UnitTestCase
                     return true;
             }
             return ObjectAccess::getProperty($that, $relativePath, true);
-        }));
+        });
 
         $fusionObjectName = 'Neos.Neos:PrimaryContent';
         $renderer = new CaseImplementation($mockRuntime, $path, $fusionObjectName);
@@ -48,7 +48,7 @@ class CaseImplementationTest extends UnitTestCase
             'condition' => 'true'
         ];
 
-        $mockRuntime->expects(self::once())->method('render')->with('page/body/content/main/default<Neos.Fusion:Matcher>')->will(self::returnValue('rendered matcher'));
+        $mockRuntime->expects(self::once())->method('render')->with('page/body/content/main/default<Neos.Fusion:Matcher>')->willReturn('rendered matcher');
 
         $result = $renderer->evaluate();
 

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -46,7 +46,7 @@ class DataStructureImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function positionalSubElements(): array
+    public static function positionalSubElements(): array
     {
         return [
             [
@@ -128,7 +128,7 @@ class DataStructureImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function positionalSubElementsThatShouldFailByInvalidPositions(): array
+    public static function positionalSubElementsThatShouldFailByInvalidPositions(): array
     {
         return [
             [

--- a/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/DataStructureImplementationTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\DataStructureImplementation;
@@ -32,9 +33,7 @@ class DataStructureImplementationTest extends UnitTestCase
         $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateWithEmptyArrayRendersEmptyArray(): void
     {
         $path = 'datastructure/test';
@@ -108,10 +107,8 @@ class DataStructureImplementationTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider positionalSubElements
-     */
+    #[DataProvider('positionalSubElements')]
+    #[Test]
     public function evaluateRendersKeysSortedByPositionMetaProperty(string $message, array $subElements, array $expectedKeyOrder): void
     {
         $this->mockRuntime->method('evaluate')->willReturnCallback(function ($path) use (&$renderedPaths) {
@@ -144,11 +141,11 @@ class DataStructureImplementationTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider positionalSubElementsThatShouldFailByInvalidPositions
      *
      * @param array $subElements
      */
+    #[DataProvider('positionalSubElementsThatShouldFailByInvalidPositions')]
+    #[Test]
     public function evaluateThrowsExceptionIfKeysSortedByPositionMetaPropertyContainsInvalidValues(array $subElements): void
     {
         $fusionObjectName = 'Neos.Fusion:DataStructure';

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects\Helpers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\FusionObjects\ValueImplementation;
 use Neos\Fusion\FusionObjects\Helpers\LazyProps;
 use Neos\Flow\Tests\UnitTestCase;
@@ -18,9 +18,7 @@ use Neos\Fusion\Core\Runtime;
 
 class LazyPropsTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function jsonEncodeSerializesAllProps()
     {
         /** @var Runtime $mockRuntime */

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Helpers/LazyPropsTest.php
@@ -11,6 +11,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects\Helpers;
  * source code.
  */
 
+use Neos\Fusion\FusionObjects\ValueImplementation;
+use Neos\Fusion\FusionObjects\Helpers\LazyProps;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 
@@ -27,8 +29,8 @@ class LazyPropsTest extends UnitTestCase
             return $path;
         });
 
-        $fusionObject = new \Neos\Fusion\FusionObjects\ValueImplementation($mockRuntime, 'test/path', 'Value');
-        $lazyProps = new \Neos\Fusion\FusionObjects\Helpers\LazyProps($fusionObject, 'test/path', $mockRuntime, ['foo', 'bar'], ['value' => 42]);
+        $fusionObject = new ValueImplementation($mockRuntime, 'test/path', 'Value');
+        $lazyProps = new LazyProps($fusionObject, 'test/path', $mockRuntime, ['foo', 'bar'], ['value' => 42]);
 
         $serializedProps = json_encode($lazyProps);
         $this->assertEquals('{"foo":"test\/path\/foo","bar":"test\/path\/bar"}', $serializedProps);

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
@@ -50,7 +50,7 @@ class ResponseHeadImplementationTest extends UnitTestCase
     {
         $path = 'responseHead/test';
 
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath) use ($path, $httpVersion, $statusCode, $headers) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath) use ($path, $httpVersion, $statusCode, $headers) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'httpVersion':
@@ -61,7 +61,7 @@ class ResponseHeadImplementationTest extends UnitTestCase
                     return $headers;
             }
             return isset($properties[$relativePath]) ? $properties[$relativePath] : null;
-        }));
+        });
 
         $fusionObjectName = 'Neos.Fusion:Http.ResponseHead';
         $renderer = new ResponseHeadImplementation($this->mockRuntime, $path, $fusionObjectName);

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
@@ -35,7 +35,7 @@ class ResponseHeadImplementationTest extends UnitTestCase
         $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
-    public function responseHeadExamples()
+    public static function responseHeadExamples()
     {
         return [
             'default properties' => [null, null, [], "HTTP/1.1 200 OK\r\n\r\n"],

--- a/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/Http/ResponseHeadImplementationTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects\Http;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use GuzzleHttp\Psr7\Response;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
@@ -43,10 +44,8 @@ class ResponseHeadImplementationTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider responseHeadExamples
-     */
+    #[DataProvider('responseHeadExamples')]
+    #[Test]
     public function evaluateTests($httpVersion, $statusCode, $headers, $expectedOutput)
     {
         $path = 'responseHead/test';

--- a/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
@@ -35,7 +35,7 @@ class JoinImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function positionalSubElements()
+    public static function positionalSubElements()
     {
         return [
             [
@@ -99,7 +99,7 @@ class JoinImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function positionalSubElementsThatShouldFailByInvalidPositions()
+    public static function positionalSubElementsThatShouldFailByInvalidPositions()
     {
         return [
             [

--- a/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\JoinImplementation;
@@ -20,9 +21,7 @@ use Neos\Fusion\FusionObjects\JoinImplementation;
  */
 class JoinImplementationTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateWithEmptyJoinRendersNull()
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
@@ -117,13 +116,13 @@ class JoinImplementationTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider positionalSubElements
      *
      * @param string $message
      * @param array $subElements
      * @param array $expectedKeyOrder
      */
+    #[DataProvider('positionalSubElements')]
+    #[Test]
     public function evaluateRendersKeysSortedByPositionMetaProperty($message, $subElements, $expectedKeyOrder)
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
@@ -144,13 +143,13 @@ class JoinImplementationTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider positionalSubElementsThatShouldFailByInvalidPositions
      *
      * @param string $message
      * @param array $subElements
      * @param array $expectedKeyOrder
      */
+    #[DataProvider('positionalSubElementsThatShouldFailByInvalidPositions')]
+    #[Test]
     public function evaluateRendersKeysSortedByPositionMetaPropertyThatShouldFail($message, $subElements, $expectedKeyOrder)
     {
         try {

--- a/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/JoinImplementationTest.php
@@ -127,9 +127,9 @@ class JoinImplementationTest extends UnitTestCase
     {
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
-        $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
+        $mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($path) use (&$renderedPaths) {
             $renderedPaths[] = $path;
-        }));
+        });
 
         $path = '';
         $fusionObjectName = 'Neos.Fusion:Join';
@@ -155,9 +155,9 @@ class JoinImplementationTest extends UnitTestCase
         try {
             $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
-            $mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($path) use (&$renderedPaths) {
+            $mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($path) use (&$renderedPaths) {
                 $renderedPaths[] = $path;
-            }));
+            });
 
             $path = '';
             $fusionObjectName = 'Neos.Fusion:Join';

--- a/Neos.Fusion/Tests/Unit/FusionObjects/ResourceUriImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/ResourceUriImplementationTest.php
@@ -63,9 +63,9 @@ class ResourceUriImplementationTest extends UnitTestCase
         $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
 
         $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
-        $this->mockControllerContext->expects(self::any())->method('getRequest')->will(self::returnValue($this->mockActionRequest));
+        $this->mockControllerContext->expects(self::any())->method('getRequest')->willReturn($this->mockActionRequest);
 
-        $this->mockRuntime->expects(self::any())->method('getControllerContext')->will(self::returnValue($this->mockControllerContext));
+        $this->mockRuntime->expects(self::any())->method('getControllerContext')->willReturn($this->mockControllerContext);
 
         $this->resourceUriImplementation = new ResourceUriImplementation($this->mockRuntime, 'resourceUri/test', 'Neos.Fusion:ResourceUri');
 
@@ -88,10 +88,10 @@ class ResourceUriImplementationTest extends UnitTestCase
     public function evaluateReturnsResourceUriForAGivenResource()
     {
         $validResource = $this->getMockBuilder(PersistentResource::class)->disableOriginalConstructor()->getMock();
-        $this->mockRuntime->expects(self::atLeastOnce())->method('evaluate')->with('resourceUri/test/resource')->will(self::returnCallback(function ($evaluatePath, $that) use ($validResource) {
+        $this->mockRuntime->expects(self::atLeastOnce())->method('evaluate')->with('resourceUri/test/resource')->willReturnCallback(function ($evaluatePath, $that) use ($validResource) {
             return $validResource;
-        }));
-        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPersistentResourceUri')->with($validResource)->will(self::returnValue('the/resolved/resource/uri'));
+        });
+        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPersistentResourceUri')->with($validResource)->willReturn('the/resolved/resource/uri');
 
         self::assertSame('the/resolved/resource/uri', $this->resourceUriImplementation->evaluate());
     }
@@ -100,9 +100,9 @@ class ResourceUriImplementationTest extends UnitTestCase
     public function evaluateThrowsExceptionIfNeitherResourceNorPathAreSpecified()
     {
         $this->expectException(Exception::class);
-        $this->mockRuntime->expects(self::atLeastOnce())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::atLeastOnce())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             return null;
-        }));
+        });
 
         $this->resourceUriImplementation->evaluate();
     }
@@ -111,14 +111,14 @@ class ResourceUriImplementationTest extends UnitTestCase
     public function evaluateThrowsExceptionIfSpecifiedPathPointsToAPrivateResource()
     {
         $this->expectException(Exception::class);
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
                     return 'resource://Some.Package/Private/SomeResource';
             }
             return null;
-        }));
+        });
 
         $this->resourceUriImplementation->evaluate();
     }
@@ -126,16 +126,16 @@ class ResourceUriImplementationTest extends UnitTestCase
     #[Test]
     public function evaluateDeterminesCurrentPackageIfARelativePathIsSpecified()
     {
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
                     return 'Relative/Resource/Path';
             }
             return null;
-        }));
-        $this->mockActionRequest->expects(self::atLeastOnce())->method('getControllerPackageKey')->will(self::returnValue('Current.Package'));
-        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->will(self::returnValue('Static/Resources/Packages/Current.Package/Relative/Resource/Path'));
+        });
+        $this->mockActionRequest->expects(self::atLeastOnce())->method('getControllerPackageKey')->willReturn('Current.Package');
+        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->willReturn('Static/Resources/Packages/Current.Package/Relative/Resource/Path');
 
         self::assertSame('Static/Resources/Packages/Current.Package/Relative/Resource/Path', $this->resourceUriImplementation->evaluate());
     }
@@ -143,7 +143,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     #[Test]
     public function evaluateUsesSpecifiedPackageIfARelativePathIsGiven()
     {
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -152,9 +152,9 @@ class ResourceUriImplementationTest extends UnitTestCase
                     return 'Specified.Package';
             }
             return null;
-        }));
-        $this->mockActionRequest->expects(self::any())->method('getControllerPackageKey')->will(self::returnValue('Current.Package'));
-        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->will(self::returnValue('Static/Resources/Packages/Specified.Package/Relative/Resource/Path'));
+        });
+        $this->mockActionRequest->expects(self::any())->method('getControllerPackageKey')->willReturn('Current.Package');
+        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->willReturn('Static/Resources/Packages/Specified.Package/Relative/Resource/Path');
 
         self::assertSame('Static/Resources/Packages/Specified.Package/Relative/Resource/Path', $this->resourceUriImplementation->evaluate());
     }
@@ -163,15 +163,15 @@ class ResourceUriImplementationTest extends UnitTestCase
     #[Test]
     public function evaluateReturnsResourceUriForAGivenResourcePath()
     {
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
                     return 'resource://Some.Package/Public/SomeResource';
             }
             return null;
-        }));
-        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->will(self::returnValue('Static/Resources/Packages/Some.Package/SomeResource'));
+        });
+        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->willReturn('Static/Resources/Packages/Some.Package/SomeResource');
 
         self::assertSame('Static/Resources/Packages/Some.Package/SomeResource', $this->resourceUriImplementation->evaluate());
     }
@@ -179,7 +179,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     #[Test]
     public function evaluateIgnoresPackagePropertyIfAResourcePathIsGiven()
     {
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'path':
@@ -188,9 +188,9 @@ class ResourceUriImplementationTest extends UnitTestCase
                     return 'Specified.Package';
             }
             return null;
-        }));
-        $this->mockActionRequest->expects(self::any())->method('getControllerPackageKey')->will(self::returnValue('Current.Package'));
-        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->will(self::returnValue('Static/Resources/Packages/Some.Package/SomeResource'));
+        });
+        $this->mockActionRequest->expects(self::any())->method('getControllerPackageKey')->willReturn('Current.Package');
+        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->willReturn('Static/Resources/Packages/Some.Package/SomeResource');
 
         self::assertSame('Static/Resources/Packages/Some.Package/SomeResource', $this->resourceUriImplementation->evaluate());
     }
@@ -198,7 +198,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     #[Test]
     public function evaluateLocalizesFilenameIfLocalize()
     {
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) {
             $relativePath = str_replace('resourceUri/test/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'localize':
@@ -209,9 +209,9 @@ class ResourceUriImplementationTest extends UnitTestCase
                     return 'Specified.Package';
             }
             return null;
-        }));
-        $this->mockI18nService->expects(self::atLeastOnce())->method('getLocalizedFilename')->will(self::returnValue(['resource://Some.Package/Public/LocalizedFilename']));
-        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->will(self::returnValue('Static/Resources/Packages/Some.Package/LocalizedFilename'));
+        });
+        $this->mockI18nService->expects(self::atLeastOnce())->method('getLocalizedFilename')->willReturn(['resource://Some.Package/Public/LocalizedFilename']);
+        $this->mockResourceManager->expects(self::atLeastOnce())->method('getPublicPackageResourceUri')->willReturn('Static/Resources/Packages/Some.Package/LocalizedFilename');
 
         self::assertSame('Static/Resources/Packages/Some.Package/LocalizedFilename', $this->resourceUriImplementation->evaluate());
     }

--- a/Neos.Fusion/Tests/Unit/FusionObjects/ResourceUriImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/ResourceUriImplementationTest.php
@@ -10,7 +10,7 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\I18n\Service;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
@@ -76,9 +76,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         $this->inject($this->resourceUriImplementation, 'i18nService', $this->mockI18nService);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateThrowsExceptionIfSpecifiedResourceIsInvalid()
     {
         $this->expectException(Exception::class);
@@ -86,9 +84,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         $this->resourceUriImplementation->evaluate();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateReturnsResourceUriForAGivenResource()
     {
         $validResource = $this->getMockBuilder(PersistentResource::class)->disableOriginalConstructor()->getMock();
@@ -100,9 +96,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         self::assertSame('the/resolved/resource/uri', $this->resourceUriImplementation->evaluate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateThrowsExceptionIfNeitherResourceNorPathAreSpecified()
     {
         $this->expectException(Exception::class);
@@ -113,9 +107,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         $this->resourceUriImplementation->evaluate();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateThrowsExceptionIfSpecifiedPathPointsToAPrivateResource()
     {
         $this->expectException(Exception::class);
@@ -131,9 +123,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         $this->resourceUriImplementation->evaluate();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateDeterminesCurrentPackageIfARelativePathIsSpecified()
     {
         $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
@@ -150,9 +140,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         self::assertSame('Static/Resources/Packages/Current.Package/Relative/Resource/Path', $this->resourceUriImplementation->evaluate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateUsesSpecifiedPackageIfARelativePathIsGiven()
     {
         $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
@@ -172,9 +160,7 @@ class ResourceUriImplementationTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateReturnsResourceUriForAGivenResourcePath()
     {
         $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
@@ -190,9 +176,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         self::assertSame('Static/Resources/Packages/Some.Package/SomeResource', $this->resourceUriImplementation->evaluate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateIgnoresPackagePropertyIfAResourcePathIsGiven()
     {
         $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {
@@ -211,9 +195,7 @@ class ResourceUriImplementationTest extends UnitTestCase
         self::assertSame('Static/Resources/Packages/Some.Package/SomeResource', $this->resourceUriImplementation->evaluate());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateLocalizesFilenameIfLocalize()
     {
         $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) {

--- a/Neos.Fusion/Tests/Unit/FusionObjects/TagImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/TagImplementationTest.php
@@ -32,7 +32,7 @@ class TagImplementationTest extends UnitTestCase
         $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
     }
 
-    public function tagExamples()
+    public static function tagExamples()
     {
         return [
             'default properties' => [[], null, null, '<div></div>'],

--- a/Neos.Fusion/Tests/Unit/FusionObjects/TagImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/TagImplementationTest.php
@@ -50,7 +50,7 @@ class TagImplementationTest extends UnitTestCase
     public function evaluateTests($properties, $attributes, $content, $expectedOutput)
     {
         $path = 'tag/test';
-        $this->mockRuntime->expects(self::any())->method('evaluate')->will(self::returnCallback(function ($evaluatePath, $that) use ($properties, $path, $attributes, $content) {
+        $this->mockRuntime->expects(self::any())->method('evaluate')->willReturnCallback(function ($evaluatePath, $that) use ($properties, $path, $attributes, $content) {
             $relativePath = str_replace($path . '/', '', $evaluatePath);
             switch ($relativePath) {
                 case 'attributes':
@@ -59,7 +59,7 @@ class TagImplementationTest extends UnitTestCase
                     return $content;
             }
             return isset($properties[$relativePath]) ? $properties[$relativePath] : null;
-        }));
+        });
 
         $fusionObjectName = 'Neos.Fusion:Tag';
         $renderer = new TagImplementation($this->mockRuntime, $path, $fusionObjectName);

--- a/Neos.Fusion/Tests/Unit/FusionObjects/TagImplementationTest.php
+++ b/Neos.Fusion/Tests/Unit/FusionObjects/TagImplementationTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\FusionObjects;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\Runtime;
 use Neos\Fusion\FusionObjects\TagImplementation;
@@ -44,10 +45,8 @@ class TagImplementationTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider tagExamples
-     */
+    #[DataProvider('tagExamples')]
+    #[Test]
     public function evaluateTests($properties, $attributes, $content, $expectedOutput)
     {
         $path = 'tag/test';

--- a/Neos.Fusion/Tests/Unit/Migrations/EelExpressionTransformerTest.php
+++ b/Neos.Fusion/Tests/Unit/Migrations/EelExpressionTransformerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Neos\Fusion\Tests\Unit\Migrations;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Fusion\Migrations\EelExpression\EelExpressionTransformer;
 use PHPUnit\Framework\TestCase;
 
@@ -241,9 +242,7 @@ class EelExpressionTransformerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider examples
-     */
+    #[DataProvider('examples')]
     public function testReplacements(\Closure $eelModifier, string $input, string $expectedOutput): void
     {
         self::assertEquals(

--- a/Neos.Fusion/Tests/Unit/Migrations/EelExpressionTransformerTest.php
+++ b/Neos.Fusion/Tests/Unit/Migrations/EelExpressionTransformerTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class EelExpressionTransformerTest extends TestCase
 {
-    public function examples(): iterable
+    public static function examples(): iterable
     {
         yield 'L ' . __LINE__ => [
             fn (string $eelExpression) => str_replace('someVariable', 'myNewVariable', $eelExpression),

--- a/Neos.Fusion/Tests/Unit/Migrations/FusionMigrationTest.php
+++ b/Neos.Fusion/Tests/Unit/Migrations/FusionMigrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Neos\Fusion\Tests\Unit\Migrations;
 
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Fusion\Migrations\FusionMigrationTrait;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
@@ -29,7 +30,7 @@ class FusionMigrationTest extends TestCase
         return 'Neos.Fusion-XXX';
     }
 
-    /** @test */
+    #[Test]
     public function doesNoReplacementsIfPackageDoesNotContainFusionFiles(): void
     {
         $stream = vfsStream::setup('fusion', null, $expectedStructure = [
@@ -67,7 +68,7 @@ class FusionMigrationTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function doesNoReplacementsIfNoFusionFilesNeedAdjustments(): void
     {
         $stream = vfsStream::setup('fusion', null, $expectedStructure = [
@@ -104,7 +105,7 @@ class FusionMigrationTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function doesReplacementFusionFileOfPackage(): void
     {
         $stream = vfsStream::setup('fusion', null, [
@@ -157,7 +158,7 @@ class FusionMigrationTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function doesMultipleReplacementInAllFusionFilesOfPackage(): void
     {
         $stream = vfsStream::setup('fusion', null, [
@@ -225,7 +226,7 @@ class FusionMigrationTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function doesFusionPrototypeNameReplacementInAllFusionFilesOfPackage(): void
     {
         $stream = vfsStream::setup('fusion', null, [

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -419,7 +419,7 @@ class HtmlAugmenterTest extends UnitTestCase
                 'attributes' => ['data-foo' => (object)[]],
                 'fallbackTagName' => null,
                 'exclusiveAttributes' => null,
-                'expectedResult' => '<root>array value ignored</root>',
+                'allowEmpty' => '<root>array value ignored</root>',
             ],
         ];
     }

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -10,7 +10,8 @@ namespace Neos\Fusion\Tests\Unit\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Service\HtmlAugmenter;
 
@@ -30,9 +31,7 @@ class HtmlAugmenterTest extends UnitTestCase
         $this->htmlAugmenter = new HtmlAugmenter();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addAttributesDoesNotAlterHtmlIfAttributesArrayIsEmpty()
     {
         $html = '<p>This is some html</p><p>Without a unique root element</p>';
@@ -432,9 +431,9 @@ class HtmlAugmenterTest extends UnitTestCase
      * @param string $expectedResult
      * @param bool $allowEmpty
      * @param array $exclusiveAttributes
-     * @test
-     * @dataProvider addAttributesDataProvider
      */
+    #[DataProvider('addAttributesDataProvider')]
+    #[Test]
     public function addAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes, $allowEmpty, $expectedResult)
     {
         if ($fallbackTagName === null) {
@@ -450,9 +449,9 @@ class HtmlAugmenterTest extends UnitTestCase
      * @param string $fallbackTagName
      * @param array $exclusiveAttributes
      * @param bool $allowEmpty
-     * @test
-     * @dataProvider invalidAttributesDataProvider
      */
+    #[DataProvider('invalidAttributesDataProvider')]
+    #[Test]
     public function invalidAttributesTests($html, array $attributes, $fallbackTagName, $exclusiveAttributes, $allowEmpty)
     {
         $this->expectException(\Error::class);

--- a/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
+++ b/Neos.Fusion/Tests/Unit/Service/HtmlAugmenterTest.php
@@ -38,7 +38,7 @@ class HtmlAugmenterTest extends UnitTestCase
         self::assertSame($html, $this->htmlAugmenter->addAttributes($html, []));
     }
 
-    public function addAttributesDataProvider()
+    public static function addAttributesDataProvider()
     {
         eval('
             class ClassWithToStringMethod {
@@ -410,7 +410,7 @@ class HtmlAugmenterTest extends UnitTestCase
         ];
     }
 
-    public function invalidAttributesDataProvider()
+    public static function invalidAttributesDataProvider()
     {
         return [
             // invalid attributes

--- a/Neos.Media/Tests/Functional/AbstractTestCase.php
+++ b/Neos.Media/Tests/Functional/AbstractTestCase.php
@@ -20,7 +20,7 @@ use Neos\Utility\Files;
 /**
  * Abstract Functional Test template
  */
-abstract class AbstractTest extends FunctionalTestCase
+abstract class AbstractTestCase extends FunctionalTestCase
 {
     /**
      * @var string

--- a/Neos.Media/Tests/Functional/AbstractTestCase.php
+++ b/Neos.Media/Tests/Functional/AbstractTestCase.php
@@ -65,13 +65,13 @@ abstract class AbstractTestCase extends FunctionalTestCase
      */
     protected function createMockResourceAndPointerFromHash($hash)
     {
-        $mockResource = $this->getMockBuilder(PersistentResource::class)->setMethods(['getHash', 'getUri'])->getMock();
+        $mockResource = $this->getMockBuilder(PersistentResource::class)->addMethods(['getHash', 'getUri'])->getMock();
         $mockResource->expects(self::any())
                 ->method('getHash')
-                ->will(self::returnValue($hash));
+                ->willReturn($hash);
         $mockResource->expects(self::any())
             ->method('getUri')
-            ->will(self::returnValue('resource://' . $hash));
+            ->willReturn('resource://' . $hash);
         return $mockResource;
     }
 

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -146,7 +146,7 @@ class AssetTest extends AbstractTestCase
         $mockExternalAssetSource = $this->getMockBuilder(AssetSourceInterface::class)->disableOriginalConstructor()->getMock();
         $this->inject($asset, 'assetSources', ['test-source' => $mockExternalAssetSource]);
 
-        $mockImportedAssetRepository = $this->getMockBuilder(Repository::class)->disableOriginalConstructor()->setMethods(['findOneByLocalAssetIdentifier'])->getMock();
+        $mockImportedAssetRepository = $this->getMockBuilder(Repository::class)->disableOriginalConstructor()->addMethods(['findOneByLocalAssetIdentifier'])->getMock();
         $this->inject($asset, 'importedAssetRepository', $mockImportedAssetRepository);
 
         $mockImportedAssetRepository->expects(self::atLeastOnce())->method('findOneByLocalAssetIdentifier')->with($asset->getIdentifier())->willReturn(null);

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -12,6 +12,7 @@ namespace Neos\Media\Tests\Functional\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Doctrine\Common\Collections\ArrayCollection;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Repository;
@@ -63,9 +64,7 @@ class AssetTest extends AbstractTestCase
         $this->tagRepository = $this->objectManager->get(TagRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setTags()
     {
         $tagLabels = ['foo', 'bar'];
@@ -88,9 +87,7 @@ class AssetTest extends AbstractTestCase
         $this->assertAssetHasTags($asset, $tagLabels);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addTag()
     {
         $asset = $this->buildAssetObject();
@@ -124,9 +121,7 @@ class AssetTest extends AbstractTestCase
         self::assertCount(0, $expectedTagLabels);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAssetProxyReturnsAssetProxyForLocalAssets()
     {
         $asset = $this->buildAssetObject();
@@ -134,9 +129,7 @@ class AssetTest extends AbstractTestCase
         $this->assertNotNull($asset->getAssetProxy());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAssetProxyReturnsNullIfAssetSourceIdentifierPointsToNonExistingAssetSource()
     {
         $asset = $this->buildAssetObject();
@@ -144,9 +137,7 @@ class AssetTest extends AbstractTestCase
         self::assertNull($asset->getAssetProxy());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAssetProxyReturnsNullIfNoCorrespondingImportedAssetExists()
     {
         $asset = $this->buildAssetObject();

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -21,12 +21,12 @@ use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\TagRepository;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
 /**
  * Testcase for an asset model
  */
-class AssetTest extends AbstractTest
+class AssetTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Domain/Model/TagTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/TagTest.php
@@ -16,9 +16,9 @@ namespace Neos\Media\Tests\Functional\Domain\Model;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\TagRepository;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
-class TagTest extends AbstractTest
+class TagTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Domain/Model/TagTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/TagTest.php
@@ -12,7 +12,7 @@ namespace Neos\Media\Tests\Functional\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\TagRepository;
@@ -43,9 +43,7 @@ class TagTest extends AbstractTestCase
         $this->tagRepository = $this->objectManager->get(TagRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parentChildrenRelation(): void
     {
         $child1 = new Tag('child1');

--- a/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
@@ -22,13 +22,13 @@ use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\TagRepository;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
 /**
  * Testcase for an asset repository
  *
  */
-class AssetRepositoryTest extends AbstractTest
+class AssetRepositoryTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/AssetRepositoryTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Doctrine\Common\Collections\ArrayCollection;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\AssetCollection;
@@ -77,9 +77,7 @@ class AssetRepositoryTest extends AbstractTestCase
         Files::removeDirectoryRecursively($this->temporaryDirectory);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function assetsCanBePersisted()
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/license.txt');
@@ -98,9 +96,7 @@ class AssetRepositoryTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findBySearchTermReturnsFilteredResult()
     {
         $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/license.txt');
@@ -128,9 +124,7 @@ class AssetRepositoryTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findBySearchTermAndTagsReturnsFilteredResult()
     {
         $tag = new Tag('home');
@@ -160,9 +154,7 @@ class AssetRepositoryTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testAddAssetVariantFilterClauseWithoutAssetCollection()
     {
         $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');
@@ -199,9 +191,7 @@ class AssetRepositoryTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testAddAssetVariantFilterClauseWithAssetCollection()
     {
         $resource1 = $this->resourceManager->importResource(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');

--- a/Neos.Media/Tests/Functional/Domain/Repository/ImportedAssetRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/ImportedAssetRepositoryTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\ImportedAsset;
 use Neos\Media\Domain\Repository\ImportedAssetRepository;
@@ -41,9 +41,7 @@ class ImportedAssetRepositoryTest extends AbstractTestCase
         $this->importedAssetRepository = $this->objectManager->get(ImportedAssetRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findOneByAssetSourceIdentifierAndRemoteAssetIdentifier_selects_original_asset()
     {
         // To validate original is not found accidentally by implicit identifier sorting, this is fixated in the test (there's no foreign key constraint)

--- a/Neos.Media/Tests/Functional/Domain/Repository/ImportedAssetRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/ImportedAssetRepositoryTest.php
@@ -14,9 +14,9 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\ImportedAsset;
 use Neos\Media\Domain\Repository\ImportedAssetRepository;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
-class ImportedAssetRepositoryTest extends AbstractTest
+class ImportedAssetRepositoryTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Domain/Repository/TagRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/TagRepositoryTest.php
@@ -14,13 +14,13 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\TagRepository;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
 /**
  * Testcase for an tag repository
  *
  */
-class TagRepositoryTest extends AbstractTest
+class TagRepositoryTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Domain/Repository/TagRepositoryTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Repository/TagRepositoryTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Functional\Domain\Repository;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\TagRepository;
@@ -45,9 +45,7 @@ class TagRepositoryTest extends AbstractTestCase
         $this->tagRepository = $this->objectManager->get(TagRepository::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagsCanBePersisted(): void
     {
         $tag = new Tag('foobar');
@@ -59,9 +57,7 @@ class TagRepositoryTest extends AbstractTestCase
         self::assertInstanceOf(Tag::class, $this->tagRepository->findAll()->getFirst());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findBySearchTermReturnsFilteredResult(): void
     {
         $tag1 = new Tag('foobar');
@@ -80,9 +76,7 @@ class TagRepositoryTest extends AbstractTestCase
         self::assertCount(1, $this->tagRepository->findBySearchTerm(' foo '));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parentRemoveRemovesCompleteHierarchy(): void
     {
         $grandchild = new Tag('grandChild');

--- a/Neos.Media/Tests/Functional/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Service/AssetServiceTest.php
@@ -56,7 +56,7 @@ class AssetServiceTest extends AbstractTestCase
         $this->assetService = $this->objectManager->get(AssetService::class);
     }
 
-    public function replaceAssetResourceDataProvider(): array
+    public static function replaceAssetResourceDataProvider(): array
     {
         return [
             'jpgWithJpg' => [

--- a/Neos.Media/Tests/Functional/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Service/AssetServiceTest.php
@@ -23,9 +23,9 @@ use Neos\Media\Domain\Model\ThumbnailConfiguration;
 use Neos\Media\Domain\Service\AssetService;
 use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Media\Domain\Strategy\AssetModelMappingStrategyInterface;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
-class AssetServiceTest extends AbstractTest
+class AssetServiceTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Service/AssetServiceTest.php
@@ -12,7 +12,8 @@ namespace Neos\Media\Tests\Functional\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\ResourceManagement\Exception;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -78,14 +79,14 @@ class AssetServiceTest extends AbstractTestCase
     }
 
     /**
-     * @test
-     * @dataProvider replaceAssetResourceDataProvider
      *
      * @param string $replacementFilePath
      * @param array $options
      * @throws IllegalObjectTypeException
      * @throws Exception
      */
+    #[DataProvider('replaceAssetResourceDataProvider')]
+    #[Test]
     public function replaceAssetResource(string $replacementFilePath, array $options): void
     {
         $asset = $this->prepareImportedAsset(__DIR__ . '/../../Fixtures/Resources/417px-Mihaly_Csikszentmihalyi.jpg');

--- a/Neos.Media/Tests/Functional/Eel/AssetsHelperTest.php
+++ b/Neos.Media/Tests/Functional/Eel/AssetsHelperTest.php
@@ -21,13 +21,13 @@ use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\Tag;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Media\Domain\Repository\TagRepository;
-use Neos\Media\Tests\Functional\AbstractTest;
+use Neos\Media\Tests\Functional\AbstractTestCase;
 
 /**
  * Testcase for the asset helper
  *
  */
-class AssetsHelperTest extends AbstractTest
+class AssetsHelperTest extends AbstractTestCase
 {
     /**
      * @var boolean

--- a/Neos.Media/Tests/Functional/Eel/AssetsHelperTest.php
+++ b/Neos.Media/Tests/Functional/Eel/AssetsHelperTest.php
@@ -11,7 +11,7 @@ namespace Neos\Media\Tests\Functional\Eel;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
@@ -70,9 +70,7 @@ class AssetsHelperTest extends AbstractTestCase
         Files::removeDirectoryRecursively($this->temporaryDirectory);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByTagFindAssetsByTagLabel(): void
     {
         $tagA = new Tag('tagA');
@@ -98,9 +96,7 @@ class AssetsHelperTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByTagFindAssetsByTagInstance(): void
     {
         $tagA = new Tag('tagA');
@@ -129,18 +125,14 @@ class AssetsHelperTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByTagReturnsNullIfTagIsNull(): void
     {
         $helper = new AssetsHelper();
         self::assertNull($helper->findByTag(null));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByCollectionReturnsAssetsForCollectionLabel(): void
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
@@ -163,9 +155,7 @@ class AssetsHelperTest extends AbstractTestCase
         self::assertNull($helper->findByCollection(''));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByCollectionReturnsAssetsForCollectionInstace(): void
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');
@@ -188,9 +178,7 @@ class AssetsHelperTest extends AbstractTestCase
         self::assertNull($helper->findByCollection(null));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByCollectionReturnsNullIfCollectionIsNull(): void
     {
         $helper = new AssetsHelper();
@@ -198,9 +186,7 @@ class AssetsHelperTest extends AbstractTestCase
         self::assertNull($helper->findByCollection(''));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function searchWithoutSearchTermReturnsNull(): void
     {
         $helper = new AssetsHelper();
@@ -208,9 +194,7 @@ class AssetsHelperTest extends AbstractTestCase
         self::assertNull($helper->search(''));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function searchWithSearchTermAndTagFindsAsset(): void
     {
         $tagA = new Tag('tagA');
@@ -251,9 +235,7 @@ class AssetsHelperTest extends AbstractTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function searchWithSearchTermAndCollectionFindsAsset(): void
     {
         $resource = $this->resourceManager->importResource(__DIR__ . '/../Fixtures/Resources/license.txt');

--- a/Neos.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\Model\Adjustment;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Imagine\Gd\Imagine;
 use Imagine\Image\Box;
 use Imagine\Image\Palette\Color\ColorInterface;
@@ -34,9 +35,7 @@ class CropImageAdjustmentTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aspectRatioCanBeSetInsteadOfAbsoluteDimensions(): void
     {
         $imagine = new Imagine();
@@ -49,9 +48,7 @@ class CropImageAdjustmentTest extends UnitTestCase
         self::assertTrue($cropImageAdjustment->canBeApplied($image));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settingAnAspectRatioRemovesValuesForManualDimensions(): void
     {
         $cropImageAdjustment = new CropImageAdjustment();
@@ -70,9 +67,7 @@ class CropImageAdjustmentTest extends UnitTestCase
         self::assertSame((string)$cropImageAdjustment->getAspectRatio(), '16:9');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settingManualDimensionsRemovesAspectRatio(): void
     {
         $cropImageAdjustment = new CropImageAdjustment();
@@ -94,9 +89,7 @@ class CropImageAdjustmentTest extends UnitTestCase
         self::assertNull($cropImageAdjustment->getAspectRatio());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBeAppliedReturnsFalseIfAspectRatioEqualsOriginalAspectRatio(): void
     {
         $imagine = new Imagine();
@@ -122,8 +115,6 @@ class CropImageAdjustmentTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider imageCropByAspectRatioDataProvider
      * @param string $aspectRatio
      * @param int $originalWidth
      * @param int $originalHeight
@@ -132,6 +123,8 @@ class CropImageAdjustmentTest extends UnitTestCase
      * @param int $expectedWidth
      * @param int $expectedHeight
      */
+    #[DataProvider('imageCropByAspectRatioDataProvider')]
+    #[Test]
     public function aspectRatioIsAppliedWithMaximumPossibleClipping(string $aspectRatio, int $originalWidth, int $originalHeight, int $expectedX, int $expectedY, int $expectedWidth, int $expectedHeight): void
     {
         $imagine = new Imagine();
@@ -153,9 +146,7 @@ class CropImageAdjustmentTest extends UnitTestCase
         self::assertSame(100, $image->getColorAt(new Point(0, 0))->getValue(ColorInterface::COLOR_RED));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBeAppliedReturnsTrueIfCropClippingIsSmallerThanTheImage(): void
     {
         $imagine = new Imagine();
@@ -171,9 +162,7 @@ class CropImageAdjustmentTest extends UnitTestCase
         self::assertTrue($cropImageAdjustment->canBeApplied($image));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canBeAppliedReturnsFalseIfCropClippingIsTheFullImage(): void
     {
         $imagine = new Imagine();

--- a/Neos.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Adjustment/CropImageAdjustmentTest.php
@@ -105,7 +105,7 @@ class CropImageAdjustmentTest extends UnitTestCase
     /**
      * @return array
      */
-    public function imageCropByAspectRatioDataProvider(): array
+    public static function imageCropByAspectRatioDataProvider(): array
     {
         return [
             ['16:9', 1600, 1000, 0, 50, 1600, 900],

--- a/Neos.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\Model\Adjustment;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Media\Imagine\Box;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Adjustment\ResizeImageAdjustment;
@@ -21,9 +22,7 @@ use Neos\Media\Domain\Model\ImageInterface;
  */
 class ResizeImageAdjustmentTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function widthAndHeightDeterminedByExplicitlySetWidthAndHeightWithInsetMode()
     {
         /** @var ResizeImageAdjustment $adjustment */
@@ -40,9 +39,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function widthAndHeightDeterminedByExplicitlySetWidthAndHeightWithOutboundMode()
     {
         /** @var ResizeImageAdjustment $adjustment */
@@ -58,9 +55,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         self::assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ifWidthIsSetHeightIsDeterminedByTheOriginalAspectRatio()
     {
         /** @var ResizeImageAdjustment $adjustment */
@@ -74,9 +69,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         self::assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ifHeightIsSetWidthIsDeterminedByTheOriginalAspectRatio()
     {
         /** @var ResizeImageAdjustment $adjustment */
@@ -90,9 +83,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         self::assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function minimumHeightIsGreaterZero()
     {
         /** @var ResizeImageAdjustment $adjustment */
@@ -110,9 +101,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         self::assertEquals($expectedDimensions, $adjustment->_call('calculateDimensions', $originalDimensions));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function minimumWidthIsGreaterZero()
     {
         /** @var ResizeImageAdjustment $adjustment */
@@ -152,10 +141,8 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider minimumAndMaximumDimensions()
-     * @test
-     */
+    #[DataProvider('minimumAndMaximumDimensions')]
+    #[Test]
     public function combinationsOfMaximumAndMinimumWidthAndHeightAreCalculatedCorrectly($width, $maximumWidth, $height, $maximumHeight, $expectedWidth, $expectedHeight, $ratioMode, $allowUpScaling)
     {
         $options = [

--- a/Neos.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
@@ -124,7 +124,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
      *
      * @return array
      */
-    public function minimumAndMaximumDimensions()
+    public static function minimumAndMaximumDimensions()
     {
         return [
             [null, 110, null, null, 110, 83, ImageInterface::RATIOMODE_INSET, false], # maximum width respects aspect ratio

--- a/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
@@ -212,14 +212,14 @@ class AssetConstraintsTest extends UnitTestCase
     public static function applyToAssetTypeFilterDataProvider(): array
     {
         return [
-            ['mediaTypes' => [], 'assetType' => null, 'expectedResult' => 'All'],
-            ['mediaTypes' => [], 'assetType' => 'All', 'expectedResult' => 'All'],
-            ['mediaTypes' => [], 'assetType' => 'Image', 'expectedResult' => 'Image'],
-            ['mediaTypes' => ['image/*'], 'assetType' => 'Image', 'expectedResult' => 'Image'],
-            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'Image', 'expectedResult' => 'Image'],
-            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => null, 'expectedResult' => 'Audio'],
-            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'Video', 'expectedResult' => 'Audio'],
-            ['mediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'All', 'expectedResult' => 'Audio'],
+            ['allowedMediaTypes' => [], 'assetType' => null, 'expectedResult' => 'All'],
+            ['allowedMediaTypes' => [], 'assetType' => 'All', 'expectedResult' => 'All'],
+            ['allowedMediaTypes' => [], 'assetType' => 'Image', 'expectedResult' => 'Image'],
+            ['allowedMediaTypes' => ['image/*'], 'assetType' => 'Image', 'expectedResult' => 'Image'],
+            ['allowedMediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'Image', 'expectedResult' => 'Image'],
+            ['allowedMediaTypes' => ['audio/*', 'image/*'], 'assetType' => null, 'expectedResult' => 'Audio'],
+            ['allowedMediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'Video', 'expectedResult' => 'Audio'],
+            ['allowedMediaTypes' => ['audio/*', 'image/*'], 'assetType' => 'All', 'expectedResult' => 'Audio'],
         ];
     }
 
@@ -239,12 +239,12 @@ class AssetConstraintsTest extends UnitTestCase
     public static function getAllowedAssetTypeFilterOptionsDataProvider(): array
     {
         return [
-            ['mediaTypes' => [], 'expectedResult' => ['All', 'Image', 'Document', 'Video', 'Audio']],
-            ['mediaTypes' => ['image/*'], 'expectedResult' => []],
-            ['mediaTypes' => ['unknown/media-type'], 'expectedResult' => []],
-            ['mediaTypes' => ['video/*', 'image/*'], 'expectedResult' => ['Video', 'Image']],
-            ['mediaTypes' => ['video/*', 'image/jpeg', 'image/gif'], 'expectedResult' => ['Video', 'Image']],
-            ['mediaTypes' => ['unknown/media-type', 'video/*'], 'expectedResult' => ['Document', 'Video']],
+            ['allowedMediaTypes' => [], 'expectedResult' => ['All', 'Image', 'Document', 'Video', 'Audio']],
+            ['allowedMediaTypes' => ['image/*'], 'expectedResult' => []],
+            ['allowedMediaTypes' => ['unknown/media-type'], 'expectedResult' => []],
+            ['allowedMediaTypes' => ['video/*', 'image/*'], 'expectedResult' => ['Video', 'Image']],
+            ['allowedMediaTypes' => ['video/*', 'image/jpeg', 'image/gif'], 'expectedResult' => ['Video', 'Image']],
+            ['allowedMediaTypes' => ['unknown/media-type', 'video/*'], 'expectedResult' => ['Document', 'Video']],
         ];
     }
 

--- a/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
@@ -29,7 +29,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertFalse($constraints->hasMediaTypeConstraint());
     }
 
-    public function fromArrayDataProvider(): array
+    public static function fromArrayDataProvider(): array
     {
         return [
             ['input' => [], 'expectedAllowedAssetSourceIdentifiers' => [], 'expectedAllowedMediaTypes' => []],
@@ -55,7 +55,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame($expectedAllowedMediaTypes, $constraints->getAllowedMediaTypes());
     }
 
-    public function invalidFromArrayDataProvider(): array
+    public static function invalidFromArrayDataProvider(): array
     {
         return [
             [['unknown-constraint' => 'foo']],
@@ -183,7 +183,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame([], $resultingAssetSources);
     }
 
-    public function applyToAssetSourceIdentifiersDataProvider(): array
+    public static function applyToAssetSourceIdentifiersDataProvider(): array
     {
         return [
             ['allowedAssetSourceIdentifiers' => [], 'assetSourceIdentifier' => null, 'expectedResult' => null],
@@ -209,7 +209,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame($expectedResult, $constraints->applyToAssetSourceIdentifiers($assetSourceIdentifier));
     }
 
-    public function applyToAssetTypeFilterDataProvider(): array
+    public static function applyToAssetTypeFilterDataProvider(): array
     {
         return [
             ['mediaTypes' => [], 'assetType' => null, 'expectedResult' => 'All'],
@@ -236,7 +236,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame($expectedResult, (string)$constraints->applyToAssetTypeFilter($assetType));
     }
 
-    public function getAllowedAssetTypeFilterOptionsDataProvider(): array
+    public static function getAllowedAssetTypeFilterOptionsDataProvider(): array
     {
         return [
             ['mediaTypes' => [], 'expectedResult' => ['All', 'Image', 'Document', 'Video', 'Audio']],

--- a/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Dto/AssetConstraintsTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\Model\Dto;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
 use Neos\Media\Domain\Model\Dto\AssetConstraints;
@@ -20,9 +21,7 @@ use Neos\Media\Domain\Model\Dto\AssetConstraints;
  */
 class AssetConstraintsTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createCreatesInstanceWithoutConstraints(): void
     {
         $constraints = AssetConstraints::create();
@@ -46,9 +45,9 @@ class AssetConstraintsTest extends UnitTestCase
      * @param array $input
      * @param array $expectedAllowedAssetSourceIdentifiers
      * @param array $expectedAllowedMediaTypes
-     * @test
-     * @dataProvider fromArrayDataProvider
      */
+    #[DataProvider('fromArrayDataProvider')]
+    #[Test]
     public function fromArrayTests(array $input, array $expectedAllowedAssetSourceIdentifiers, array $expectedAllowedMediaTypes): void
     {
         $constraints = AssetConstraints::fromArray($input);
@@ -74,18 +73,16 @@ class AssetConstraintsTest extends UnitTestCase
 
     /**
      * @param array $input
-     * @test
-     * @dataProvider invalidFromArrayDataProvider
      */
+    #[DataProvider('invalidFromArrayDataProvider')]
+    #[Test]
     public function invalidFromArrayTests(array $input): void
     {
         $this->expectException(\InvalidArgumentException::class);
         AssetConstraints::fromArray($input);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withAssetSourceConstraintAllowsToChangeAssetSourceIdentifiers(): void
     {
         $constraints = AssetConstraints::fromArray(['assetSources' => ['id1'], 'mediaTypes' => ['image/*']]);
@@ -94,9 +91,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame(['image/*'], $constraints->getAllowedMediaTypes());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withoutAssetSourceConstraintClearsAssetSourceIdentifiers(): void
     {
         $constraints = AssetConstraints::fromArray(['assetSources' => ['id1', 'id2'], 'mediaTypes' => ['image/*']]);
@@ -105,9 +100,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame(['image/*'], $constraints->getAllowedMediaTypes());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withMediaTypeConstraintAllowsToChangeAllowedMediaTypes(): void
     {
         $constraints = AssetConstraints::fromArray(['assetSources' => ['id1']]);
@@ -116,9 +109,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame(['image/*'], $constraints->getAllowedMediaTypes());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withoutAssetTypeConstraintClearsAllowedMediaTypes(): void
     {
         $constraints = AssetConstraints::fromArray(['assetSources' => ['id1'], 'mediaTypes' => ['image/*']]);
@@ -127,27 +118,21 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertFalse($constraints->hasMediaTypeConstraint());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getMediaTypeAcceptAttributeReturnsAnEmptyStringIfNoAssetConstraintsAreSet(): void
     {
         $constraints = AssetConstraints::create();
         self::assertSame('', $constraints->getMediaTypeAcceptAttribute());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getMediaTypeAcceptAttributeReturnsACommaSeparatedListOfAllActiveMediaTypeConstraints(): void
     {
         $constraints = AssetConstraints::create()->withMediaTypeConstraint(['image/*', 'audio/wav']);
         self::assertSame('image/*,audio/wav', $constraints->getMediaTypeAcceptAttribute());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function applyToAssetSourcesDoesNotHaveAnyEffectWhenNoAssetSourceConstraintsAreActive(): void
     {
         $constraints = AssetConstraints::create();
@@ -159,9 +144,7 @@ class AssetConstraintsTest extends UnitTestCase
         self::assertSame($mockAssetSources, $resultingAssetSources);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function applyToAssetSourcesFiltersDisallowedAssetSources(): void
     {
         $constraints = AssetConstraints::fromArray(['assetSources' => ['id1']]);
@@ -181,9 +164,7 @@ class AssetConstraintsTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function applyToAssetSourcesFiltersAllAssetSourcesIfThereIsNoMatch(): void
     {
         $constraints = AssetConstraints::fromArray(['assetSources' => ['id3']]);
@@ -219,9 +200,9 @@ class AssetConstraintsTest extends UnitTestCase
      * @param array $allowedAssetSourceIdentifiers
      * @param string|null $assetSourceIdentifier
      * @param string|null $expectedResult
-     * @test
-     * @dataProvider applyToAssetSourceIdentifiersDataProvider
      */
+    #[DataProvider('applyToAssetSourceIdentifiersDataProvider')]
+    #[Test]
     public function applyToAssetSourceIdentifiersTests(array $allowedAssetSourceIdentifiers, ?string $assetSourceIdentifier = null, ?string $expectedResult = null): void
     {
         $constraints = AssetConstraints::create()->withAssetSourceConstraint($allowedAssetSourceIdentifiers);
@@ -246,9 +227,9 @@ class AssetConstraintsTest extends UnitTestCase
      * @param array $allowedMediaTypes
      * @param string|null $assetType
      * @param string $expectedResult
-     * @test
-     * @dataProvider applyToAssetTypeFilterDataProvider
      */
+    #[DataProvider('applyToAssetTypeFilterDataProvider')]
+    #[Test]
     public function applyToAssetTypeFilterTests(array $allowedMediaTypes, ?string $assetType, string $expectedResult): void
     {
         $constraints = AssetConstraints::create()->withMediaTypeConstraint($allowedMediaTypes);
@@ -270,9 +251,9 @@ class AssetConstraintsTest extends UnitTestCase
     /**
      * @param array $allowedMediaTypes
      * @param array $expectedResult
-     * @test
-     * @dataProvider getAllowedAssetTypeFilterOptionsDataProvider
      */
+    #[DataProvider('getAllowedAssetTypeFilterOptionsDataProvider')]
+    #[Test]
     public function getAllowedAssetTypeFilterOptionsTests(array $allowedMediaTypes, array $expectedResult): void
     {
         $constraints = AssetConstraints::create()->withMediaTypeConstraint($allowedMediaTypes);

--- a/Neos.Media/Tests/Unit/Domain/Model/VideoTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/VideoTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Video;
@@ -20,9 +20,7 @@ use Neos\Media\Domain\Model\Video;
  */
 class VideoTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function dimensionsDefaultToMinusOneOnConstruct()
     {
         $mockResource = $this->createMock(PersistentResource::class);

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
@@ -11,6 +11,7 @@ namespace Neos\Media\Tests\Unit\Domain\Service;
  * source code.
  */
 
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\Audio;
@@ -48,7 +49,7 @@ class AssetServiceTest extends UnitTestCase
     {
         $mockAsset = $this->getMockBuilder($modelClassName)->disableOriginalConstructor()->getMock();
 
-        $mockObjectManager = $this->createMock(\Neos\Flow\ObjectManagement\ObjectManagerInterface::class);
+        $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager->expects(self::once())
             ->method('get')
             ->willReturn($this->createMock($expectedRepositoryClassName));

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Asset;
@@ -42,9 +43,9 @@ class AssetServiceTest extends UnitTestCase
     /**
      * @param $modelClassName
      * @param $expectedRepositoryClassName
-     * @dataProvider getRepositoryReturnsRepositoryForGivenAssetProvider
-     * @test
      */
+    #[DataProvider('getRepositoryReturnsRepositoryForGivenAssetProvider')]
+    #[Test]
     public function getRepositoryReturnsRepositoryForGivenAsset($modelClassName, $expectedRepositoryClassName): void
     {
         $mockAsset = $this->getMockBuilder($modelClassName)->disableOriginalConstructor()->getMock();

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
@@ -31,7 +31,7 @@ class AssetServiceTest extends UnitTestCase
     /**
      * @return array
      */
-    public function getRepositoryReturnsRepositoryForGivenAssetProvider(): array
+    public static function getRepositoryReturnsRepositoryForGivenAssetProvider(): array
     {
         return [
             [Audio::class, AudioRepository::class],

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\Tests\UnitTestCase;
@@ -29,9 +29,7 @@ use Neos\Media\Exception\AssetVariantGeneratorException;
  */
 class AssetVariantGeneratorTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getVariantPresetsReturnsConfiguration(): void
     {
         $configuration = [
@@ -58,9 +56,9 @@ class AssetVariantGeneratorTest extends UnitTestCase
     }
 
     /**
-     * @test
      * @throws
      */
+    #[Test]
     public function variantsAreCreatedAccordingToPreset(): void
     {
         $asset = $this->mockImage();
@@ -70,9 +68,9 @@ class AssetVariantGeneratorTest extends UnitTestCase
     }
 
     /**
-     * @test
      * @throws
      */
+    #[Test]
     public function noVariantsAreCreatedForUnsupportedAssetTypes(): void
     {
         $assetVariantGenerator = $this->mockAssetVariantGenerator(['createVariant']);
@@ -93,9 +91,9 @@ class AssetVariantGeneratorTest extends UnitTestCase
     }
 
     /**
-     * @test
      * @throws
      */
+    #[Test]
     public function createVariantCreatesVariantAccordingToPreset(): void
     {
         $variantPresetsConfiguration = [
@@ -130,12 +128,12 @@ class AssetVariantGeneratorTest extends UnitTestCase
     }
 
     /**
-     * @test
      * @throws \Neos\Flow\Configuration\Exception\InvalidConfigurationException
      * @throws \Neos\Flow\ResourceManagement\Exception
      * @throws \Neos\Media\Exception\AssetVariantGeneratorException
      * @throws \Neos\Media\Exception\ImageFileException
      */
+    #[Test]
     public function createVariantThrowsExceptionOnUnknownAdjustmentType(): void
     {
         $this->expectException(AssetVariantGeneratorException::class);

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
@@ -11,6 +11,7 @@ namespace Neos\Media\Tests\Unit\Domain\Service;
  * source code.
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
@@ -168,7 +169,7 @@ class AssetVariantGeneratorTest extends UnitTestCase
     /**
      * @param array $methods
      * @param array $variantPresetsConfiguration
-     * @return AssetVariantGenerator|\PHPUnit\Framework\MockObject\MockObject
+     * @return AssetVariantGenerator|MockObject
      */
     private function mockAssetVariantGenerator(array $methods, array $variantPresetsConfiguration = [])
     {
@@ -225,7 +226,7 @@ class AssetVariantGeneratorTest extends UnitTestCase
     }
 
     /**
-     * @return Image|\PHPUnit\Framework\MockObject\MockObject
+     * @return Image|MockObject
      */
     private function mockImage()
     {

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
@@ -163,7 +163,6 @@ class AssetVariantGeneratorTest extends UnitTestCase
 
     // ------------------------------------------------------------------------------------------------------------
     // TEST HELPER METHODS
-
     /**
      * @param array $methods
      * @param array $variantPresetsConfiguration
@@ -215,7 +214,7 @@ class AssetVariantGeneratorTest extends UnitTestCase
             function (Image $imageAsset) use ($that) {
                 return $that->getMockBuilder(ImageVariant::class)
                     ->setConstructorArgs([$imageAsset])
-                    ->setMethods(['refresh', 'renderResource'])
+                    ->onlyMethods(['refresh', 'renderResource'])
                     ->getMock();
             }
         );
@@ -230,7 +229,8 @@ class AssetVariantGeneratorTest extends UnitTestCase
     {
         $mock = $this->getMockBuilder(Image::class)
             ->setConstructorArgs([$this->createMock(PersistentResource::class)])
-            ->setMethods(['refresh', 'renderResource', 'getMediaType'])
+            ->onlyMethods(['refresh', 'getMediaType'])
+            ->addMethods(['renderResource'])
             ->getMock();
         $mock->method('getMediaType')->willReturn('image/jpeg');
 

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AdjustmentTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\ValueObject\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
 use Neos\Media\Domain\ValueObject\Configuration\Adjustment;
@@ -31,36 +32,30 @@ class AdjustmentTest extends UnitTestCase
 
     /**
      * @param $identifier
-     * @dataProvider invalidIdentifiers()
-     * @test
      */
+    #[DataProvider('invalidIdentifiers')]
+    #[Test]
     public function invalidIdentifiersAreRejected($identifier): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new Adjustment($identifier, '');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function adjustmentIdentifierCanBeRetrieved(): void
     {
         $adjustment = new Adjustment('someAdjustment', '');
         self::assertSame('someAdjustment', $adjustment->identifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function missingTypeIsRejected(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Adjustment::fromConfiguration('someAdjustment', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromConfiguration(): void
     {
         $configuration = [

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AdjustmentTest.php
@@ -21,7 +21,7 @@ class AdjustmentTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidIdentifiers(): array
+    public static function invalidIdentifiers(): array
     {
         return [
             ['something with spaces'],

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AspectRatioTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AspectRatioTest.php
@@ -44,7 +44,7 @@ class AspectRatioTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validStrings(): array
+    public static function validStrings(): array
     {
         return [
             ['16:9'],
@@ -69,7 +69,7 @@ class AspectRatioTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidStrings(): array
+    public static function invalidStrings(): array
     {
         return [
             ['invalid'],
@@ -97,7 +97,7 @@ class AspectRatioTest extends UnitTestCase
     /**
      * @return array
      */
-    public function aspectRatiosAndOrientations(): array
+    public static function aspectRatiosAndOrientations(): array
     {
         return [
             ['4:3', AspectRatio::ORIENTATION_LANDSCAPE],

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AspectRatioTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/AspectRatioTest.php
@@ -12,16 +12,17 @@ namespace Neos\Media\Tests\Unit\Domain\ValueObject\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\ValueObject\Configuration\AspectRatio;
 
 class AspectRatioTest extends UnitTestCase
 {
     /**
-     * @test
      * @return void
      */
+    #[Test]
     public function aspectRatioCanBeConvertedToString(): void
     {
         $aspectRatio = new AspectRatio(16, 9);
@@ -29,9 +30,9 @@ class AspectRatioTest extends UnitTestCase
     }
 
     /**
-     * @test
      * @return void
      */
+    #[Test]
     public function aspectRatioCanBeCreatedFromString(): void
     {
         $aspectRatio = AspectRatio::fromString('16:9');
@@ -54,11 +55,11 @@ class AspectRatioTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider validStrings
      * @param string $validString
      * @return void
      */
+    #[DataProvider('validStrings')]
+    #[Test]
     public function validStringIsAccepted(string $validString): void
     {
         $aspectRatio = AspectRatio::fromString($validString);
@@ -81,11 +82,11 @@ class AspectRatioTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider invalidStrings
      * @param string $invalidString
      * @return void
      */
+    #[DataProvider('invalidStrings')]
+    #[Test]
     public function invalidStringIsRejected(string $invalidString): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -109,11 +110,11 @@ class AspectRatioTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider aspectRatiosAndOrientations
      * @param string $aspectRatioAsString
      * @param string $expectedOrientation
      */
+    #[DataProvider('aspectRatiosAndOrientations')]
+    #[Test]
     public function getOrientationReturnsCorrectValue(string $aspectRatioAsString, string $expectedOrientation): void
     {
         $aspectRatio = AspectRatio::fromString($aspectRatioAsString);

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/MediaTypePatternTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/MediaTypePatternTest.php
@@ -20,7 +20,7 @@ class MediaTypePatternTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validMediaTypePatterns(): array
+    public static function validMediaTypePatterns(): array
     {
         return [
             ['/image\/.*/'],
@@ -42,7 +42,7 @@ class MediaTypePatternTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidMediaTypePatterns(): array
+    public static function invalidMediaTypePatterns(): array
     {
         return [
             [''],

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/MediaTypePatternTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/MediaTypePatternTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\ValueObject\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\ValueObject\Configuration\MediaTypePattern;
 
@@ -29,9 +30,9 @@ class MediaTypePatternTest extends UnitTestCase
 
     /**
      * @param $mediaTypePatternAsString
-     * @dataProvider validMediaTypePatterns()
-     * @test
      */
+    #[DataProvider('validMediaTypePatterns')]
+    #[Test]
     public function validMediaTypePatternsAreAccepted($mediaTypePatternAsString): void
     {
         $mediaType = new MediaTypePattern($mediaTypePatternAsString);
@@ -53,18 +54,16 @@ class MediaTypePatternTest extends UnitTestCase
 
     /**
      * @param $mediaTypePatternAsString
-     * @test
-     * @dataProvider invalidMediaTypePatterns()
      */
+    #[DataProvider('invalidMediaTypePatterns')]
+    #[Test]
     public function invalidMediaTypePatternsAreRejected($mediaTypePatternAsString): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new MediaTypePattern($mediaTypePatternAsString);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchesChecksIfMediaTypeMatchesPattern(): void
     {
         $mediaTypePattern = new MediaTypePattern('~image/(jpe?g|png)~');

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/PresetLabelTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/PresetLabelTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\ValueObject\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\ValueObject\Configuration\Label;
 
@@ -39,9 +40,9 @@ class PresetLabelTest extends UnitTestCase
 
     /**
      * @param $label
-     * @dataProvider validLabels()
-     * @test
      */
+    #[DataProvider('validLabels')]
+    #[Test]
     public function validLabelsAreAccepted($label): void
     {
         $presetLabel = new Label($label);
@@ -62,9 +63,9 @@ class PresetLabelTest extends UnitTestCase
 
     /**
      * @param $label
-     * @test
-     * @dataProvider invalidLabels()
      */
+    #[DataProvider('invalidLabels')]
+    #[Test]
     public function invalidLabelsAreRejected($label): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/PresetLabelTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/PresetLabelTest.php
@@ -20,7 +20,7 @@ class PresetLabelTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validLabels(): array
+    public static function validLabels(): array
     {
         return [
             ['Demo Preset 1'],
@@ -52,7 +52,7 @@ class PresetLabelTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidLabels(): array
+    public static function invalidLabels(): array
     {
         return [
             [''],

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/VariantPresetTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/VariantPresetTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Unit\Domain\ValueObject\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
 use Neos\Media\Domain\ValueObject\Configuration\Adjustment;
@@ -21,9 +21,7 @@ use Neos\Media\Domain\ValueObject\Configuration\Variant;
 
 class VariantPresetTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function imageVariantLabelCanBeRetrieved(): void
     {
         $label = new Label('Demo Preset 1');
@@ -31,9 +29,7 @@ class VariantPresetTest extends UnitTestCase
         self::assertSame($label, $preset->label());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromConfiguration(): void
     {
         $configuration = [

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/VariantTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/VariantTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Domain\ValueObject\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Adjustment\CropImageAdjustment;
 use Neos\Media\Domain\ValueObject\Configuration\Adjustment;
@@ -33,18 +34,16 @@ class VariantTest extends UnitTestCase
 
     /**
      * @param $identifier
-     * @dataProvider invalidIdentifiers()
-     * @test
      */
+    #[DataProvider('invalidIdentifiers')]
+    #[Test]
     public function invalidIdentifiersAreRejected($identifier): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new Variant($identifier, new Label('Test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function variantIdentifierCanBeRetrieved(): void
     {
         $variant = new Variant('someVariant', new Label('Test'));
@@ -52,9 +51,7 @@ class VariantTest extends UnitTestCase
         self::assertSame('someVariant', $variant->identifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function variantLabelCanBeRetrieved(): void
     {
         $label = new Label('This is a variant');
@@ -63,9 +60,7 @@ class VariantTest extends UnitTestCase
         self::assertSame($label, $variant->label());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function variantFromArray(): void
     {
         $configuration = [

--- a/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/VariantTest.php
+++ b/Neos.Media/Tests/Unit/Domain/ValueObject/Configuration/VariantTest.php
@@ -23,7 +23,7 @@ class VariantTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidIdentifiers(): array
+    public static function invalidIdentifiers(): array
     {
         return [
             ['something with spaces'],

--- a/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
+++ b/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
@@ -107,9 +107,9 @@ class ImageInterfaceConverterTest extends UnitTestCase
     #[Test]
     public function convertFromReturnsNullIfResourcePropertyIsNotConverted()
     {
-        $this->mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->will(self::returnCallback(function ($objectType) {
+        $this->mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->willReturnCallback(function ($objectType) {
             return $objectType;
-        }));
+        });
         $configuration = new PropertyMappingConfiguration();
         $configuration->setTypeConverterOption(ImageInterfaceConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, true);
 

--- a/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
+++ b/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
@@ -76,9 +76,11 @@ class ImageInterfaceConverterTest extends UnitTestCase
     /**
      * @return array
      */
-    public function canConvertFromDataProvider()
+    public static function canConvertFromDataProvider()
     {
-        $dummyResource = $this->createMock(PersistentResource::class);
+        // data providers must be static and cannot build mocks, so the resource is
+        // described by a marker that canConvertFromTests() replaces with a mock
+        $dummyResource = '__mock:PersistentResource';
         return [
             [['resource' => $dummyResource], Image::class, true],
             [['__identity' => 'foo'], Image::class, false],
@@ -96,6 +98,9 @@ class ImageInterfaceConverterTest extends UnitTestCase
     #[Test]
     public function canConvertFromTests($source, $targetType, $expected)
     {
+        if (($source['resource'] ?? null) === '__mock:PersistentResource') {
+            $source['resource'] = $this->createMock(PersistentResource::class);
+        }
         self::assertEquals($expected, $this->converter->canConvertFrom($source, $targetType));
     }
 

--- a/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
+++ b/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
@@ -10,6 +10,8 @@ namespace Neos\Media\Tests\Unit\TypeConverter;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
@@ -63,9 +65,7 @@ class ImageInterfaceConverterTest extends UnitTestCase
         $this->inject($this->converter, 'objectManager', $this->mockObjectManager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function checkMetadata()
     {
         self::assertEquals(['string', 'array'], $this->converter->getSupportedSourceTypes());
@@ -87,21 +87,19 @@ class ImageInterfaceConverterTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider canConvertFromDataProvider
      *
      * @param mixed $source
      * @param string $targetType
      * @param boolean $expected
      */
+    #[DataProvider('canConvertFromDataProvider')]
+    #[Test]
     public function canConvertFromTests($source, $targetType, $expected)
     {
         self::assertEquals($expected, $this->converter->canConvertFrom($source, $targetType));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertFromReturnsNullIfResourcePropertyIsNotConverted()
     {
         $this->mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->will(self::returnCallback(function ($objectType) {

--- a/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
+++ b/Neos.Media/Tests/Unit/TypeConverter/ImageInterfaceConverterTest.php
@@ -10,6 +10,7 @@ namespace Neos\Media\Tests\Unit\TypeConverter;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfiguration;
@@ -32,17 +33,17 @@ class ImageInterfaceConverterTest extends UnitTestCase
     protected $converter;
 
     /**
-     * @var ReflectionService|\PHPUnit\Framework\MockObject\MockObject
+     * @var ReflectionService|MockObject
      */
     protected $mockReflectionService;
 
     /**
-     * @var PersistenceManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var PersistenceManagerInterface|MockObject
      */
     protected $mockPersistenceManager;
 
     /**
-     * @var ObjectManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var ObjectManagerInterface|MockObject
      */
     protected $mockObjectManager;
 

--- a/Neos.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Media\Domain\Model\ImageInterface;
@@ -22,9 +23,7 @@ use Neos\Media\Validator\ImageOrientationValidator;
  */
 class ImageOrientationValidatorTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function validatorReturnsErrorsIfGivenValueIsNoImage()
     {
         $validator = new ImageOrientationValidator(['allowedOrientations' => [ImageInterface::ORIENTATION_LANDSCAPE]]);
@@ -48,10 +47,10 @@ class ImageOrientationValidatorTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider invalidOptionsTestsDataProvider
      * @param array $options
      */
+    #[DataProvider('invalidOptionsTestsDataProvider')]
+    #[Test]
     public function invalidOptionsTests(array $options)
     {
         $this->expectException(InvalidValidationOptionsException::class);
@@ -75,12 +74,12 @@ class ImageOrientationValidatorTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider validatorTestsDataProvider
      * @param array $options
      * @param integer $imageOrientation (one of the ImageOrientation_* constants)
      * @param boolean $isValid
      */
+    #[DataProvider('validatorTestsDataProvider')]
+    #[Test]
     public function validatorTests(array $options, $imageOrientation, $isValid)
     {
         $validator = new ImageOrientationValidator($options);

--- a/Neos.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
@@ -84,7 +84,7 @@ class ImageOrientationValidatorTest extends UnitTestCase
     {
         $validator = new ImageOrientationValidator($options);
         $image = $this->createMock(ImageInterface::class);
-        $image->expects(self::any())->method('getOrientation')->will(self::returnValue($imageOrientation));
+        $image->expects(self::any())->method('getOrientation')->willReturn($imageOrientation);
 
         $validationResult = $validator->validate($image);
         if ($isValid) {

--- a/Neos.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageOrientationValidatorTest.php
@@ -35,7 +35,7 @@ class ImageOrientationValidatorTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidOptionsTestsDataProvider()
+    public static function invalidOptionsTestsDataProvider()
     {
         return [
             [[]],
@@ -62,7 +62,7 @@ class ImageOrientationValidatorTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validatorTestsDataProvider()
+    public static function validatorTestsDataProvider()
     {
         return [
             [['allowedOrientations' => ['landscape']], null, false],

--- a/Neos.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
@@ -104,8 +104,8 @@ class ImageSizeValidatorTest extends UnitTestCase
     {
         $validator = new ImageSizeValidator($options);
         $image = $this->createMock(ImageInterface::class);
-        $image->expects(self::any())->method('getWidth')->will(self::returnValue($imageWidth));
-        $image->expects(self::any())->method('getHeight')->will(self::returnValue($imageHeight));
+        $image->expects(self::any())->method('getWidth')->willReturn($imageWidth);
+        $image->expects(self::any())->method('getHeight')->willReturn($imageHeight);
 
         $validationResult = $validator->validate($image);
         if ($isValid) {

--- a/Neos.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
@@ -35,7 +35,7 @@ class ImageSizeValidatorTest extends UnitTestCase
     /**
      * @return array
      */
-    public function invalidOptionsTestsDataProvider()
+    public static function invalidOptionsTestsDataProvider()
     {
         return [
             [[]],
@@ -62,7 +62,7 @@ class ImageSizeValidatorTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validatorTestsDataProvider()
+    public static function validatorTestsDataProvider()
     {
         return [
             [['minimumWidth' => 123], 122, 0, false],

--- a/Neos.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageSizeValidatorTest.php
@@ -10,6 +10,8 @@ namespace Neos\Media\Tests\Unit\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Media\Domain\Model\ImageInterface;
@@ -21,9 +23,7 @@ use Neos\Media\Validator\ImageSizeValidator;
  */
 class ImageSizeValidatorTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function validatorReturnsErrorsIfGivenValueIsNoImage()
     {
         $validator = new ImageSizeValidator(['minimumWidth' => 123]);
@@ -47,10 +47,10 @@ class ImageSizeValidatorTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider invalidOptionsTestsDataProvider
      * @param array $options
      */
+    #[DataProvider('invalidOptionsTestsDataProvider')]
+    #[Test]
     public function invalidOptionsTests(array $options)
     {
         $this->expectException(InvalidValidationOptionsException::class);
@@ -93,13 +93,13 @@ class ImageSizeValidatorTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider validatorTestsDataProvider
      * @param array $options
      * @param integer $imageWidth
      * @param integer $imageHeight
      * @param boolean $isValid
      */
+    #[DataProvider('validatorTestsDataProvider')]
+    #[Test]
     public function validatorTests(array $options, $imageWidth, $imageHeight, $isValid)
     {
         $validator = new ImageSizeValidator($options);

--- a/Neos.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
@@ -53,7 +53,7 @@ class ImageTypeValidatorTest extends UnitTestCase
     public function validatorTests(array $options, $actualMediaType, $supposedToBeValid)
     {
         $image = $this->getMockBuilder(Image::class)->disableOriginalConstructor()->getMock();
-        $image->expects(self::any())->method('getMediaType')->will(self::returnValue($actualMediaType));
+        $image->expects(self::any())->method('getMediaType')->willReturn($actualMediaType);
 
         $validator = new ImageTypeValidator($options);
         $validationResult = $validator->validate($image);

--- a/Neos.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
@@ -10,7 +10,8 @@ namespace Neos\Media\Tests\Unit\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Validator\ImageTypeValidator;
@@ -20,9 +21,7 @@ use Neos\Media\Validator\ImageTypeValidator;
  */
 class ImageTypeValidatorTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function validatorReturnsErrorsIfGivenValueIsNoImage()
     {
         $validator = new ImageTypeValidator(['allowedTypes' => ['png']]);
@@ -45,12 +44,12 @@ class ImageTypeValidatorTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider validatorTestsDataProvider
      * @param array $options
      * @param string $actualMediaType
      * @param boolean $supposedToBeValid
      */
+    #[DataProvider('validatorTestsDataProvider')]
+    #[Test]
     public function validatorTests(array $options, $actualMediaType, $supposedToBeValid)
     {
         $image = $this->getMockBuilder(Image::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
+++ b/Neos.Media/Tests/Unit/Validator/ImageTypeValidatorTest.php
@@ -32,7 +32,7 @@ class ImageTypeValidatorTest extends UnitTestCase
     /**
      * @return array
      */
-    public function validatorTestsDataProvider()
+    public static function validatorTestsDataProvider()
     {
         return [
             [['allowedTypes' => ['png']], null, false],

--- a/Neos.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
+++ b/Neos.Media/Tests/Unit/ViewHelpers/ImageViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Unit\ViewHelpers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Media\ViewHelpers\ImageViewHelper;
 
@@ -30,9 +30,7 @@ class ImageViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doNotThrowExceptionIfImageIsNull(): void
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper);

--- a/Neos.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
+++ b/Neos.Media/Tests/Unit/ViewHelpers/Uri/ImageViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Media\Tests\Unit\ViewHelpers\Uri;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Media\ViewHelpers\ImageViewHelper;
 
@@ -30,9 +30,7 @@ class ImageViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doNotThrowExceptionIfImageIsNull(): void
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper);

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/FeatureContext.php
@@ -9,7 +9,7 @@
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use Behat\Behat\Context\Context;
 use Behat\Behat\Definition\Call\Then;
 use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
@@ -54,7 +54,7 @@ require_once(__DIR__ . '/FusionTrait.php');
 /**
  * Features context
  */
-class FeatureContext implements Behat\Behat\Context\Context
+class FeatureContext implements Context
 {
     use FlowContextTrait;
     use NodeOperationsTrait;

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/HistoryDefinitionsTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+use Doctrine\DBAL\DBALException;
+use PHPUnit\Framework\ExpectationFailedException;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Neos\Neos\Domain\Service\UserService;
@@ -29,7 +31,7 @@ trait HistoryDefinitionsTrait
             $eventRepository = $this->getEventRepository();
             $eventRepository->removeAll();
             $this->getContentRepositoryIntegrationService()->reset();
-        } catch (\Doctrine\DBAL\DBALException $e) {
+        } catch (DBALException $e) {
             // Ignore DB exceptions, because the trait runs before applying migrations in FlowContext
         }
     }
@@ -61,7 +63,7 @@ trait HistoryDefinitionsTrait
                         $this->checkSingleEvent($row, $event, $eventsByInternalId, $unmatchedParentEvents);
                         // no exception thrown so far, so that means there is an $event which fits to the current expectation row $i. Thus, we continue in the next iteration.
                         continue 2;
-                    } catch (\PHPUnit\Framework\ExpectationFailedException $assertionFailed) {
+                    } catch (ExpectationFailedException $assertionFailed) {
                         // do nothing, we just retry the row on the next event.
                     }
                 }

--- a/Neos.Neos/Tests/Functional/AbstractNodeTestCase.php
+++ b/Neos.Neos/Tests/Functional/AbstractNodeTestCase.php
@@ -21,7 +21,7 @@ use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 /**
  * Base test case for nodes
  */
-abstract class AbstractNodeTest extends FunctionalTestCase
+abstract class AbstractNodeTestCase extends FunctionalTestCase
 {
     /**
      * @var boolean

--- a/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Neos/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -23,28 +23,21 @@ class ConfigurationValidationTest extends FlowConfigurationValidationTest
      *
      * @var array<string>
      */
-    protected array $contextNames = ['Development', 'Production', 'Testing'];
+    protected static array $contextNames = ['Development', 'Production', 'Testing'];
 
     /**
      * The configuration-types that are validated
      *
      * @var array<string>
      */
-    protected array $configurationTypes = ['Caches', 'Objects', 'Policy', 'Routes', 'Settings', 'NodeTypes'];
-
-    /**
-     * The packages that are searched for schemas
-     *
-     * @var array<string>
-     */
-    protected array $schemaPackageKeys = ['Neos.Flow', 'Neos.Neos', 'Neos.ContentRepository', 'Neos.Fusion'];
+    protected static array $configurationTypes = ['Caches', 'Objects', 'Policy', 'Routes', 'Settings', 'NodeTypes'];
 
     /**
      * The packages that contain the configuration that is validated
      *
      * @var array<string>
      */
-    protected array $configurationPackageKeys = [
+    protected static array $configurationPackageKeys = [
         'Neos.Flow', 'Neos.FluidAdaptor', 'Neos.Eel', 'Neos.Kickstart',
         'Neos.ContentRepository', 'Neos.Neos', 'Neos.Fusion', 'Neos.Media',
         'Neos.Media.Browser'

--- a/Neos.Neos/Tests/Functional/Configuration/SchemaValidationTest.php
+++ b/Neos.Neos/Tests/Functional/Configuration/SchemaValidationTest.php
@@ -23,5 +23,5 @@ class SchemaValidationTest extends FlowSchemaValidationTest
     /**
      * @var array<string>
      */
-    protected $schemaPackageKeys = ['Neos.ContentRepository', 'Neos.Neos'];
+    protected static array $schemaPackageKeys = ['Neos.ContentRepository', 'Neos.Neos'];
 }

--- a/Neos.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
+++ b/Neos.Neos/Tests/Functional/Controller/Backend/BackendControllerSecurityTest.php
@@ -10,16 +10,16 @@ namespace Neos\Neos\Tests\Functional\Controller\Backend;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Controller\Backend\BackendController;
 use Neos\Neos\Service\BackendRedirectionService;
 
 /**
  * Testcase for method security of the backend controller
- *
- * @group large
  */
+#[Large]
 class BackendControllerSecurityTest extends FunctionalTestCase
 {
     /**
@@ -27,9 +27,7 @@ class BackendControllerSecurityTest extends FunctionalTestCase
      */
     protected $testableSecurityEnabled = true;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function indexActionIsGrantedForAdministrator()
     {
         $backendRedirectionServiceMock = $this->getMockBuilder(BackendRedirectionService::class)->getMock();
@@ -46,9 +44,7 @@ class BackendControllerSecurityTest extends FunctionalTestCase
         $this->browser->request('http://localhost/neos/login');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function indexActionIsDeniedForEverybody()
     {
         $this->browser->request('http://localhost/neos/');

--- a/Neos.Neos/Tests/Functional/Domain/NodeUriTest.php
+++ b/Neos.Neos/Tests/Functional/Domain/NodeUriTest.php
@@ -11,12 +11,12 @@ namespace Neos\Neos\Tests\Functional\Domain;
  * source code.
  */
 
-use Neos\Neos\Tests\Functional\AbstractNodeTest;
+use Neos\Neos\Tests\Functional\AbstractNodeTestCase;
 
 /**
  * Tests checking correct Uri behavior for Neos nodes.
  */
-class NodeUriTest extends AbstractNodeTest
+class NodeUriTest extends AbstractNodeTestCase
 {
     /**
      * @var string the Nodes fixture

--- a/Neos.Neos/Tests/Functional/Domain/NodeUriTest.php
+++ b/Neos.Neos/Tests/Functional/Domain/NodeUriTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\Domain;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Neos\Tests\Functional\AbstractNodeTestCase;
 
 /**
@@ -32,9 +32,8 @@ class NodeUriTest extends AbstractNodeTestCase
      * Note: You cannot hide a node in a context that doesn't show invisible content and afterwards move it because moving breaks then.
      * The context used in this test therefor needs to be able to show hidden nodes.
      * TODO: Investigate this behavior, currently it executes without problems but the result is wrong.
-     *
-     * @test
      */
+    #[Test]
     public function hiddenNodeGetsNewUriSegmentOnMoveIfUriAlreadyExists()
     {
         $contextProperties = array_merge($this->node->getContext()->getProperties(), ['invisibleContentShown' => true]);
@@ -54,9 +53,7 @@ class NodeUriTest extends AbstractNodeTestCase
         self::assertEquals('neos-1', $uriPathSegment);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeInNonDefaultDimensionGetsNewUriSegmentOnMoveIfUriAlreadyExists()
     {
         $homeNodeInNonDefaultDimension = $this->getNodeWithContextPath($this->nodeContextPath . '@live;language=de');

--- a/Neos.Neos/Tests/Functional/Domain/Service/FusionSourceCodeFactoryPrototypeGeneratorTest.php
+++ b/Neos.Neos/Tests/Functional/Domain/Service/FusionSourceCodeFactoryPrototypeGeneratorTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Neos\Domain\Exception;
 use Neos\Neos\Domain\Service\FusionSourceCodeFactory;
 use Symfony\Component\Yaml\Parser as YamlParser;
@@ -65,7 +65,7 @@ class FusionSourceCodeFactoryPrototypeGeneratorTest extends FunctionalTestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function generateFusionForNodeThrowsExceptionForInvalidFusionPrototypeGenerator()
     {
         $this->expectException(Exception::class);
@@ -73,7 +73,7 @@ class FusionSourceCodeFactoryPrototypeGeneratorTest extends FunctionalTestCase
         $this->factory->createFromNodeTypeDefinitions();
     }
 
-    /** @test */
+    #[Test]
     public function generateFusionForNodeDoesNotUseFusionPrototypeGeneratorWithoutConfiguration()
     {
         $this->mockNodeTypeManagerToOnlyReturnNodeType('Neos.Neos:NodeTypeWithoutFusionPrototypeGenerator');
@@ -81,7 +81,7 @@ class FusionSourceCodeFactoryPrototypeGeneratorTest extends FunctionalTestCase
         self::assertSame(0, $this->testablePrototypeGenerator->getCallCount());
     }
 
-    /** @test */
+    #[Test]
     public function generateFusionForNodeUsesDirectlyConfiguredFusionPrototypeGenerator()
     {
         $this->mockNodeTypeManagerToOnlyReturnNodeType('Neos.Neos:NodeTypeWithPrototypeGenerator');
@@ -89,7 +89,7 @@ class FusionSourceCodeFactoryPrototypeGeneratorTest extends FunctionalTestCase
         self::assertSame(1, $this->testablePrototypeGenerator->getCallCount());
     }
 
-    /** @test */
+    #[Test]
     public function generateFusionForNodeUsesInheritedFusionPrototypeGenerator()
     {
         $this->mockNodeTypeManagerToOnlyReturnNodeType('Neos.Neos:NodeTypeWithInheritedPrototypeGenerator');

--- a/Neos.Neos/Tests/Functional/Domain/Service/FusionSourceCodeFactoryTest.php
+++ b/Neos.Neos/Tests/Functional/Domain/Service/FusionSourceCodeFactoryTest.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\Tests\Functional\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Domain\Service\FusionSourceCodeFactory;
 
@@ -25,9 +25,7 @@ class FusionSourceCodeFactoryTest extends FunctionalTestCase
         $this->factory = $this->objectManager->get(FusionSourceCodeFactory::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sourceCodeCreatedFromAutoIncludes()
     {
         $sourceCodeCollection = $this->factory->createFromAutoIncludes();

--- a/Neos.Neos/Tests/Functional/Domain/Service/SiteImportExportServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Domain/Service/SiteImportExportServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Service\SiteExportService;
@@ -78,9 +78,7 @@ class SiteImportExportServiceTest extends FunctionalTestCase
         $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exportingAPreviouslyImportedSiteLeadsToTheSameStructure()
     {
         $expectedResult = file_get_contents(__DIR__ . '/Fixtures/Sites.xml');

--- a/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
+++ b/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
@@ -11,6 +11,11 @@ namespace Neos\Neos\Tests\Functional\FlowQueryOperations;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\Neos\Domain\Service\SiteImportService;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\FlowQueryException;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Eel\FlowQueryOperations\SortOperation;
@@ -47,14 +52,14 @@ class SortOperationTest extends FunctionalTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $workspaceRepository = $this->objectManager->get(\Neos\ContentRepository\Domain\Repository\WorkspaceRepository::class);
+        $workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
         $workspaceRepository->add(new Workspace('live'));
         $this->persistenceManager->persistAll();
-        $this->contextFactory = $this->objectManager->get(\Neos\ContentRepository\Domain\Service\ContextFactoryInterface::class);
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
         $this->context = $this->contextFactory->create(['workspaceName' => 'live']);
 
 
-        $siteImportService = $this->objectManager->get(\Neos\Neos\Domain\Service\SiteImportService::class);
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
         $siteImportService->importFromFile(__DIR__ . '/Fixtures/SortableNodes.xml', $this->context);
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
@@ -62,7 +67,7 @@ class SortOperationTest extends FunctionalTestCase
 
         // The context is not important here, just a quick way to get a (live) workspace
         //        $context = $this->contextFactory->create();
-        $this->nodeDataRepository = $this->objectManager->get(\Neos\ContentRepository\Domain\Repository\NodeDataRepository::class);
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
     }
 
     /**
@@ -80,7 +85,7 @@ class SortOperationTest extends FunctionalTestCase
     public function callWithoutArgumentsCausesException()
     {
         $this->expectException(FlowQueryException::class);
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery([]);
+        $flowQuery = new FlowQuery([]);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, []);
     }
@@ -91,7 +96,7 @@ class SortOperationTest extends FunctionalTestCase
     public function invalidSortDirectionCausesException()
     {
         $this->expectException(FlowQueryException::class);
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery([]);
+        $flowQuery = new FlowQuery([]);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['title', 'FOO']);
     }
@@ -111,7 +116,7 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115adde', $this->context->getWorkspace(true), [])
         ];
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $flowQuery = new FlowQuery($nodesToSort);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['title', 'ASC']);
 
@@ -133,7 +138,7 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), [])
         ];
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $flowQuery = new FlowQuery($nodesToSort);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['title', 'DESC']);
 
@@ -155,7 +160,7 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), [])
         ];
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $flowQuery = new FlowQuery($nodesToSort);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['_lastPublicationDateTime', 'ASC']);
 
@@ -177,7 +182,7 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addf', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115adde', $this->context->getWorkspace(true), [])
         ];
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $flowQuery = new FlowQuery($nodesToSort);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['_lastPublicationDateTime', 'DESC']);
 
@@ -190,7 +195,7 @@ class SortOperationTest extends FunctionalTestCase
     public function invalidSortOptionCausesException()
     {
         $this->expectException(FlowQueryException::class);
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery([]);
+        $flowQuery = new FlowQuery([]);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['title', 'ASC', 'SORT_BAR']);
     }
@@ -214,7 +219,7 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addd', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115adde', $this->context->getWorkspace(true), [])
         ];
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $flowQuery = new FlowQuery($nodesToSort);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['title', 'ASC', ['SORT_NATURAL', 'SORT_FLAG_CASE']]);
 
@@ -234,7 +239,7 @@ class SortOperationTest extends FunctionalTestCase
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addb', $this->context->getWorkspace(true), []),
             $this->nodeDataRepository->findOneByIdentifier('c381f64d-4269-429a-9c21-6d846115addc', $this->context->getWorkspace(true), []),
         ];
-        $flowQuery = new \Neos\Eel\FlowQuery\FlowQuery($nodesToSort);
+        $flowQuery = new FlowQuery($nodesToSort);
         $operation = new SortOperation();
         $operation->evaluate($flowQuery, ['text', 'DESC', 'SORT_NUMERIC']);
 

--- a/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
+++ b/Neos.Neos/Tests/Functional/FlowQueryOperations/SortOperationTest.php
@@ -10,11 +10,11 @@ namespace Neos\Neos\Tests\Functional\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\FlowQueryException;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -79,9 +79,7 @@ class SortOperationTest extends FunctionalTestCase
         $this->inject($this->contextFactory, 'contextInstances', []);
     }
 
-    /**
-     * @test+
-     */
+    #[Test]
     public function callWithoutArgumentsCausesException()
     {
         $this->expectException(FlowQueryException::class);
@@ -90,9 +88,7 @@ class SortOperationTest extends FunctionalTestCase
         $operation->evaluate($flowQuery, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidSortDirectionCausesException()
     {
         $this->expectException(FlowQueryException::class);
@@ -101,9 +97,7 @@ class SortOperationTest extends FunctionalTestCase
         $operation->evaluate($flowQuery, ['title', 'FOO']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByStringAscending()
     {
         $nodesToSort = [
@@ -123,9 +117,7 @@ class SortOperationTest extends FunctionalTestCase
         self::assertEquals($correctOrder, $flowQuery->getContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByStringDescending()
     {
         $nodesToSort = [
@@ -145,9 +137,7 @@ class SortOperationTest extends FunctionalTestCase
         self::assertEquals($correctOrder, $flowQuery->getContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByDateTimeAscending()
     {
         $nodesToSort = [
@@ -167,9 +157,7 @@ class SortOperationTest extends FunctionalTestCase
         self::assertEquals($correctOrder, $flowQuery->getContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByDateTimeDescending()
     {
         $nodesToSort = [
@@ -189,9 +177,7 @@ class SortOperationTest extends FunctionalTestCase
         self::assertEquals($correctOrder, $flowQuery->getContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidSortOptionCausesException()
     {
         $this->expectException(FlowQueryException::class);
@@ -200,9 +186,7 @@ class SortOperationTest extends FunctionalTestCase
         $operation->evaluate($flowQuery, ['title', 'ASC', 'SORT_BAR']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByStringNaturalCaseAscending()
     {
         $nodesToSort = [
@@ -226,9 +210,7 @@ class SortOperationTest extends FunctionalTestCase
         self::assertEquals($correctOrder, $flowQuery->getContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sortByNumericDescending()
     {
         $nodesToSort = [

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Tests\Functional\Fusion\Cache;
  * source code.
  */
 
+use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
@@ -63,7 +64,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         $this->contentCacheFlusher = $this->objectManager->get(ContentCacheFlusher::class);
 
         $this->context = $this->contextFactory->create(['workspaceName' => 'live']);
-        $siteImportService = $this->objectManager->get(\Neos\Neos\Domain\Service\SiteImportService::class);
+        $siteImportService = $this->objectManager->get(SiteImportService::class);
         $siteImportService->importFromFile(__DIR__ . '/Fixtures/CacheableNodes.xml', $this->context);
 
         // Assume an empty state for $contentCacheFlusher - this is needed as importing nodes will register

--- a/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/Cache/ContentCacheFlusherTest.php
@@ -10,8 +10,8 @@ namespace Neos\Neos\Tests\Functional\Fusion\Cache;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 use Neos\Neos\Domain\Service\SiteImportService;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
@@ -76,9 +76,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flushingANodeWillResolveAllWorkspacesToFlush()
     {
         // Add more workspaces
@@ -122,9 +120,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         self::assertArrayHasKey('third-level', $workspaceChain);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flushingANodeWithAnAdditionalTargetWorkspaceWillAlsoResolveThatWorkspace()
     {
         // Add more workspaces
@@ -167,9 +163,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         self::assertArrayHasKey('first-level', $workspacesToFlush);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aNodeChangeWillRegisterNodeIdentifierTagsForAllWorkspaces()
     {
         $workspaceFirstLevel = new Workspace('first-level');
@@ -200,9 +194,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aNodeChangeWillRegisterNodeTypeTagsForAllWorkspaces()
     {
         $workspaceFirstLevel = new Workspace('first-level');
@@ -235,9 +227,7 @@ class ContentCacheFlusherTest extends FunctionalTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aNodeChangeWillRegisterAllDescendantOfTagsForAllWorkspaces()
     {
         $workspaceFirstLevel = new Workspace('first-level');

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\Fusion;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Fusion\Tests\Functional\FusionObjects\AbstractFusionObjectTestCase;
@@ -27,9 +27,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
      */
     protected $textNode;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function defaultNodeLabel()
     {
         $view = $this->buildView();
@@ -40,9 +38,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
         self::assertEquals('Some title', (string)$view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withPropertyFallback()
     {
         $view = $this->buildView();
@@ -53,9 +49,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
         self::assertEquals('Some text', (string)$view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withPrefixOverrideAndPostfix()
     {
         $view = $this->buildView();
@@ -66,9 +60,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
         self::assertEquals('Hello world how are you', (string)$view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTypeFallback()
     {
         $view = $this->buildView();
@@ -79,9 +71,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
         self::assertEquals($this->textNode->getNodeType()->getLabel(), (string)$view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function crop()
     {
         $view = $this->buildView();

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -99,7 +99,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getName', 'getLabel'])
+            ->onlyMethods(['getName', 'getLabel'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -111,7 +111,7 @@ class NodeHelperTest extends AbstractFusionObjectTestCase
 
         $textNode = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['hasProperty', 'getProperty', 'getNodeType', 'isAutoCreated', 'getContext'])
+            ->onlyMethods(['hasProperty', 'getProperty', 'getNodeType', 'isAutoCreated', 'getContext'])
             ->disableOriginalConstructor()
             ->getMock();
         $textNode

--- a/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/NodeHelperTest.php
@@ -13,14 +13,14 @@ namespace Neos\Neos\Tests\Functional\Fusion;
 
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeType;
-use Neos\Fusion\Tests\Functional\FusionObjects\AbstractFusionObjectTest;
+use Neos\Fusion\Tests\Functional\FusionObjects\AbstractFusionObjectTestCase;
 use Neos\Neos\Domain\Service\ContentContext;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for the Fusion NodeLabel helper
  */
-class NodeHelperTest extends AbstractFusionObjectTest
+class NodeHelperTest extends AbstractFusionObjectTestCase
 {
     /**
      * @var Node|MockObject

--- a/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Fusion\Core\ExceptionHandlers\ThrowingHandler;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Domain\Service\FusionService;
-use Neos\Neos\Tests\Functional\AbstractNodeTest;
+use Neos\Neos\Tests\Functional\AbstractNodeTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
@@ -29,7 +29,7 @@ use Symfony\Component\DomCrawler\Crawler;
  *
  * @group large
  */
-class RenderingTest extends AbstractNodeTest
+class RenderingTest extends AbstractNodeTestCase
 {
     /**
      * @test

--- a/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Functional\Fusion;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Exception;
 use Neos\Fusion\Core\Runtime;
 use GuzzleHttp\Psr7\ServerRequest;
@@ -28,14 +29,11 @@ use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * Functional test case which tests the rendering
- *
- * @group large
  */
+#[Large]
 class RenderingTest extends AbstractNodeTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function basicRenderingWorks(): void
     {
         $output = $this->simulateRendering();
@@ -45,9 +43,7 @@ class RenderingTest extends AbstractNodeTestCase
         $this->assertSidebarConformsToBasicRendering($output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debugModeSettingWorks(): void
     {
         $output = $this->simulateRendering(null, true);
@@ -57,9 +53,7 @@ class RenderingTest extends AbstractNodeTestCase
         $this->assertStringNotContainsString('<!-- Beginning to render Fusion path', $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function overriddenValueInPrototype(): void
     {
         $output = $this->simulateRendering('Test_OverriddenValueInPrototype.fusion');
@@ -72,9 +66,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.sidebar', '[COMMIT WIDGET]', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function additionalProcessorInPrototype(): void
     {
         $output = $this->simulateRendering('Test_AdditionalProcessorInPrototype.fusion');
@@ -85,9 +77,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div > .processor-wrap', 'BEFOREStatic HeadlineAFTER', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function additionalProcessorInPrototype2(): void
     {
         $output = $this->simulateRendering('Test_AdditionalProcessorInPrototype2.fusion');
@@ -99,9 +89,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline > div > header > .processor-wrap', 'BEFOREStatic HeadlineAFTER', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function replaceElementRenderingCompletelyInSidebar(): void
     {
         $output = $this->simulateRendering('Test_ReplaceElementRenderingCompletelyInSidebar.fusion');
@@ -113,9 +101,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-text > div', 'Below, you\'ll see the most recent activity', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function prototypeInheritance(): void
     {
         $output = $this->simulateRendering('Test_PrototypeInheritance.fusion');
@@ -127,9 +113,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-text > div', 'Below, you\'ll see the most recent activity', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function replaceElementRenderingCompletelyBasedOnAdvancedCondition(): void
     {
         $output = $this->simulateRendering('Test_ReplaceElementRenderingCompletelyBasedOnAdvancedCondition.fusion');
@@ -139,9 +123,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.main > .neos-contentcollection > .acme-demo-threecolumn > .left > .neos-contentcollection > .acme-demo-headline > div > header', 'DOCS: Documentation', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function overriddenValueInNestedPrototype(): void
     {
         $output = $this->simulateRendering('Test_OverriddenValueInNestedPrototype.fusion');
@@ -153,9 +135,7 @@ class RenderingTest extends AbstractNodeTestCase
         $this->assertSidebarConformsToBasicRendering($output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function overriddenValueInNestedPrototype2(): void
     {
         $output = $this->simulateRendering('Test_OverriddenValueInNestedPrototype2.fusion');
@@ -167,9 +147,7 @@ class RenderingTest extends AbstractNodeTestCase
         $this->assertSidebarConformsToBasicRendering($output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function contentCollectionsAndWrappedContentElementsCanBeRenderedWithCustomTagsAndAttributes(): void
     {
         $output = $this->simulateRendering();
@@ -177,18 +155,14 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.main > .neos-contentcollection > .acme-demo-list > ul.my-list > li.my-list-item > p', 'First', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function menuIsRenderedAsExpected(): void
     {
         $output = $this->simulateRendering();
         self::assertSelectEquals('.navigation > ul > li.normal > a', 'Frameworks', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function classesAreAppendedAsExpected(): void
     {
         $output = $this->simulateRendering('Test_AppendingClassesToContent.fusion');
@@ -196,9 +170,7 @@ class RenderingTest extends AbstractNodeTestCase
         self::assertSelectEquals('.sidebar > .neos-contentcollection > .acme-demo-headline.test h1', 'Last Commits', true, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function menuWithNegativeEntryLevelIsRenderedAsExpected(): void
     {
         $output = $this->simulateRendering('Test_MenuNegativeEntryLevel.fusion');

--- a/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
+++ b/Neos.Neos/Tests/Functional/Fusion/RenderingTest.php
@@ -11,6 +11,8 @@ namespace Neos\Neos\Tests\Functional\Fusion;
  * source code.
  */
 
+use PHPUnit\Framework\Exception;
+use Neos\Fusion\Core\Runtime;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
@@ -308,7 +310,7 @@ class RenderingTest extends AbstractNodeTestCase
                 self::assertTrue($found <= $count['<='], $message);
             }
         } else {
-            throw new \PHPUnit\Framework\Exception('Invalid count format');
+            throw new Exception('Invalid count format');
         }
     }
 
@@ -353,7 +355,7 @@ class RenderingTest extends AbstractNodeTestCase
      * @throws \Neos\Fusion\Exception
      * @throws \Neos\Neos\Domain\Exception
      */
-    protected function createRuntimeWithFixtures($additionalFusionFile = null): \Neos\Fusion\Core\Runtime
+    protected function createRuntimeWithFixtures($additionalFusionFile = null): Runtime
     {
         $fusionService = new FusionService();
         $fusionService->setSiteRootFusionPattern(__DIR__ . '/Fixtures/Base.fusion');

--- a/Neos.Neos/Tests/Functional/NodeRenamingTest.php
+++ b/Neos.Neos/Tests/Functional/NodeRenamingTest.php
@@ -10,6 +10,8 @@ namespace Neos\Neos\Tests\Functional;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Security\Authorization\TestingPrivilegeManager;
 use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
@@ -19,9 +21,8 @@ use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
  *
  * Is placed here instead of the ContentRepository package because that's where we have the correct
  * test fixtures in place.
- *
- * @group large
  */
+#[Large]
 class NodeRenamingTest extends AbstractNodeTestCase
 {
     /**
@@ -46,9 +47,7 @@ class NodeRenamingTest extends AbstractNodeTestCase
         $this->nodeInTestWorkspace = $this->getNodeWithContextPath('/sites/example/home@user-test');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renamedNodeInPersonalWorkspaceDoesNotRenameInLiveWorkspace()
     {
         $teaserTestWorkspace = $this->nodeInTestWorkspace->getNode('teaser');
@@ -62,9 +61,7 @@ class NodeRenamingTest extends AbstractNodeTestCase
         self::assertNull($this->node->getNode('teaser-new/dummy46a'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function movedIntoInPersonalWorkspaceDoesNotAffectLiveWorkspace()
     {
         // move headline of "teaser" into "main"
@@ -79,9 +76,7 @@ class NodeRenamingTest extends AbstractNodeTestCase
         self::assertNull($this->node->getNode('main/dummy46a'), 'moving shined through into live workspace (3)');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveBeforeInPersonalWorkspaceDoesNotAffectLiveWorkspace()
     {
         // move headline of "teaser" before "main/dummy42"
@@ -96,9 +91,7 @@ class NodeRenamingTest extends AbstractNodeTestCase
         self::assertNull($this->node->getNode('main/dummy46a'), 'moving shined through into live workspace (3)');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function moveAfterInPersonalWorkspaceDoesNotAffectLiveWorkspace()
     {
         // move headline of "teaser" after "main/dummy42"

--- a/Neos.Neos/Tests/Functional/NodeRenamingTest.php
+++ b/Neos.Neos/Tests/Functional/NodeRenamingTest.php
@@ -22,7 +22,7 @@ use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
  *
  * @group large
  */
-class NodeRenamingTest extends AbstractNodeTest
+class NodeRenamingTest extends AbstractNodeTestCase
 {
     /**
      * @var \Neos\ContentRepository\Domain\Model\NodeInterface

--- a/Neos.Neos/Tests/Functional/Service/LinkingServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/LinkingServiceTest.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Tests\Functional\Service;
  * source code.
  */
 
+use Neos\Media\Domain\Repository\AssetRepository;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\ServerRequestAttributes;
 use Neos\Flow\Mvc\ActionResponse;
@@ -28,7 +29,6 @@ use Neos\Neos\Domain\Repository\SiteRepository;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Domain\Service\SiteImportService;
 use Neos\Neos\Exception as NeosException;
-use Neos\Neos\Exception;
 use Neos\Neos\Service\LinkingService;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -256,7 +256,7 @@ class LinkingServiceTest extends FunctionalTestCase
      */
     public function linkingServiceCanConvertUriToObject()
     {
-        $assetRepository = $this->objectManager->get(\Neos\Media\Domain\Repository\AssetRepository::class);
+        $assetRepository = $this->objectManager->get(AssetRepository::class);
         $asset = $assetRepository->findByIdentifier('89cd85cc-270e-0902-7113-d14ac7539c75');
 
         self::assertSame($this->baseNode, $this->linkingService->convertUriToObject('node://3239baee-3e7f-785c-0853-f4302ef32570', $this->baseNode));
@@ -268,7 +268,7 @@ class LinkingServiceTest extends FunctionalTestCase
      */
     public function linkingServiceThrowsAnExceptionWhenTryingToLinkToANonExistingNode()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(NeosException::class);
         $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/not-found', $this->baseNode);
     }
 
@@ -277,7 +277,7 @@ class LinkingServiceTest extends FunctionalTestCase
      */
     public function linkingServiceThrowsAnExceptionWhenItIsGivenAnEmptyString()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(NeosException::class);
         $this->linkingService->createNodeUri($this->controllerContext, '', $this->baseNode);
     }
 

--- a/Neos.Neos/Tests/Functional/Service/LinkingServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/LinkingServiceTest.php
@@ -185,7 +185,7 @@ class LinkingServiceTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/home/about-us/mission@live'));
     }
 
-    public function supportedSchemesDataProvider()
+    public static function supportedSchemesDataProvider()
     {
         return [
             ['node://aeabe76a-551a-495f-a324-ad9a86b2aff7', true],

--- a/Neos.Neos/Tests/Functional/Service/LinkingServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/LinkingServiceTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Functional\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Media\Domain\Repository\AssetRepository;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\ServerRequestAttributes;
@@ -140,18 +141,14 @@ class LinkingServiceTest extends FunctionalTestCase
         $this->inject($this->objectManager->get(AssetInterfaceConverter::class), 'resourcesAlreadyConvertedToAssets', []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCreatesUriViaGivenNodeObject()
     {
         $targetNode = $this->propertyMapper->convert('/sites/example/home', Node::class);
         $this->assertOutputLinkValid('en/home', $this->linkingService->createNodeUri($this->controllerContext, $targetNode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCreatesUriViaAbsoluteNodePathString()
     {
         $this->assertOutputLinkValid('en/home', $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/home', $this->baseNode));
@@ -159,9 +156,7 @@ class LinkingServiceTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/home/about-us/mission', $this->baseNode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCreatesUriViaStringStartingWithTilde()
     {
         $this->assertOutputLinkValid('en/home', $this->linkingService->createNodeUri($this->controllerContext, '~', $this->baseNode));
@@ -170,9 +165,7 @@ class LinkingServiceTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $this->linkingService->createNodeUri($this->controllerContext, '~/home/about-us/mission', $this->baseNode));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCreatesUriViaStringPointingToSubNodes()
     {
         $this->assertOutputLinkValid('en/home/about-us/history', $this->linkingService->createNodeUri($this->controllerContext, '../history', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission')));
@@ -183,9 +176,8 @@ class LinkingServiceTest extends FunctionalTestCase
     /**
      * We empty the TemplateVariableContainer for this test, as it shouldn't be needed for rendering a link to a node
      * identified by ContextNodePath
-     *
-     * @test
      */
+    #[Test]
     public function linkingServiceCreatesUriViaContextNodePathString()
     {
         $this->assertOutputLinkValid('en/home', $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/home@live'));
@@ -202,58 +194,44 @@ class LinkingServiceTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @dataProvider supportedSchemesDataProvider
-     * @test
-     */
+    #[DataProvider('supportedSchemesDataProvider')]
+    #[Test]
     public function linkingServiceOnlySupportsNodesAndAssetSchemes($scheme, $match)
     {
         self::assertSame($match, $this->linkingService->hasSupportedScheme($scheme));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCanGetSchemeFromUrl()
     {
         self::assertSame('node', $this->linkingService->getScheme('node://aeabe76a-551a-495f-a324-ad9a86b2aff7'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCanResolveNodeUri()
     {
         self::assertSame('/en/home', $this->linkingService->resolveNodeUri('node://3239baee-3e7f-785c-0853-f4302ef32570', $this->baseNode, $this->controllerContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceResolveNodeUriReturnsNullForUnresolvableNodes()
     {
         self::assertSame(null, $this->linkingService->resolveNodeUri('node://3239baee-3e7f-785c-0853-f4302ef3257x', $this->baseNode, $this->controllerContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCanResolveAssetUri()
     {
         self::assertSame('http://neos.test/_Resources/Testing/Persistent/bed9a3e45070e97b921877e2bd9c35ba368beca0/Neos-logo_sRGB_color.pdf', $this->linkingService->resolveAssetUri('asset://1af89e5c-9e23-9a9d-ae15-1d77160cfb57'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceResolveAssetUriReturnsNullForUnresolvableAssets()
     {
         self::assertSame(null, $this->linkingService->resolveAssetUri('asset://89cd85cc-270e-0902-7113-d14ac7539c7x'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceCanConvertUriToObject()
     {
         $assetRepository = $this->objectManager->get(AssetRepository::class);
@@ -263,36 +241,28 @@ class LinkingServiceTest extends FunctionalTestCase
         self::assertSame($asset, $this->linkingService->convertUriToObject('asset://89cd85cc-270e-0902-7113-d14ac7539c75'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceThrowsAnExceptionWhenTryingToLinkToANonExistingNode()
     {
         $this->expectException(NeosException::class);
         $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/not-found', $this->baseNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceThrowsAnExceptionWhenItIsGivenAnEmptyString()
     {
         $this->expectException(NeosException::class);
         $this->linkingService->createNodeUri($this->controllerContext, '', $this->baseNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceThrowsAnExceptionWhenItIsGivenADifferentObject()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->linkingService->createNodeUri($this->controllerContext, new \stdClass());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceStoresLastLinkedNode()
     {
         $targetNodeA = $this->baseNode;
@@ -303,18 +273,14 @@ class LinkingServiceTest extends FunctionalTestCase
         self::assertSame($targetNodeB, $this->linkingService->getLastLinkedNode());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceStoresLastLinkedNodeEvenIfItsAShortcutToAnExternalUri()
     {
         $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/home/shortcuts/shortcut-to-target-uri', $this->baseNode);
         self::assertNotNull($this->linkingService->getLastLinkedNode());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function linkingServiceUnsetsLastLinkedNodeOnFailure()
     {
         $this->linkingService->createNodeUri($this->controllerContext, '/sites/example/home', $this->baseNode);

--- a/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
@@ -31,7 +31,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -41,7 +41,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -72,7 +72,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -82,7 +82,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -108,7 +108,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -118,7 +118,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -148,7 +148,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -158,7 +158,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node
@@ -209,7 +209,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $nodeType = $this
             ->getMockBuilder(NodeType::class)
-            ->setMethods(['getPropertyType'])
+            ->onlyMethods(['getPropertyType'])
             ->disableOriginalConstructor()
             ->getMock();
         $nodeType
@@ -219,7 +219,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
 
         $node = $this
             ->getMockBuilder(Node::class)
-            ->setMethods(['getProperty', 'getNodeType'])
+            ->onlyMethods(['getProperty', 'getNodeType'])
             ->disableOriginalConstructor()
             ->getMock();
         $node

--- a/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/Mapping/NodePropertyConverterServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\Service\Mapping;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use GuzzleHttp\Psr7\Uri;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Model\NodeType;
@@ -24,9 +24,7 @@ use Neos\Neos\Service\Mapping\NodePropertyConverterService;
  */
 class NodePropertyConverterServiceTest extends FunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function anArrayOfArrayIsReturnedAsIs()
     {
         $expected = $propertyValue = [[]];
@@ -62,9 +60,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function arrayOfObjectsWithToStringMethodIsReturnedAsIsUnlessTypeConverterIsProvided()
     {
         $objectWithToStringMethod = new Domain();
@@ -105,9 +101,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function arrayOfStringsHasToProvideTypeConverterToBeConvertedToArrayOfStrings()
     {
         $expected = $propertyValue = ['Hello'];
@@ -143,9 +137,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function complexTypesWithGivenTypeConverterAreConvertedByTypeConverter()
     {
         $propertyValue = $this->getMockForAbstractClass(ImageInterface::class);
@@ -185,9 +177,7 @@ class NodePropertyConverterServiceTest extends FunctionalTestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function jsonSerializedAbleTypesAreDirectlySerialized()
     {
         $voClassName = 'Value' . md5(uniqid(mt_rand(), true));

--- a/Neos.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
+++ b/Neos.Neos/Tests/Functional/Service/NodeTypeSchemaBuilderTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Neos\Service\NodeTypeSchemaBuilder;
 
@@ -38,9 +38,7 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
         $this->schema = $this->nodeTypeSchemaBuilder->generateNodeTypeSchema();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function inheritanceMapContainsTransitiveSubTypes()
     {
         self::assertTrue(array_key_exists('Neos.Neos.BackendSchemaControllerTest:Document', $this->schema['inheritanceMap']['subTypes']), 'Document must be found in InheritanceMap');
@@ -53,9 +51,7 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
         self::assertEquals($expectedSubTypesOfDocument, $this->schema['inheritanceMap']['subTypes']['Neos.Neos.BackendSchemaControllerTest:Document']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTypesContainCorrectSuperTypes()
     {
         self::assertTrue(array_key_exists('Neos.Neos.BackendSchemaControllerTest:SimpleNodeType', $this->schema['nodeTypes']), 'SimpleNodeType');
@@ -73,9 +69,7 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
         self::assertEquals($expectedPropertyConfiguration, $this->schema['nodeTypes']['Neos.Neos.BackendSchemaControllerTest:SimpleNodeType']['properties']['text']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function theNodeTypeSchemaIncludesSubTypesInheritanceMap()
     {
         $subTypesDefinition = $this->schema['inheritanceMap']['subTypes'];
@@ -87,9 +81,7 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
         self::assertContains('Neos.Neos.BackendSchemaControllerTest:TwoColumn', $subTypesDefinition['Neos.Neos.BackendSchemaControllerTest:Content']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function constraintsAreEvaluatedForANodeType()
     {
         $expectedConstraints = [
@@ -101,9 +93,7 @@ class NodeTypeSchemaBuilderTest extends FunctionalTestCase
         self::assertEquals($expectedConstraints, $this->schema['constraints']['Neos.Neos.BackendSchemaControllerTest:Page']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function constraintsForNamedChildNodeTypesAreEvaluatedForANodeType()
     {
         self::assertFalse(array_key_exists('Neos.Neos.BackendSchemaControllerTest:SubPage', $this->schema['constraints']['Neos.Neos.BackendSchemaControllerTest:TwoColumn']['childNodes']['column1']['nodeTypes']));

--- a/Neos.Neos/Tests/Functional/Service/XliffServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/XliffServiceTest.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\Tests\Functional\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Composer\ComposerUtility;
 use Neos\Flow\I18n\Locale;
@@ -131,9 +131,7 @@ class XliffServiceTest extends FunctionalTestCase
         return new Package($packageKey, $composerName, $packagePath);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCachedJsonRespectsIncludedFiles()
     {
         $translationResult = json_decode($this->xliffService->getCachedJson(new Locale('de')), true);
@@ -144,9 +142,7 @@ class XliffServiceTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCachedJsonDoesNotRespectNotIncludedFiles()
     {
         $translationResult = json_decode($this->xliffService->getCachedJson(new Locale('de')), true);
@@ -157,9 +153,7 @@ class XliffServiceTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCachedJsonRespectsOverride()
     {
         $translationResult = json_decode($this->xliffService->getCachedJson(new Locale('de')), true);

--- a/Neos.Neos/Tests/Functional/Service/XliffServiceTest.php
+++ b/Neos.Neos/Tests/Functional/Service/XliffServiceTest.php
@@ -60,14 +60,14 @@ class XliffServiceTest extends FunctionalTestCase
             ->getMock();
         $mockPackageManager->expects(self::any())
             ->method('getFlowPackages')
-            ->will(self::returnValue($this->packages));
+            ->willReturn($this->packages);
         $mockPackageManager->expects(self::any())
             ->method('getPackage')
             ->with($this->logicalOr(
                 $this->equalTo('Vendor.BasePackage'),
                 $this->equalTo('Vendor.DependentPackage')
             ))
-            ->will(self::returnCallback([$this, 'myCallback']));
+            ->willReturnCallback([$this, 'myCallback']);
         $this->inject($this->xliffService, 'packageManager', $mockPackageManager);
         $this->inject($this->fileProvider, 'packageManager', $mockPackageManager);
 

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\ViewHelpers\Link;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
@@ -164,9 +164,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         return $this->viewHelperInvoker->invoke($this->viewHelper, $arguments, $this->renderingContext);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaGivenNodeObject(): void
     {
         $propertyMapper = $this->objectManager->get(PropertyMapper::class);
@@ -176,9 +174,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         self::assertSame('<a href="/en/home">' . $targetNode->getLabel() . '</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaAbsoluteNodePathString(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home']);
@@ -189,9 +185,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         self::assertSame('<a href="/en/home/about-us/our-mission">Our mission</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaStringStartingWithTilde(): void
     {
         $result = $this->invoke(['node' => '~']);
@@ -204,9 +198,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         self::assertSame('<a href="/en/home/about-us/our-mission">Our mission</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaStringPointingToSubNodes(): void
     {
         $this->runtime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
@@ -222,9 +214,8 @@ class NodeViewHelperTest extends FunctionalTestCase
     /**
      * We empty the TemplateVariableContainer for this test, as it shouldn't be needed for rendering a link to a node
      * identified by ContextNodePath
-     *
-     * @test
      */
+    #[Test]
     public function viewHelperRendersUriViaContextNodePathString(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home@live']);
@@ -247,9 +238,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         self::assertSame('<a href="/en/home/about-us/our-mission">Our mission</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaNodeUriPathString(): void
     {
         $result = $this->invoke(['node' => 'node://3239baee-3e7f-785c-0853-f4302ef32570']);
@@ -260,27 +249,21 @@ class NodeViewHelperTest extends FunctionalTestCase
         self::assertSame('<a href="/en/home/about-us/our-mission">Our mission</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRespectsAbsoluteParameter(): void
     {
         $result = $this->invoke(['absolute' => true]);
         self::assertSame('<a href="http://neos.test/en/home">Home</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRespectsBaseNodeNameParameter(): void
     {
         $result = $this->invoke(['baseNodeName' => 'alternativeDocumentNode']);
         self::assertSame('<a href="/en/home/about-us/our-mission">Our mission</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRespectsArgumentsParameter(): void
     {
         $result = $this->invoke([
@@ -290,63 +273,49 @@ class NodeViewHelperTest extends FunctionalTestCase
         self::assertSame('<a href="/en/home?foo=bar">Home</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperCatchesExceptionExceptionIfTargetNodeDoesNotExist(): void
     {
         $result = $this->invoke(['node' => '/sites/example/non-existing-node']);
         self::assertSame('<a></a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperResolvesLinksToChildNodeShortcutPages(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-child-node']);
         self::assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/child-node">Shortcut to child node</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperResolvesLinksToParentNodeShortcutPages(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-parent-node']);
         self::assertSame('<a href="/en/home/shortcuts">Shortcut to parent node</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperResolvesLinksToTargetNodeShortcutPages(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-target-node']);
         self::assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/target-node">Shortcut to target node</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperResolvesLinksToUriShortcutPages(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home/shortcuts/shortcut-to-target-node']);
         self::assertSame('<a href="/en/home/shortcuts/shortcut-to-child-node/target-node">Shortcut to target node</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperUsesNodeTitleIfEmpty(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home@live']);
         self::assertSame('<a href="/en/home">Home</a>', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperAssignsLinkedNodeToNodeVariableName(): void
     {
         $templateVariableContainer = new TemplateVariableContainer([]);

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Tests\Functional\ViewHelpers\Link;
  * source code.
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
@@ -130,7 +131,7 @@ class NodeViewHelperTest extends FunctionalTestCase
             'alternativeDocumentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission')
         ]);
         $this->inject($fusionObject, 'runtime', $this->runtime);
-        /** @var AbstractTemplateView|\PHPUnit\Framework\MockObject\MockObject $mockView */
+        /** @var AbstractTemplateView|MockObject $mockView */
         $mockView = $this->getAccessibleMock(FluidView::class, [], [], '', false);
         $mockView->expects(self::any())->method('getFusionObject')->willReturn($fusionObject);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Link/NodeViewHelperTest.php
@@ -132,7 +132,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         ]);
         $this->inject($fusionObject, 'runtime', $this->runtime);
         /** @var AbstractTemplateView|MockObject $mockView */
-        $mockView = $this->getAccessibleMock(FluidView::class, [], [], '', false);
+        $mockView = $this->getAccessibleMock(FluidView::class, ['getFusionObject'], [], '', false);
         $mockView->expects(self::any())->method('getFusionObject')->willReturn($fusionObject);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -123,7 +123,7 @@ class NodeViewHelperTest extends FunctionalTestCase
             'alternativeDocumentNode' => $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission')
         ]);
         $this->inject($fusionObject, 'runtime', $this->runtime);
-        $mockView = $this->getAccessibleMock(FluidView::class, [], [], '', false);
+        $mockView = $this->getAccessibleMock(FluidView::class, ['getFusionObject'], [], '', false);
         $mockView->expects(self::any())->method('getFusionObject')->willReturn($fusionObject);
         $viewHelperVariableContainer = new ViewHelperVariableContainer();
         $viewHelperVariableContainer->setView($mockView);

--- a/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
+++ b/Neos.Neos/Tests/Functional/ViewHelpers/Uri/NodeViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Functional\ViewHelpers\Uri;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use GuzzleHttp\Psr7\Uri;
 use Neos\ContentRepository\Domain\Model\Node;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
@@ -146,9 +146,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         return $this->viewHelperInvoker->invoke($this->viewHelper, $arguments, $this->renderingContext);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaGivenNodeObject(): void
     {
         $propertyMapper = $this->objectManager->get(PropertyMapper::class);
@@ -158,9 +156,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('home', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaAbsoluteNodePathString(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home']);
@@ -171,9 +167,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaStringStartingWithTilde(): void
     {
         $result = $this->invoke(['node' => '~']);
@@ -186,9 +180,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaStringPointingToSubNodes(): void
     {
         $this->runtime->pushContext('documentNode', $this->contentContext->getCurrentSiteNode()->getNode('home/about-us/mission'));
@@ -204,9 +196,8 @@ class NodeViewHelperTest extends FunctionalTestCase
     /**
      * We empty the TemplateVariableContainer for this test, as it shouldn't be needed for rendering a link to a node
      * identified by ContextNodePath
-     *
-     * @test
      */
+    #[Test]
     public function viewHelperRendersUriViaContextNodePathString(): void
     {
         $result = $this->invoke(['node' => '/sites/example/home@live']);
@@ -229,9 +220,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRendersUriViaNodeUriPathString(): void
     {
         $result = $this->invoke(['node' => 'node://3239baee-3e7f-785c-0853-f4302ef32570']);
@@ -242,27 +231,21 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRespectsAbsoluteParameter(): void
     {
         $result = $this->invoke(['absolute' => true]);
         $this->assertOutputLinkValid('http://neos.test/en/home', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRespectsBaseNodeNameParameter(): void
     {
         $result = $this->invoke(['baseNodeName' => 'alternativeDocumentNode']);
         $this->assertOutputLinkValid('en/home/about-us/our-mission', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperRespectsArgumentsParameter(): void
     {
         $result = $this->invoke([
@@ -272,9 +255,7 @@ class NodeViewHelperTest extends FunctionalTestCase
         $this->assertOutputLinkValid('en/home?foo=bar', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperCatchesExceptionAndReturnsEmptyStringIfTargetNodeDoesNotExist(): void
     {
         $result = $this->invoke(['node' => '/sites/example/non-existing-node']);

--- a/Neos.Neos/Tests/Unit/CodeMigrations/Version20251005080230/Version20251005080230Test.php
+++ b/Neos.Neos/Tests/Unit/CodeMigrations/Version20251005080230/Version20251005080230Test.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Neos\Neos\Tests\Unit\CodeMigrations\Version20251005080230;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Core\Migrations\Manager;
 use Neos\Flow\Core\Migrations\Version20251005080230;
 use org\bovigo\vfs\vfsStream;
@@ -34,10 +36,8 @@ class Version20251005080230Test extends TestCase
         }
     }
 
-    /**
-     * @dataProvider fixtures
-     * @test
-     */
+    #[DataProvider('fixtures')]
+    #[Test]
     public function executeMigration(string $fusionInputFile, string $expectedFusionOutputFile): void
     {
         vfsStream::setup('fusion', null, [
@@ -74,10 +74,8 @@ class Version20251005080230Test extends TestCase
         );
     }
 
-    /**
-     * @dataProvider fixtures
-     * @test
-     */
+    #[DataProvider('fixtures')]
+    #[Test]
     public function reExecuteMigrationEmitsNoChanges(string $_, string $migratedFusionFile): void
     {
         vfsStream::setup('fusion', null, [

--- a/Neos.Neos/Tests/Unit/Domain/Model/DomainTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Model/DomainTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Domain\Model\Site;
@@ -21,9 +21,7 @@ use Neos\Neos\Domain\Model\Site;
  */
 class DomainTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function setHostPatternAllowsForSettingTheHostPatternOfTheDomain()
     {
         $domain = new Domain();
@@ -31,9 +29,7 @@ class DomainTest extends UnitTestCase
         self::assertSame('neos.io', $domain->getHostname());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setSiteSetsTheSiteTheDomainIsPointingTo()
     {
         /** @var Site $mockSite */

--- a/Neos.Neos/Tests/Unit/Domain/Model/SiteTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Model/SiteTest.php
@@ -10,6 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Site;
 
@@ -19,9 +20,7 @@ use Neos\Neos\Domain\Model\Site;
  */
 class SiteTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function aNameCanBeSetAndRetrievedFromTheSite()
     {
         $site = new Site('');
@@ -29,18 +28,14 @@ class SiteTest extends UnitTestCase
         self::assertSame('My cool website', $site->getName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function theDefaultStateOfASiteIsOffline()
     {
         $site = new Site('');
         self::assertSame(Site::STATE_OFFLINE, $site->getState());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function theStateCanBeSetAndRetrieved()
     {
         $site = new Site('');
@@ -48,9 +43,7 @@ class SiteTest extends UnitTestCase
         self::assertSame(Site::STATE_ONLINE, $site->getState());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function theSiteResourcesPackageKeyCanBeSetAndRetrieved()
     {
         $site = new Site('');

--- a/Neos.Neos/Tests/Unit/Domain/Model/UserTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Model/UserTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Model;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\User;
 use Neos\Neos\Domain\Model\UserPreferences;
@@ -21,9 +21,7 @@ use Neos\Neos\Domain\Model\UserPreferences;
  */
 class UserTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function constructorInitializesPreferences()
     {
         $user = new User();

--- a/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/NodeTypePostprocessor/CreationDialogPostprocessorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Neos\Neos\Tests\Unit\NodeTypePostprocessor;
 
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\NodeTypePostprocessor\CreationDialogPostprocessor;
@@ -24,9 +25,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
         $this->mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processCopiesInspectorConfigurationToCreationDialogElements(): void
     {
         $configuration = [
@@ -77,9 +76,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
         self::assertSame($expectedElements, $configuration['ui']['creationDialog']['elements']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processDoesNotCreateEmptyCreationDialogs(): void
     {
         $configuration = [
@@ -101,9 +98,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
         self::assertSame($originalConfiguration, $configuration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processRespectsDataTypeDefaultConfiguration(): void
     {
         $configuration = [
@@ -146,9 +141,7 @@ class CreationDialogPostprocessorTest extends UnitTestCase
         self::assertSame($expectedElements, $configuration['ui']['creationDialog']['elements']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processRespectsEditorDefaultConfiguration(): void
     {
         $configuration = [

--- a/Neos.Neos/Tests/Unit/Domain/Repository/Configuration/DomainRepositoryTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Repository/Configuration/DomainRepositoryTest.php
@@ -34,12 +34,12 @@ class DomainRepositoryTest extends UnitTestCase
         $expectedDomains = [$mockDomains[0], $mockDomains[2]];
 
         $mockDomainMatchingStrategy = $this->getMockBuilder(DomainMatchingStrategy::class)->disableOriginalConstructor()->getMock();
-        $mockDomainMatchingStrategy->expects(self::any())->method('getSortedMatches')->with('myhost', $mockDomains)->will(self::returnValue($expectedDomains));
+        $mockDomainMatchingStrategy->expects(self::any())->method('getSortedMatches')->with('myhost', $mockDomains)->willReturn($expectedDomains);
 
         $mockResult = $this->createMock(QueryResultInterface::class);
-        $mockResult->expects(self::once())->method('toArray')->will(self::returnValue($mockDomains));
+        $mockResult->expects(self::once())->method('toArray')->willReturn($mockDomains);
         $domainRepository = $this->getAccessibleMock(DomainRepository::class, ['findAll'], [], '', false);
-        $domainRepository->expects(self::once())->method('findAll')->will(self::returnValue($mockResult));
+        $domainRepository->expects(self::once())->method('findAll')->willReturn($mockResult);
         $domainRepository->_set('domainMatchingStrategy', $mockDomainMatchingStrategy);
 
         $actualDomains = $domainRepository->findByHost('myhost');

--- a/Neos.Neos/Tests/Unit/Domain/Repository/Configuration/DomainRepositoryTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Repository/Configuration/DomainRepositoryTest.php
@@ -10,6 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Repository\Configuration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Domain;
@@ -22,9 +23,7 @@ use Neos\Neos\Domain\Service\DomainMatchingStrategy;
  */
 class DomainRepositoryTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function findByHostInvokesTheDomainMatchingStrategyToFindDomainsMatchingTheGivenHost()
     {
         $mockDomains = [];

--- a/Neos.Neos/Tests/Unit/Domain/Service/ConfigurationContentDimensionPresetSourceTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/ConfigurationContentDimensionPresetSourceTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Service\ConfigurationContentDimensionPresetSource;
 
@@ -56,9 +56,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         ]
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findPresetByUriSegmentWithExistingUriSegmentReturnsPreset()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -68,9 +66,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertEquals(['de_DE', 'de_ZZ', 'mul_ZZ'], $preset['values']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findPresetByUriSegmentWithoutExistingUriSegmentReturnsNull()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -79,9 +75,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertNull($preset);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findPresetByDimensionValuesWithExistingValuesReturnsPreset()
     {
         $source = new ConfigurationContentDimensionPresetSource();
@@ -91,9 +85,7 @@ class ConfigurationContentDimensionPresetSourceTest extends UnitTestCase
         self::assertEquals('deutsch', $preset['uriSegment']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findPresetByDimensionValuesWithoutExistingUriSegmentReturnsNull()
     {
         $source = new ConfigurationContentDimensionPresetSource();

--- a/Neos.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
@@ -33,19 +33,19 @@ class ContentContextFactoryTest extends UnitTestCase
         $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
         $mockDomain = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();
-        $mockDomain->expects(self::atLeastOnce())->method('getSite')->will(self::returnValue($mockSite));
-        $mockDomainRepository->expects(self::atLeastOnce())->method('findOneByActiveRequest')->will(self::returnValue($mockDomain));
+        $mockDomain->expects(self::atLeastOnce())->method('getSite')->willReturn($mockSite);
+        $mockDomainRepository->expects(self::atLeastOnce())->method('findOneByActiveRequest')->willReturn($mockDomain);
 
         $mockSiteRepository = $this->getMockBuilder(SiteRepository::class)->disableOriginalConstructor()->getMock();
-        $mockSiteRepository->expects(self::any())->method('findFirstOnline')->will(self::returnValue(null));
+        $mockSiteRepository->expects(self::any())->method('findFirstOnline')->willReturn(null);
 
-        $contentContextFactory = $this->getMockBuilder(ContentContextFactory::class)->setMethods([
+        $contentContextFactory = $this->getMockBuilder(ContentContextFactory::class)->onlyMethods([
             'validateContextProperties',
             'mergeDimensionValues',
             'mergeTargetDimensionContextProperties',
             'getIdentifier'
         ])->disableOriginalConstructor()->getMock();
-        $contentContextFactory->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('abc'));
+        $contentContextFactory->expects(self::atLeastOnce())->method('getIdentifier')->willReturn('abc');
 
         $this->inject($contentContextFactory, 'domainRepository', $mockDomainRepository);
         $this->inject($contentContextFactory, 'siteRepository', $mockSiteRepository);

--- a/Neos.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
@@ -10,8 +10,8 @@ namespace Neos\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\DomainRepository;
@@ -25,9 +25,7 @@ use Neos\Neos\Domain\Service\ContentContextFactory;
  */
 class ContentContextFactoryTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function createWillSetDomainAndSiteFromCurrentRequestIfNotGiven()
     {
         $mockDomainRepository = $this->getMockBuilder(DomainRepository::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/ContentContextFactoryTest.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Service;
  * source code.
  */
 
+use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\DomainRepository;
@@ -22,7 +23,7 @@ use Neos\Neos\Domain\Service\ContentContextFactory;
  * Testcase for the ContentContextFactory
  *
  */
-class ContentContextFactoryTest extends \Neos\Flow\Tests\UnitTestCase
+class ContentContextFactoryTest extends UnitTestCase
 {
     /**
      * @test

--- a/Neos.Neos/Tests/Unit/Domain/Service/ContentContextTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/ContentContextTest.php
@@ -10,6 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Domain\Model\Site;
@@ -32,9 +33,7 @@ class ContentContextTest extends UnitTestCase
         $this->contextFactory = new ContentContextFactory();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCurrentSiteReturnsTheCurrentSite()
     {
         $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
@@ -55,9 +54,7 @@ class ContentContextTest extends UnitTestCase
         self::assertSame($mockSite, $contentContext->getCurrentSite());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getCurrentDomainReturnsTheCurrentDomainIfAny()
     {
         $mockDomain = $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
@@ -25,7 +25,7 @@ class DomainMatchingStrategyTest extends UnitTestCase
     public function getSortedMatchesReturnsOneGivenDomainIfItMatchesExactly()
     {
         $mockDomains = [$this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock()];
-        $mockDomains[0]->expects(self::any())->method('getHostname')->will(self::returnValue('www.neos.io'));
+        $mockDomains[0]->expects(self::any())->method('getHostname')->willReturn('www.neos.io');
         $expectedDomains = [$mockDomains[0]];
 
         $strategy = new DomainMatchingStrategy();
@@ -37,10 +37,10 @@ class DomainMatchingStrategyTest extends UnitTestCase
     public function getSortedMatchesFiltersTheGivenDomainsByTheSpecifiedHostAndReturnsThemSortedWithBestMatchesFirst()
     {
         $mockDomains = [
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
         ];
 
         $mockDomains[0]->setHostname('neos.io');
@@ -62,7 +62,7 @@ class DomainMatchingStrategyTest extends UnitTestCase
     public function getSortedMatchesReturnsNoMatchIfDomainIsLongerThanHostname()
     {
         $mockDomains = [
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
         ];
 
         $mockDomains[0]->setHostname('flow.neos.io');

--- a/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Domain;
 use Neos\Neos\Domain\Service\DomainMatchingStrategy;
@@ -21,9 +21,7 @@ use Neos\Neos\Domain\Service\DomainMatchingStrategy;
  */
 class DomainMatchingStrategyTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getSortedMatchesReturnsOneGivenDomainIfItMatchesExactly()
     {
         $mockDomains = [$this->getMockBuilder(Domain::class)->disableOriginalConstructor()->getMock()];
@@ -35,9 +33,7 @@ class DomainMatchingStrategyTest extends UnitTestCase
         self::assertSame($expectedDomains, $actualDomains);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSortedMatchesFiltersTheGivenDomainsByTheSpecifiedHostAndReturnsThemSortedWithBestMatchesFirst()
     {
         $mockDomains = [
@@ -62,9 +58,7 @@ class DomainMatchingStrategyTest extends UnitTestCase
         self::assertSame($expectedDomains, $actualDomains);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSortedMatchesReturnsNoMatchIfDomainIsLongerThanHostname()
     {
         $mockDomains = [

--- a/Neos.Neos/Tests/Unit/Domain/Service/FusionConfigurationCacheTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/FusionConfigurationCacheTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Domain\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Fusion\Core\FusionConfiguration;
@@ -50,9 +50,7 @@ class FusionConfigurationCacheTest extends UnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cacheGetMergedFusionObjectTreeNormalizesCacheIdentifier()
     {
         $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
@@ -63,9 +61,7 @@ class FusionConfigurationCacheTest extends UnitTestCase
         $this->fusionConfigurationCache->cacheFusionConfigurationBySite($mockSite, fn () => FusionConfiguration::fromArray([]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cacheGetMergedFusionObjectTreeAddsResultToCache()
     {
         $mergedObjectTree = ['some' => 'Fusion tree'];
@@ -81,9 +77,7 @@ class FusionConfigurationCacheTest extends UnitTestCase
         ));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function cacheGetMergedFusionObjectTreeReturnsResultsFromCacheIfExists()
     {
         $mergedObjectTree = ['some' => 'Fusion tree'];

--- a/Neos.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
+++ b/Neos.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\FlowQueryOperations;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Exception\NodeException;
@@ -24,10 +24,10 @@ use Neos\Neos\Eel\FlowQueryOperations\ParentsOperation;
 class ParentsOperationTest extends UnitTestCase
 {
     /**
-     * @test
      * @throws \ReflectionException
      * @throws \Neos\Eel\Exception
      */
+    #[Test]
     public function parentsWillReturnTheSiteNodeAsRootLevelParent()
     {
         $rootNode = $this->createMock(TraversableNodeInterface::class);

--- a/Neos.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
+++ b/Neos.Neos/Tests/Unit/FlowQueryOperations/ParentsOperationTest.php
@@ -36,16 +36,16 @@ class ParentsOperationTest extends UnitTestCase
         $firstLevelNode = $this->createMock(TraversableNodeInterface::class);
         $secondLevelNode = $this->createMock(TraversableNodeInterface::class);
 
-        $rootNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/')));
-        $rootNode->expects(self::any())->method('findParentNode')->will(self::throwException(new NodeException('No parent')));
-        $sitesNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/sites')));
-        $sitesNode->expects(self::any())->method('findParentNode')->will(self::returnValue($rootNode));
-        $siteNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/sites/site')));
-        $siteNode->expects(self::any())->method('findParentNode')->will(self::returnValue($sitesNode));
-        $firstLevelNode->expects(self::any())->method('findParentNode')->will(self::returnValue($siteNode));
-        $firstLevelNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/sites/site/first')));
-        $secondLevelNode->expects(self::any())->method('findParentNode')->will(self::returnValue($firstLevelNode));
-        $secondLevelNode->expects(self::any())->method('findNodePath')->will(self::returnValue(NodePath::fromString('/sites/site/first/second')));
+        $rootNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/'));
+        $rootNode->expects(self::any())->method('findParentNode')->willThrowException(new NodeException('No parent'));
+        $sitesNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/sites'));
+        $sitesNode->expects(self::any())->method('findParentNode')->willReturn($rootNode);
+        $siteNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/sites/site'));
+        $siteNode->expects(self::any())->method('findParentNode')->willReturn($sitesNode);
+        $firstLevelNode->expects(self::any())->method('findParentNode')->willReturn($siteNode);
+        $firstLevelNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/sites/site/first'));
+        $secondLevelNode->expects(self::any())->method('findParentNode')->willReturn($firstLevelNode);
+        $secondLevelNode->expects(self::any())->method('findNodePath')->willReturn(NodePath::fromString('/sites/site/first/second'));
 
         $context = [$secondLevelNode];
         $q = new FlowQuery($context);

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Fusion\Cache;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Model\Workspace;
@@ -22,9 +22,7 @@ use Neos\Neos\Fusion\Cache\ContentCacheFlusher;
  */
 class ContentCacheFlusherTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function theWorkspaceChainWillOnlyEvaluatedIfNeeded()
     {
         $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->setMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();

--- a/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Cache/ContentCacheFlusherTest.php
@@ -25,7 +25,7 @@ class ContentCacheFlusherTest extends UnitTestCase
     #[Test]
     public function theWorkspaceChainWillOnlyEvaluatedIfNeeded()
     {
-        $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->setMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();
+        $contentCacheFlusher = $this->getMockBuilder(ContentCacheFlusher::class)->onlyMethods(['resolveWorkspaceChain', 'registerChangeOnNodeIdentifier', 'registerChangeOnNodeType'])->disableOriginalConstructor()->getMock();
         $contentCacheFlusher->expects(self::never())->method('resolveWorkspaceChain');
 
         $contentCacheFlusher->expects($this->once())->method('registerChangeOnNodeIdentifier');

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -90,25 +90,25 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
         $this->mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $this->mockContext->expects(self::any())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
+        $this->mockContext->expects(self::any())->method('getWorkspace')->willReturn($this->mockWorkspace);
         $this->mockContext->expects(self::any())->method('getWorkspaceName')->willReturnCallback(function () {
             return $this->mockWorkspace->getName();
         });
 
         $this->mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
-        $this->mockNode->expects(self::any())->method('getContext')->will(self::returnValue($this->mockContext));
+        $this->mockNode->expects(self::any())->method('getContext')->willReturn($this->mockContext);
 
         $this->mockHttpUri = $this->getMockBuilder(Uri::class)->disableOriginalConstructor()->getMock();
-        $this->mockHttpUri->expects(self::any())->method('getHost')->will(self::returnValue('localhost'));
+        $this->mockHttpUri->expects(self::any())->method('getHost')->willReturn('localhost');
 
         $this->mockHttpRequest = $this->getMockBuilder(ServerRequestInterface::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpRequest->expects(self::any())->method('getUri')->willReturn($this->mockHttpUri);
 
         $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
-        $this->mockActionRequest->expects(self::any())->method('getHttpRequest')->will(self::returnValue($this->mockHttpRequest));
+        $this->mockActionRequest->expects(self::any())->method('getHttpRequest')->willReturn($this->mockHttpRequest);
 
         $this->mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
-        $this->mockControllerContext->expects(self::any())->method('getRequest')->will(self::returnValue($this->mockActionRequest));
+        $this->mockControllerContext->expects(self::any())->method('getRequest')->willReturn($this->mockActionRequest);
 
         $this->mockLinkingService = $this->createMock(LinkingService::class);
         $this->convertUrisImplementation->_set('linkingService', $this->mockLinkingService);
@@ -117,7 +117,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->convertUrisImplementation->_set('cachingHelper', $this->mockCachingHelper);
 
         $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $this->mockRuntime->expects(self::any())->method('getControllerContext')->will(self::returnValue($this->mockControllerContext));
+        $this->mockRuntime->expects(self::any())->method('getControllerContext')->willReturn($this->mockControllerContext);
         $this->convertUrisImplementation->_set('runtime', $this->mockRuntime);
     }
 
@@ -126,7 +126,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->convertUrisImplementation
             ->expects(self::atLeastOnce())
             ->method('fusionValue')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['value', $value],
                 ['node', $node ?: $this->mockNode],
                 ['forceConversion', $forceConversion],
@@ -135,7 +135,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
                 ['absolute', $absolute],
                 ['setNoOpener', $setNoOpener],
                 ['setExternal', $setExternal]
-            ]));
+            ]);
     }
 
     #[Test]
@@ -163,7 +163,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = ' this Is some string with line' . chr(10) . ' breaks, special chärß and leading/trailing space  ';
         $this->addValueExpectation($value);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $actualResult = $this->convertUrisImplementation->evaluate();
         self::assertSame($value, $actualResult);
@@ -172,7 +172,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
     #[Test]
     public function evaluateDoesNotModifyTheValueIfNotExecutedInLiveWorkspace()
     {
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('not-live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('not-live');
 
         $value = 'This string contains a node URI: node://aeabe76a-551a-495f-a324-ad9a86b2aff7 and two <a href="node://cb2d0e4a-7d2f-4601-981a-f9a01530f53f">node</a> <a href="node://aeabe76a-551a-495f-a324-ad9a86b2aff7">links</a>.';
         $this->addValueExpectation($value);
@@ -189,10 +189,10 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains a node URI: node://' . $nodeIdentifier1 . ' and two <a href="node://' . $nodeIdentifier2 . '">node</a> <a href="node://' . $nodeIdentifier1 . '">links</a>.';
         $this->addValueExpectation($value, null, true);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->will(self::returnCallback(function ($nodeUri) use ($self, $nodeIdentifier1, $nodeIdentifier2) {
+        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->willReturnCallback(function ($nodeUri) use ($self, $nodeIdentifier1, $nodeIdentifier2) {
             if ($nodeUri === 'node://' . $nodeIdentifier1) {
                 return 'http://localhost/replaced/uri/01';
             } elseif ($nodeUri === 'node://' . $nodeIdentifier2) {
@@ -200,7 +200,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
-        }));
+        });
 
         $expectedResult = 'This string contains a node URI: http://localhost/replaced/uri/01 and two <a href="http://localhost/replaced/uri/02">node</a> <a href="http://localhost/replaced/uri/01">links</a>.';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -215,10 +215,10 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains a node URI: node://' . $nodeIdentifier1 . ' and two <a href="node://' . $nodeIdentifier2 . '">node</a> <a href="node://' . $nodeIdentifier1 . '">links</a>.';
         $this->addValueExpectation($value);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->will(self::returnCallback(function ($nodeUri) use ($self, $nodeIdentifier1, $nodeIdentifier2) {
+        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->willReturnCallback(function ($nodeUri) use ($self, $nodeIdentifier1, $nodeIdentifier2) {
             if ($nodeUri === 'node://' . $nodeIdentifier1) {
                 return 'http://localhost/replaced/uri/01';
             } elseif ($nodeUri === 'node://' . $nodeIdentifier2) {
@@ -226,7 +226,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
-        }));
+        });
 
         $expectedResult = 'This string contains a node URI: http://localhost/replaced/uri/01 and two <a href="http://localhost/replaced/uri/02">node</a> <a href="http://localhost/replaced/uri/01">links</a>.';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -244,7 +244,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains an unresolvable node URI: node://' . $unknownNodeIdentifier . ' and a <a href="node://' . $unknownNodeIdentifier . '">link</a>.';
         $this->addValueExpectation($value);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $expectedResult = 'This string contains an unresolvable node URI:  and a link.';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -263,16 +263,16 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains a link to a node: <a href="node://' . $nodeIdentifier . '">node</a> and one to an external url with a target set <a target="top" href="http://www.example.org">example</a> and one without a target <a href="http://www.example.org">example2</a>';
         $this->addValueExpectation($value, null, false, $externalLinkTarget, null);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->will(self::returnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {
+        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->willReturnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {
             if ($nodeUri === 'node://' . $nodeIdentifier) {
                 return 'http://localhost/uri/01';
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
-        }));
+        });
 
         $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a rel="noopener external" target="top" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="noopener external" href="http://www.example.org">example2</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -291,15 +291,15 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains two asset links and an external link: one with a target set <a target="top" href="asset://' . $assetIdentifier . '">example</a> and one without a target <a href="asset://' . $assetIdentifier . '">example2</a> and an external link <a href="http://www.example.org">example3</a>';
         $this->addValueExpectation($value, null, false, null, $resourceLinkTarget);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveAssetUri')->will(self::returnCallback(function ($assetUri) use ($self, $assetIdentifier) {
+        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveAssetUri')->willReturnCallback(function ($assetUri) use ($self, $assetIdentifier) {
             if ($assetUri !== 'asset://' . $assetIdentifier) {
                 $self->fail('Unexpected asset URI "' . $assetUri . '"');
             }
             return 'http://localhost/_Resources/01';
-        }));
+        });
 
         $expectedResult = 'This string contains two asset links and an external link: one with a target set <a target="top" href="http://localhost/_Resources/01">example</a> and one without a target <a target="' . $resourceLinkTarget . '" href="http://localhost/_Resources/01">example2</a> and an external link <a rel="noopener external" href="http://www.example.org">example3</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -315,16 +315,16 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains a link to a node: <a href="node://' . $nodeIdentifier . '">node</a> and one to an external url with a target set <a target="top" href="http://www.example.org">example</a> and one without a target <a href="http://www.example.org">example2</a>';
         $this->addValueExpectation($value, null, false, $externalLinkTarget, null, false, false);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->will(self::returnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {
+        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->willReturnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {
             if ($nodeUri === 'node://' . $nodeIdentifier) {
                 return 'http://localhost/uri/01';
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
-        }));
+        });
 
         $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a rel="external" target="top" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="external" href="http://www.example.org">example2</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -340,16 +340,16 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'This string contains a link to a node: <a href="node://' . $nodeIdentifier . '">node</a> and one to an external url with a target set <a target="top" href="http://www.example.org">example</a> and one without a target <a href="http://www.example.org">example2</a>';
         $this->addValueExpectation($value, null, false, $externalLinkTarget, null, false, true, false);
 
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->will(self::returnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {
+        $this->mockLinkingService->expects(self::atLeastOnce())->method('resolveNodeUri')->willReturnCallback(function ($nodeUri) use ($self, $nodeIdentifier) {
             if ($nodeUri === 'node://' . $nodeIdentifier) {
                 return 'http://localhost/uri/01';
             } else {
                 $self->fail('Unexpected node URI "' . $nodeUri . '"');
             }
-        }));
+        });
 
         $expectedResult = 'This string contains a link to a node: <a href="http://localhost/uri/01">node</a> and one to an external url with a target set <a rel="noopener" target="top" href="http://www.example.org">example</a> and one without a target <a target="' . $externalLinkTarget . '" rel="noopener" href="http://www.example.org">example2</a>';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -368,15 +368,15 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $value = 'and an external link inside another tag beginning with a <article> test <a href="asset://' . $assetIdentifier . '">example1</a></article>';
         $this->addValueExpectation($value, null, false, null, $resourceLinkTarget);
 
-        $this->mockWorkspace->expects($this->any())->method('getName')->will($this->returnValue('live'));
+        $this->mockWorkspace->expects($this->any())->method('getName')->willReturn('live');
 
         $self = $this;
-        $this->mockLinkingService->expects($this->atLeastOnce())->method('resolveAssetUri')->will($this->returnCallback(function ($assetUri) use ($self, $assetIdentifier) {
+        $this->mockLinkingService->expects($this->atLeastOnce())->method('resolveAssetUri')->willReturnCallback(function ($assetUri) use ($self, $assetIdentifier) {
             if ($assetUri !== 'asset://' . $assetIdentifier) {
                 $self->fail('Unexpected asset URI "' . $assetUri . '"');
             }
             return 'http://localhost/_Resources/01';
-        }));
+        });
 
         $expectedResult = 'and an external link inside another tag beginning with a <article> test <a target="' . $resourceLinkTarget . '" href="http://localhost/_Resources/01">example1</a></article>';
         $actualResult = $this->convertUrisImplementation->evaluate();
@@ -398,8 +398,18 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
         $this->mockWorkspace->expects(self::any())->method('getName')->willReturn($workspaceName);
         $this->mockCachingHelper->expects(self::any())->method('renderWorkspaceTagForContextNode')->with($workspaceName)->willReturn($workspaceNameHash);
+        $matcher = self::exactly(2);
 
-        $this->mockRuntime->expects(self::exactly(2))->method('addCacheTag')->withConsecutive(['node', $nodeCacheIdentifier], ['asset', $assetCacheIdentifier]);
+        $this->mockRuntime->expects($matcher)->method('addCacheTag')->willReturnCallback(function (...$parameters) use ($matcher, $nodeCacheIdentifier, $assetCacheIdentifier) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('node', $parameters[0]);
+                $this->assertSame($nodeCacheIdentifier, $parameters[1]);
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('asset', $parameters[0]);
+                $this->assertSame($assetCacheIdentifier, $parameters[1]);
+            }
+        });
 
         $this->convertUrisImplementation->evaluate();
     }

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\Tests\Unit\Fusion;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
@@ -138,9 +138,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
             ]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateThrowsExceptionIfValueIsNoString()
     {
         $this->expectException(Exception::class);
@@ -150,9 +148,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->convertUrisImplementation->evaluate();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateThrowsExceptionIfTheCurrentContextArrayDoesNotContainANode()
     {
         $this->expectException(Exception::class);
@@ -161,9 +157,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->convertUrisImplementation->evaluate();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateDoesNotModifyTheValueIfItDoesNotContainNodeUris()
     {
         $value = ' this Is some string with line' . chr(10) . ' breaks, special chärß and leading/trailing space  ';
@@ -175,9 +169,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         self::assertSame($value, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateDoesNotModifyTheValueIfNotExecutedInLiveWorkspace()
     {
         $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('not-live'));
@@ -189,9 +181,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         self::assertSame($value, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateDoesModifyTheValueIfExecutedInLiveWorkspaceWithTheForceConvertionOptionSet()
     {
         $nodeIdentifier1 = 'aeabe76a-551a-495f-a324-ad9a86b2aff7';
@@ -217,9 +207,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateReplacesAllNodeUrisInTheGivenValue()
     {
         $nodeIdentifier1 = 'aeabe76a-551a-495f-a324-ad9a86b2aff7';
@@ -248,9 +236,8 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     /**
      * This only verifies the current behavior that might be changed in the future (e.g. we could remove unresolved links instead of creating empty href attributes)
-     *
-     * @test
      */
+    #[Test]
     public function evaluateReplacesUnresolvableNodeUrisWithAnEmptyString()
     {
         $unknownNodeIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff7';
@@ -266,9 +253,8 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     /**
      * This test checks that targets for external links are correctly replaced
-     *
-     * @test
      */
+    #[Test]
     public function evaluateReplaceExternalLinkTargets()
     {
         $nodeIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff7';
@@ -295,9 +281,8 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     /**
      * This test checks that targets for resource links are correctly replaced
-     *
-     * @test
      */
+    #[Test]
     public function evaluateReplaceResourceLinkTargets()
     {
         $assetIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff8';
@@ -321,9 +306,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function disablingSetNoOpenerWorks()
     {
         $nodeIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff7';
@@ -348,9 +331,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function disablingSetExternalWorks()
     {
         $nodeIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff7';
@@ -377,9 +358,8 @@ class ConvertUrisImplementationTest extends UnitTestCase
 
     /**
      * This test checks that targets for resource links are correctly replaced if the a Tag is inside a tag with the name beginning wit a
-     *
-     * @test
      */
+    #[Test]
     public function evaluateReplaceResourceLinkTargetsInsideTag()
     {
         $assetIdentifier = 'aeabe76a-551a-495f-a324-ad9a86b2aff8';
@@ -403,9 +383,7 @@ class ConvertUrisImplementationTest extends UnitTestCase
         $this->assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateDoesAddCacheTags()
     {
         $workspaceName = 'live';

--- a/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/ConvertUrisImplementationTest.php
@@ -26,6 +26,7 @@ use Neos\ContentRepository\Domain\Model\Workspace;
 use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Service\Context;
 use Neos\Fusion\Core\Runtime;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -82,6 +83,21 @@ class ConvertUrisImplementationTest extends UnitTestCase
      * @var CachingHelper
      */
     protected $mockCachingHelper;
+
+    /**
+     * @var Uri|MockObject
+     */
+    protected $mockHttpUri;
+
+    /**
+     * @var ServerRequestInterface|MockObject
+     */
+    protected $mockHttpRequest;
+
+    /**
+     * @var ActionRequest|MockObject
+     */
+    protected $mockActionRequest;
 
     public function setUp(): void
     {

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -24,25 +24,67 @@ use Neos\Neos\Fusion\Helper\CachingHelper;
  */
 class CachingHelperTest extends UnitTestCase
 {
+    private const WORKSPACE_NAME = 'live';
+
+    /**
+     * Data providers have to be static and therefore cannot build mocks. Instead they
+     * describe the needed objects with the sentinel arrays understood by this helper,
+     * and the test methods turn those descriptions into actual mocks.
+     *
+     * @param mixed $specification
+     * @return mixed
+     */
+    private function materialize($specification)
+    {
+        if (!is_array($specification)) {
+            return $specification;
+        }
+        if (isset($specification['__nodeType'])) {
+            $nodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
+            $nodeType->expects(self::any())->method('getName')->willReturn($specification['__nodeType']);
+            return $nodeType;
+        }
+        if (isset($specification['__node'])) {
+            return $this->mockNode($specification['__node']);
+        }
+        if (isset($specification['__arrayObject'])) {
+            return new \ArrayObject($this->materialize($specification['__arrayObject']));
+        }
+        return array_map(fn ($item) => $this->materialize($item), $specification);
+    }
+
+    /**
+     * Builds a node mock with the given identifier, living in the "live" workspace.
+     */
+    private function mockNode(string $nodeIdentifier): NodeInterface
+    {
+        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
+        $workspaceMock->expects(self::any())->method('getName')->willReturn(self::WORKSPACE_NAME);
+
+        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
+        $contextMock->expects(self::any())->method('getWorkspace')->willReturn($workspaceMock);
+
+        $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
+        $node->expects(self::any())->method('getContext')->willReturn($contextMock);
+        $node->expects(self::any())->method('getIdentifier')->willReturn($nodeIdentifier);
+
+        return $node;
+    }
+
     /**
      * Provides datasets for testing the CachingHelper::nodeTypeTag method.
      *
      * @return array
      */
-    public function nodeTypeTagDataProvider()
+    public static function nodeTypeTagDataProvider()
     {
         $nodeTypeName1 = 'Neos.Neos:Foo';
         $nodeTypeName2 = 'Neos.Neos:Bar';
         $nodeTypeName3 = 'Neos.Neos:Moo';
 
-        $nodeTypeObject1 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeTypeObject1->expects(self::any())->method('getName')->willReturn($nodeTypeName1);
-
-        $nodeTypeObject2 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeTypeObject2->expects(self::any())->method('getName')->willReturn($nodeTypeName2);
-
-        $nodeTypeObject3 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeTypeObject3->expects(self::any())->method('getName')->willReturn($nodeTypeName3);
+        $nodeTypeObject1 = ['__nodeType' => $nodeTypeName1];
+        $nodeTypeObject2 = ['__nodeType' => $nodeTypeName2];
+        $nodeTypeObject3 = ['__nodeType' => $nodeTypeName3];
 
         return [
             [$nodeTypeName1, 'NodeType_' . $nodeTypeName1],
@@ -61,7 +103,7 @@ class CachingHelperTest extends UnitTestCase
                     'NodeType_' . $nodeTypeName3
                 ]
             ],
-            [(new \ArrayObject([$nodeTypeObject1, $nodeTypeObject2, $nodeTypeObject3])),
+            [['__arrayObject' => [$nodeTypeObject1, $nodeTypeObject2, $nodeTypeObject3]],
                 [
                     'NodeType_' . $nodeTypeName1,
                     'NodeType_' . $nodeTypeName2,
@@ -81,7 +123,7 @@ class CachingHelperTest extends UnitTestCase
     public function nodeTypeTagProvidesExpectedResult($input, $expectedResult)
     {
         $helper = new CachingHelper();
-        $actualResult = $helper->nodeTypeTag($input);
+        $actualResult = $helper->nodeTypeTag($this->materialize($input));
         self::assertEquals($expectedResult, $actualResult);
     }
 
@@ -90,34 +132,21 @@ class CachingHelperTest extends UnitTestCase
      *
      * @return array
      */
-    public function nodeTypeTagWithContextNodeDataProvider()
+    public static function nodeTypeTagWithContextNodeDataProvider()
     {
         $cacheHelper = new CachingHelper();
 
-        $workspaceName = 'live';
-        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $workspaceMock->expects(self::any())->method('getName')->willReturn($workspaceName);
+        $contextNode = ['__node' => 'ca511a55-c5c0-f7d7-8d71-8edeffc75306'];
 
-        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $contextMock->expects(self::any())->method('getWorkspace')->willReturn($workspaceMock);
-
-        $contextNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $contextNode->expects(self::any())->method('getContext')->willReturn($contextMock);
-
-        $hashedWorkspaceName = $cacheHelper->renderWorkspaceTagForContextNode($workspaceName);
+        $hashedWorkspaceName = $cacheHelper->renderWorkspaceTagForContextNode(self::WORKSPACE_NAME);
 
         $nodeTypeName1 = 'Neos.Neos:Foo';
         $nodeTypeName2 = 'Neos.Neos:Bar';
         $nodeTypeName3 = 'Neos.Neos:Moo';
 
-        $nodeTypeObject1 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeTypeObject1->expects(self::any())->method('getName')->willReturn($nodeTypeName1);
-
-        $nodeTypeObject2 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeTypeObject2->expects(self::any())->method('getName')->willReturn($nodeTypeName2);
-
-        $nodeTypeObject3 = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $nodeTypeObject3->expects(self::any())->method('getName')->willReturn($nodeTypeName3);
+        $nodeTypeObject1 = ['__nodeType' => $nodeTypeName1];
+        $nodeTypeObject2 = ['__nodeType' => $nodeTypeName2];
+        $nodeTypeObject3 = ['__nodeType' => $nodeTypeName3];
 
         return [
             [$nodeTypeName1, $contextNode, 'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1],
@@ -136,7 +165,7 @@ class CachingHelperTest extends UnitTestCase
                     'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName3
                 ]
             ],
-            [(new \ArrayObject([$nodeTypeObject1, $nodeTypeObject2, $nodeTypeObject3])), $contextNode,
+            [['__arrayObject' => [$nodeTypeObject1, $nodeTypeObject2, $nodeTypeObject3]], $contextNode,
                 [
                     'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName1,
                     'NodeType_'.$hashedWorkspaceName.'_' . $nodeTypeName2,
@@ -158,35 +187,24 @@ class CachingHelperTest extends UnitTestCase
     public function nodeTypeTagRespectsContextNodesWorkspace($input, $contextNode, $expectedResult)
     {
         $helper = new CachingHelper();
-        $actualResult = $helper->nodeTypeTag($input, $contextNode);
+        $actualResult = $helper->nodeTypeTag($this->materialize($input), $this->materialize($contextNode));
         self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
      *
      */
-    public function nodeDataProvider()
+    public static function nodeDataProvider()
     {
         $cachingHelper = new CachingHelper();
 
-        $workspaceName = 'live';
-        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $workspaceMock->expects(self::any())->method('getName')->willReturn($workspaceName);
-
-        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $contextMock->expects(self::any())->method('getWorkspace')->willReturn($workspaceMock);
-
         $nodeIdentifier = 'ca511a55-c5c0-f7d7-8d71-8edeffc75306';
-        $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $node->expects(self::any())->method('getContext')->willReturn($contextMock);
-        $node->expects(self::any())->method('getIdentifier')->willReturn($nodeIdentifier);
+        $node = ['__node' => $nodeIdentifier];
 
         $anotherNodeIdentifier = '7005c7cf-4d19-ce36-0873-476b6cadb71a';
-        $anotherNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $anotherNode->expects(self::any())->method('getContext')->willReturn($contextMock);
-        $anotherNode->expects(self::any())->method('getIdentifier')->willReturn($anotherNodeIdentifier);
+        $anotherNode = ['__node' => $anotherNodeIdentifier];
 
-        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($workspaceName);
+        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode(self::WORKSPACE_NAME);
 
         return [
             [$node, ['Node_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
@@ -207,7 +225,7 @@ class CachingHelperTest extends UnitTestCase
     public function nodeTagsAreSetupWithWorkspaceAndIdentifier($nodes, $expectedResult)
     {
         $helper = new CachingHelper();
-        $actualResult = $helper->nodeTag($nodes);
+        $actualResult = $helper->nodeTag($this->materialize($nodes));
         self::assertEquals($expectedResult, $actualResult);
     }
 
@@ -248,28 +266,17 @@ class CachingHelperTest extends UnitTestCase
     /**
      *
      */
-    public function descendantOfDataProvider()
+    public static function descendantOfDataProvider()
     {
         $cachingHelper = new CachingHelper();
 
-        $workspaceName = 'live';
-        $workspaceMock = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $workspaceMock->expects(self::any())->method('getName')->willReturn($workspaceName);
-
-        $contextMock = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
-        $contextMock->expects(self::any())->method('getWorkspace')->willReturn($workspaceMock);
-
         $nodeIdentifier = 'ca511a55-c5c0-f7d7-8d71-8edeffc75306';
-        $node = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $node->expects(self::any())->method('getContext')->willReturn($contextMock);
-        $node->expects(self::any())->method('getIdentifier')->willReturn($nodeIdentifier);
+        $node = ['__node' => $nodeIdentifier];
 
         $anotherNodeIdentifier = '7005c7cf-4d19-ce36-0873-476b6cadb71a';
-        $anotherNode = $this->getMockBuilder(NodeInterface::class)->disableOriginalConstructor()->getMock();
-        $anotherNode->expects(self::any())->method('getContext')->willReturn($contextMock);
-        $anotherNode->expects(self::any())->method('getIdentifier')->willReturn($anotherNodeIdentifier);
+        $anotherNode = ['__node' => $anotherNodeIdentifier];
 
-        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode($workspaceName);
+        $hashedWorkspaceName = $cachingHelper->renderWorkspaceTagForContextNode(self::WORKSPACE_NAME);
 
         return [
             [$node, ['DescendantOf_' . $hashedWorkspaceName.'_'.$nodeIdentifier]],
@@ -290,7 +297,7 @@ class CachingHelperTest extends UnitTestCase
     public function descendantOfTagsAreSetupWithWorkspaceAndIdentifier($nodes, $expectedResult)
     {
         $helper = new CachingHelper();
-        $actualResult = $helper->descendantOfTag($nodes);
+        $actualResult = $helper->descendantOfTag($this->materialize($nodes));
         self::assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/Helper/CachingHelperTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Unit\Fusion\Helper;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Model\Workspace;
@@ -72,12 +73,11 @@ class CachingHelperTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider nodeTypeTagDataProvider
-     *
      * @param mixed $input
      * @param array $expectedResult
      */
+    #[DataProvider('nodeTypeTagDataProvider')]
+    #[Test]
     public function nodeTypeTagProvidesExpectedResult($input, $expectedResult)
     {
         $helper = new CachingHelper();
@@ -148,13 +148,13 @@ class CachingHelperTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider nodeTypeTagWithContextNodeDataProvider
      *
      * @param $input
      * @param $contextNode
      * @param $expectedResult
      */
+    #[DataProvider('nodeTypeTagWithContextNodeDataProvider')]
+    #[Test]
     public function nodeTypeTagRespectsContextNodesWorkspace($input, $contextNode, $expectedResult)
     {
         $helper = new CachingHelper();
@@ -199,12 +199,11 @@ class CachingHelperTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider nodeDataProvider
-     *
      * @param $nodes
      * @param $expectedResult
      */
+    #[DataProvider('nodeDataProvider')]
+    #[Test]
     public function nodeTagsAreSetupWithWorkspaceAndIdentifier($nodes, $expectedResult)
     {
         $helper = new CachingHelper();
@@ -212,9 +211,7 @@ class CachingHelperTest extends UnitTestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTagsCanBeInitializedWithAnIdentifierString()
     {
         $helper = new CachingHelper();
@@ -238,9 +235,7 @@ class CachingHelperTest extends UnitTestCase
         self::assertEquals('Node_'.$hashedWorkspaceName.'_'.$nodeIdentifier, $actual);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nodeTagForIdentifierStringWillFallbackToLegacyTagIfNoContextNodeIsGiven()
     {
         $helper = new CachingHelper();
@@ -287,12 +282,11 @@ class CachingHelperTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider descendantOfDataProvider
-     *
      * @param $nodes
      * @param $expectedResult
      */
+    #[DataProvider('descendantOfDataProvider')]
+    #[Test]
     public function descendantOfTagsAreSetupWithWorkspaceAndIdentifier($nodes, $expectedResult)
     {
         $helper = new CachingHelper();

--- a/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
@@ -91,7 +91,7 @@ class PluginImplementationTest extends UnitTestCase
     /**
      * @return array
      */
-    public function responseHeadersDataProvider(): array
+    public static function responseHeadersDataProvider(): array
     {
         return [
             [

--- a/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
+++ b/Neos.Neos/Tests/Unit/Fusion/PluginImplementationTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Unit\Fusion;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
@@ -113,10 +114,9 @@ class PluginImplementationTest extends UnitTestCase
 
     /**
      * Test if the response headers of the plugin - set within the plugin action / dispatch - were set into the parent response.
-     *
-     * @dataProvider responseHeadersDataProvider
-     * @test
      */
+    #[DataProvider('responseHeadersDataProvider')]
+    #[Test]
     public function evaluateSetHeaderIntoParent(string $message, array $input, array $expected): void
     {
         $this->pluginImplementation->method('buildPluginRequest')->willReturn($this->mockActionRequest);

--- a/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
@@ -12,6 +12,7 @@ namespace Neos\Neos\Tests\Unit\Fusion;
  * source code.
  */
 
+use Neos\Neos\Exception;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\NodeTypePostprocessor\DefaultPropertyEditorPostprocessor;
@@ -259,7 +260,7 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
      */
     public function processThrowsExceptionIfNoPropertyEditorCanBeResolved(): void
     {
-        $this->expectException(\Neos\Neos\Exception::class);
+        $this->expectException(Exception::class);
 
         $configuration = [
             'properties' => [

--- a/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
+++ b/Neos.Neos/Tests/Unit/NodeTypePostprocessor/DefaultPropertyEditorPostprocessorTest.php
@@ -11,7 +11,7 @@ namespace Neos\Neos\Tests\Unit\Fusion;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Neos\Exception;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\Tests\UnitTestCase;
@@ -33,9 +33,7 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
         return $configuration;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processConvertsPropertyConfiguration(): void
     {
         $configuration = [
@@ -255,9 +253,7 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processThrowsExceptionIfNoPropertyEditorCanBeResolved(): void
     {
         $this->expectException(Exception::class);
@@ -276,9 +272,7 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
         $this->processConfiguration($configuration, $dataTypesDefaultConfiguration, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processConvertsCreationDialogConfiguration(): void
     {
         $configuration = [
@@ -461,9 +455,7 @@ class DefaultPropertyEditorPostprocessorTest extends UnitTestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processDoesNotThrowExceptionIfNoCreationDialogEditorCanBeResolved(): void
     {
         $configuration = [

--- a/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
+++ b/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
@@ -80,8 +80,8 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         }
 
         $mockPackage = $this->createMock(FlowPackageInterface::class);
-        $mockPackage->expects(self::any())->method('getPackagePath')->will(self::returnValue('vfs://Packages/Application/Some.Package'));
-        $this->mockPackageManager->expects(self::once())->method('getPackage')->with('Some.Package')->will(self::returnValue($mockPackage));
+        $mockPackage->expects(self::any())->method('getPackagePath')->willReturn('vfs://Packages/Application/Some.Package');
+        $this->mockPackageManager->expects(self::once())->method('getPackage')->with('Some.Package')->willReturn($mockPackage);
 
         $result = $this->nodeTypesStreamWrapper->open($forbiddenPath, 'r', 0, $openedPathAndFilename);
         $this->assertFalse($result);
@@ -106,8 +106,8 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         file_put_contents('vfs://Foo/NodeTypes/Path', 'fixture');
 
         $mockPackage = $this->createMock(FlowPackageInterface::class);
-        $mockPackage->expects(self::any())->method('getPackagePath')->will(self::returnValue('vfs://Foo'));
-        $this->mockPackageManager->expects(self::once())->method('getPackage')->with($packageKey)->will(self::returnValue($mockPackage));
+        $mockPackage->expects(self::any())->method('getPackagePath')->willReturn('vfs://Foo');
+        $this->mockPackageManager->expects(self::once())->method('getPackage')->with($packageKey)->willReturn($mockPackage);
 
         $openedPathAndFilename = '';
         self::assertTrue($this->nodeTypesStreamWrapper->open('nodetypes://' . $packageKey . '/Path', 'r', 0, $openedPathAndFilename));
@@ -125,8 +125,8 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         file_put_contents('vfs://Foo/NodeTypes/Path', 'fixture');
 
         $mockPackage = $this->createMock(FlowPackageInterface::class);
-        $mockPackage->expects(self::any())->method('getPackagePath')->will(self::returnValue('vfs://Foo'));
-        $this->mockPackageManager->expects(self::once())->method('getPackage')->with($packageKey)->will(self::returnValue($mockPackage));
+        $mockPackage->expects(self::any())->method('getPackagePath')->willReturn('vfs://Foo');
+        $this->mockPackageManager->expects(self::once())->method('getPackage')->with($packageKey)->willReturn($mockPackage);
 
         $openedPathAndFilename = '';
         self::assertTrue($this->nodeTypesStreamWrapper->open('nodetypes://' . $packageKey . '/Path', 'r', 0, $openedPathAndFilename));

--- a/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
+++ b/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Unit\ResourceManagement;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\Flow\Package\Exception\UnknownPackageException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Package\FlowPackageInterface;
@@ -45,9 +46,7 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         $this->inject($this->nodeTypesStreamWrapper, 'packageManager', $this->mockPackageManager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function openThrowsExceptionForInvalidScheme()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -72,10 +71,8 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider providePathesToCheckForForbiddenTraversalOutOfPath
-     */
+    #[DataProvider('providePathesToCheckForForbiddenTraversalOutOfPath')]
+    #[Test]
     public function openThrowsExceptionForPathesThatTryToTraverseUpwards(string $forbiddenPath, bool $expectException)
     {
         if ($expectException) {
@@ -90,9 +87,7 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function openThrowsExceptionForNonExistingPackages()
     {
         $this->expectException(Exception::class);
@@ -103,9 +98,7 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         $this->nodeTypesStreamWrapper->open('nodetypes://' . $packageKey . '/Some/Path', 'r', 0, $openedPathAndFilename);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function openResolvesPackageKeysUsingThePackageManager()
     {
         $packageKey = 'Some.Package';
@@ -123,8 +116,8 @@ class NodetypesStreamWrapperTest extends UnitTestCase
 
     /**
      * This makes sure the code does not see a 40-charatcer package key as a resource hash.
-     * @test
      */
+    #[Test]
     public function openResolves40CharacterLongPackageKeysUsingThePackageManager()
     {
         $packageKey = 'Some.PackageKey.Containing.40.Characters';

--- a/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
+++ b/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
@@ -11,6 +11,8 @@ namespace Neos\Neos\Tests\Unit\ResourceManagement;
  * source code.
  */
 
+use Neos\Flow\Package\Exception\UnknownPackageException;
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Flow\ResourceManagement\Exception;
 use org\bovigo\vfs\vfsStream;
@@ -29,7 +31,7 @@ class NodetypesStreamWrapperTest extends UnitTestCase
     protected $nodeTypesStreamWrapper;
 
     /**
-     * @var PackageManager|\PHPUnit\Framework\MockObject\MockObject
+     * @var PackageManager|MockObject
      */
     protected $mockPackageManager;
 
@@ -95,7 +97,7 @@ class NodetypesStreamWrapperTest extends UnitTestCase
     {
         $this->expectException(Exception::class);
         $packageKey = 'Non.Existing.Package';
-        $this->mockPackageManager->expects(self::once())->method('getPackage')->willThrowException(new \Neos\Flow\Package\Exception\UnknownPackageException('Test exception'));
+        $this->mockPackageManager->expects(self::once())->method('getPackage')->willThrowException(new UnknownPackageException('Test exception'));
 
         $openedPathAndFilename = '';
         $this->nodeTypesStreamWrapper->open('nodetypes://' . $packageKey . '/Some/Path', 'r', 0, $openedPathAndFilename);

--- a/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
+++ b/Neos.Neos/Tests/Unit/ResourceManagement/NodetypesStreamWrapperTest.php
@@ -54,7 +54,7 @@ class NodetypesStreamWrapperTest extends UnitTestCase
         $this->nodeTypesStreamWrapper->open('invalid-scheme://foo/bar', 'r', 0, $openedPathAndFilename);
     }
 
-    public function providePathesToCheckForForbiddenTraversalOutOfPath(): array
+    public static function providePathesToCheckForForbiddenTraversalOutOfPath(): array
     {
         return [
             // pathes that traverse out of package scope

--- a/Neos.Neos/Tests/Unit/Routing/BackendModuleRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/BackendModuleRoutePartHandlerTest.php
@@ -10,6 +10,8 @@ namespace Neos\Neos\Tests\Unit\Routing;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Controller\Module\Administration\UsersController;
 use Neos\Neos\Controller\Module\AdministrationController;
@@ -44,10 +46,8 @@ class BackendModuleRoutePartHandlerTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider requestPaths
-     */
+    #[DataProvider('requestPaths')]
+    #[Test]
     public function matchFindsCorrectValues($requestPath, $matchResult, $expectedValue)
     {
         $routePartHandler = new BackendModuleRoutePartHandler();

--- a/Neos.Neos/Tests/Unit/Routing/BackendModuleRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/BackendModuleRoutePartHandlerTest.php
@@ -26,7 +26,7 @@ class BackendModuleRoutePartHandlerTest extends UnitTestCase
     /**
      * Data provider for ... see below
      */
-    public function requestPaths()
+    public static function requestPaths()
     {
         return [
             'empty' => ['', BackendModuleRoutePartHandler::MATCHRESULT_NOSUCHMODULE, null],

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -102,9 +102,9 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->routePartHandler->setName('node');
 
         // The mockContextFactory is configured to return the last mock context which has been built with buildMockContext():
-        $mockContextFactory = $this->getMockBuilder(ContextFactory::class)->setMethods(['create'])->getMock();
+        $mockContextFactory = $this->getMockBuilder(ContextFactory::class)->onlyMethods(['create'])->getMock();
         $mockContextFactory->mockContext = null;
-        $mockContextFactory->expects(self::any())->method('create')->will(self::returnCallback(function ($contextProperties) use ($mockContextFactory) {
+        $mockContextFactory->expects(self::any())->method('create')->willReturnCallback(function ($contextProperties) use ($mockContextFactory) {
             if (isset($contextProperties['currentSite'])) {
                 $mockContextFactory->mockContext->mockSite = $contextProperties['currentSite'];
             }
@@ -118,7 +118,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 $mockContextFactory->mockContext->mockTargetDimensions = $contextProperties['targetDimensions'];
             }
             return $mockContextFactory->mockContext;
-        }));
+        });
         $this->mockContextFactory = $mockContextFactory;
         $this->inject($this->routePartHandler, 'contextFactory', $this->mockContextFactory);
 
@@ -255,7 +255,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
         $mockSubNode->mockProperties['uriPathSegment'] = 'features';
-        $mockSubNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/examplecom/features@user-robert'));
+        $mockSubNode->expects(self::any())->method('getContextPath')->willReturn('/sites/examplecom/features@user-robert');
 
         $routePath = 'features';
         $matchResult = $this->matchForHost($routePath, 'localhost');
@@ -328,10 +328,10 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSubNode->mockProperties['uriPathSegment'] = 'home';
 
         $that = $this;
-        $this->mockContextFactory->expects(self::once())->method('create')->will(self::returnCallback(function ($contextProperties) use ($that, $mockContext) {
+        $this->mockContextFactory->expects(self::once())->method('create')->willReturnCallback(function ($contextProperties) use ($that, $mockContext) {
             $that->assertSame('live', $contextProperties['workspaceName']);
             return $mockContext;
-        }));
+        });
 
         $routePath = 'home';
         $this->matchForHost($routePath, 'localhost');
@@ -348,10 +348,10 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSubNode->mockProperties['uriPathSegment'] = 'home';
 
         $that = $this;
-        $this->mockContextFactory->expects(self::once())->method('create')->will(self::returnCallback(function ($contextProperties) use ($that, $mockContext) {
+        $this->mockContextFactory->expects(self::once())->method('create')->willReturnCallback(function ($contextProperties) use ($that, $mockContext) {
             $that->assertSame('user-john', $contextProperties['workspaceName']);
             return $mockContext;
-        }));
+        });
 
         $routePath = 'home@user-john';
         $this->matchForHost($routePath, 'localhost');
@@ -455,11 +455,11 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'home');
         $mockSubNode->mockProperties['uriPathSegment'] = 'home';
-        $mockSubNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/examplecom/home@user-robert'));
+        $mockSubNode->expects(self::any())->method('getContextPath')->willReturn('/sites/examplecom/home@user-robert');
 
         $mockSubSubNode = $this->buildSubNode($mockSubNode, 'ae178bc9184');
         $mockSubSubNode->mockProperties['uriPathSegment'] = 'coffee-brands';
-        $mockSubSubNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/examplecom/home/ae178bc9184@user-robert'));
+        $mockSubSubNode->expects(self::any())->method('getContextPath')->willReturn('/sites/examplecom/home/ae178bc9184@user-robert');
         $mockSubSubNode->method('getPath')->willReturn('/sites/examplecom/home/ae178bc9184');
 
         $routeValues = ['node' => $mockSubSubNode];
@@ -477,11 +477,11 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
         $mockSubNode = $this->buildSubNode($this->buildSiteNode($mockContext, '/sites/otherdotcom'), 'home');
         $mockSubNode->mockProperties['uriPathSegment'] = 'home';
-        $mockSubNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/otherdotcom/home@user-robert'));
+        $mockSubNode->expects(self::any())->method('getContextPath')->willReturn('/sites/otherdotcom/home@user-robert');
 
         $mockSubSubNode = $this->buildSubNode($mockSubNode, 'ae178bc9184');
         $mockSubSubNode->mockProperties['uriPathSegment'] = 'coffee-brands';
-        $mockSubSubNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/otherdotcom/home/ae178bc9184@user-robert'));
+        $mockSubSubNode->expects(self::any())->method('getContextPath')->willReturn('/sites/otherdotcom/home/ae178bc9184@user-robert');
 
         $mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
         $this->mockSiteRepository->method('findOneByNodeName')->with('otherdotcom')->willReturn($mockSite);
@@ -520,16 +520,16 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSubNode->mockProperties['uriPathSegment'] = 'home';
 
         // resolveValue() will use $contentContext to retrieve the resolved node:
-        $mockContext->expects(self::any())->method('getNode')->will(self::returnCallback(function ($nodePath) use ($mockSubNode) {
+        $mockContext->expects(self::any())->method('getNode')->willReturnCallback(function ($nodePath) use ($mockSubNode) {
             return ($nodePath === '/sites/examplecom/home') ? $mockSubNode : null;
-        }));
+        });
 
         $that = $this;
-        $this->mockContextFactory->expects(self::atLeastOnce())->method('create')->will(self::returnCallback(function ($contextProperties) use ($that, $mockContext) {
+        $this->mockContextFactory->expects(self::atLeastOnce())->method('create')->willReturnCallback(function ($contextProperties) use ($that, $mockContext) {
             // The important assertion:
             $that->assertSame('live', $contextProperties['workspaceName']);
             return $mockContext;
-        }));
+        });
 
         $routeValues = ['node' => '/sites/examplecom/home'];
         $resolveResult = $this->resolveForHost($routeValues, 'localhost');
@@ -572,9 +572,9 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
         $mockContext->mockSiteNode = $mockSiteNode;
 
-        $mockContext->expects(self::any())->method('getNode')->will(self::returnCallback(function ($nodePath) use ($mockSiteNode) {
+        $mockContext->expects(self::any())->method('getNode')->willReturnCallback(function ($nodePath) use ($mockSiteNode) {
             return ($nodePath === '/sites/examplecom') ? $mockSiteNode : null;
-        }));
+        });
 
         // resolve() should only return false because we remove the workspace, without the following line it returns true:
         $mockContext->mockWorkspace = null;
@@ -606,9 +606,9 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'some-content', 'Neos.Neos:Content');
         $mockSubNode->mockProperties['uriPathSegment'] = 'some-content';
 
-        $mockContext->expects(self::any())->method('getNode')->will(self::returnCallback(function ($nodePath) use ($mockSubNode) {
+        $mockContext->expects(self::any())->method('getNode')->willReturnCallback(function ($nodePath) use ($mockSubNode) {
             return ($nodePath === '/sites/examplecom/some-content') ? $mockSubNode : null;
-        }));
+        });
 
         $routeValues = ['node' => '/sites/examplecom/some-content'];
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
@@ -626,9 +626,9 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
         $mockSubNode->mockProperties['uriPathSegment'] = 'features';
 
-        $mockContext->expects(self::any())->method('getNode')->will(self::returnCallback(function ($nodePath) use ($mockSubNode) {
+        $mockContext->expects(self::any())->method('getNode')->willReturnCallback(function ($nodePath) use ($mockSubNode) {
             return ($nodePath === '/sites/examplecom/features') ? $mockSubNode : null;
-        }));
+        });
 
         $routeValues = ['node' => '/sites/examplecom/features'];
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
@@ -644,9 +644,9 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
         $mockSubNode->mockProperties['uriPathSegment'] = 'features';
 
-        $mockContext->expects(self::any())->method('getNode')->will(self::returnCallback(function ($nodePath) use ($mockSubNode) {
+        $mockContext->expects(self::any())->method('getNode')->willReturnCallback(function ($nodePath) use ($mockSubNode) {
             return ($nodePath === '/sites/examplecom/features') ? $mockSubNode : null;
-        }));
+        });
 
         $routeValues = ['node' => $mockSubNode];
 
@@ -707,14 +707,14 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockContext->mockSite = $this->getMockBuilder(Site::class)->disableOriginalConstructor()->getMock();
 
         $mockSiteNode = $this->buildSiteNode($mockContext, '/sites/examplecom');
-        $mockSiteNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/examplecom'));
+        $mockSiteNode->expects(self::any())->method('getContextPath')->willReturn('/sites/examplecom');
         $mockContext->mockSiteNode = $mockSiteNode;
 
         $mockSubNode = $this->buildSubNode($mockContext->mockSiteNode, 'features');
         $mockSubNode->mockProperties['uriPathSegment'] = 'features';
-        $mockSubNode->expects(self::any())->method('getContextPath')->will(self::returnValue('/sites/examplecom/features'));
+        $mockSubNode->expects(self::any())->method('getContextPath')->willReturn('/sites/examplecom/features');
 
-        $mockContext->expects(self::any())->method('getNode')->will(self::returnCallback(function ($nodePath) use ($mockSubNode, $mockSiteNode) {
+        $mockContext->expects(self::any())->method('getNode')->willReturnCallback(function ($nodePath) use ($mockSubNode, $mockSiteNode) {
             switch ($nodePath) {
                 case '/sites/examplecom/features':
                     return $mockSubNode;
@@ -723,7 +723,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 default:
                     return null;
             }
-        }));
+        });
 
         $routeValues = ['node' => $contextPath];
         $this->inject($this->routePartHandler, 'supportEmptySegmentForDimensions', $supportEmptySegmentForDimensions);
@@ -825,46 +825,46 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         }
 
         $mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue($contextProperties['workspaceName']));
+        $mockWorkspace->expects(self::any())->method('getName')->willReturn($contextProperties['workspaceName']);
 
         $mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
         $mockContext->mockWorkspace = $mockWorkspace;
-        $mockContext->expects(self::any())->method('getWorkspace')->will(self::returnCallback(function () use ($mockContext) {
+        $mockContext->expects(self::any())->method('getWorkspace')->willReturnCallback(function () use ($mockContext) {
             return $mockContext->mockWorkspace;
-        }));
+        });
 
-        $mockContext->expects(self::any())->method('getWorkspaceName')->will(self::returnCallback(function () use ($mockContext) {
+        $mockContext->expects(self::any())->method('getWorkspaceName')->willReturnCallback(function () use ($mockContext) {
             return $mockContext->mockWorkspace->getName();
-        }));
+        });
 
         $mockContext->mockDomain = null;
-        $mockContext->expects(self::any())->method('getCurrentDomain')->will(self::returnCallback(function () use ($mockContext) {
+        $mockContext->expects(self::any())->method('getCurrentDomain')->willReturnCallback(function () use ($mockContext) {
             return $mockContext->mockDomain;
-        }));
+        });
 
         $mockContext->mockSite = null;
-        $mockContext->expects(self::any())->method('getCurrentSite')->will(self::returnCallback(function () use ($mockContext) {
+        $mockContext->expects(self::any())->method('getCurrentSite')->willReturnCallback(function () use ($mockContext) {
             return $mockContext->mockSite;
-        }));
+        });
 
         $mockContext->mockDimensions = [];
-        $mockContext->expects(self::any())->method('getDimensions')->will(self::returnCallback(function () use ($mockContext) {
+        $mockContext->expects(self::any())->method('getDimensions')->willReturnCallback(function () use ($mockContext) {
             return $mockContext->mockDimensions;
-        }));
+        });
 
         $mockContext->mockTargetDimensions = [];
-        $mockContext->expects(self::any())->method('getTargetDimensions')->will(self::returnCallback(function () use ($mockContext) {
+        $mockContext->expects(self::any())->method('getTargetDimensions')->willReturnCallback(function () use ($mockContext) {
             return $mockContext->mockTargetDimensions;
-        }));
+        });
 
-        $mockContext->expects(self::any())->method('getNodeByIdentifier')->will(self::returnCallback(function ($identifier) use ($mockContext) {
+        $mockContext->expects(self::any())->method('getNodeByIdentifier')->willReturnCallback(function ($identifier) use ($mockContext) {
             if (array_key_exists($identifier, $mockContext->mockNodesByIdentifier)) {
                 return $mockContext->mockNodesByIdentifier[$identifier];
             }
             return null;
-        }));
+        });
 
-        $mockContext->expects(self::any())->method('getProperties')->will(self::returnCallback(function () use ($mockContext, $contextProperties) {
+        $mockContext->expects(self::any())->method('getProperties')->willReturnCallback(function () use ($mockContext, $contextProperties) {
             return [
                 'workspaceName' => $contextProperties['workspaceName'],
                 'currentDateTime' => $contextProperties['currentDateTime'],
@@ -876,7 +876,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 'currentSite' => $mockContext->getCurrentSite(),
                 'currentDomain' => $mockContext->getCurrentDomain()
             ];
-        }));
+        });
 
         $this->mockContextFactory->mockContext = $mockContext;
 
@@ -890,38 +890,38 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
      * @param ContentContext $mockContext
      * @param string $nodeName
      * @param string $nodeTypeName
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     protected function buildNode(ContentContext $mockContext, $nodeName, $nodeTypeName = 'Neos.Neos:Document')
     {
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $mockNodeType->expects(self::any())->method('isOfType')->will(self::returnCallback(function ($expectedNodeTypeName) use ($nodeTypeName) {
+        $mockNodeType->expects(self::any())->method('isOfType')->willReturnCallback(function ($expectedNodeTypeName) use ($nodeTypeName) {
             return $expectedNodeTypeName === $nodeTypeName;
-        }));
+        });
 
         $mockNode = $this->createMock(NodeInterface::class);
-        $mockNode->expects(self::any())->method('getContext')->will(self::returnValue($mockContext));
-        $mockNode->expects(self::any())->method('getName')->will(self::returnValue($nodeName));
-        $mockNode->expects(self::any())->method('getNodeType')->will(self::returnValue($mockNodeType));
-        $mockNode->expects(self::any())->method('getWorkspace')->will(self::returnValue($mockContext->getWorkspace()));
+        $mockNode->expects(self::any())->method('getContext')->willReturn($mockContext);
+        $mockNode->expects(self::any())->method('getName')->willReturn($nodeName);
+        $mockNode->expects(self::any())->method('getNodeType')->willReturn($mockNodeType);
+        $mockNode->expects(self::any())->method('getWorkspace')->willReturn($mockContext->getWorkspace());
 
         $mockNodeIdentifier = Algorithms::generateUUID();
-        $mockNode->expects(self::any())->method('getIdentifier')->will(self::returnValue($mockNodeIdentifier));
+        $mockNode->expects(self::any())->method('getIdentifier')->willReturn($mockNodeIdentifier);
         $mockContext->mockNodesByIdentifier[$mockNodeIdentifier] = $mockNode;
 
         // Parent node is set by buildSubNode()
         $mockNode->mockParentNode = null;
-        $mockNode->expects(self::any())->method('getParent')->will(self::returnCallback(function () use ($mockNode) {
+        $mockNode->expects(self::any())->method('getParent')->willReturnCallback(function () use ($mockNode) {
             return $mockNode->mockParentNode;
-        }));
+        });
 
         $mockNode->mockChildNodes = [];
-        $mockNode->expects(self::any())->method('getChildNodes')->will(self::returnCallback(function ($nodeTypeFilter) use ($mockNode) {
+        $mockNode->expects(self::any())->method('getChildNodes')->willReturnCallback(function ($nodeTypeFilter) use ($mockNode) {
             return $mockNode->mockChildNodes;
-        }));
+        });
 
-        $mockNode->expects(self::any())->method('getNode')->will(self::returnCallback(function ($relativeNodePath) use ($mockNode) {
+        $mockNode->expects(self::any())->method('getNode')->willReturnCallback(function ($relativeNodePath) use ($mockNode) {
             $foundNode = null;
             foreach ($mockNode->mockChildNodes as $nodeName => $mockChildNode) {
                 if ($nodeName === $relativeNodePath) {
@@ -929,20 +929,20 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
                 }
             }
             return $foundNode;
-        }));
+        });
 
         $mockNode->mockProperties = [];
-        $mockNode->expects(self::any())->method('getProperties')->will(self::returnCallback(function () use ($mockNode) {
+        $mockNode->expects(self::any())->method('getProperties')->willReturnCallback(function () use ($mockNode) {
             return $mockNode->mockProperties;
-        }));
+        });
 
         $mockNode->mockProperties = [];
-        $mockNode->expects(self::any())->method('getProperty')->will(self::returnCallback(function ($propertyName) use ($mockNode) {
+        $mockNode->expects(self::any())->method('getProperty')->willReturnCallback(function ($propertyName) use ($mockNode) {
             return isset($mockNode->mockProperties[$propertyName]) ? $mockNode->mockProperties[$propertyName] : null;
-        }));
-        $mockNode->expects(self::any())->method('hasProperty')->will(self::returnCallback(function ($propertyName) use ($mockNode) {
+        });
+        $mockNode->expects(self::any())->method('hasProperty')->willReturnCallback(function ($propertyName) use ($mockNode) {
             return array_key_exists($propertyName, $mockNode->mockProperties);
-        }));
+        });
 
         return $mockNode;
     }
@@ -960,10 +960,10 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $nodeName = substr($nodePath, strrpos($nodePath, '/') + 1);
         $parentNodePath = substr($nodePath, 0, strrpos($nodePath, '/'));
         $mockSiteNode = $this->buildNode($mockContext, $nodeName);
-        $mockSiteNode->expects(self::any())->method('getPath')->will(self::returnValue($nodePath));
-        $mockSiteNode->expects(self::any())->method('getContextPath')->will(self::returnValue(NodePaths::generateContextPath($nodePath, $mockContext->getWorkspaceName(), $mockContext->getDimensions())));
-        $mockSiteNode->expects(self::any())->method('getParentPath')->will(self::returnValue($parentNodePath));
-        $mockContext->expects(self::any())->method('getCurrentSiteNode')->will(self::returnValue($mockSiteNode));
+        $mockSiteNode->expects(self::any())->method('getPath')->willReturn($nodePath);
+        $mockSiteNode->expects(self::any())->method('getContextPath')->willReturn(NodePaths::generateContextPath($nodePath, $mockContext->getWorkspaceName(), $mockContext->getDimensions()));
+        $mockSiteNode->expects(self::any())->method('getParentPath')->willReturn($parentNodePath);
+        $mockContext->expects(self::any())->method('getCurrentSiteNode')->willReturn($mockSiteNode);
         return $mockSiteNode;
     }
 
@@ -982,12 +982,12 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $mockNode->mockParentNode = $mockParentNode;
 
         $mockParentNode->mockChildNodes[$nodeName] = $mockNode;
-        $mockNode->method('getChildNodes')->will(self::returnCallback(function ($nodeTypeFilter) use ($mockNode) {
+        $mockNode->method('getChildNodes')->willReturnCallback(function ($nodeTypeFilter) use ($mockNode) {
             return $mockNode->mockChildNodes;
-        }));
+        });
         $nodePath = $mockParentNode->getPath() . '/' . $nodeName;
         $mockNode->method('getPath')->willReturn($nodePath);
-        $mockNode->method('getContextPath')->will(self::returnValue(NodePaths::generateContextPath($nodePath, $mockParentNode->getContext()->getWorkspaceName(), $mockParentNode->getContext()->getDimensions())));
+        $mockNode->method('getContextPath')->willReturn(NodePaths::generateContextPath($nodePath, $mockParentNode->getContext()->getWorkspaceName(), $mockParentNode->getContext()->getDimensions()));
         return $mockNode;
     }
 

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Unit\Routing;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 use Neos\Flow\Mvc\Routing\Dto\MatchResult;
 use Neos\Flow\Mvc\Routing\Dto\ResolveResult;
@@ -167,9 +168,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersReturnsMatchResultIfTheNodeExists()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -190,9 +189,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
     /**
      * If convertRequestPathToNode() throws any exception and the request path is '' a "missing homepage" message should appear.
-     *
-     * @test
      */
+    #[Test]
     public function matchWithParametersThrowsAnExceptionIfNoHomepageExists()
     {
         $this->expectException(NoHomepageException::class);
@@ -201,9 +199,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->matchForHost($routePath, 'localhost');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersReturnsFalseIfASiteExistsButNoSiteNodeExists()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -213,9 +209,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->matchForHost($routePath, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersReturnsFalseIfTheNodeCouldNotBeFound()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -231,9 +225,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
     /**
      * If a node matches the given request path but the context contains now Workspace, match() must return false
-     *
-     * @test
      */
+    #[Test]
     public function matchWithParametersReturnsFalseIfTheWorkspaceCouldNotBeFound()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -252,9 +245,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
     /**
      * If a node matches the given request path, the node's context path is stored in $this->value and true is returned.
-     *
-     * @test
      */
+    #[Test]
     public function valueContainsContextPathOfFoundNode()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'user-robert']);
@@ -277,9 +269,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
      *
      * This case is needed in order allow routes matching "/" without a suffix for a website's homepage even if "defaultUriSuffix"
      * is empty.
-     *
-     * @test
      */
+    #[Test]
     public function matchWithParametersReturnsFalseOnNotMatchingSiteNodes()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -303,9 +294,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersRespectsTheSpecifiedNodeTypeOption()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -328,9 +317,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->matchForHost($routePath, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersCreatesContextForLiveWorkspaceByDefault()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -350,9 +337,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->matchForHost($routePath, 'localhost');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersCreatesContextForCustomWorkspaceIfSpecifiedInNodeContextPath()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -372,10 +357,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         $this->matchForHost($routePath, 'localhost');
     }
 
-    /**
-     * @test
-     * @dataProvider contextPathsAndRequestPathsDataProvider
-     */
+    #[DataProvider('contextPathsAndRequestPathsDataProvider')]
+    #[Test]
     public function matchWithParametersConsidersDimensionValuePresetsSpecifiedInTheRequestUriWhileBuildingTheContext($expectedContextPath, $requestPath, $supportEmptySegmentForDimensions)
     {
         $this->contentDimensionPresetSource->setConfiguration([
@@ -432,9 +415,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
 
     /**
      * Note: In this case the ".html" suffix is not stripped of the context path because no split string is set
-     *
-     * @test
      */
+    #[Test]
     public function matchWithParametersReturnsFalseIfContextPathIsInvalid()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -448,9 +430,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->matchForHost($routePath, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function matchWithParametersStripsOffSuffixIfSplitStringIsSpecified()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -466,9 +446,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->matchForHost($routePath, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveSetsValueToContextPathIfPassedNodeCouldBeResolved()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'user-robert']);
@@ -490,9 +468,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertSame('home/coffee-brands@user-robert', $resolveResult->getResolvedValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveSetsValueToContextPathIfPassedNodeCouldBeResolvedButIsInAnotherSite()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'user-robert']);
@@ -516,9 +492,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertSame('home/coffee-brands@user-robert', (string)$resolveResult->getResolvedValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveReturnsFalseIfGivenRouteValueIsNeitherStringNorNode()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -535,9 +509,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveCreatesContextForLiveWorkspaceByDefault()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -564,9 +536,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertInstanceOf(ResolveResult::class, $resolveResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveCreatesContextForTheWorkspaceMentionedInTheContextString()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'user-johndoe']);
@@ -594,9 +564,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertInstanceOf(ResolveResult::class, $resolveResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveReturnsFalseIfWorkspaceMentionedInTheContextDoesNotExist()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'user-johndoe']);
@@ -615,9 +583,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveReturnsFalseIfNodeMentionedInTheContextPathDoesNotExist()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -629,9 +595,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveReturnsFalseIfNodeIsNoDocument()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -650,9 +614,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveReturnsFalseIfOnlyMatchSiteNodesOptionIsSetAndResolvedNodeIsNoSiteNode()
     {
         $this->routePartHandler->setOptions(['onlyMatchSiteNodes' => true]);
@@ -672,9 +634,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveRespectsTheSpecifiedNodeTypeOption()
     {
         $mockContext = $this->buildMockContext(['workspaceName' => 'live']);
@@ -699,10 +659,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         self::assertFalse($this->resolveForHost($routeValues, 'localhost'));
     }
 
-    /**
-     * @dataProvider contextPathsAndRequestPathsDataProvider
-     * @test
-     */
+    #[DataProvider('contextPathsAndRequestPathsDataProvider')]
+    #[Test]
     public function resolveConsidersDimensionValuesPassedViaTheContextPathForRenderingTheUrl($contextPath, $expectedUriPath, $supportEmptySegmentForDimensions)
     {
         $this->contentDimensionPresetSource->setConfiguration([
@@ -831,10 +789,8 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider dimensionRequestPathMatcherDataProvider
-     * @test
-     */
+    #[DataProvider('dimensionRequestPathMatcherDataProvider')]
+    #[Test]
     public function dimensionRequestPathRegex($requestPath, $doesMatch, $expected)
     {
         $matches = [];

--- a/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
+++ b/Neos.Neos/Tests/Unit/Routing/FrontendNodeRoutePartHandlerTest.php
@@ -155,7 +155,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
      *
      * @return array
      */
-    public function contextPathsAndRequestPathsDataProvider()
+    public static function contextPathsAndRequestPathsDataProvider()
     {
         return [
             ['/sites/examplecom@live;language=en_US', '', true],
@@ -734,7 +734,7 @@ class FrontendNodeRoutePartHandlerTest extends UnitTestCase
     /**
      * data provider for dimensionRequestPathRegex
      */
-    public function dimensionRequestPathMatcherDataProvider()
+    public static function dimensionRequestPathMatcherDataProvider()
     {
         return [
             'an empty request path does not match' => [

--- a/Neos.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -85,10 +85,10 @@ class PublishingServiceTest extends UnitTestCase
     {
         $this->publishingService = new PublishingService();
 
-        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->setMethods(['findOneByName'])->getMock();
+        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->addMethods(['findOneByName'])->getMock();
         $this->inject($this->publishingService, 'workspaceRepository', $this->mockWorkspaceRepository);
 
-        $this->mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->setMethods(['findByWorkspace'])->getMock();
+        $this->mockNodeDataRepository = $this->getMockBuilder(NodeDataRepository::class)->disableOriginalConstructor()->onlyMethods(['findByWorkspace'])->getMock();
         $this->inject($this->publishingService, 'nodeDataRepository', $this->mockNodeDataRepository);
 
         $this->mockNodeFactory = $this->getMockBuilder(NodeFactory::class)->disableOriginalConstructor()->getMock();
@@ -98,22 +98,22 @@ class PublishingServiceTest extends UnitTestCase
         $this->inject($this->publishingService, 'contextFactory', $this->mockContextFactory);
 
         $this->mockBaseWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $this->mockBaseWorkspace->expects(self::any())->method('getName')->will(self::returnValue('live'));
-        $this->mockBaseWorkspace->expects(self::any())->method('getBaseWorkspace')->will(self::returnValue(null));
+        $this->mockBaseWorkspace->expects(self::any())->method('getName')->willReturn('live');
+        $this->mockBaseWorkspace->expects(self::any())->method('getBaseWorkspace')->willReturn(null);
 
         $this->mockContentDimensionPresetSource = $this->getMockBuilder(ContentDimensionPresetSourceInterface::class)->disableOriginalConstructor()->getMock();
-        $this->mockContentDimensionPresetSource->expects(self::any())->method('findPresetsByTargetValues')->will($this->returnArgument(0));
+        $this->mockContentDimensionPresetSource->expects(self::any())->method('findPresetsByTargetValues')->willReturnArgument(0);
         $this->inject($this->publishingService, 'contentDimensionPresetSource', $this->mockContentDimensionPresetSource);
 
         $this->mockWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
-        $this->mockWorkspace->expects(self::any())->method('getName')->will(self::returnValue('workspace-name'));
-        $this->mockWorkspace->expects(self::any())->method('getBaseWorkspace')->will(self::returnValue($this->mockBaseWorkspace));
+        $this->mockWorkspace->expects(self::any())->method('getName')->willReturn('workspace-name');
+        $this->mockWorkspace->expects(self::any())->method('getBaseWorkspace')->willReturn($this->mockBaseWorkspace);
     }
 
     #[Test]
     public function getUnpublishedNodesReturnsAnEmptyArrayIfThereAreNoNodesInTheGivenWorkspace()
     {
-        $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->will(self::returnValue([]));
+        $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->willReturn([]);
 
         $actualResult = $this->publishingService->getUnpublishedNodes($this->mockWorkspace);
         self::assertSame($actualResult, []);
@@ -131,28 +131,38 @@ class PublishingServiceTest extends UnitTestCase
             'removedContentShown' => true,
             'dimensions' => []
         ];
-        $this->mockContextFactory->expects(self::any())->method('create')->with($expectedContextProperties)->will(self::returnValue($mockContext));
+        $this->mockContextFactory->expects(self::any())->method('create')->with($expectedContextProperties)->willReturn($mockContext);
 
         $mockNodeData1 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
         $mockNodeData2 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
 
-        $mockNodeData1->expects(self::any())->method('getDimensionValues')->will(self::returnValue([]));
-        $mockNodeData2->expects(self::any())->method('getDimensionValues')->will(self::returnValue([]));
+        $mockNodeData1->expects(self::any())->method('getDimensionValues')->willReturn([]);
+        $mockNodeData2->expects(self::any())->method('getDimensionValues')->willReturn([]);
 
         $mockNode1 = $this->getMockBuilder(NodeInterface::class)->getMock();
         $mockNode2 = $this->getMockBuilder(NodeInterface::class)->getMock();
 
-        $mockNode1->expects(self::any())->method('getNodeData')->will(self::returnValue($mockNodeData1));
-        $mockNode1->expects(self::any())->method('getPath')->will(self::returnValue('/node1'));
-        $mockNode2->expects(self::any())->method('getNodeData')->will(self::returnValue($mockNodeData2));
-        $mockNode2->expects(self::any())->method('getPath')->will(self::returnValue('/node2'));
+        $mockNode1->expects(self::any())->method('getNodeData')->willReturn($mockNodeData1);
+        $mockNode1->expects(self::any())->method('getPath')->willReturn('/node1');
+        $mockNode2->expects(self::any())->method('getNodeData')->willReturn($mockNodeData2);
+        $mockNode2->expects(self::any())->method('getPath')->willReturn('/node2');
+        $matcher = self::atLeast(2);
 
-        $this->mockNodeFactory->expects(self::atLeast(2))
-            ->method('createFromNodeData')
-            ->withConsecutive([$mockNodeData1, $mockContext], [$mockNodeData2, $mockContext])
-            ->willReturnOnConsecutiveCalls($mockNode1, $mockNode2);
+        $this->mockNodeFactory->expects($matcher)
+            ->method('createFromNodeData')->willReturnCallback(function (...$parameters) use ($matcher, $mockNodeData1, $mockContext, $mockNodeData2, $mockNode1, $mockNode2) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame($mockNodeData1, $parameters[0]);
+                $this->assertSame($mockContext, $parameters[1]);
+                return $mockNode1;
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame($mockNodeData2, $parameters[0]);
+                $this->assertSame($mockContext, $parameters[1]);
+                return $mockNode2;
+            }
+        });
 
-        $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->will(self::returnValue([$mockNodeData1, $mockNodeData2]));
+        $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->willReturn([$mockNodeData1, $mockNodeData2]);
 
         $actualResult = $this->publishingService->getUnpublishedNodes($this->mockWorkspace);
         self::assertSame($actualResult, [$mockNode2, $mockNode1]);
@@ -170,25 +180,35 @@ class PublishingServiceTest extends UnitTestCase
             'removedContentShown' => true,
             'dimensions' => []
         ];
-        $this->mockContextFactory->expects(self::any())->method('create')->with($expectedContextProperties)->will(self::returnValue($mockContext));
+        $this->mockContextFactory->expects(self::any())->method('create')->with($expectedContextProperties)->willReturn($mockContext);
 
         $mockNodeData1 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
         $mockNodeData2 = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
 
-        $mockNodeData1->expects(self::any())->method('getDimensionValues')->will(self::returnValue([]));
-        $mockNodeData2->expects(self::any())->method('getDimensionValues')->will(self::returnValue([]));
+        $mockNodeData1->expects(self::any())->method('getDimensionValues')->willReturn([]);
+        $mockNodeData2->expects(self::any())->method('getDimensionValues')->willReturn([]);
 
         $mockNode1 = $this->getMockBuilder(NodeInterface::class)->getMock();
 
-        $mockNode1->expects(self::any())->method('getNodeData')->will(self::returnValue($mockNodeData1));
-        $mockNode1->expects(self::any())->method('getPath')->will(self::returnValue('/node1'));
+        $mockNode1->expects(self::any())->method('getNodeData')->willReturn($mockNodeData1);
+        $mockNode1->expects(self::any())->method('getPath')->willReturn('/node1');
+        $matcher = self::atLeast(2);
 
-        $this->mockNodeFactory->expects(self::atLeast(2))
-            ->method('createFromNodeData')
-            ->withConsecutive([$mockNodeData1, $mockContext], [$mockNodeData2, $mockContext])
-            ->willReturnOnConsecutiveCalls($mockNode1, null);
+        $this->mockNodeFactory->expects($matcher)
+            ->method('createFromNodeData')->willReturnCallback(function (...$parameters) use ($matcher, $mockNodeData1, $mockContext, $mockNodeData2, $mockNode1) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame($mockNodeData1, $parameters[0]);
+                $this->assertSame($mockContext, $parameters[1]);
+                return $mockNode1;
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame($mockNodeData2, $parameters[0]);
+                $this->assertSame($mockContext, $parameters[1]);
+                return null;
+            }
+        });
 
-        $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->will(self::returnValue([$mockNodeData1, $mockNodeData2]));
+        $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->willReturn([$mockNodeData1, $mockNodeData2]);
 
         $actualResult = $this->publishingService->getUnpublishedNodes($this->mockWorkspace);
         self::assertSame($actualResult, [$mockNode1]);
@@ -197,7 +217,7 @@ class PublishingServiceTest extends UnitTestCase
     #[Test]
     public function getUnpublishedNodesCountReturnsTheNumberOfNodesInTheGivenWorkspaceMinusItsRootNode()
     {
-        $this->mockWorkspace->expects(self::atLeastOnce())->method('getNodeCount')->will(self::returnValue(123));
+        $this->mockWorkspace->expects(self::atLeastOnce())->method('getNodeCount')->willReturn(123);
         $actualResult = $this->publishingService->getUnpublishedNodesCount($this->mockWorkspace);
         $expectedResult = 122;
         self::assertSame($expectedResult, $actualResult);
@@ -209,9 +229,9 @@ class PublishingServiceTest extends UnitTestCase
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
 
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->will(self::returnValue($mockNodeType));
+        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->willReturn($mockNodeType);
 
-        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
+        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->willReturn($this->mockWorkspace);
 
         $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
@@ -225,9 +245,9 @@ class PublishingServiceTest extends UnitTestCase
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
 
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->will(self::returnValue($mockNodeType));
+        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->willReturn($mockNodeType);
 
-        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
+        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->willReturn($this->mockWorkspace);
 
         $this->mockWorkspace->expects(self::atLeastOnce())->method('publishNodes')->with([$mockNode], $this->mockBaseWorkspace);
         $this->publishingService->publishNode($mockNode);
@@ -238,14 +258,14 @@ class PublishingServiceTest extends UnitTestCase
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
         $mockChildNode = $this->getMockBuilder(NodeInterface::class)->getMock();
-        $mockChildNode->expects(self::any())->method('getChildNodes')->with('!Neos.Neos:Document')->will(self::returnValue([]));
+        $mockChildNode->expects(self::any())->method('getChildNodes')->with('!Neos.Neos:Document')->willReturn([]);
 
         $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->getMock();
-        $mockNodeType->expects(self::atLeastOnce())->method('isOfType')->with('Neos.Neos:Document')->will(self::returnValue(true));
-        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->will(self::returnValue($mockNodeType));
+        $mockNodeType->expects(self::atLeastOnce())->method('isOfType')->with('Neos.Neos:Document')->willReturn(true);
+        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->willReturn($mockNodeType);
 
-        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
-        $mockNode->expects(self::atLeastOnce())->method('getChildNodes')->with('!Neos.Neos:Document')->will(self::returnValue([$mockChildNode]));
+        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->willReturn($this->mockWorkspace);
+        $mockNode->expects(self::atLeastOnce())->method('getChildNodes')->with('!Neos.Neos:Document')->willReturn([$mockChildNode]);
 
         $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 
@@ -259,14 +279,14 @@ class PublishingServiceTest extends UnitTestCase
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
         $mockChildNode = $this->getMockBuilder(NodeInterface::class)->getMock();
-        $mockChildNode->expects(self::any())->method('getChildNodes')->with('!Neos.Neos:Document')->will(self::returnValue([]));
+        $mockChildNode->expects(self::any())->method('getChildNodes')->with('!Neos.Neos:Document')->willReturn([]);
 
-        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->setMethods(['hasConfiguration', 'isOfType'])->getMock();
-        $mockNodeType->expects(self::atLeastOnce())->method('hasConfiguration')->with('childNodes')->will(self::returnValue(true));
-        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->will(self::returnValue($mockNodeType));
+        $mockNodeType = $this->getMockBuilder(NodeType::class)->disableOriginalConstructor()->onlyMethods(['hasConfiguration', 'isOfType'])->getMock();
+        $mockNodeType->expects(self::atLeastOnce())->method('hasConfiguration')->with('childNodes')->willReturn(true);
+        $mockNode->expects(self::atLeastOnce())->method('getNodeType')->willReturn($mockNodeType);
 
-        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->will(self::returnValue($this->mockWorkspace));
-        $mockNode->expects(self::atLeastOnce())->method('getChildNodes')->with('!Neos.Neos:Document')->will(self::returnValue([$mockChildNode]));
+        $mockNode->expects(self::atLeastOnce())->method('getWorkspace')->willReturn($this->mockWorkspace);
+        $mockNode->expects(self::atLeastOnce())->method('getChildNodes')->with('!Neos.Neos:Document')->willReturn([$mockChildNode]);
 
         $mockTargetWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
 

--- a/Neos.Neos/Tests/Unit/Service/PublishingServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/PublishingServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\Site;
@@ -110,9 +110,7 @@ class PublishingServiceTest extends UnitTestCase
         $this->mockWorkspace->expects(self::any())->method('getBaseWorkspace')->will(self::returnValue($this->mockBaseWorkspace));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUnpublishedNodesReturnsAnEmptyArrayIfThereAreNoNodesInTheGivenWorkspace()
     {
         $this->mockNodeDataRepository->expects(self::atLeastOnce())->method('findByWorkspace')->with($this->mockWorkspace)->will(self::returnValue([]));
@@ -121,9 +119,7 @@ class PublishingServiceTest extends UnitTestCase
         self::assertSame($actualResult, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUnpublishedNodesReturnsANodeInstanceForEveryNodeInTheGivenWorkspace()
     {
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
@@ -162,9 +158,7 @@ class PublishingServiceTest extends UnitTestCase
         self::assertSame($actualResult, [$mockNode2, $mockNode1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUnpublishedNodesDoesNotReturnInvalidNodes()
     {
         $mockContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
@@ -200,9 +194,7 @@ class PublishingServiceTest extends UnitTestCase
         self::assertSame($actualResult, [$mockNode1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUnpublishedNodesCountReturnsTheNumberOfNodesInTheGivenWorkspaceMinusItsRootNode()
     {
         $this->mockWorkspace->expects(self::atLeastOnce())->method('getNodeCount')->will(self::returnValue(123));
@@ -211,9 +203,7 @@ class PublishingServiceTest extends UnitTestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publishNodePublishesTheGivenNodeFromItsWorkspaceToTheSpecifiedTargetWorkspace()
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
@@ -229,9 +219,7 @@ class PublishingServiceTest extends UnitTestCase
         $this->publishingService->publishNode($mockNode, $mockTargetWorkspace);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publishNodePublishesTheGivenNodeToItsBaseWorkspaceIfNoTargetWorkspaceIsSpecified()
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
@@ -245,9 +233,7 @@ class PublishingServiceTest extends UnitTestCase
         $this->publishingService->publishNode($mockNode);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publishNodePublishesTheNodeAndItsChildNodeCollectionsIfTheNodeIsADocument()
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();
@@ -268,9 +254,7 @@ class PublishingServiceTest extends UnitTestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publishNodePublishesTheNodeAndItsChildNodeCollectionsIfTheNodeTypeHasChildNodes()
     {
         $mockNode = $this->getMockBuilder(NodeInterface::class)->getMock();

--- a/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
@@ -88,7 +88,7 @@ class UserServiceTest extends UnitTestCase
         $this->mockUserDomainService = $this->getMockBuilder(UserDomainService::class)->getMock();
         $this->inject($this->userService, 'userDomainService', $this->mockUserDomainService);
 
-        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->setMethods(['findOneByName'])->getMock();
+        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->addMethods(['findOneByName'])->getMock();
         $this->inject($this->userService, 'workspaceRepository', $this->mockWorkspaceRepository);
 
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->getMock();
@@ -112,14 +112,14 @@ class UserServiceTest extends UnitTestCase
     {
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue($mockUser));
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->willReturn($mockUser);
         self::assertSame($mockUser, $this->userService->getBackendUser());
     }
 
     #[Test]
     public function getPersonalWorkspaceReturnsNullIfNoUserIsLoggedIn()
     {
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue(null));
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->willReturn(null);
         self::assertNull($this->userService->getPersonalWorkspace());
     }
 
@@ -130,17 +130,17 @@ class UserServiceTest extends UnitTestCase
         $mockUserWorkspace = $this->getMockBuilder(Workspace::class)->disableOriginalConstructor()->getMock();
         $mockAccount = $this->getMockBuilder(Account::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAccount')->will(self::returnValue($mockAccount));
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue($mockUser));
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getUserName')->with($mockUser)->will(self::returnValue('TheUserName'));
-        $this->mockWorkspaceRepository->expects(self::atLeastOnce())->method('findOneByName')->with('user-TheUserName')->will(self::returnValue($mockUserWorkspace));
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAccount')->willReturn($mockAccount);
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->willReturn($mockUser);
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getUserName')->with($mockUser)->willReturn('TheUserName');
+        $this->mockWorkspaceRepository->expects(self::atLeastOnce())->method('findOneByName')->with('user-TheUserName')->willReturn($mockUserWorkspace);
         self::assertSame($mockUserWorkspace, $this->userService->getPersonalWorkspace());
     }
 
     #[Test]
     public function getPersonalWorkspaceNameReturnsNullIfNoUserIsLoggedIn()
     {
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue(null));
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->willReturn(null);
         self::assertNull($this->userService->getPersonalWorkspaceName());
     }
 
@@ -150,9 +150,9 @@ class UserServiceTest extends UnitTestCase
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
         $mockAccount = $this->getMockBuilder(Account::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAccount')->will(self::returnValue($mockAccount));
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue($mockUser));
-        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getUserName')->with($mockUser)->will(self::returnValue('TheUserName'));
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAccount')->willReturn($mockAccount);
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->willReturn($mockUser);
+        $this->mockUserDomainService->expects(self::atLeastOnce())->method('getUserName')->with($mockUser)->willReturn('TheUserName');
         self::assertSame('user-TheUserName', $this->userService->getPersonalWorkspaceName());
     }
 
@@ -171,8 +171,7 @@ class UserServiceTest extends UnitTestCase
         $this->setUpGetUser($mockUser);
 
         $this->mockAccountRepository->expects(self::any())
-            ->method('findByAccountIdentifierAndAuthenticationProviderName')
-            ->will($this->onConsecutiveCalls(null, $mockAccount));
+            ->method('findByAccountIdentifierAndAuthenticationProviderName')->willReturnOnConsecutiveCalls(null, $mockAccount);
 
         $this->userDomainService->getUser('test-user');
 

--- a/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Service;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
@@ -107,9 +107,7 @@ class UserServiceTest extends UnitTestCase
         $this->inject($this->userDomainService, 'partyRepository', $this->mockPartyRepository);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getBackendUserReturnsTheCurrentlyLoggedInUser()
     {
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
@@ -118,18 +116,14 @@ class UserServiceTest extends UnitTestCase
         self::assertSame($mockUser, $this->userService->getBackendUser());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPersonalWorkspaceReturnsNullIfNoUserIsLoggedIn()
     {
         $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue(null));
         self::assertNull($this->userService->getPersonalWorkspace());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPersonalWorkspaceReturnsTheUsersWorkspaceIfAUserIsLoggedIn()
     {
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
@@ -143,18 +137,14 @@ class UserServiceTest extends UnitTestCase
         self::assertSame($mockUserWorkspace, $this->userService->getPersonalWorkspace());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPersonalWorkspaceNameReturnsNullIfNoUserIsLoggedIn()
     {
         $this->mockUserDomainService->expects(self::atLeastOnce())->method('getCurrentUser')->will(self::returnValue(null));
         self::assertNull($this->userService->getPersonalWorkspaceName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPersonalWorkspaceNameReturnsTheUsersWorkspaceNameIfAUserIsLoggedIn()
     {
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
@@ -166,17 +156,13 @@ class UserServiceTest extends UnitTestCase
         self::assertSame('user-TheUserName', $this->userService->getPersonalWorkspaceName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUserReturnsNullForInvalidUser()
     {
         self::assertNull($this->mockUserDomainService->getUser('NonExistantUser'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUsersWillReturnUserOnSecondCall()
     {
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();
@@ -193,9 +179,7 @@ class UserServiceTest extends UnitTestCase
         self::assertSame($mockUser, $this->userDomainService->getUser('test-user'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getUserReturnsUserForValidUser()
     {
         $mockUser = $this->getMockBuilder(User::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
@@ -11,6 +11,7 @@ namespace Neos\Neos\Tests\Unit\Service;
  * source code.
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Domain\Model\User;
@@ -45,22 +46,22 @@ class UserServiceTest extends UnitTestCase
     protected $userDomainService;
 
     /**
-     * @var WorkspaceRepository | \PHPUnit\Framework\MockObject\MockObject
+     * @var WorkspaceRepository|MockObject
      */
     protected $mockWorkspaceRepository;
 
     /**
-     * @var AccountRepository | \PHPUnit\Framework\MockObject\MockObject
+     * @var AccountRepository|MockObject
      */
     protected $mockAccountRepository;
 
     /**
-     * @var PartyService | \PHPUnit\Framework\MockObject\MockObject
+     * @var PartyService|MockObject
      */
     protected $mockPartyService;
 
     /**
-     * @var PartyRepository | \PHPUnit\Framework\MockObject\MockObject
+     * @var PartyRepository|MockObject
      */
     protected $mockPartyRepository;
 

--- a/Neos.Neos/Tests/Unit/Validation/Validator/HostNameValidatorTest.php
+++ b/Neos.Neos/Tests/Unit/Validation/Validator/HostNameValidatorTest.php
@@ -21,7 +21,7 @@ use Neos\Neos\Validation\Validator\HostnameValidator;
  */
 class HostNameValidatorTest extends UnitTestCase
 {
-    public function hostNameDataProvider()
+    public static function hostNameDataProvider()
     {
         return [
             // correct names

--- a/Neos.Neos/Tests/Unit/Validation/Validator/HostNameValidatorTest.php
+++ b/Neos.Neos/Tests/Unit/Validation/Validator/HostNameValidatorTest.php
@@ -10,7 +10,8 @@ namespace Neos\Neos\Tests\Unit\Validation\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Neos\Validation\Validator\HostnameValidator;
 
@@ -44,10 +45,8 @@ class HostNameValidatorTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider hostNameDataProvider
-     */
+    #[DataProvider('hostNameDataProvider')]
+    #[Test]
     public function validate($hostName, $valid)
     {
         $validator = new HostnameValidator();

--- a/Neos.Neos/Tests/Unit/Validation/Validator/UserDoesNotExistValidatorTest.php
+++ b/Neos.Neos/Tests/Unit/Validation/Validator/UserDoesNotExistValidatorTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\Validation\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Validation\Exception\InvalidSubjectException;
@@ -23,9 +23,7 @@ use Neos\Neos\Validation\Validator\UserDoesNotExistValidator;
  */
 class UserDoesNotExistValidatorTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function validateThrowsExceptionForNonStringValue()
     {
         $this->expectException(InvalidSubjectException::class);
@@ -33,9 +31,7 @@ class UserDoesNotExistValidatorTest extends UnitTestCase
         $validator->validate(false);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function validateReturnsNoErrorsWithNullAccount()
     {
         $validator = new UserDoesNotExistValidator();
@@ -48,9 +44,7 @@ class UserDoesNotExistValidatorTest extends UnitTestCase
         self::assertFalse($result->hasErrors());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function validateReturnsAnErrorWithExistingAccount()
     {
         $validator = new UserDoesNotExistValidator();

--- a/Neos.Neos/Tests/Unit/Validation/Validator/UserDoesNotExistValidatorTest.php
+++ b/Neos.Neos/Tests/Unit/Validation/Validator/UserDoesNotExistValidatorTest.php
@@ -58,7 +58,7 @@ class UserDoesNotExistValidatorTest extends UnitTestCase
             ->expects(self::atLeastOnce())
             ->method('getUser')
             ->with('j.doe')
-            ->will(self::returnValue($mockUser));
+            ->willReturn($mockUser);
 
         $result = $validator->validate('j.doe');
 

--- a/Neos.Neos/Tests/Unit/View/FusionViewTest.php
+++ b/Neos.Neos/Tests/Unit/View/FusionViewTest.php
@@ -66,13 +66,13 @@ class FusionViewTest extends UnitTestCase
         $this->mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
 
         $mockNode = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $this->mockContextualizedNode = $this->getMockBuilder(Node::class)->setMethods(['getContext'])->setConstructorArgs([$mockNode, $this->mockContext])->getMock();
+        $this->mockContextualizedNode = $this->getMockBuilder(Node::class)->onlyMethods(['getContext'])->setConstructorArgs([$mockNode, $this->mockContext])->getMock();
         $mockSiteNode = $this->createMock(TraversableNodeInterface::class);
 
-        $this->mockContext->expects(self::any())->method('getCurrentSiteNode')->will(self::returnValue($mockSiteNode));
-        $this->mockContext->expects(self::any())->method('getDimensions')->will(self::returnValue([]));
+        $this->mockContext->expects(self::any())->method('getCurrentSiteNode')->willReturn($mockSiteNode);
+        $this->mockContext->expects(self::any())->method('getDimensions')->willReturn([]);
 
-        $this->mockContextualizedNode->expects(self::any())->method('getContext')->will(self::returnValue($this->mockContext));
+        $this->mockContextualizedNode->expects(self::any())->method('getContext')->willReturn($this->mockContext);
 
         $this->mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
 
@@ -81,10 +81,10 @@ class FusionViewTest extends UnitTestCase
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
         $mockFusionService = $this->createMock(FusionService::class);
-        $mockFusionService->expects(self::any())->method('createRuntime')->will(self::returnValue($this->mockRuntime));
+        $mockFusionService->expects(self::any())->method('createRuntime')->willReturn($this->mockRuntime);
 
         $this->mockView = $this->getAccessibleMock(FusionView::class, ['getClosestDocumentNode']);
-        $this->mockView->expects(self::any())->method('getClosestDocumentNode')->will(self::returnValue($this->mockContextualizedNode));
+        $this->mockView->expects(self::any())->method('getClosestDocumentNode')->willReturn($this->mockContextualizedNode);
 
         $this->inject($this->mockView, 'controllerContext', $mockControllerContext);
         $this->inject($this->mockView, 'securityContext', $this->mockSecurityContext);
@@ -124,30 +124,30 @@ class FusionViewTest extends UnitTestCase
         $mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();
 
         $mockNode = $this->getMockBuilder(NodeData::class)->disableOriginalConstructor()->getMock();
-        $mockContextualizedNode = $this->getMockBuilder(Node::class)->setMethods(['getContext'])->setConstructorArgs([$mockNode, $mockContext])->getMock();
+        $mockContextualizedNode = $this->getMockBuilder(Node::class)->onlyMethods(['getContext'])->setConstructorArgs([$mockNode, $mockContext])->getMock();
         $mockSiteNode = $this->createMock(TraversableNodeInterface::class);
 
-        $mockContext->expects(self::any())->method('getCurrentSiteNode')->will(self::returnValue($mockSiteNode));
-        $mockContext->expects(self::any())->method('getDimensions')->will(self::returnValue([]));
+        $mockContext->expects(self::any())->method('getCurrentSiteNode')->willReturn($mockSiteNode);
+        $mockContext->expects(self::any())->method('getDimensions')->willReturn([]);
 
-        $mockContextualizedNode->expects(self::any())->method('getContext')->will(self::returnValue($mockContext));
+        $mockContextualizedNode->expects(self::any())->method('getContext')->willReturn($mockContext);
 
         $mockResponse = new ActionResponse();
 
         $mockControllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
-        $mockControllerContext->expects(self::any())->method('getResponse')->will(self::returnValue($mockResponse));
+        $mockControllerContext->expects(self::any())->method('getResponse')->willReturn($mockResponse);
 
         $mockRuntime = $this->getMockBuilder(Runtime::class)->disableOriginalConstructor()->getMock();
-        $mockRuntime->expects(self::any())->method('render')->will(self::returnValue("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\nMessage body"));
-        $mockRuntime->expects(self::any())->method('getControllerContext')->will(self::returnValue($mockControllerContext));
+        $mockRuntime->expects(self::any())->method('render')->willReturn("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\nMessage body");
+        $mockRuntime->expects(self::any())->method('getControllerContext')->willReturn($mockControllerContext);
 
         $mockFusionService = $this->createMock(FusionService::class);
-        $mockFusionService->expects(self::any())->method('createRuntime')->will(self::returnValue($mockRuntime));
+        $mockFusionService->expects(self::any())->method('createRuntime')->willReturn($mockRuntime);
 
         $mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
         $view = $this->getAccessibleMock(FusionView::class, ['getClosestDocumentNode']);
-        $view->expects(self::any())->method('getClosestDocumentNode')->will(self::returnValue($mockContextualizedNode));
+        $view->expects(self::any())->method('getClosestDocumentNode')->willReturn($mockContextualizedNode);
 
         $this->inject($view, 'securityContext', $mockSecurityContext);
 

--- a/Neos.Neos/Tests/Unit/View/FusionViewTest.php
+++ b/Neos.Neos/Tests/Unit/View/FusionViewTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\View;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\ControllerContext;
@@ -93,9 +93,7 @@ class FusionViewTest extends UnitTestCase
         $this->mockView->_set('variables', ['value' => $this->mockContextualizedNode]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attemptToRenderWithoutNodeInformationAtAllThrowsException()
     {
         $this->expectException(Exception::class);
@@ -103,9 +101,7 @@ class FusionViewTest extends UnitTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attemptToRenderWithInvalidNodeInformationThrowsException()
     {
         $this->expectException(Exception::class);
@@ -114,9 +110,7 @@ class FusionViewTest extends UnitTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderPutsSiteNodeInFusionContext()
     {
         $this->setUpMockView();
@@ -124,9 +118,7 @@ class FusionViewTest extends UnitTestCase
         $this->mockView->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderMergesHttpResponseIfOutputIsHttpMessage()
     {
         $mockContext = $this->getMockBuilder(ContentContext::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\ViewHelpers;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Flow\Security\Authorization\PrivilegeManagerInterface;
@@ -140,9 +140,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelperVariableContainer->expects(self::any())->method('getView')->willReturn($this->mockView);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfTheGivenPropertyIsNotAccessible(): void
     {
         $this->expectException(Exception::class);
@@ -152,9 +150,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->editableViewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfTheTsTemplateObjectIsNotSet(): void
     {
         $this->expectException(Exception::class);
@@ -166,9 +162,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->editableViewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderSetsThePropertyValueAsTagContentIfItExists(): void
     {
         $this->mockContentElementEditableService->expects(self::once())->method('wrapContentProperty')->willReturn('someWrappedContent');
@@ -182,9 +176,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->editableViewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderSetsTheChildNodesAsTagContentIfTheyAreSet(): void
     {
         $this->mockContentElementEditableService->expects(self::once())->method('wrapContentProperty')->willReturn('someWrappedContent');
@@ -200,9 +192,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->editableViewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderCallsContentElementEditableServiceForAugmentation(): void
     {
         $this->templateVariables = [
@@ -216,9 +206,7 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->editableViewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderUsesTheNodeArgumentIfSet(): void
     {
         $this->mockContentElementEditableService->expects(self::once())->method('wrapContentProperty')->willReturn('someWrappedContent');

--- a/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/ContentElement/EditableViewHelperTest.php
@@ -112,7 +112,9 @@ class EditableViewHelperTest extends ViewHelperBaseTestcase
         $this->mockContext = ['node' => $this->mockNode];
         $this->mockRuntime->expects(self::any())->method('getCurrentContext')->willReturn($this->mockContext);
         $this->mockTemplateImplementation->expects(self::any())->method('getRuntime')->willReturn($this->mockRuntime);
-        $this->mockView = $this->getAccessibleMock(FluidView::class, [], [], '', false);
+        // onlyMethods([]) mocks nothing in PHPUnit 10+, unlike the old setMethods([]),
+        // so the method configured below has to be listed explicitly
+        $this->mockView = $this->getAccessibleMock(FluidView::class, ['getFusionObject'], [], '', false);
         $this->mockView->expects(self::any())->method('getFusionObject')->willReturn($this->mockTemplateImplementation);
     }
 

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
@@ -50,7 +50,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper = $this->getAccessibleMock(ModuleViewHelper::class, ['renderChildren']);
         $this->tagBuilder = $this->createMock(TagBuilder::class);
         $this->tagBuilder->expects(self::once())->method('render')->willReturn('renderingResult');
-        $this->uriModuleViewHelper = $this->getMockBuilder(UriModuleViewHelper::class)->setMethods(['setRenderingContext', 'setArguments', 'render'])->getMock();
+        $this->uriModuleViewHelper = $this->getMockBuilder(UriModuleViewHelper::class)->onlyMethods(['setRenderingContext', 'setArguments', 'render'])->getMock();
 
         $this->dummyRenderingContext = $this->createMock(RenderingContextInterface::class);
         $this->inject($this->viewHelper, 'renderingContext', $this->dummyRenderingContext);

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Link/ModuleViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\ViewHelpers\Link;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Neos\ViewHelpers\Link\ModuleViewHelper;
 use Neos\Neos\ViewHelpers\Uri\ModuleViewHelper as UriModuleViewHelper;
@@ -59,9 +59,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->inject($this->viewHelper, 'uriModuleViewHelper', $this->uriModuleViewHelper);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderSetsTheRenderingContextOnTheUriViewHelper(): void
     {
         $this->uriModuleViewHelper->expects(self::once())->method('setRenderingContext')->with($this->dummyRenderingContext);
@@ -69,9 +67,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderCallsTheUriModuleViewHelpersSetArgumentsMethodWithTheCorrectArguments(): void
     {
         $this->uriModuleViewHelper->expects(self::once())->method('setArguments')->with([
@@ -97,9 +93,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderAddsUriViewHelpersReturnAsTagHrefAttributeIfItsNotEmpty(): void
     {
         $this->uriModuleViewHelper->expects(self::once())->method('render')->willReturn('moduleUri');
@@ -108,9 +102,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderSetsTheTagBuildersContentWithRenderChildrenResult(): void
     {
         $this->viewHelper->expects(self::once())->method('renderChildren')->willReturn('renderChildrenResult');
@@ -119,9 +111,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderSetsForceClosingTagOnTagBuilder(): void
     {
         $this->tagBuilder->expects(self::once())->method('forceClosingTag')->with(true);
@@ -129,9 +119,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderReturnsTagBuildersRenderResult(): void
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['path' => 'path']);

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
@@ -35,7 +35,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
     public function setUp(): void
     {
         parent::setUp();
-        $this->viewHelper = $this->getMockBuilder(ModuleViewHelper::class)->setMethods(['setMainRequestToUriBuilder'])->getMock();
+        $this->viewHelper = $this->getMockBuilder(ModuleViewHelper::class)->onlyMethods(['setMainRequestToUriBuilder'])->getMock();
         $this->uriBuilder = $this->createMock(UriBuilder::class);
         $this->inject($this->viewHelper, 'uriBuilder', $this->uriBuilder);
     }
@@ -43,10 +43,10 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
     #[Test]
     public function callingRenderAssignsVariablesCorrectlyToUriBuilder()
     {
-        $this->uriBuilder->expects(self::once())->method('setSection')->with('section')->will(self::returnSelf());
-        $this->uriBuilder->expects(self::once())->method('setArguments')->with(['additionalParams'])->will(self::returnSelf());
-        $this->uriBuilder->expects(self::once())->method('setArgumentsToBeExcludedFromQueryString')->with(['argumentsToBeExcludedFromQueryString'])->will(self::returnSelf());
-        $this->uriBuilder->expects(self::once())->method('setFormat')->with('format')->will(self::returnSelf());
+        $this->uriBuilder->expects(self::once())->method('setSection')->with('section')->willReturnSelf();
+        $this->uriBuilder->expects(self::once())->method('setArguments')->with(['additionalParams'])->willReturnSelf();
+        $this->uriBuilder->expects(self::once())->method('setArgumentsToBeExcludedFromQueryString')->with(['argumentsToBeExcludedFromQueryString'])->willReturnSelf();
+        $this->uriBuilder->expects(self::once())->method('setFormat')->with('format')->willReturnSelf();
 
         $expectedModifiedArguments = [
             'module' => 'the/path',

--- a/Neos.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
+++ b/Neos.Neos/Tests/Unit/ViewHelpers/Uri/ModuleViewHelperTest.php
@@ -10,7 +10,7 @@ namespace Neos\Neos\Tests\Unit\ViewHelpers\Uri;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\Neos\ViewHelpers\Uri\ModuleViewHelper;
@@ -40,9 +40,7 @@ class ModuleViewHelperTest extends ViewHelperBaseTestcase
         $this->inject($this->viewHelper, 'uriBuilder', $this->uriBuilder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function callingRenderAssignsVariablesCorrectlyToUriBuilder()
     {
         $this->uriBuilder->expects(self::once())->method('setSection')->with('section')->will(self::returnSelf());

--- a/Neos.SiteKickstarter/Tests/Unit/Service/SimpleTemplateRendererTest.php
+++ b/Neos.SiteKickstarter/Tests/Unit/Service/SimpleTemplateRendererTest.php
@@ -12,6 +12,7 @@ namespace Neos\SiteKickstarter\Tests\Unit\Service;
  * source code.
  */
 
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\SiteKickstarter\Service\SimpleTemplateRenderer;
 
@@ -27,9 +28,7 @@ class SimpleTemplateRendererTest extends UnitTestCase
         $this->simpleTemplateRenderer = new SimpleTemplateRenderer();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function replaceSimpleKeyInString()
     {
         $filePath = __DIR__ . '/Fixtures/Templates/simpleString.txt';
@@ -44,9 +43,8 @@ class SimpleTemplateRendererTest extends UnitTestCase
 
     /**
      * Just a test to be sure nothing gets changed if the contextVariables array has no matching key
-     *
-     * @test
      */
+    #[Test]
     public function nothingGetsChangedInString()
     {
         $filePath = __DIR__ . '/Fixtures/Templates/simpleString.txt';

--- a/Neos.SiteKickstarter/Tests/Unit/Service/SitePackageGeneratorNameServiceTest.php
+++ b/Neos.SiteKickstarter/Tests/Unit/Service/SitePackageGeneratorNameServiceTest.php
@@ -45,9 +45,9 @@ class SitePackageGeneratorNameServiceTest extends UnitTestCase
     #[Test]
     public function getNameOfSitePackageGeneratorWithName()
     {
-        $this->mockObjectManager->expects(self::any())->method('get')->will(self::returnCallback(function ($className) {
+        $this->mockObjectManager->expects(self::any())->method('get')->willReturnCallback(function ($className) {
             return new NamedSitePackageGenerator();
-        }));
+        });
 
         $this->assertEquals(
             $this->sitePackageGeneratorNameService->getNameOfSitePackageGenerator(NamedSitePackageGenerator::class),
@@ -58,9 +58,9 @@ class SitePackageGeneratorNameServiceTest extends UnitTestCase
     #[Test]
     public function getClassNameOfSitePackageGenerator()
     {
-        $this->mockObjectManager->expects(self::any())->method('get')->will(self::returnCallback(function ($className) {
+        $this->mockObjectManager->expects(self::any())->method('get')->willReturnCallback(function ($className) {
             return new BlankSitePackageGenerator();
-        }));
+        });
 
         $this->assertEquals(
             $this->sitePackageGeneratorNameService->getNameOfSitePackageGenerator(BlankSitePackageGenerator::class),

--- a/Neos.SiteKickstarter/Tests/Unit/Service/SitePackageGeneratorNameServiceTest.php
+++ b/Neos.SiteKickstarter/Tests/Unit/Service/SitePackageGeneratorNameServiceTest.php
@@ -12,6 +12,7 @@ namespace Neos\SiteKickstarter\Tests\Unit\Service;
  * source code.
  */
 
+use PHPUnit\Framework\Attributes\Test;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\SiteKickstarter\Service\SitePackageGeneratorNameService;
@@ -41,9 +42,7 @@ class SitePackageGeneratorNameServiceTest extends UnitTestCase
         $this->inject($this->sitePackageGeneratorNameService, 'objectManager', $this->mockObjectManager);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNameOfSitePackageGeneratorWithName()
     {
         $this->mockObjectManager->expects(self::any())->method('get')->will(self::returnCallback(function ($className) {
@@ -56,9 +55,7 @@ class SitePackageGeneratorNameServiceTest extends UnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getClassNameOfSitePackageGenerator()
     {
         $this->mockObjectManager->expects(self::any())->method('get')->will(self::returnCallback(function ($className) {

--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "~11.5"
     }
 }


### PR DESCRIPTION
See upgrade to PHPUnit 11 in Flow https://github.com/neos/flow-development-collection/pull/3563

**Upgrade instructions**

The only thing you might need to adjust (besides catering to all the changes in PhpUnit 11), is the signature of `getAccessibleMock()` in our base testcase class. The arguments

- `$callAutoload`
- `$callOriginalMethods`
- `$proxyTarget`

have been removed, as the underlying PHPUnit methods are deprecated.

**Review instructions**

All tests should still pass – have fun verifying they still do test the correct stuff.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed (OH YEAH!)
- [x] The PR is created against the correct branch – 8.4 is correct for this PR
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
