### PR TITLE
BUGFIX: Handle workspace states on asset usage indexing processor

### DIFF
--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -63,7 +63,6 @@ final readonly class AssetUsageIndexingProcessor
 
         /** @var Workspace $workspace */
         foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
-
             $this->dispatchMessage($callback, sprintf('  Workspace: %s', $workspace->workspaceName->value));
 
             // We do not need to index workspaces without any changes, as they are already indexed by baseworkspace

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -62,13 +62,16 @@ final readonly class AssetUsageIndexingProcessor
 
         /** @var Workspace $workspace */
         foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
+
+            $this->dispatchMessage($callback, sprintf('  Workspace: %s', $workspace->workspaceName->value));
+
             // We do not need to index workspaces without any changes, as they are already indexed by baseworkspace
             if (!$workspace->workspaceName->isLive() && !$workspace->hasPublishableChanges()) {
+                $this->dispatchMessage($callback, '    ... skipped, no changes to baseworkspace');
                 continue;
             }
 
             $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
-            $this->dispatchMessage($callback, sprintf('  Workspace: %s', $contentGraph->getWorkspaceName()->value));
 
             $dimensionSpacePoints = $variationGraph->getDimensionSpacePoints();
 

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -52,7 +52,8 @@ final readonly class AssetUsageIndexingProcessor
 
             if (count($dirtyWorkspacesWithUnpublishedChanges) > 0) {
                 $this->dispatchMessage($callback, "\n!!! Some workspaces are not up to date and have additional unpublished changes. The indexing may produce false asset usages for these cases.");
-                $this->dispatchMessage($callback, "\n!!! Please rebase the corresponding workspaces or publish all pending changes. If you still want to run the index, run it with the 'force' option.");
+                $this->dispatchMessage($callback, "\n!!! Please rebase the corresponding workspaces or publish all pending changes.\n./flow workspace:rebaseoutdated\n./flow workspace:publish <workspace>");
+                $this->dispatchMessage($callback, "\nIf you still want to run the index, run it with the 'force' option.");
                 $this->dispatchMessage($callback, sprintf("\nAffected Workspaces: \n%s\n", implode("\n", array_map(fn ($workspace) => "  - " . $workspace->workspaceName->value, $dirtyWorkspacesWithUnpublishedChanges))));
                 return false;
             }

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -10,6 +10,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindChildNodesFil
 use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
+use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\Neos\AssetUsage\Service\AssetUsageIndexingService;
 
@@ -38,7 +39,13 @@ final readonly class AssetUsageIndexingProcessor
         $workspacesDependingOnLive = $allWorkspaces->getDependantWorkspacesRecursively(WorkspaceName::forLive());
 
         $this->dispatchMessage($callback, sprintf('ContentRepository "%s"', $contentRepository->id->value));
+        /** @var Workspace $workspace */
         foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
+            // We do not need to index workspaces without any changes, as they are already indexed by baseworkspace
+            if (!$workspace->workspaceName->isLive() && !$workspace->hasPublishableChanges()) {
+                continue;
+            }
+
             $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
             $this->dispatchMessage($callback, sprintf('  Workspace: %s', $contentGraph->getWorkspaceName()->value));
 

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -42,8 +42,8 @@ final readonly class AssetUsageIndexingProcessor
 
         // Check workspaces first for there state and unpublished changes
         if ($force === false) {
-            /** @var Workspace $workspace */
             $dirtyWorkspacesWithUnpublishedChanges = [];
+            /** @var Workspace $workspace */
             foreach ($workspacesDependingOnLive as $workspace) {
                 if ($workspace->status === WorkspaceStatus::OUTDATED && $workspace->hasPublishableChanges() === true) {
                     $dirtyWorkspacesWithUnpublishedChanges[] = $workspace;

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -41,11 +41,11 @@ final readonly class AssetUsageIndexingProcessor
         $this->dispatchMessage($callback, sprintf('ContentRepository "%s"', $contentRepository->id->value));
 
         // Check workspaces first for there state and unpublished changes
-        if($force === false) {
+        if ($force === false) {
             /** @var Workspace $workspace */
             $dirtyWorkspacesWithUnpublishedChanges = [];
-            foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
-                if (!$workspace->workspaceName->isLive() && $workspace->status === WorkspaceStatus::OUTDATED && $workspace->hasPublishableChanges() === true) {
+            foreach ($workspacesDependingOnLive as $workspace) {
+                if ($workspace->status === WorkspaceStatus::OUTDATED && $workspace->hasPublishableChanges() === true) {
                     $dirtyWorkspacesWithUnpublishedChanges[] = $workspace;
                 }
             }
@@ -53,7 +53,7 @@ final readonly class AssetUsageIndexingProcessor
             if (count($dirtyWorkspacesWithUnpublishedChanges) > 0) {
                 $this->dispatchMessage($callback, "\n!!! Some workspaces are not up to date and have additional unpublished changes. The indexing may produce false asset usages for these cases.");
                 $this->dispatchMessage($callback, "\n!!! Please rebase the corresponding workspaces or publish all pending changes. If you still want to run the index, run it with the 'force' option.");
-                $this->dispatchMessage($callback, sprintf("\nAffected Workspaces: \n%s\n", implode("\n", array_map(fn($workspace) => "  - ".$workspace->workspaceName->value,$dirtyWorkspacesWithUnpublishedChanges))));
+                $this->dispatchMessage($callback, sprintf("\nAffected Workspaces: \n%s\n", implode("\n", array_map(fn ($workspace) => "  - " . $workspace->workspaceName->value, $dirtyWorkspacesWithUnpublishedChanges))));
                 return false;
             }
         }

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -40,7 +40,7 @@ final readonly class AssetUsageIndexingProcessor
 
         $this->dispatchMessage($callback, sprintf('ContentRepository "%s"', $contentRepository->id->value));
 
-        // Check workspaces first for there state and unpublished changes
+        // Check workspaces first for their state and unpublished changes
         if ($force === false) {
             $dirtyWorkspacesWithUnpublishedChanges = [];
             /** @var Workspace $workspace */
@@ -99,6 +99,7 @@ final readonly class AssetUsageIndexingProcessor
 
                     $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($childNode->nodeTypeName);
                     if ($nodeType === null) {
+                        $this->dispatchMessage($callback, sprintf('    ERROR: NodeType (%s) does not exist.', $childNode->nodeTypeName->value));
                         return false;
                     }
                     $this->assetUsageIndexingService->updateIndex($contentRepository->id, $childNode, $nodeType, $allWorkspaces);

--- a/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
+++ b/Neos.Neos/Classes/AssetUsage/AssetUsageIndexingProcessor.php
@@ -12,6 +12,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\Exception\WorkspaceDoesNotExist;
 use Neos\ContentRepository\Core\SharedModel\Workspace\Workspace;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceStatus;
 use Neos\Neos\AssetUsage\Service\AssetUsageIndexingService;
 
 final readonly class AssetUsageIndexingProcessor
@@ -23,8 +24,9 @@ final readonly class AssetUsageIndexingProcessor
 
     /**
      * @param callable(string $message):void|null $callback
+     * @param bool $force Force the indexing processor to index also outdated workspaces with unpublished changes.
      */
-    public function buildIndex(ContentRepository $contentRepository, NodeTypeName $nodeTypeName, ?callable $callback = null): void
+    public function buildIndex(ContentRepository $contentRepository, NodeTypeName $nodeTypeName, bool $force = false, ?callable $callback = null): bool
     {
         $variationGraph = $contentRepository->getVariationGraph();
 
@@ -34,11 +36,30 @@ final readonly class AssetUsageIndexingProcessor
             throw WorkspaceDoesNotExist::butWasSupposedTo(WorkspaceName::forLive());
         }
 
-        $this->assetUsageIndexingService->pruneIndex($contentRepository->id);
-
         $workspacesDependingOnLive = $allWorkspaces->getDependantWorkspacesRecursively(WorkspaceName::forLive());
 
         $this->dispatchMessage($callback, sprintf('ContentRepository "%s"', $contentRepository->id->value));
+
+        // Check workspaces first for there state and unpublished changes
+        if($force === false) {
+            /** @var Workspace $workspace */
+            $dirtyWorkspacesWithUnpublishedChanges = [];
+            foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
+                if (!$workspace->workspaceName->isLive() && $workspace->status === WorkspaceStatus::OUTDATED && $workspace->hasPublishableChanges() === true) {
+                    $dirtyWorkspacesWithUnpublishedChanges[] = $workspace;
+                }
+            }
+
+            if (count($dirtyWorkspacesWithUnpublishedChanges) > 0) {
+                $this->dispatchMessage($callback, "\n!!! Some workspaces are not up to date and have additional unpublished changes. The indexing may produce false asset usages for these cases.");
+                $this->dispatchMessage($callback, "\n!!! Please rebase the corresponding workspaces or publish all pending changes. If you still want to run the index, run it with the 'force' option.");
+                $this->dispatchMessage($callback, sprintf("\nAffected Workspaces: \n%s\n", implode("\n", array_map(fn($workspace) => "  - ".$workspace->workspaceName->value,$dirtyWorkspacesWithUnpublishedChanges))));
+                return false;
+            }
+        }
+
+        $this->assetUsageIndexingService->pruneIndex($contentRepository->id);
+
         /** @var Workspace $workspace */
         foreach ([$liveWorkspace, ...$workspacesDependingOnLive] as $workspace) {
             // We do not need to index workspaces without any changes, as they are already indexed by baseworkspace
@@ -75,13 +96,14 @@ final readonly class AssetUsageIndexingProcessor
 
                     $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($childNode->nodeTypeName);
                     if ($nodeType === null) {
-                        return;
+                        return false;
                     }
                     $this->assetUsageIndexingService->updateIndex($contentRepository->id, $childNode, $nodeType, $allWorkspaces);
                     array_push($childNodes, ...iterator_to_array($subgraph->findChildNodes($childNode->aggregateId, FindChildNodesFilter::create())));
                 }
             }
         }
+        return true;
     }
 
     private function dispatchMessage(?callable $callback, string $value): void

--- a/Neos.Neos/Classes/AssetUsage/Command/AssetUsageCommandController.php
+++ b/Neos.Neos/Classes/AssetUsage/Command/AssetUsageCommandController.php
@@ -20,21 +20,32 @@ final class AssetUsageCommandController extends CommandController
         parent::__construct();
     }
 
-    public function indexCommand(string $contentRepository = 'default', string $nodeTypeName = NodeTypeNameFactory::NAME_SITES): void
+    /**
+     * @param string $contentRepository The content repository identifier. (Default: 'default')
+     * @param string $nodeTypeName Name of the root nodetype (Default: 'Neos.Neos:Sites')
+     * @param bool $force Flag to enforce the index creation also with outdated workspaces with unpublished changes
+     * @return void
+     */
+    public function indexCommand(string $contentRepository = 'default', string $nodeTypeName = NodeTypeNameFactory::NAME_SITES, bool $force = false): void
     {
         $contentRepositoryId = ContentRepositoryId::fromString($contentRepository);
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
 
         $this->outputFormatted("Start indexing asset usages");
 
-        $this->assetUsageIndexingProcessor->buildIndex(
-            $contentRepository,
+        $successful = $this->assetUsageIndexingProcessor->buildIndex(
+            $this->contentRepositoryRegistry->get($contentRepositoryId),
             NodeTypeName::fromString($nodeTypeName),
+            $force,
             function (string $message) {
                 $this->outputFormatted($message);
             }
         );
 
-        $this->outputFormatted("Finished.");
+        if ($successful) {
+            $this->outputFormatted("Finished.");
+        } else {
+            $this->outputFormatted("An error occured while indexing asset usages.");
+            $this->quit(1);
+        }
     }
 }

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
@@ -1,7 +1,7 @@
 @flowEntities
 Feature: Build index for existing nodes without dimensions
 
-  Scenario:
+  Background:
     Given using no content dimensions
     And using the following node types:
     """yaml
@@ -53,6 +53,17 @@ Feature: Build index for existing nodes without dimensions
       | workspaceName | "user-workspace" |
     And I am in dimension space point {}
 
+  Scenario: All workspaces are rebased
+    When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-2 | nody-mc-nodeface           | assets       | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+
+
+  Scenario: All workspaces are rebased, with additional assets on the user workspace
     When I am in workspace "user-workspace"
     And the following CreateNodeAggregateWithNode commands are executed:
       | nodeAggregateId           | nodeName | parentNodeAggregateId      | nodeTypeName                                           | initialPropertyValues          |
@@ -84,3 +95,112 @@ Feature: Build index for existing nodes without dimensions
       | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
       | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
 
+  Scenario: User workspace is behind live, with additional assets on the user workspace
+    When I am in workspace "user-workspace"
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId           | nodeName | parentNodeAggregateId      | nodeTypeName                                           | initialPropertyValues          |
+      | sir-nodeward-nodington-iv | bakura   | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"text": "Text Without Asset"} |
+      | sir-nodeward-nodington-v  | quatilde | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assets": ["Asset:asset-2"]}  |
+
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                      |
+      | workspaceName             | "user-workspace"           |
+      | nodeAggregateId           | "sir-david-nodenborough"   |
+      | originDimensionSpacePoint | {}                         |
+      | propertyValues            | {"asset": "Asset:asset-2"} |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-2 | nody-mc-nodeface           | assets       | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+    When I am in workspace "live"
+    And the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+    When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+  Scenario: User workspace is behind live, with additional assets on the user workspace - with rebase afterwards
+    When I am in workspace "user-workspace"
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId           | nodeName | parentNodeAggregateId      | nodeTypeName                                           | initialPropertyValues          |
+      | sir-nodeward-nodington-iv | bakura   | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"text": "Text Without Asset"} |
+      | sir-nodeward-nodington-v  | quatilde | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assets": ["Asset:asset-2"]}  |
+
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                      |
+      | workspaceName             | "user-workspace"           |
+      | nodeAggregateId           | "sir-david-nodenborough"   |
+      | originDimensionSpacePoint | {}                         |
+      | propertyValues            | {"asset": "Asset:asset-2"} |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-2 | nody-mc-nodeface           | assets       | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+    When I am in workspace "live"
+    And the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+    When the command RebaseWorkspace is executed with payload:
+      | Key           | Value            |
+      | workspaceName | "user-workspace" |
+    And I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+  Scenario: User workspace is behind live, without any additional assets in user workspace
+    When I am in workspace "live"
+    And the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+
+    When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
@@ -55,8 +55,8 @@ Feature: Build index for existing nodes without dimensions
 
   Scenario: All workspaces are rebased
     When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
-
-    Then I expect the AssetUsageService to have the following AssetUsages:
+    Then I expect the last asset usage index to have succeeded
+    And I expect the AssetUsageService to have the following AssetUsages:
       | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
       | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
       | asset-2 | nody-mc-nodeface           | assets       | live           | {}                        |
@@ -86,8 +86,8 @@ Feature: Build index for existing nodes without dimensions
       | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
 
     When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
-
-    Then I expect the AssetUsageService to have the following AssetUsages:
+    Then I expect the last asset usage index to have succeeded
+    And I expect the AssetUsageService to have the following AssetUsages:
       | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
       | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
       | asset-2 | nody-mc-nodeface           | assets       | live           | {}                        |
@@ -131,8 +131,8 @@ Feature: Build index for existing nodes without dimensions
       | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
 
     When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
-
-    Then I expect the AssetUsageService to have the following AssetUsages:
+    Then I expect the last asset usage index to have failed
+    And I expect the AssetUsageService to have the following AssetUsages:
       | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
       | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
       | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
@@ -199,8 +199,8 @@ Feature: Build index for existing nodes without dimensions
       | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
 
     When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
-
-    Then I expect the AssetUsageService to have the following AssetUsages:
+    Then I expect the last asset usage index to have succeeded
+    And I expect the AssetUsageService to have the following AssetUsages:
       | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
       | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
       | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/01-Indexing_WithoutDimensions.feature
@@ -139,6 +139,53 @@ Feature: Build index for existing nodes without dimensions
       | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
       | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
 
+  Scenario: User workspace is behind live, with additional assets on the user workspace - but running with force
+    When I am in workspace "user-workspace"
+    And the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId           | nodeName | parentNodeAggregateId      | nodeTypeName                                           | initialPropertyValues          |
+      | sir-nodeward-nodington-iv | bakura   | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"text": "Text Without Asset"} |
+      | sir-nodeward-nodington-v  | quatilde | sir-nodeward-nodington-iii | Neos.ContentRepository.Testing:NodeWithAssetProperties | {"assets": ["Asset:asset-2"]}  |
+
+    When the command SetNodeProperties is executed with payload:
+      | Key                       | Value                      |
+      | workspaceName             | "user-workspace"           |
+      | nodeAggregateId           | "sir-david-nodenborough"   |
+      | originDimensionSpacePoint | {}                         |
+      | propertyValues            | {"asset": "Asset:asset-2"} |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-2 | nody-mc-nodeface           | assets       | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+    When I am in workspace "live"
+    And the command RemoveNodeAggregate is executed with payload:
+      | Key                          | Value              |
+      | nodeAggregateId              | "nody-mc-nodeface" |
+      | nodeVariantSelectionStrategy | "allVariants"      |
+
+    Then I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
+    When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root" with force
+    Then I expect the last asset usage index to have succeeded
+    And I expect the AssetUsageService to have the following AssetUsages:
+      | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint |
+      | asset-1 | sir-david-nodenborough     | asset        | live           | {}                        |
+      # This is asset usage is actually false, as it was removed in live. But we can't distinguish between missing events and new events on the workspace.
+      # Running with force acknowledge this.
+      | asset-2 | nody-mc-nodeface           | assets       | user-workspace | {}                        |
+      | asset-3 | sir-nodeward-nodington-iii | text         | live           | {}                        |
+      | asset-2 | sir-nodeward-nodington-v   | assets       | user-workspace | {}                        |
+      | asset-2 | sir-david-nodenborough     | asset        | user-workspace | {}                        |
+
   Scenario: User workspace is behind live, with additional assets on the user workspace - with rebase afterwards
     When I am in workspace "user-workspace"
     And the following CreateNodeAggregateWithNode commands are executed:

--- a/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/02-Indexing_WithDimensions.feature
+++ b/Neos.Neos/Tests/Behavior/Features/AssetUsage/Indexing/02-Indexing_WithDimensions.feature
@@ -91,8 +91,8 @@ Feature: Build index for existing nodes with dimensions
       | asset-2 | nody-mc-nodeface           | assets       | user-workspace | {"language": "gsw", "market": "EU"} |
 
     When I run the AssetUsageIndexingProcessor with rootNodeTypeName "Neos.ContentRepository:Root"
-
-    Then I expect the AssetUsageService to have the following AssetUsages:
+    Then I expect the last asset usage index to have succeeded
+    And I expect the AssetUsageService to have the following AssetUsages:
       | assetId | nodeAggregateId            | propertyName | workspaceName  | originDimensionSpacePoint           |
       | asset-1 | sir-david-nodenborough     | asset        | live           | {"language": "de", "market": "DE"}  |
       | asset-1 | sir-david-nodenborough     | asset        | live           | {"language": "gsw", "market": "EU"} |

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
@@ -81,12 +81,21 @@ trait AssetUsageTrait
     /**
      * @When I run the AssetUsageIndexingProcessor with rootNodeTypeName ":rootNodeTypeName"
      */
-    public function iRunTheAssetUsageIndexingProcessor(string $rootNodeTypeName): void
+    public function iRunTheAssetUsageIndexingProcessor(string $rootNodeTypeName, bool $force = false): void
     {
         $this->lastIndexWasSuccessful = $this->getObject(AssetUsageIndexingProcessor::class)->buildIndex(
             $this->currentContentRepository,
             NodeTypeName::fromString($rootNodeTypeName),
+            $force
         );
+    }
+
+    /**
+     * @When I run the AssetUsageIndexingProcessor with rootNodeTypeName ":rootNodeTypeName" with force
+     */
+    public function iRunTheAssetUsageIndexingProcessorWithForce(string $rootNodeTypeName): void
+    {
+        $this->iRunTheAssetUsageIndexingProcessor($rootNodeTypeName, true);
     }
 
     /**

--- a/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
+++ b/Neos.Neos/Tests/Behavior/Features/Bootstrap/AssetUsageTrait.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\Assert;
  */
 trait AssetUsageTrait
 {
+    protected $lastIndexWasSuccessful = false;
+
     /**
      * @template T of object
      * @param class-string<T> $className
@@ -49,7 +51,7 @@ trait AssetUsageTrait
     /**
      * @Then I expect the AssetUsageService to have the following AssetUsages:
      */
-    public function iExpectTheAssetUsageServiceToHaveTheFollowingAssetUsages(TableNode $table)
+    public function iExpectTheAssetUsageServiceToHaveTheFollowingAssetUsages(TableNode $table): void
     {
         $assetUsageService = $this->getObject(AssetUsageService::class);
         $assetUsages = iterator_to_array($assetUsageService->findByFilter($this->currentContentRepository->id, AssetUsageFilter::create()));
@@ -79,11 +81,27 @@ trait AssetUsageTrait
     /**
      * @When I run the AssetUsageIndexingProcessor with rootNodeTypeName ":rootNodeTypeName"
      */
-    public function iRunTheAssetUsageIndexingProcessor(string $rootNodeTypeName)
+    public function iRunTheAssetUsageIndexingProcessor(string $rootNodeTypeName): void
     {
-        $this->getObject(AssetUsageIndexingProcessor::class)->buildIndex(
+        $this->lastIndexWasSuccessful = $this->getObject(AssetUsageIndexingProcessor::class)->buildIndex(
             $this->currentContentRepository,
             NodeTypeName::fromString($rootNodeTypeName),
         );
+    }
+
+    /**
+     * @Then I expect the last asset usage index to have succeeded
+     */
+    public function iExpectTheLastAssetUsageIndexToHaveSucceeded(): void
+    {
+        Assert::assertTrue($this->lastIndexWasSuccessful);
+    }
+
+    /**
+     * @Then I expect the last asset usage index to have failed
+     */
+    public function iExpectTheLastAssetUsageIndexToHaveFailed(): void
+    {
+        Assert::assertFalse($this->lastIndexWasSuccessful);
     }
 }


### PR DESCRIPTION
This PR add addtional handling of workspace states to asset indexing processor (re-index) to address issues with asset usages, when running the re-indexing while some workspaces are outdated and/or contain any unpublished changes. For more background please check also [this comment](https://github.com/neos/neos-development-collection/issues/5953#issuecomment-5294134956).

**1) Skip workspaces without publishable changes during indexing**
To fix issues with outdated workspaces (and no additional unpublushed changes) we simply skip these workspaces, as we don't expect any other asset usages as in base workspace. This saves time on indexing and prevents false asset usage entries.

**2) Check for outdated workspaces with unpublished changes**
We check for outdated workspaces with unpublished changes and do not run the re-index if at least one affected workspace has been found. The use can overrule this with an `--force` flag, but may end up with false asset usage entries in the index.

**Example output**
```
Start indexing asset usages
ContentRepository "default"

!!! Some workspaces are not up to date and have additional unpublished changes.
The indexing may produce false asset usages for these cases.

!!! Please rebase the corresponding workspaces or publish all pending changes.
./flow workspace:rebaseoutdated
./flow workspace:publish <workspace>

If you still want to run the index, run it with the 'force' option.

Affected Workspaces: 
  - review

An error occured while indexing asset usages.
```

Fixes #5953 