### PR TITLE
TASK: Hack PHPUnit assertion support in Behat

### DIFF
--- a/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
+++ b/Neos.ContentRepository.TestSuite/Classes/Behavior/Features/Bootstrap/CRTestSuiteTrait.php
@@ -71,6 +71,15 @@ trait CRTestSuiteTrait
     use ProjectionIntegrityViolationDetectionTrait;
 
     /**
+     * Hack PHPUnit assertion support, see https://github.com/Behat/Behat/issues/1618
+     * @BeforeSuite
+     */
+    public static function initPhpunit(): void
+    {
+        (new \PHPUnit\TextUI\Configuration\Builder())->build([]);
+    }
+
+    /**
      * @BeforeScenario
      * @throws \Exception
      */


### PR DESCRIPTION
followup to the PHPUnit 11 upgrade #5950 

Unfortunately the new PHPUnit versions have a not so pure design and thus exceptions thrown by `Assert::*` expect to get some random global state from $someWhere to do magic stuff.
And more unfortunately for us is that its fully intended and apparently not wanted to have other contexts using the `Assert::` class despite it being marked api?!.

There is currently no alternative id know which gives me the diff output id expect when working with php objects and values.
I think we should find a fork of PHPUnit which cleanly and purely exposes the `Assert` library as before. Or build it ourselves.

see https://github.com/Behat/Behat/issues/1618
