### PR TITLE
TASK: Replace deprecated addMethods() in tests

### DIFF
--- a/Neos.Media/Tests/Functional/AbstractTestCase.php
+++ b/Neos.Media/Tests/Functional/AbstractTestCase.php
@@ -57,7 +57,7 @@ abstract class AbstractTestCase extends FunctionalTestCase
     }
 
     /**
-     * Creates a mock ResourcePointer and PersistentResource from a given hash.
+     * Creates a mock PersistentResource from a given hash.
      * Make sure that a file representation already exists, e.g. with
      * file_put_content('resource://' . $hash) before
      *
@@ -66,13 +66,8 @@ abstract class AbstractTestCase extends FunctionalTestCase
      */
     protected function createMockResourceAndPointerFromHash($hash)
     {
-        $mockResource = $this->getMockBuilder(PersistentResource::class)->addMethods(['getHash', 'getUri'])->getMock();
-        $mockResource->expects(self::any())
-                ->method('getHash')
-                ->willReturn($hash);
-        $mockResource->expects(self::any())
-            ->method('getUri')
-            ->willReturn('resource://' . $hash);
+        $mockResource = $this->createMock(PersistentResource::class);
+        $mockResource->method('getSha1')->willReturn($hash);
         return $mockResource;
     }
 

--- a/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
+++ b/Neos.Media/Tests/Functional/Domain/Model/AssetTest.php
@@ -15,7 +15,6 @@ namespace Neos\Media\Tests\Functional\Domain\Model;
  */
 use Doctrine\Common\Collections\ArrayCollection;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
-use Neos\Flow\Persistence\Repository;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceInterface;
@@ -147,11 +146,20 @@ class AssetTest extends AbstractTestCase
         $mockExternalAssetSource = $this->getMockBuilder(AssetSourceInterface::class)->disableOriginalConstructor()->getMock();
         $this->inject($asset, 'assetSources', ['test-source' => $mockExternalAssetSource]);
 
-        $mockImportedAssetRepository = $this->getMockBuilder(Repository::class)->disableOriginalConstructor()->addMethods(['findOneByLocalAssetIdentifier'])->getMock();
-        $this->inject($asset, 'importedAssetRepository', $mockImportedAssetRepository);
+        // ImportedAssetRepository is final and cannot be doubled, so this records the lookup itself.
+        $importedAssetRepository = new class () {
+            public array $lookedUpIdentifiers = [];
 
-        $mockImportedAssetRepository->expects(self::atLeastOnce())->method('findOneByLocalAssetIdentifier')->with($asset->getIdentifier())->willReturn(null);
+            public function findOneByLocalAssetIdentifier(string $localAssetIdentifier)
+            {
+                $this->lookedUpIdentifiers[] = $localAssetIdentifier;
+                return null;
+            }
+        };
+        $this->inject($asset, 'importedAssetRepository', $importedAssetRepository);
+
         self::assertNull($asset->getAssetProxy());
+        self::assertSame([$asset->getIdentifier()], $importedAssetRepository->lookedUpIdentifiers);
     }
 
     /**

--- a/Neos.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Model/Adjustment/ResizeImageAdjustmentTest.php
@@ -27,7 +27,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function widthAndHeightDeterminedByExplicitlySetWidthAndHeightWithInsetMode()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy']);
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, []);
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(110, 83);
@@ -44,7 +44,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function widthAndHeightDeterminedByExplicitlySetWidthAndHeightWithOutboundMode()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy']);
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, []);
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(110, 110);
@@ -60,7 +60,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function ifWidthIsSetHeightIsDeterminedByTheOriginalAspectRatio()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy']);
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, []);
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(110, 83);
@@ -74,7 +74,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function ifHeightIsSetWidthIsDeterminedByTheOriginalAspectRatio()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy']);
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, []);
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box(127, 95);
@@ -88,7 +88,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function minimumHeightIsGreaterZero()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy'], [
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, [], [
             [
                 'maximumWidth' => 250,
                 'maximumHeight' => 250,
@@ -106,7 +106,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
     public function minimumWidthIsGreaterZero()
     {
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy'], [
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, [], [
             [
                 'maximumWidth' => 250,
                 'maximumHeight' => 250,
@@ -156,7 +156,7 @@ class ResizeImageAdjustmentTest extends UnitTestCase
         ];
 
         /** @var ResizeImageAdjustment $adjustment */
-        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, ['dummy'], [$options]);
+        $adjustment = $this->getAccessibleMock(ResizeImageAdjustment::class, [], [$options]);
 
         $originalDimensions = new Box(400, 300);
         $expectedDimensions = new Box($expectedWidth, $expectedHeight);

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetServiceTest.php
@@ -56,7 +56,7 @@ class AssetServiceTest extends UnitTestCase
             ->method('get')
             ->willReturn($this->createMock($expectedRepositoryClassName));
 
-        $mockAssetService = $this->getAccessibleMock(AssetService::class, ['dummy'], [], '', false);
+        $mockAssetService = $this->getAccessibleMock(AssetService::class, [], [], '', false);
         $this->inject($mockAssetService, 'objectManager', $mockObjectManager);
 
         $repository = $mockAssetService->_call('getRepository', $mockAsset);

--- a/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
+++ b/Neos.Media/Tests/Unit/Domain/Service/AssetVariantGeneratorTest.php
@@ -231,7 +231,6 @@ class AssetVariantGeneratorTest extends UnitTestCase
         $mock = $this->getMockBuilder(Image::class)
             ->setConstructorArgs([$this->createMock(PersistentResource::class)])
             ->onlyMethods(['refresh', 'getMediaType'])
-            ->addMethods(['renderResource'])
             ->getMock();
         $mock->method('getMediaType')->willReturn('image/jpeg');
 

--- a/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
+++ b/Neos.Neos/Tests/Unit/Domain/Service/DomainMatchingStrategyTest.php
@@ -38,10 +38,10 @@ class DomainMatchingStrategyTest extends UnitTestCase
     public function getSortedMatchesFiltersTheGivenDomainsByTheSpecifiedHostAndReturnsThemSortedWithBestMatchesFirst()
     {
         $mockDomains = [
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->onlyMethods([])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->onlyMethods([])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->onlyMethods([])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->onlyMethods([])->getMock(),
         ];
 
         $mockDomains[0]->setHostname('neos.io');
@@ -63,7 +63,7 @@ class DomainMatchingStrategyTest extends UnitTestCase
     public function getSortedMatchesReturnsNoMatchIfDomainIsLongerThanHostname()
     {
         $mockDomains = [
-            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->addMethods(['dummy'])->getMock(),
+            $this->getMockBuilder(Domain::class)->disableOriginalConstructor()->onlyMethods([])->getMock(),
         ];
 
         $mockDomains[0]->setHostname('flow.neos.io');

--- a/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
+++ b/Neos.Neos/Tests/Unit/Service/UserServiceTest.php
@@ -90,7 +90,7 @@ class UserServiceTest extends UnitTestCase
         $this->mockUserDomainService = $this->getMockBuilder(UserDomainService::class)->getMock();
         $this->inject($this->userService, 'userDomainService', $this->mockUserDomainService);
 
-        $this->mockWorkspaceRepository = $this->getMockBuilder(WorkspaceRepository::class)->disableOriginalConstructor()->addMethods(['findOneByName'])->getMock();
+        $this->mockWorkspaceRepository = $this->createMock(WorkspaceRepository::class);
         $this->inject($this->userService, 'workspaceRepository', $this->mockWorkspaceRepository);
 
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->getMock();

--- a/Neos.Neos/Tests/Unit/View/FusionViewTest.php
+++ b/Neos.Neos/Tests/Unit/View/FusionViewTest.php
@@ -100,7 +100,7 @@ class FusionViewTest extends UnitTestCase
     public function attemptToRenderWithoutNodeInformationAtAllThrowsException()
     {
         $this->expectException(Exception::class);
-        $view = $this->getAccessibleMock(FusionView::class, ['dummy']);
+        $view = $this->getAccessibleMock(FusionView::class, []);
         $view->render();
     }
 
@@ -108,7 +108,7 @@ class FusionViewTest extends UnitTestCase
     public function attemptToRenderWithInvalidNodeInformationThrowsException()
     {
         $this->expectException(Exception::class);
-        $view = $this->getAccessibleMock(FusionView::class, ['dummy']);
+        $view = $this->getAccessibleMock(FusionView::class, []);
         $view->_set('variables', ['value' => 'foo']);
         $view->render();
     }


### PR DESCRIPTION
MockBuilder::addMethods() is removed in PHPUnit 12 without replacement.

* getAccessibleMock(X::class, ['dummy']) becomes getAccessibleMock(X::class, []) - since PHPUnit 10 onlyMethods([]) already means "replace none of the real methods", which is what the 'dummy' idiom was for.
* DomainMatchingStrategyTest used the same idiom on a raw mock builder. Note that just dropping addMethods(['dummy']) would be wrong: without any onlyMethods()/addMethods() call the builder mocks *every* method. The equivalent is ->onlyMethods([]).
* AssetVariantGeneratorTest added Image::renderResource(), which only exists on ImageVariant and was never called on that mock.
* Neos.Media's functional AbstractTestCase added PersistentResource::getHash() and ::getUri(). Neither exists any more; getSha1() is the current equivalent.
* AssetTest doubled the generic Neos\Flow\Persistence\Repository and bolted findOneByLocalAssetIdentifier() on. ImportedAssetRepository declares that method but is final and cannot be doubled - and Flow injects through an untyped property, so a small anonymous class recording the lookup does the job without a test double.
* UserServiceTest is skipped in its entirety and WorkspaceRepository no longer exists, but the call is replaced too so it does not turn into a fatal once the test is revived.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the correct branch: The earliest possibe branch
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
