### PR TITLE
Experiment: Path-based queries vs CTEs

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/DoctrineDbalProjectionIntegrityViolatorTrait.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Bootstrap/DoctrineDbalProjectionIntegrityViolatorTrait.php
@@ -68,7 +68,7 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
         $record = $this->transformDatasetToHierarchyRelationRecord($dataset);
         $subtreeTags = NodeFactory::extractNodeTagsFromJson($record['subtreetags']);
         unset($record['subtreetags']);
-        unset($record['position']);
+        unset($record['sortpath']);
 
         if (!$subtreeTags->contain($subtreeTagToRemove)) {
             throw new \RuntimeException(sprintf('Failed to remove subtree tag "%s" because that tag is not set', $subtreeTagToRemove->value), 1708618267);
@@ -104,7 +104,7 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
     {
         $dataset = $this->transformPayloadTableToDataset($payloadTable);
         $record = $this->transformDatasetToHierarchyRelationRecord($dataset);
-        unset($record['position']);
+        unset($record['sortpath']);
         unset($record['subtreetags']);
 
         $newParentHierarchyRelation = $this->findHierarchyRelationByIds(
@@ -133,7 +133,7 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
     {
         $dataset = $this->transformPayloadTableToDataset($payloadTable);
         $record = $this->transformDatasetToHierarchyRelationRecord($dataset);
-        unset($record['position']);
+        unset($record['sortpath']);
         unset($record['subtreetags']);
 
         $this->dbal->update(
@@ -183,11 +183,11 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
     }
 
     /**
-     * @When /^I set the following position:$/
+     * @When /^I set the following sort path:$/
      * @param TableNode $payloadTable
      * @throws DBALException
      */
-    public function iSetTheFollowingPosition(TableNode $payloadTable): void
+    public function iSetTheFollowingSortPath(TableNode $payloadTable): void
     {
         $dataset = $this->transformPayloadTableToDataset($payloadTable);
         $dimensionSpacePoint = DimensionSpacePoint::fromArray($dataset['dimensionSpacePoint']);
@@ -205,7 +205,7 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
         $this->dbal->update(
             $this->tableNames()->hierarchyRelation(),
             [
-                'position' => $dataset['newPosition']
+                'sortpath' => $dataset['newSortPath']
             ],
             $record
         );
@@ -292,7 +292,7 @@ trait DoctrineDbalProjectionIntegrityViolatorTrait
             'dimensionspacepointhash' => $dimensionSpacePoint->hash,
             'parentnodeanchor' => $parentHierarchyRelation !== null ? $parentHierarchyRelation['childnodeanchor'] : 9999999,
             'childnodeanchor' => $childHierarchyRelation !== null ? $childHierarchyRelation['childnodeanchor'] : 8888888,
-            'position' => $dataset['position'] ?? $parentHierarchyRelation !== null ? $parentHierarchyRelation['position'] : 0,
+            'sortpath' => $dataset['sortpath'] ?? ($parentHierarchyRelation !== null ? $parentHierarchyRelation['sortpath'] : ''),
             'subtreetags' => $parentHierarchyRelation !== null ? $parentHierarchyRelation['subtreetags'] : '{}',
         ];
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/ProjectionIntegrityViolationDetection/SiblingsAreDistinctlySorted.feature
@@ -37,18 +37,18 @@ Feature: Run integrity violation detection regarding sibling sorting
       | nodeTypeName                | "Neos.ContentRepository.Testing:Document"                |
       | originDimensionSpacePoint   | {"language":"de"}                                        |
       | parentNodeAggregateId       | "lady-eleonode-rootford"                                 |
-    And I set the following position:
+    And I set the following sort path:
       | Key                  | Value              |
       | contentStreamId      | "cs-identifier"    |
       | dimensionSpacePoint  | {"language":"de"}  |
       | childNodeAggregateId | "nody-mc-nodeface" |
-      | newPosition          | 128                |
-    And I set the following position:
+      | newSortPath          | "a0"               |
+    And I set the following sort path:
       | Key                  | Value                   |
       | contentStreamId      | "cs-identifier"         |
       | dimensionSpacePoint  | {"language":"de"}       |
       | childNodeAggregateId | "noderella-mc-nodeface" |
-      | newPosition          | 128                     |
+      | newSortPath          | "a0"                    |
     And I run integrity violation detection
     Then I expect the integrity violation detection result to contain exactly 1 error
     And I expect integrity violation detection result error number 1 to have code 1597910918

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SiblingPositions.feature
@@ -1,8 +1,10 @@
 Feature: Sibling positions are properly resolved
 
-  In the general DBAL adapter, hierarchy relations are sorted by an integer field. It defaults to a distance of 128,
-  which is reduced each time a node is inserted between two siblings. Once the number becomes uneven, the siblings positions are recalculated.
-  These are the test cases for this behavior.
+  In the general DBAL adapter, hierarchy relations are sorted by a materialised sort path: one base 62 fractional
+  index key per tree level, joined with "/" (e.g. a0/a0/b3/ZzV). Inserting between two siblings generates a key
+  strictly between their two keys, so there is no fixed distance to run out of - the key simply grows, by roughly
+  0.17 characters per insert into the same gap. Only once a key passes NodeSortPath::MAX_KEY_LENGTH is the whole
+  sibling set rebalanced. These are the test cases for this behavior.
 
   Background:
     Given using the following content dimensions:
@@ -40,43 +42,38 @@ Feature: Sibling positions are properly resolved
 
   Scenario: Trigger position update in DBAL graph
     Given I am in workspace "live" and dimension space point {"example": "general"}
-    # distance i to x: 128
-    # distance ii to x: 64
+    # Every move below inserts into the same gap, directly before nodington-x. With the integer scheme the
+    # distance halved each time (128, 64, 32 ... 1) and the siblings had to be renumbered at the end; with
+    # fractional keys the key simply grows instead, and no renumbering happens at this scale.
     When the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-ii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    # distance iii to x: 32
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                        |
       | nodeAggregateId                     | "lady-nodette-nodington-iii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"   |
-    # distance iv to x: 16
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-iv" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    # distance v to x: 8
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                      |
       | nodeAggregateId                     | "lady-nodette-nodington-v" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x" |
-    # distance vi to x: 4
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-vi" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"  |
-    # distance vii to x: 2
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                        |
       | nodeAggregateId                     | "lady-nodette-nodington-vii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"   |
-    # distance viii to x: 1 -> reorder -> 128
+    # with the integer scheme this was the point the siblings had to be renumbered; fractional keys just grow
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                         |
       | nodeAggregateId                     | "lady-nodette-nodington-viii" |
       | newSucceedingSiblingNodeAggregateId | "lady-nodette-nodington-x"    |
-    # distance ix to x: 64 after reorder
     And the command MoveNodeAggregate is executed with payload:
       | Key                                 | Value                       |
       | nodeAggregateId                     | "lady-nodette-nodington-ix" |

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SubtreeTagHierarchyLayer.feature
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Behavior/Features/Projection/SubtreeTagHierarchyLayer.feature
@@ -48,8 +48,10 @@ Feature: Subtree tags are only inserted to the current write layer if differing 
       | newParentNodeAggregateId     | "lady-eleonode-rootford" |
 
     And I am in workspace "user"
-    # All 4 covered DSPs of the single node
-    Then I expect 4 hierarchies to exist in the active write layer
+    # The 4 covered DSPs of the moved node, plus the 4 of its single descendant: the descendant's sort
+    # path is built from the moved node's, so it is re-pathed into the write layer as well. This is the
+    # write amplification the materialised sort path trades for range-scan reads {@see NodeSortPath}.
+    Then I expect 8 hierarchies to exist in the active write layer
 
   Scenario: Move a node within a tagged subtree
   If not implemented carefully move node could create hierarchies for all descendents and tag them with the current tag
@@ -78,8 +80,10 @@ Feature: Subtree tags are only inserted to the current write layer if differing 
       | newParentNodeAggregateId     | "lady-abigail-nodenborough" |
 
     And I am in workspace "user"
-    # All 4 covered DSPs of the single node
-    Then I expect 4 hierarchies to exist in the active write layer
+    # The 4 covered DSPs of the moved node, plus the 4 of its single descendant: the descendant's sort
+    # path is built from the moved node's, so it is re-pathed into the write layer as well. This is the
+    # write amplification the materialised sort path trades for range-scan reads {@see NodeSortPath}.
+    Then I expect 8 hierarchies to exist in the active write layer
 
   Scenario: Tag a node in user where its child node and descendants are already tagged via live
     When the command TagSubtree is executed with payload:

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/Domain/Projection/NodeSortPathTest.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/Domain/Projection/NodeSortPathTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Tests\Domain\Projection;
+
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeSortPath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class NodeSortPathTest extends TestCase
+{
+    #[Test]
+    public function rootIsEmptyAndChildrenOfRootCarryBareKeys(): void
+    {
+        $root = NodeSortPath::root();
+        self::assertTrue($root->isRoot());
+        self::assertSame('', $root->value);
+        // root edges have no ingoing relation, so root nodes get a key without a leading separator
+        self::assertSame('a0', $root->child('a0')->value);
+    }
+
+    #[Test]
+    public function childAppendsWithSeparator(): void
+    {
+        self::assertSame('a0/b3/ZzV', NodeSortPath::fromString('a0/b3')->child('ZzV')->value);
+    }
+
+    #[Test]
+    public function localKeyIsTheLastSegment(): void
+    {
+        self::assertSame('ZzV', NodeSortPath::fromString('a0/b3/ZzV')->localKey());
+        self::assertSame('a0', NodeSortPath::fromString('a0')->localKey());
+    }
+
+    #[Test]
+    public function parentStripsTheLastSegment(): void
+    {
+        self::assertSame('a0/b3', NodeSortPath::fromString('a0/b3/ZzV')->parent()->value);
+        self::assertTrue(NodeSortPath::fromString('a0')->parent()->isRoot());
+    }
+
+    #[Test]
+    public function ancestorPathsAreTheProperPrefixesClosestFirst(): void
+    {
+        self::assertSame(['a0/b3', 'a0'], NodeSortPath::fromString('a0/b3/ZzV')->ancestorPaths());
+        self::assertSame([], NodeSortPath::fromString('a0')->ancestorPaths());
+    }
+
+    #[Test]
+    public function depthCountsSegments(): void
+    {
+        self::assertSame(0, NodeSortPath::root()->depth());
+        self::assertSame(1, NodeSortPath::fromString('a0')->depth());
+        self::assertSame(3, NodeSortPath::fromString('a0/b3/ZzV')->depth());
+    }
+
+    /**
+     * The descendant range must contain every descendant and nothing else. That works because the separator
+     * '/' is 0x2F, directly below '0' (0x30), the lowest base 62 digit.
+     */
+    #[DataProvider('dataForDescendantRange')]
+    #[Test]
+    public function descendantRangeIsExact(string $candidate, bool $expectedInRange): void
+    {
+        $node = NodeSortPath::fromString('a0/b3');
+        $inRange = strcmp($candidate, $node->rangeStart()) >= 0 && strcmp($candidate, $node->rangeEnd()) < 0;
+        self::assertSame($expectedInRange, $inRange, sprintf('"%s" should%s be in range', $candidate, $expectedInRange ? '' : ' not'));
+    }
+
+    public static function dataForDescendantRange(): iterable
+    {
+        yield 'direct child' => ['a0/b3/a0', true];
+        yield 'grandchild' => ['a0/b3/a0/ZzV', true];
+        yield 'lowest possible child key' => ['a0/b3/A00000000000000000000000001', true];
+        yield 'the node itself' => ['a0/b3', false];
+        yield 'preceding sibling' => ['a0/b2', false];
+        // 'V' (0x56) sorts above '/' (0x2F), so a sibling with a longer key stays outside the range
+        yield 'succeeding sibling with longer key' => ['a0/b3V', false];
+        // a legal key: head 'b' denotes a three character integer part, so it lands exactly on the upper bound
+        yield 'succeeding sibling keyed exactly at the upper bound' => ['a0/b30', false];
+        yield 'descendant of that sibling' => ['a0/b30/a0', false];
+        yield 'unrelated branch' => ['a1/a0', false];
+    }
+
+    #[Test]
+    public function rangeBoundsAreTheExpectedLiterals(): void
+    {
+        $node = NodeSortPath::fromString('a0/b3');
+        self::assertSame('a0/b3/', $node->rangeStart());
+        self::assertSame('a0/b30', $node->rangeEnd());
+    }
+
+    #[Test]
+    public function rangeAccessorsRejectTheRootPath(): void
+    {
+        $this->expectExceptionCode(1775980003);
+        NodeSortPath::root()->rangeStart();
+    }
+
+    #[Test]
+    public function anOverLongKeyIsRecoverableByRebalancing(): void
+    {
+        $longKey = NodeSortPath::fromString('a0/' . str_repeat('z', NodeSortPath::MAX_KEY_LENGTH + 1));
+        self::assertTrue($longKey->exceedsMaxKeyLength());
+        // it still fits the column, so the rebalance gets a chance to run before anything is written
+        $longKey->assertFitsColumn();
+    }
+
+    #[Test]
+    public function anOverLongPathIsNotRecoverableAndThrows(): void
+    {
+        // short keys throughout, just too many levels - no rebalance can shorten this
+        $tooDeep = NodeSortPath::fromString(substr(str_repeat('a0/', NodeSortPath::MAX_LENGTH), 0, NodeSortPath::MAX_LENGTH + 1));
+        self::assertFalse($tooDeep->exceedsMaxKeyLength());
+
+        $this->expectExceptionCode(1775980001);
+        $tooDeep->assertFitsColumn();
+    }
+
+    /**
+     * Ordering the paths as raw bytes must yield depth-first document order. This is the property the
+     * VARBINARY column type exists to guarantee: under the server default case-insensitive collations
+     * 'Z' would equal 'z' and this ordering would silently fall apart.
+     */
+    #[Test]
+    public function byteOrderingYieldsDocumentOrder(): void
+    {
+        $paths = ['a0/b3/ZzV', 'a1', 'a0', 'a0/b3', 'a0/b30', 'a0/a0', 'a0/b3/a0'];
+        usort($paths, static fn (string $a, string $b): int => strcmp($a, $b));
+
+        self::assertSame([
+            'a0',
+            'a0/a0',
+            'a0/b3',
+            'a0/b3/ZzV',
+            'a0/b3/a0',
+            'a0/b30',
+            'a1',
+        ], $paths);
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/FractionalIndexingTest.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Tests/Unit/FractionalIndexingTest.php
@@ -1,0 +1,171 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\Tests\Unit;
+
+use Neos\ContentGraph\DoctrineDbalAdapter\FractionalIndexing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class FractionalIndexingTest extends TestCase
+{
+
+    #[DataProvider('dataForTestGenerateKeyBetween')]
+    #[Test]
+    public function testGenerateKeyBetween($a, $b, $expected)
+    {
+        $this->assertEquals($expected, FractionalIndexing::generateKeyBetween($a, $b));
+    }
+
+    public static function dataForTestGenerateKeyBetween()
+    {
+        return [
+            [null, null, 'a0'],
+            [null, 'a0', 'Zz'],
+            ["a0", null, "a1"],
+            ["a0", "a1", "a0V"],
+            ["a0V", "a1", "a0l"],
+            ["Zz", "a0", "ZzV"],
+            ["Zz", "a1", "a0"],
+            [null, "Y00", "Xzzz"],
+            ["bzz", null, "c000"],
+            ["a0", "a0V", "a0G"],
+            ["a0", "a0G", "a08"],
+            ["b125", "b129", "b127"],
+            ["a0", "a1V", "a1"],
+            ["Zz", "a01", "a0"],
+            [null, "a0V", "a0"],
+            [null, "b999", "b99"],
+            [null, "A000000000000000000000000001", "A000000000000000000000000000V"],
+            ["zzzzzzzzzzzzzzzzzzzzzzzzzzy", null, "zzzzzzzzzzzzzzzzzzzzzzzzzzz"],
+            ["zzzzzzzzzzzzzzzzzzzzzzzzzzz", null, "zzzzzzzzzzzzzzzzzzzzzzzzzzzV"],
+            ["ZzI", "ZzIV", "ZzIG"],
+            ["d153V", "d3B81", "d153W"],
+            ["d153W", "d3B81", "d153X"],
+            ["d153X", "d3B81", "d153Y"],
+            ["d153Y", "d3B81", "d153Z"],
+        ];
+    }
+
+    #[DataProvider('dataForTestGenerateKeyBetweenValidation')]
+    #[Test]
+    public function testGenerateKeyBetweenValidation($a, $b)
+    {
+        $this->expectException(\RuntimeException::class);
+        FractionalIndexing::generateKeyBetween($a, $b);
+    }
+
+    public static function dataForTestGenerateKeyBetweenValidation()
+    {
+        return [
+            [null, "A00000000000000000000000000"],
+            ['a00', null],
+            ['a00', 'a1'],
+            ['0', '1'],
+            ['a1', 'a0'],
+        ];
+    }
+
+    #[DataProvider('dataForTestGenerateKeyBetweenInsertAlwaysBefore')]
+    #[Test]
+    public function testGenerateKeyBetweenInsertAlwaysBefore(int $iterations, string $expected)
+    {
+
+        $a = null;
+        $b = null;
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $b = FractionalIndexing::generateKeyBetween($a, $b);
+        }
+
+        $this->assertEquals($expected, $b);
+    }
+
+    public static function dataForTestGenerateKeyBetweenInsertAlwaysBefore()
+    {
+        yield [1, 'a0'];
+        yield [10, 'Zr'];
+        yield [100, 'YzP'];
+        yield [1000, 'Ykt'];
+        yield [10000, 'XyPj'];
+        yield [100000, 'Xb07'];
+        yield [1000000, 'Wworz'];
+    }
+
+    #[DataProvider('dataForTestGenerateKeyBetweenInsertAlwaysAfter')]
+    #[Test]
+    public function testGenerateKeyBetweenInsertAlwaysAfter(int $iterations, string $expected)
+    {
+
+        $a = null;
+        $b = null;
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $a = FractionalIndexing::generateKeyBetween($a, $b);
+        }
+
+        $this->assertEquals($expected, $a);
+    }
+
+    public static function dataForTestGenerateKeyBetweenInsertAlwaysAfter()
+    {
+        yield [1, 'a0'];
+        yield [10, 'a9'];
+        yield [100, 'b0b'];
+        yield [1000, 'bF7'];
+        yield [10000, 'c1aH'];
+        yield [100000, 'cOzt'];
+        yield [1000000, 'd3B81'];
+    }
+
+    #[DataProvider('dataForTestGenerateKeyBetweenInsertAlwaysIntoSameGap')]
+    #[Test]
+    public function testGenerateKeyBetweenInsertAlwaysIntoSameGap(int $iterations, string $expected)
+    {
+
+        $a = FractionalIndexing::generateKeyBetween(null, null);
+        $b = FractionalIndexing::generateKeyBetween($a, null);
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $b = FractionalIndexing::generateKeyBetween($a, $b);
+        }
+
+        $this->assertEquals($expected, $b);
+    }
+
+    public static function dataForTestGenerateKeyBetweenInsertAlwaysIntoSameGap()
+    {
+        yield [1, 'a0V']; // 3 chars
+        yield [10, 'a004']; // 4 chars
+        yield [100, 'a000000000000000004']; // 19 chard
+        yield [128, 'a0000000000000000000000G']; // 24 chars
+        // 169 chars
+        yield [1000, 'a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004'];
+        // 1669 chars
+        yield [10000, 'a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004'];
+    }
+
+    #[DataProvider('dataForTestGenerateNKeysBetween')]
+    #[Test]
+    public function testGenerateNKeysBetween($a, $b, $numberOfKeys, $expectedLowestKey, $expectedMiddleKey, $expectedHighestKey)
+    {
+
+        $keys = FractionalIndexing::generateNKeysBetween($a, $b, $numberOfKeys);
+
+        $this->assertCount($numberOfKeys, $keys);
+        $this->assertEquals($expectedLowestKey, $keys[0], 'Lowest key should be the same');
+        $this->assertEquals($expectedMiddleKey, $keys[ceil((count($keys) / 2) - 1) ], 'Middle key should be the same');
+        $this->assertEquals($expectedHighestKey, $keys[count($keys) - 1], 'Highest key should be the same');
+    }
+
+    public static function dataForTestGenerateNKeysBetween()
+    {
+        yield [null, null, 10, 'a0', 'a4', 'a9']; // 2 chars
+        yield [null, null, 100, 'a0', 'an', 'b0b']; // 3 chars
+        yield [null, null, 1000, 'a0', 'b73', 'bF7']; // 3 chars
+        yield [null, null, 10000, 'a0', 'c0Hd', 'c1aH']; // 4 chars
+        yield [null, null, 100000, 'a0', 'cBzR', 'cOzt']; // 4 chars
+        yield [null, null, 1000000, 'a0', 'd153V', 'd3B81']; // 5 chars
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphProjection.php
@@ -19,6 +19,7 @@ use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelationId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRecord;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeSortPath;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentStreamLayerFinder;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\DimensionSpacePointsRepository;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ProjectionContentGraph;
@@ -86,8 +87,6 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
     use NodeVariation;
     use SubtreeTagging;
     use Workspace;
-
-    public const RELATION_DEFAULT_OFFSET = 128;
 
     private SqlTableSubqueryFactory $subqueries;
 
@@ -308,7 +307,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                   contentstreamlayer,
                   parentnodeanchor,
                   childnodeanchor,
-                  position,
+                  sortpath,
                   subtreetags,
                   dimensionspacepointhash
                 )
@@ -317,7 +316,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                   :contentStreamLayerToMergeInto AS contentstreamlayer,
                   h.parentnodeanchor,
                   h.childnodeanchor,
-                  h.position,
+                  h.sortpath,
                   h.subtreetags,
                   h.dimensionspacepointhash
                 -- using table instead of HierarchyRelationStatement because merging is a low level operation and combines exactly two layers without taking any other layers into account
@@ -328,7 +327,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 ON DUPLICATE KEY UPDATE
                   parentnodeanchor = VALUES(parentnodeanchor),
                   childnodeanchor = VALUES(childnodeanchor),
-                  position = VALUES(position),
+                  sortpath = VALUES(sortpath),
                   subtreetags = VALUES(subtreetags),
                   dimensionspacepointhash = VALUES(dimensionspacepointhash)
                 SQL;
@@ -428,7 +427,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               contentstreamlayer,
               parentnodeanchor,
               childnodeanchor,
-              position,
+              sortpath,
               subtreetags,
               dimensionspacepointhash
             )
@@ -436,7 +435,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               :targetContentStreamLayer as contentstreamlayer,
               h.parentnodeanchor,
               h.childnodeanchor,
-              h.position,
+              h.sortpath,
               h.subtreetags,
               :newDimensionSpacePointHash AS dimensionspacepointhash
             FROM
@@ -504,7 +503,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               contentstreamlayer,
               parentnodeanchor,
               childnodeanchor,
-              position,
+              sortpath,
               subtreetags,
               dimensionspacepointhash
             )
@@ -513,7 +512,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
               :targetContentStreamLayer as contentstreamlayer,
               h.parentnodeanchor,
               h.childnodeanchor,
-              h.position,
+              h.sortpath,
               h.subtreetags,
               :newDimensionSpacePointHash AS dimensionspacepointhash
             FROM {$hierarchyRelationQuery->toSql()} AS h
@@ -919,7 +918,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                   id,
                   parentnodeanchor,
                   childnodeanchor,
-                  position,
+                  sortpath,
                   subtreetags,
                   dimensionspacepointhash,
                   contentstreamlayer
@@ -930,7 +929,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                   IF(h.parentnodeanchor = :originalNodeAnchor, :newNodeAnchor, h.parentnodeanchor) as parentnodeanchor,
                   -- if our (copied) node is the child, we update h.childNodeAnchor
                   IF(h.childnodeanchor = :originalNodeAnchor, :newNodeAnchor, h.childnodeanchor) as childnodeanchor,
-                  h.position,
+                  h.sortpath,
                   h.subtreetags,
                   h.dimensionspacepointhash,
                   :targetContentStreamLayer as contentstreamlayer
@@ -1094,7 +1093,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         ?NodeRelationAnchorPoint $succeedingSiblingNodeAnchorPoint,
     ): void {
         foreach ($dimensionSpacePointSet as $dimensionSpacePoint) {
-            $position = $this->getRelationPosition(
+            $sortPath = $this->getRelationSortPath(
                 $parentNodeAnchorPoint,
                 null,
                 $succeedingSiblingNodeAnchorPoint,
@@ -1112,7 +1111,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $childNodeAnchorPoint,
                 $dimensionSpacePoint,
                 $dimensionSpacePoint->hash,
-                $position,
+                $sortPath,
                 $inheritedSubtreeTags,
             );
 
@@ -1120,14 +1119,14 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
         }
     }
 
-    private function getRelationPosition(
+    private function getRelationSortPath(
         ?NodeRelationAnchorPoint $parentAnchorPoint,
         ?NodeRelationAnchorPoint $childAnchorPoint,
         ?NodeRelationAnchorPoint $succeedingSiblingAnchorPoint,
         ContentStreamLayers $contentStreamLayers,
         DimensionSpacePoint $dimensionSpacePoint
-    ): int {
-        $position = $this->projectionContentGraph->determineHierarchyRelationPosition(
+    ): NodeSortPath {
+        $sortPath = $this->projectionContentGraph->determineHierarchySortPath(
             $parentAnchorPoint,
             $childAnchorPoint,
             $succeedingSiblingAnchorPoint,
@@ -1135,8 +1134,10 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             $dimensionSpacePoint
         );
 
-        if ($position % 2 !== 0) {
-            $position = $this->getRelationPositionAfterRecalculation(
+        // This replaces the odd/even heuristic of the integer scheme. Fractional indexing never runs out of
+        // room - keys just get longer - so the trigger is length, and the fallback is a rebalance of the level.
+        if ($sortPath->exceedsMaxKeyLength()) {
+            $sortPath = $this->rebalanceSiblingKeys(
                 $parentAnchorPoint,
                 $childAnchorPoint,
                 $succeedingSiblingAnchorPoint,
@@ -1145,25 +1146,36 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             );
         }
 
-        return $position;
+        // only meaningful once the value is final: a rebalance is exactly what makes an over-long key short again
+        $sortPath->assertFitsColumn();
+
+        return $sortPath;
     }
 
-    private function getRelationPositionAfterRecalculation(
+    /**
+     * Regenerates the keys of a whole sibling set and returns the slot reserved for the incoming node.
+     *
+     * The new keys are generated *above* the current maximum key rather than from scratch. That is what makes
+     * the rewrite collision free: every new key is strictly greater than every old one, so assigning a new key
+     * can never land on a slot an unprocessed sibling still occupies. The keys stay short regardless, because
+     * generateKeyBetween($max, null) increments the integer part and drops the fraction entirely.
+     *
+     * Unlike the integer renumbering this replaced, rebalancing is O(subtree) rather than O(siblings): changing
+     * a sibling's key changes the prefix of everything beneath it, so each sibling's descendants are re-pathed.
+     */
+    private function rebalanceSiblingKeys(
         ?NodeRelationAnchorPoint $parentAnchorPoint,
         ?NodeRelationAnchorPoint $childAnchorPoint,
         ?NodeRelationAnchorPoint $succeedingSiblingAnchorPoint,
         ContentStreamLayers $contentStreamLayers,
         DimensionSpacePoint $dimensionSpacePoint
-    ): int {
+    ): NodeSortPath {
         if (!$childAnchorPoint && !$parentAnchorPoint) {
             throw new \InvalidArgumentException(
-                'You must either specify a parent or child node anchor'
-                . ' to get relation positions after recalculation.',
+                'You must either specify a parent or child node anchor to rebalance sibling keys.',
                 1519847858
             );
         }
-        $offset = 0;
-        $position = 0;
         $hierarchyRelations = $parentAnchorPoint
             ? $this->projectionContentGraph->getOutgoingHierarchyRelationsForNodeAndSubgraph(
                 $parentAnchorPoint,
@@ -1176,24 +1188,172 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
                 $dimensionSpacePoint
             );
 
+        if ($hierarchyRelations === []) {
+            // unreachable in practice: with no siblings the generated key is "a0", which never exceeds the limit
+            throw new \RuntimeException('Cannot rebalance an empty sibling set', 1775980020);
+        }
+
         usort(
             $hierarchyRelations,
-            static fn (HierarchyRelation $relationA, HierarchyRelation $relationB): int => $relationA->position <=> $relationB->position
+            static fn (HierarchyRelation $relationA, HierarchyRelation $relationB): int
+                => strcmp($relationA->sortPath->value, $relationB->sortPath->value)
         );
 
+        $parentSortPath = $hierarchyRelations[0]->sortPath->parent();
+        $greatestKey = $hierarchyRelations[array_key_last($hierarchyRelations)]->sortPath->localKey();
+        // one key per existing sibling, plus one for the node being inserted
+        $keys = array_map(
+            static function (?string $key): string {
+                if ($key === null || $key === '') {
+                    throw new \RuntimeException('Failed to generate fractional index keys while rebalancing a sibling set', 1775980024);
+                }
+                return $key;
+            },
+            FractionalIndexing::generateNKeysBetween($greatestKey, null, count($hierarchyRelations) + 1)
+        );
+
+        $reservedSortPath = null;
+        $keyIndex = 0;
         foreach ($hierarchyRelations as $relation) {
-            $offset += self::RELATION_DEFAULT_OFFSET;
             if (
                 $succeedingSiblingAnchorPoint
                 && $relation->childNodeAnchor->equals($succeedingSiblingAnchorPoint)
             ) {
-                $position = $offset;
-                $offset += self::RELATION_DEFAULT_OFFSET;
+                // the incoming node takes the slot directly before its succeeding sibling
+                $reservedSortPath = $parentSortPath->child($keys[$keyIndex]);
+                $keyIndex++;
             }
-            $relation->assignNewPosition($offset, $this->dbal, $this->tableNames);
+            $this->assignRebalancedSortPath(
+                $relation,
+                $parentSortPath->child($keys[$keyIndex]),
+                $contentStreamLayers,
+                $dimensionSpacePoint
+            );
+            $keyIndex++;
         }
 
-        return $position;
+        // without a succeeding sibling the incoming node is appended, so it takes the last remaining slot
+        return $reservedSortPath ?? $parentSortPath->child($keys[$keyIndex]);
+    }
+
+    private function assignRebalancedSortPath(
+        HierarchyRelation $relation,
+        NodeSortPath $newSortPath,
+        ContentStreamLayers $contentStreamLayers,
+        DimensionSpacePoint $dimensionSpacePoint,
+    ): void {
+        $oldSortPath = $relation->sortPath;
+        if ($oldSortPath->equals($newSortPath)) {
+            return;
+        }
+        $newSortPath->assertFitsColumn();
+        $this->repathDescendants($contentStreamLayers, $dimensionSpacePoint, $oldSortPath, $newSortPath);
+
+        if ($contentStreamLayers->getWriteLayer()->equals($relation->contentStreamLayer)) {
+            $relation->assignNewSortPath($newSortPath, $this->dbal, $this->tableNames);
+            return;
+        }
+        // The relation lives in a shared lower layer, which must stay immutable, so copy it up instead of
+        // updating in place. The integer renumbering this replaced got exactly this wrong.
+        $relation
+            ->with(contentStreamLayer: $contentStreamLayers->getWriteLayer(), sortPath: $newSortPath)
+            ->addToDatabase($this->dbal, $this->tableNames);
+    }
+
+    /**
+     * Rewrites the sort path prefix of every descendant of $oldSortPath to $newSortPath, into the write layer.
+     *
+     * Because the path is materialised, the descendants are exactly the contiguous range
+     * [oldPath . '/', oldPath . '0') - so this needs no recursive CTE, only an index range scan.
+     */
+    private function repathDescendants(
+        ContentStreamLayers $contentStreamLayers,
+        DimensionSpacePoint $dimensionSpacePoint,
+        NodeSortPath $oldSortPath,
+        NodeSortPath $newSortPath,
+    ): void {
+        if ($oldSortPath->equals($newSortPath)) {
+            return;
+        }
+
+        // The range predicate must go through withWhereCondition(), never the id-based prefilter:
+        // sortpath is not layer invariant {@see HierarchyRelationSubquery}.
+        $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)
+            ->withDimensionSpacePoint($dimensionSpacePoint)
+            ->withWhereCondition(StaticWhereCondition::fromString('h', 'h.sortpath >= :descendantRangeStart AND h.sortpath < :descendantRangeEnd'));
+        $rangeParameters = [
+            'descendantRangeStart' => $oldSortPath->rangeStart(),
+            'descendantRangeEnd' => $oldSortPath->rangeEnd(),
+        ];
+
+        // Guard the column width in PHP: without STRICT_TRANS_TABLES, MariaDB would truncate the CONCAT result
+        // instead of erroring, which corrupts the ordering silently.
+        $longestDescendantStatement = <<<SQL
+            SELECT
+                MAX(LENGTH(h.sortpath))
+            FROM
+                {$hierarchyRelationQuery->toSql()} h
+            SQL;
+        try {
+            $longestDescendantLength = (int)$this->dbal->fetchOne($longestDescendantStatement, [
+                ...$rangeParameters,
+                ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
+            ], [
+                ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to determine the longest descendant sort path below %s: %s', $oldSortPath->value, $e->getMessage()), 1775980021, $e);
+        }
+        if ($longestDescendantLength === 0) {
+            return;
+        }
+        $longestResultingLength = $longestDescendantLength - strlen($oldSortPath->value) + strlen($newSortPath->value);
+        if ($longestResultingLength > NodeSortPath::MAX_LENGTH) {
+            throw new \RuntimeException(sprintf(
+                'Re-pathing the subtree of "%s" to "%s" would produce a sort path of %d bytes, exceeding the maximum of %d',
+                $oldSortPath->value,
+                $newSortPath->value,
+                $longestResultingLength,
+                NodeSortPath::MAX_LENGTH
+            ), 1775980022);
+        }
+
+        $repathStatement = <<<SQL
+            INSERT INTO {$this->tableNames->hierarchyRelation()} (
+              id,
+              parentnodeanchor,
+              childnodeanchor,
+              sortpath,
+              subtreetags,
+              dimensionspacepointhash,
+              contentstreamlayer
+            )
+            SELECT
+              h.id,
+              h.parentnodeanchor,
+              h.childnodeanchor,
+              CONCAT(:newSortPath, SUBSTRING(h.sortpath, :oldSortPathLength + 1)) AS sortpath,
+              h.subtreetags,
+              h.dimensionspacepointhash,
+              :targetContentStreamLayer AS contentstreamlayer
+            FROM
+              {$hierarchyRelationQuery->toSql()} h
+            ON DUPLICATE KEY UPDATE sortpath = VALUES(sortpath)
+            SQL;
+        try {
+            $this->dbal->executeStatement($repathStatement, [
+                'newSortPath' => $newSortPath->value,
+                // passed as an int rather than LENGTH(:oldSortPath) so the optimizer sees a constant
+                'oldSortPathLength' => strlen($oldSortPath->value),
+                'targetContentStreamLayer' => $contentStreamLayers->getWriteLayer()->value,
+                ...$rangeParameters,
+                ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
+            ], [
+                ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to re-path the subtree of "%s" to "%s": %s', $oldSortPath->value, $newSortPath->value, $e->getMessage()), 1775980023, $e);
+        }
     }
 
     private function copyHierarchyRelationToDimensionSpacePoint(
@@ -1213,7 +1373,7 @@ final class DoctrineDbalContentGraphProjection implements ContentGraphProjection
             $newChild,
             $dimensionSpacePoint,
             $dimensionSpacePoint->hash,
-            $this->getRelationPosition(
+            $this->getRelationSortPath(
                 $newParent,
                 $newChild,
                 $newSucceedingSibling,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/DoctrineDbalContentGraphSchemaBuilder.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeSortPath;
 use Neos\ContentRepository\Dbal\DbalSchemaFactory;
 
 /**
@@ -64,7 +65,7 @@ class DoctrineDbalContentGraphSchemaBuilder
         $table = self::createTable($this->tableNames->hierarchyRelation(), [
             (new Column('id', Type::getType(Types::INTEGER)))->setAutoincrement(true)->setNotnull(true),
             (new Column('contentstreamlayer', self::type(Types::INTEGER)))->setNotnull(true),
-            (new Column('position', self::type(Types::INTEGER)))->setNotnull(false),
+            (new Column('sortpath', self::type(Types::BINARY)))->setLength(NodeSortPath::MAX_LENGTH)->setNotnull(false),
             DbalSchemaFactory::columnForDimensionSpacePointHash('dimensionspacepointhash', $platform)->setNotnull(false),
             DbalSchemaFactory::columnForNodeAnchorPoint('parentnodeanchor', $platform)->setNotnull(false),
             DbalSchemaFactory::columnForNodeAnchorPoint('childnodeanchor', $platform)->setNotnull(false),
@@ -77,11 +78,15 @@ class DoctrineDbalContentGraphSchemaBuilder
             ->addIndex(['childnodeanchor'])
             ->addIndex(['contentstreamlayer'])
             ->addIndex(['parentnodeanchor'])
-            ->addIndex(['position'])
-            /** Optimize the $rightmostSucceedingSiblingRelationStatement in {@see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ProjectionContentGraph::determineHierarchyRelationPosition()} */
-            ->addIndex(['parentnodeanchor', 'position'])
-            ->addIndex(['childnodeanchor', 'contentstreamlayer', 'dimensionspacepointhash', 'position'])
-            ->addIndex(['parentnodeanchor', 'contentstreamlayer', 'dimensionspacepointhash', 'position'])
+            /** Optimize the $rightmostSucceedingSiblingRelationStatement in {@see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ProjectionContentGraph::determineHierarchySortPath()} */
+            ->addIndex(['parentnodeanchor', 'sortpath'])
+            ->addIndex(['childnodeanchor', 'contentstreamlayer', 'dimensionspacepointhash'])
+            ->addIndex(['parentnodeanchor', 'contentstreamlayer', 'dimensionspacepointhash', 'sortpath'])
+            /**
+             * Serves the subtree range scans over {@see NodeSortPath::rangeStart()} / {@see NodeSortPath::rangeEnd()},
+             * which replace the recursive CTEs in {@see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\ContentSubgraph}.
+             */
+            ->addIndex(['contentstreamlayer', 'dimensionspacepointhash', 'sortpath'])
             ->addIndex(['contentstreamlayer', 'dimensionspacepointhash']);
     }
 

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeMove.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeMove.php
@@ -91,7 +91,7 @@ trait NodeMove
         }
 
         // fetch...
-        $newPosition = $this->getRelationPosition(
+        $newSortPath = $this->getRelationSortPath(
             $ingoingHierarchyRelation->parentNodeAnchor,
             null,
             $newSucceedingSibling?->relationAnchorPoint,
@@ -99,17 +99,33 @@ trait NodeMove
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
 
-        // ...and assign the new position
+        // A rebalance inside getRelationSortPath() may have re-pathed this very relation - the node being moved
+        // is itself a member of the sibling set here - so re-read it before using its path as the re-path source.
+        $ingoingHierarchyRelation = $this->findIngoingHierarchyRelationToBeMoved(
+            $nodeToBeMoved,
+            $contentStreamLayers,
+            $succeedingSiblingForCoverage->dimensionSpacePoint
+        );
+
+        // the descendants' paths are built from this node's, so the whole subtree moves with it
+        $this->repathDescendants(
+            $contentStreamLayers,
+            $succeedingSiblingForCoverage->dimensionSpacePoint,
+            $ingoingHierarchyRelation->sortPath,
+            $newSortPath
+        );
+
+        // ...and assign the new sort path
         if ($contentStreamLayers->getWriteLayer()->equals($ingoingHierarchyRelation->contentStreamLayer)) {
-            $ingoingHierarchyRelation->assignNewPosition(
-                $newPosition,
+            $ingoingHierarchyRelation->assignNewSortPath(
+                $newSortPath,
                 $this->dbal,
                 $this->tableNames
             );
         } else {
             $copiedHierarchyRelation = $ingoingHierarchyRelation->with(
                 contentStreamLayer: $contentStreamLayers->getWriteLayer(),
-                position: $newPosition,
+                sortPath: $newSortPath,
             );
             $copiedHierarchyRelation->addToDatabase(
                 $this->dbal,
@@ -162,8 +178,8 @@ trait NodeMove
             }
         }
 
-        // assign new position
-        $newPosition = $this->getRelationPosition(
+        // assign new sort path
+        $newSortPath = $this->getRelationSortPath(
             $newParent->relationAnchorPoint,
             null,
             $newSucceedingSibling?->relationAnchorPoint,
@@ -171,11 +187,26 @@ trait NodeMove
             $succeedingSiblingForCoverage->dimensionSpacePoint
         );
 
+        // a rebalance inside getRelationSortPath() may have re-pathed relations, so re-read before re-pathing
+        $ingoingHierarchyRelation = $this->findIngoingHierarchyRelationToBeMoved(
+            $nodeToBeMoved,
+            $contentStreamLayers,
+            $succeedingSiblingForCoverage->dimensionSpacePoint
+        );
+
+        // the descendants' paths are built from this node's, so the whole subtree moves with it
+        $this->repathDescendants(
+            $contentStreamLayers,
+            $succeedingSiblingForCoverage->dimensionSpacePoint,
+            $ingoingHierarchyRelation->sortPath,
+            $newSortPath
+        );
+
         // this is the actual move
         if ($contentStreamLayers->getWriteLayer()->equals($ingoingHierarchyRelation->contentStreamLayer)) {
             $ingoingHierarchyRelation->assignNewParentNode(
                 $newParent->relationAnchorPoint,
-                $newPosition,
+                $newSortPath,
                 $this->dbal,
                 $this->tableNames
             );
@@ -183,7 +214,7 @@ trait NodeMove
             $copiedHierarchyRelation = $ingoingHierarchyRelation->with(
                 parentNodeAnchor: $newParent->relationAnchorPoint,
                 contentStreamLayer: $contentStreamLayers->getWriteLayer(),
-                position: $newPosition,
+                sortPath: $newSortPath,
             );
             $copiedHierarchyRelation->addToDatabase(
                 $this->dbal,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeRemoval.php
@@ -76,7 +76,7 @@ trait NodeRemoval
                   id,
                   parentnodeanchor,
                   childnodeanchor,
-                  position,
+                  sortpath,
                   subtreetags,
                   dimensionspacepointhash,
                   contentstreamlayer
@@ -85,7 +85,7 @@ trait NodeRemoval
                   h.id,
                   NULL as parentnodeanchor,
                   NULL as childnodeanchor,
-                  NULL as position,
+                  NULL as sortpath,
                   NULL as subtreetags,
                   NULL as dimensionspacepointhash,
                   :targetContentStreamLayer as contentstreamlayer

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeVariation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/NodeVariation.php
@@ -103,7 +103,9 @@ trait NodeVariation
                     $specializedNode->relationAnchorPoint,
                     $uncoveredDimensionSpacePoint,
                     $uncoveredDimensionSpacePoint->hash,
-                    $this->projectionContentGraph->determineHierarchyRelationPosition(
+                    // routed through getRelationSortPath() rather than calling the repository directly, so that
+                    // an over-long key triggers a rebalance here too - the direct call used to bypass that guard
+                    $this->getRelationSortPath(
                         $parentNode->relationAnchorPoint,
                         $specializedNode->relationAnchorPoint,
                         $specializationSucceedingSiblingNode?->relationAnchorPoint,

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/Feature/SubtreeTagging.php
@@ -35,7 +35,7 @@ trait SubtreeTagging
               id,
               parentnodeanchor,
               childnodeanchor,
-              position,
+              sortpath,
               subtreetags,
               dimensionspacepointhash,
               contentstreamlayer
@@ -44,7 +44,7 @@ trait SubtreeTagging
               h.id,
               h.parentnodeanchor,
               h.childnodeanchor,
-              h.position,
+              h.sortpath,
               JSON_INSERT(h.subtreetags, :tagPath, null) as subtreetags,
               h.dimensionspacepointhash,
               :targetContentStreamLayer as contentstreamlayer
@@ -102,7 +102,7 @@ trait SubtreeTagging
               id,
               parentnodeanchor,
               childnodeanchor,
-              position,
+              sortpath,
               subtreetags,
               dimensionspacepointhash,
               contentstreamlayer
@@ -111,7 +111,7 @@ trait SubtreeTagging
               h.id,
               h.parentnodeanchor,
               h.childnodeanchor,
-              h.position,
+              h.sortpath,
               JSON_SET(h.subtreetags, :tagPath, true) as subtreetags,
               h.dimensionspacepointhash,
               :targetContentStreamLayer as contentstreamlayer
@@ -145,7 +145,7 @@ trait SubtreeTagging
               id,
               parentnodeanchor,
               childnodeanchor,
-              position,
+              sortpath,
               subtreetags,
               dimensionspacepointhash,
               contentstreamlayer
@@ -154,7 +154,7 @@ trait SubtreeTagging
               h2.id,
               h2.parentnodeanchor,
               h2.childnodeanchor,
-              h2.position,
+              h2.sortpath,
               h2.subtreetags,
               h2.dimensionspacepointhash,
               h2.contentstreamlayer
@@ -164,7 +164,7 @@ trait SubtreeTagging
                   h.id,
                   h.parentnodeanchor,
                   h.childnodeanchor,
-                  h.position,
+                  h.sortpath,
                   IF(subquery.inheritsTag, JSON_SET(h.subtreetags, :tagPath, null), JSON_REMOVE(h.subtreetags, :tagPath)) as subtreetags,
                   h.subtreetags as currentsubtreetags,
                   h.dimensionspacepointhash,
@@ -231,14 +231,14 @@ trait SubtreeTagging
         $moveSubtreeTagsStatement = <<<SQL
             INSERT INTO {$this->tableNames->hierarchyRelation()} (
               id, parentnodeanchor, childnodeanchor,
-              position, subtreetags, dimensionspacepointhash,
+              sortpath, subtreetags, dimensionspacepointhash,
               contentstreamlayer
             )
             SELECT
               h2.id,
               h2.parentnodeanchor,
               h2.childnodeanchor,
-              h2.position,
+              h2.sortpath,
               h2.subtreetags,
               h2.dimensionspacepointhash,
               h2.contentstreamlayer
@@ -248,7 +248,7 @@ trait SubtreeTagging
                   h.id,
                   h.parentnodeanchor,
                   h.childnodeanchor,
-                  h.position,
+                  h.sortpath,
                   h.dimensionspacepointhash,
                   (
                     SELECT

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/HierarchyRelation.php
@@ -35,7 +35,7 @@ final readonly class HierarchyRelation
         public NodeRelationAnchorPoint $childNodeAnchor,
         public DimensionSpacePoint $dimensionSpacePoint,
         public string $dimensionSpacePointHash,
-        public int $position,
+        public NodeSortPath $sortPath,
         public NodeTags $subtreeTags,
     ) {
     }
@@ -47,7 +47,7 @@ final readonly class HierarchyRelation
         ?ContentStreamLayer $contentStreamLayer = null,
         ?DimensionSpacePoint $dimensionSpacePoint = null,
         ?string $dimensionSpacePointHash = null,
-        ?int $position = null,
+        ?NodeSortPath $sortPath = null,
         ?NodeTags $subtreeTags = null,
     ): self {
         return new self(
@@ -57,7 +57,7 @@ final readonly class HierarchyRelation
             childNodeAnchor: $childNodeAnchor ?? $this->childNodeAnchor,
             dimensionSpacePoint: $dimensionSpacePoint ?? $this->dimensionSpacePoint,
             dimensionSpacePointHash: $dimensionSpacePointHash ?? $this->dimensionSpacePointHash,
-            position: $position ?? $this->position,
+            sortPath: $sortPath ?? $this->sortPath,
             subtreeTags: $subtreeTags ?? $this->subtreeTags,
         );
     }
@@ -79,7 +79,7 @@ final readonly class HierarchyRelation
                 'childnodeanchor' => $this->childNodeAnchor->value,
                 'contentstreamlayer' => $this->contentStreamLayer->value,
                 'dimensionspacepointhash' => $this->dimensionSpacePointHash,
-                'position' => $this->position,
+                'sortpath' => $this->sortPath->value,
                 'subtreetags' => $subtreeTagsJson,
             ]);
         } catch (DBALException $e) {
@@ -116,15 +116,15 @@ final readonly class HierarchyRelation
 
     public function assignNewParentNode(
         NodeRelationAnchorPoint $parentAnchorPoint,
-        ?int $position,
+        ?NodeSortPath $sortPath,
         Connection $databaseConnection,
         ContentGraphTableNames $tableNames
     ): void {
         $data = [
             'parentnodeanchor' => $parentAnchorPoint->value
         ];
-        if (!is_null($position)) {
-            $data['position'] = $position;
+        if (!is_null($sortPath)) {
+            $data['sortpath'] = $sortPath->value;
         }
         try {
             $databaseConnection->update(
@@ -137,13 +137,18 @@ final readonly class HierarchyRelation
         }
     }
 
-    public function assignNewPosition(int $position, Connection $databaseConnection, ContentGraphTableNames $tableNames): void
+    /**
+     * Note this pins the write to the relation's *own* layer via {@see getDatabaseId()}. Callers must therefore
+     * only use it when the relation already lives in the write layer - lower layers are shared and immutable.
+     * {@see \Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\Feature\NodeMove} shows the required guard.
+     */
+    public function assignNewSortPath(NodeSortPath $sortPath, Connection $databaseConnection, ContentGraphTableNames $tableNames): void
     {
         try {
             $databaseConnection->update(
                 $tableNames->hierarchyRelation(),
                 [
-                    'position' => $position
+                    'sortpath' => $sortPath->value
                 ],
                 $this->getDatabaseId()
             );

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/NodeSortPath.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/NodeSortPath.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Neos.ContentGraph.DoctrineDbalAdapter package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection;
+
+/**
+ * The materialised sort path of a hierarchy relation: one fractional index key per tree level,
+ * joined with {@see self::SEPARATOR}, e.g. `a0/a0/b3/ZzV`.
+ *
+ * Ordering the hierarchy relations of a subgraph by this value yields depth-first document order,
+ * and the descendants of a node are a contiguous range {@see rangeStart()} / {@see rangeEnd()}.
+ *
+ * WHY THE SEPARATOR IS "/"
+ * ========================
+ *
+ * Fractional index keys are base 62 {@see \Neos\ContentGraph\DoctrineDbalAdapter\FractionalIndexing},
+ * so every character is in `0-9A-Za-z` (0x30-0x7A). The separator 0x2F sorts *below* all of them,
+ * which is exactly what makes prefix ordering correct:
+ *
+ *     a0     <  a0/x      a parent sorts before its own children
+ *     a0/x   <  a0V       a child sorts before its parent's succeeding sibling ('/' 0x2F < 'V' 0x56)
+ *
+ * This holds only under byte-wise comparison, which is why the column is VARBINARY and not VARCHAR.
+ * The server default collations (utf8mb4_0900_ai_ci on MySQL 8, utf8mb4_uca1400_ai_ci on MariaDB 11.4+)
+ * are case-insensitive and would make 'Z' equal 'z', silently destroying the ordering.
+ *
+ * @internal
+ */
+final readonly class NodeSortPath
+{
+    public const SEPARATOR = '/';
+
+    /**
+     * Must match the `sortpath` column length in {@see \Neos\ContentGraph\DoctrineDbalAdapter\DoctrineDbalContentGraphSchemaBuilder}.
+     *
+     * Exceeding this is a structural error - at normal segment sizes it means a tree roughly 150 levels
+     * deep - and cannot be fixed by rebalancing, so it throws rather than triggering one.
+     */
+    public const MAX_LENGTH = 768;
+
+    /**
+     * Above this, the sibling set is rebalanced instead of the key being used as-is.
+     *
+     * Fractional keys grow by roughly 0.17 characters per insert into the *same* gap, so this is reached
+     * after ~170-190 such inserts. Pure appends and pure prepends never approach it: both stay at ~5
+     * characters even after 10^6 operations.
+     */
+    public const MAX_KEY_LENGTH = 12;
+
+    private function __construct(
+        public string $value,
+    ) {
+    }
+
+    /**
+     * The empty path above the root nodes. Root hierarchy relations use {@see NodeRelationAnchorPoint::forRootEdge()}
+     * as their parent anchor and therefore have no parent relation to inherit a prefix from; their own paths are
+     * bare keys without a leading separator.
+     */
+    public static function root(): self
+    {
+        return new self('');
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    /**
+     * Whether this node's own key has grown past {@see MAX_KEY_LENGTH} and its sibling set should be rebalanced.
+     */
+    public function exceedsMaxKeyLength(): bool
+    {
+        return !$this->isRoot() && strlen($this->localKey()) > self::MAX_KEY_LENGTH;
+    }
+
+    /**
+     * Guards the `sortpath` column width. Call this once the value is final - that is, after any rebalance -
+     * because a rebalance is what makes an over-long key short again.
+     *
+     * This must be enforced in PHP rather than left to the database: without STRICT_TRANS_TABLES, MariaDB
+     * truncates an over-long value instead of erroring, which would silently corrupt the ordering.
+     */
+    public function assertFitsColumn(): void
+    {
+        if (strlen($this->value) > self::MAX_LENGTH) {
+            throw new \RuntimeException(sprintf(
+                'Node sort path exceeds the maximum length of %d bytes (got %d): %s. '
+                . 'At normal segment sizes this means a tree roughly 150 levels deep; rebalancing cannot shorten it.',
+                self::MAX_LENGTH,
+                strlen($this->value),
+                $this->value
+            ), 1775980001);
+        }
+    }
+
+    public function isRoot(): bool
+    {
+        return $this->value === '';
+    }
+
+    /**
+     * This node's own fractional index key, i.e. the last segment of the path.
+     */
+    public function localKey(): string
+    {
+        $this->assertNotRoot(__FUNCTION__);
+        $separatorPosition = strrpos($this->value, self::SEPARATOR);
+        return $separatorPosition === false ? $this->value : substr($this->value, $separatorPosition + 1);
+    }
+
+    public function parent(): self
+    {
+        $this->assertNotRoot(__FUNCTION__);
+        $separatorPosition = strrpos($this->value, self::SEPARATOR);
+        return $separatorPosition === false ? self::root() : new self(substr($this->value, 0, $separatorPosition));
+    }
+
+    /**
+     * All proper prefixes of this path, closest ancestor first, excluding this path and the empty root.
+     *
+     * For `a0/b3/ZzV` this is `['a0/b3', 'a0']` - the paths of every ancestor, which lets ancestor lookups
+     * be a plain `sortpath IN (...)` instead of a recursive CTE.
+     *
+     * @return array<int,string>
+     */
+    public function ancestorPaths(): array
+    {
+        $paths = [];
+        $current = $this;
+        while (!$current->isRoot()) {
+            $current = $current->parent();
+            if (!$current->isRoot()) {
+                $paths[] = $current->value;
+            }
+        }
+        return $paths;
+    }
+
+    public function child(string $key): self
+    {
+        if ($key === '') {
+            throw new \RuntimeException('Cannot append an empty fractional index key to a node sort path', 1775980002);
+        }
+        return new self($this->isRoot() ? $key : $this->value . self::SEPARATOR . $key);
+    }
+
+    /**
+     * Inclusive lower bound of this node's descendants.
+     */
+    public function rangeStart(): string
+    {
+        $this->assertNotRoot(__FUNCTION__);
+        return $this->value . self::SEPARATOR;
+    }
+
+    /**
+     * Exclusive upper bound of this node's descendants.
+     *
+     * The bound is exact. For `a0/b3` the range is ['a0/b3/', 'a0/b30'): a sibling `a0/b3V` falls above it
+     * because 'V' (0x56) > '0' (0x30), and a sibling keyed literally `a0/b30` - which is legal, since the
+     * head 'b' denotes a three character integer part - is excluded by the strict upper bound.
+     */
+    public function rangeEnd(): string
+    {
+        $this->assertNotRoot(__FUNCTION__);
+        return $this->value . chr(ord(self::SEPARATOR) + 1);
+    }
+
+    public function depth(): int
+    {
+        return $this->isRoot() ? 0 : substr_count($this->value, self::SEPARATOR) + 1;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+
+    private function assertNotRoot(string $method): void
+    {
+        if ($this->isRoot()) {
+            throw new \RuntimeException(sprintf('%s() must not be called on the empty root sort path', $method), 1775980003);
+        }
+    }
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Projection/ProjectionIntegrityViolationDetector.php
@@ -266,16 +266,16 @@ final class ProjectionIntegrityViolationDetector implements ProjectionIntegrityV
                 h.contentstreamid,
                 h.dimensionspacepointhash,
                 h.parentnodeanchor,
-                COUNT(h.position)
+                COUNT(h.sortpath)
             FROM
                 {$this->allContentStreamHierarchiesSql()} AS h
             GROUP BY
                 h.contentstreamid,
-                h.position,
+                h.sortpath,
                 h.parentnodeanchor,
                 h.dimensionspacepointhash
             HAVING
-                COUNT(position) > 1
+                COUNT(sortpath) > 1
         SQL;
         try {
             $ambiguouslySortedHierarchyRelationRecords = $this->dbal->executeQuery($ambiguouslySortedHierarchyRelationStatement);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Result;
 use Neos\ContentGraph\DoctrineDbalAdapter\ContentGraphTableNames;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\ContentStreamLayers;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeSortPath;
 use Neos\ContentGraph\DoctrineDbalAdapter\HierarchyRelationSubquery;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeQueryBuilder;
@@ -65,6 +66,7 @@ use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Dbal\Query\Parameter;
 use Neos\ContentRepository\Dbal\Query\Parameters;
 use Neos\ContentRepository\Dbal\Query\QueryBuilder;
+use Neos\ContentRepository\Dbal\Query\StaticWhereCondition;
 
 /**
  * The content subgraph application repository
@@ -95,6 +97,13 @@ use Neos\ContentRepository\Dbal\Query\QueryBuilder;
  */
 final class ContentSubgraph implements ContentSubgraphInterface
 {
+    /**
+     * Orders ancestors by distance: the longer the sort path, the deeper - and therefore closer - the node.
+     * The prefixes of one path all have distinct lengths, so this is exact and reproduces the `level`
+     * ordering of the recursive CTE it replaced.
+     */
+    private const ANCESTOR_ORDERING_EXPRESSION = 'LENGTH(h.sortpath)';
+
     private readonly NodeQueryBuilder $nodeQueryBuilder;
 
     /**
@@ -285,168 +294,144 @@ final class ContentSubgraph implements ContentSubgraphInterface
         }
     }
 
+    /**
+     * The whole subtree is the contiguous sort path range below the entry node {@see NodeSortPath}, read in one
+     * range scan and re-nested in PHP.
+     *
+     * This is the one traversal where the recursive CTE genuinely *pruned*: `nodeTypes` and `maximumLevels`
+     * were applied in the recursive step, so a non-matching node took its whole subtree with it. Filtering the
+     * flat range row-wise is nevertheless equivalent, because the re-nesting below only ever attaches a node to
+     * a parent it actually finds: a node whose parent was filtered out is never reachable from the entry node
+     * and is silently dropped. A node therefore survives iff every node between it and the entry survives -
+     * which is what pruning means.
+     *
+     * The entry node itself is fetched separately because it was never subject to the `nodeTypes` filter: the
+     * CTE applied that filter only to the recursive step, never to its anchor.
+     */
     public function findSubtree(NodeAggregateId $entryNodeAggregateId, FindSubtreeFilter $filter): ?Subtree
     {
-        $nodeAggregateIdCondition = NodeAggregateIdCondition::forNodeAggregateId($entryNodeAggregateId);
+        $entryNode = $this->findNodeById($entryNodeAggregateId);
+        $entrySortPath = $this->fetchSortPath($entryNodeAggregateId);
+        if ($entryNode === null || $entrySortPath === null) {
+            return null;
+        }
 
-        $queryBuilderInitial = $this->createQueryBuilder()
-            // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
-            ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, h.sortpath')
-            ->from($this->tableNames->node(), 'n')
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'h', 'h.childnodeanchor = n.relationanchorpoint')
-            ->whereCondition('n', $nodeAggregateIdCondition);
-        $this->addSubtreeTagConstraints($queryBuilderInitial);
+        // Depth relative to the entry node: every level below it adds exactly one separator to the sort path.
+        $relativeLevelExpression = sprintf(
+            "(LENGTH(h.sortpath) - LENGTH(REPLACE(h.sortpath, '%s', '')) - %d)",
+            NodeSortPath::SEPARATOR,
+            $entrySortPath->depth() - 1
+        );
 
-        $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('c.*, h.subtreetags, p.nodeaggregateid AS parentNodeAggregateId, p.level + 1 AS level, h.sortpath')
-            ->from('tree', 'p')
-            ->innerJoinTableSubquery('p', $this->hierarchyRelationQuery, 'h', 'h.parentnodeanchor = p.relationanchorpoint')
-            ->innerJoin('p', $this->tableNames->node(), 'c', 'c.relationanchorpoint = h.childnodeanchor');
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery(
+            $this->hierarchyRelationQuery->withWhereCondition(self::descendantRangeCondition($entrySortPath)),
+            'n',
+            'n.*, h.subtreetags, p.nodeaggregateid AS parentNodeAggregateId, ' . $relativeLevelExpression . ' AS level'
+        )
+            // every row here is strictly below the entry node, so its parent relation always exists
+            ->innerJoin('h', $this->tableNames->node(), 'p', 'p.relationanchorpoint = h.parentnodeanchor')
+            // the sort path already encodes depth-first document order, so no secondary ordering is needed
+            ->orderBy('h.sortpath');
+        $this->addSubtreeTagConstraints($queryBuilder);
+
         if ($filter->maximumLevels !== null) {
-            $queryBuilderRecursive->andWhere('p.level < :maximumLevels')->setParameter('maximumLevels', $filter->maximumLevels);
+            // the CTE stopped recursing once the *parent* reached the limit, which includes children at exactly
+            // $maximumLevels - hence "<=" and not "<"
+            $queryBuilder->andWhere($relativeLevelExpression . ' <= :maximumLevels')->setParameter('maximumLevels', $filter->maximumLevels);
         }
         if ($filter->nodeTypes !== null) {
-            $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderRecursive, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'c');
+            $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilder, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager));
         }
-        $this->addSubtreeTagConstraints($queryBuilderRecursive);
 
-        $queryBuilderCte = $this->createQueryBuilder()
-            ->select('*')
-            ->from('tree')
-            // the materialised sort path already encodes depth-first document order across the whole subtree,
-            // so no secondary ordering by level is needed. The column is VARBINARY and therefore compares
-            // byte-wise, which is what base 62 ordering requires {@see NodeSortPath}.
-            ->orderBy('sortpath');
+        try {
+            $nodeRows = $this->executeQuery($queryBuilder)->fetchAllAssociative();
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to fetch subtree of node "%s": %s', $entryNodeAggregateId->value, $e->getMessage()), 1782600002, $e);
+        }
 
-        $result = $this->fetchCteResults($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
         /** @var array<string, Subtree[]> $subtreesByParentNodeId */
         $subtreesByParentNodeId = [];
-        foreach (array_reverse($result) as $nodeData) {
+        // reverse document order guarantees that all descendants of a node are built before the node itself
+        foreach (array_reverse($nodeRows) as $nodeData) {
             $nodeAggregateId = $nodeData['nodeaggregateid'];
             $parentNodeAggregateId = $nodeData['parentNodeAggregateId'];
-            $node = $this->nodeFactory->mapNodeRowToNode(
-                $nodeData,
-                $this->workspaceName,
-                $this->dimensionSpacePoint,
-                $this->visibilityConstraints
-            );
             $subtree = Subtree::create(
                 (int)$nodeData['level'],
-                $node,
+                $this->nodeFactory->mapNodeRowToNode(
+                    $nodeData,
+                    $this->workspaceName,
+                    $this->dimensionSpacePoint,
+                    $this->visibilityConstraints
+                ),
                 array_key_exists($nodeAggregateId, $subtreesByParentNodeId) ? Subtrees::fromArray(array_reverse($subtreesByParentNodeId[$nodeAggregateId])) : Subtrees::createEmpty()
             );
-            if ($subtree->level === 0) {
-                return $subtree;
-            }
             if (!array_key_exists($parentNodeAggregateId, $subtreesByParentNodeId)) {
                 $subtreesByParentNodeId[$parentNodeAggregateId] = [];
             }
             $subtreesByParentNodeId[$parentNodeAggregateId][] = $subtree;
         }
-        return null;
+
+        return Subtree::create(
+            0,
+            $entryNode,
+            array_key_exists($entryNodeAggregateId->value, $subtreesByParentNodeId) ? Subtrees::fromArray(array_reverse($subtreesByParentNodeId[$entryNodeAggregateId->value])) : Subtrees::createEmpty()
+        );
     }
 
     public function findAncestorNodes(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter $filter): Nodes
     {
-        [
-            'queryBuilderInitial' => $queryBuilderInitial,
-            'queryBuilderRecursive' => $queryBuilderRecursive,
-            'queryBuilderCte' => $queryBuilderCte
-        ] = $this->buildAncestorNodesQueries($entryNodeAggregateId, $filter);
-        $queryBuilderCte->addOrderBy('level');
-
-        $nodeRows = $this->fetchCteResults(
-            $queryBuilderInitial,
-            $queryBuilderRecursive,
-            $queryBuilderCte,
-            'ancestry'
-        );
-
-        return $this->nodeFactory->mapNodeRowsToNodes(
-            $nodeRows,
-            $this->workspaceName,
-            $this->dimensionSpacePoint,
-            $this->visibilityConstraints
-        );
+        $queryBuilder = $this->buildAncestorNodesQuery($entryNodeAggregateId, $filter);
+        if ($queryBuilder === null) {
+            return Nodes::createEmpty();
+        }
+        $queryBuilder->addOrderBy(self::ANCESTOR_ORDERING_EXPRESSION, 'DESC');
+        return $this->fetchNodes($queryBuilder);
     }
 
     public function countAncestorNodes(NodeAggregateId $entryNodeAggregateId, CountAncestorNodesFilter $filter): int
     {
-        [
-            'queryBuilderInitial' => $queryBuilderInitial,
-            'queryBuilderRecursive' => $queryBuilderRecursive,
-            'queryBuilderCte' => $queryBuilderCte
-        ] = $this->buildAncestorNodesQueries($entryNodeAggregateId, $filter);
-
-        return $this->fetchCteCountResult(
-            $queryBuilderInitial,
-            $queryBuilderRecursive,
-            $queryBuilderCte,
-            'ancestry'
-        );
+        $queryBuilder = $this->buildAncestorNodesQuery($entryNodeAggregateId, $filter);
+        if ($queryBuilder === null) {
+            return 0;
+        }
+        return $this->fetchCount($queryBuilder);
     }
 
     public function findClosestNode(NodeAggregateId $entryNodeAggregateId, FindClosestNodeFilter $filter): ?Node
     {
-        $nodeAggregateIdCondition = NodeAggregateIdCondition::forNodeAggregateId($entryNodeAggregateId);
-
-        $queryBuilderInitial = $this->createQueryBuilder()
-            ->select('n.*, ph.subtreetags, ph.parentnodeanchor')
-            ->from($this->tableNames->node(), 'n')
-            // we need to join with the hierarchy relation, because we need the node name.
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
-            ->whereCondition('n', $nodeAggregateIdCondition);
-        $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
-
-        $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('pn.*, h.subtreetags, h.parentnodeanchor')
-            ->from('ancestry', 'cn')
-            ->innerJoin('cn', $this->tableNames->node(), 'pn', 'pn.relationanchorpoint = cn.parentnodeanchor')
-            ->innerJoinTableSubquery('pn', $this->hierarchyRelationQuery, 'h', 'h.childnodeanchor = pn.relationanchorpoint');
-        $this->addSubtreeTagConstraints($queryBuilderRecursive);
-
-        $queryBuilderCte = $this->createQueryBuilder()
-            ->select('*')
-            ->from('ancestry', 'pn');
-
-        $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
-        $nodeRows = $this->fetchCteResults(
-            $queryBuilderInitial,
-            $queryBuilderRecursive,
-            $queryBuilderCte,
-            'ancestry'
-        );
-        return $this->nodeFactory->mapNodeRowsToNodes(
-            $nodeRows,
-            $this->workspaceName,
-            $this->dimensionSpacePoint,
-            $this->visibilityConstraints
-        )->first();
+        $queryBuilder = $this->buildAncestorNodesQuery($entryNodeAggregateId, $filter);
+        if ($queryBuilder === null) {
+            return null;
+        }
+        // "closest" is the longest of the candidate paths that survived the node type filter. The CTE version
+        // had no ORDER BY at all here and relied on the order in which the recursion emitted its rows.
+        $queryBuilder->addOrderBy(self::ANCESTOR_ORDERING_EXPRESSION, 'DESC')->setMaxResults(1);
+        return $this->fetchNode($queryBuilder);
     }
 
     public function findDescendantNodes(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter $filter): Nodes
     {
-        ['queryBuilderInitial' => $queryBuilderInitial, 'queryBuilderRecursive' => $queryBuilderRecursive, 'queryBuilderCte' => $queryBuilderCte] = $this->buildDescendantNodesQueries($entryNodeAggregateId, $filter);
+        $queryBuilder = $this->buildDescendantNodesQuery($entryNodeAggregateId, $filter);
+        if ($queryBuilder === null) {
+            return Nodes::createEmpty();
+        }
         if ($filter->ordering !== null) {
-            $this->applyOrdering($queryBuilderCte, $filter->ordering);
+            $this->applyOrdering($queryBuilder, $filter->ordering);
         }
         if ($filter->pagination !== null) {
-            $this->applyPagination($queryBuilderCte, $filter->pagination);
+            $this->applyPagination($queryBuilder, $filter->pagination);
         }
-        $queryBuilderCte->addOrderBy('sortpath');
-        $nodeRows = $this->fetchCteResults($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
-        return $this->nodeFactory->mapNodeRowsToNodes(
-            $nodeRows,
-            $this->workspaceName,
-            $this->dimensionSpacePoint,
-            $this->visibilityConstraints
-        );
+        $queryBuilder->addOrderBy('h.sortpath');
+        return $this->fetchNodes($queryBuilder);
     }
 
     public function countDescendantNodes(NodeAggregateId $entryNodeAggregateId, CountDescendantNodesFilter $filter): int
     {
-        ['queryBuilderInitial' => $queryBuilderInitial, 'queryBuilderRecursive' => $queryBuilderRecursive, 'queryBuilderCte' => $queryBuilderCte] = $this->buildDescendantNodesQueries($entryNodeAggregateId, $filter);
-        return $this->fetchCteCountResult($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
+        $queryBuilder = $this->buildDescendantNodesQuery($entryNodeAggregateId, $filter);
+        if ($queryBuilder === null) {
+            return 0;
+        }
+        return $this->fetchCount($queryBuilder);
     }
 
     public function countNodes(): int
@@ -483,6 +468,41 @@ final class ContentSubgraph implements ContentSubgraphInterface
     private function createQueryBuilder(): QueryBuilder
     {
         return QueryBuilder::createForConnection($this->dbal);
+    }
+
+    /**
+     * The materialised sort path of a node within this subgraph, or NULL if the node is not part of it.
+     *
+     * This is the anchor of every range based traversal {@see NodeSortPath}: a node's descendants are the
+     * contiguous sort path range below it, its ancestors are its proper prefixes. One point lookup buys
+     * that, which is what makes the recursive CTEs unnecessary.
+     *
+     * A removed node resolves to a tombstone row whose `sortpath` is NULL, so it correctly yields NULL here
+     * and callers short-circuit to an empty result. The same holds for a node hidden by the visibility
+     * constraints, which is what the previous recursive CTEs enforced in their anchor queries.
+     */
+    private function fetchSortPath(NodeAggregateId $nodeAggregateId): ?NodeSortPath
+    {
+        $nodeAggregateIdCondition = NodeAggregateIdCondition::forNodeAggregateId($nodeAggregateId);
+
+        $queryBuilder = $this->createQueryBuilder()
+            ->select('h.sortpath')
+            ->fromTableSubquery($this->hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'h')
+            ->innerJoin('h', $this->tableNames->node(), 'n', 'n.relationanchorpoint = h.childnodeanchor')
+            ->whereCondition('n', $nodeAggregateIdCondition)
+            ->setMaxResults(1);
+        $this->addSubtreeTagConstraints($queryBuilder);
+
+        try {
+            $sortPath = $this->executeQuery($queryBuilder)->fetchOne();
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to fetch sort path for node "%s": %s', $nodeAggregateId->value, $e->getMessage()), 1782600001, $e);
+        }
+
+        if (!is_string($sortPath) || $sortPath === '') {
+            return null;
+        }
+        return NodeSortPath::fromString($sortPath);
     }
 
     private function addSubtreeTagConstraints(QueryBuilder $queryBuilder, string $hierarchyRelationTableAlias = 'h'): void
@@ -662,79 +682,112 @@ final class ContentSubgraph implements ContentSubgraphInterface
     }
 
     /**
-     * @return array{queryBuilderInitial: QueryBuilder, queryBuilderRecursive: QueryBuilder, queryBuilderCte: QueryBuilder}
+     * A node's ancestors are exactly the proper prefixes of its own sort path
+     * {@see NodeSortPath::ancestorPaths()}, so ancestor lookups are a literal `IN` list on an indexed column
+     * rather than a recursive CTE. Sort paths are unique within a subgraph, so each prefix matches one row.
+     *
+     * {@see FindClosestNodeFilter} also considers the entry node itself, hence its own path is prepended in
+     * that case.
+     *
+     * The subtree tag constraint stays row-wise, and could never have pruned here anyway: tags are inherited
+     * *downwards*, so an excluded ancestor implies an excluded entry node, for which {@see fetchSortPath()}
+     * already returns NULL.
+     *
+     * Returns NULL when there is nothing to look up - either the entry node is not visible in this subgraph,
+     * or it is a root node and thus has no ancestors.
      */
-    private function buildAncestorNodesQueries(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter|CountAncestorNodesFilter|FindClosestNodeFilter $filter): array
+    private function buildAncestorNodesQuery(NodeAggregateId $entryNodeAggregateId, FindAncestorNodesFilter|CountAncestorNodesFilter|FindClosestNodeFilter $filter): ?QueryBuilder
     {
-        $nodeAggregateIdCondition = NodeAggregateIdCondition::forNodeAggregateId($entryNodeAggregateId);
+        $entrySortPath = $this->fetchSortPath($entryNodeAggregateId);
+        if ($entrySortPath === null) {
+            return null;
+        }
+        $sortPaths = $entrySortPath->ancestorPaths();
+        if ($filter instanceof FindClosestNodeFilter) {
+            array_unshift($sortPaths, $entrySortPath->value);
+        }
+        if ($sortPaths === []) {
+            return null;
+        }
 
-        $queryBuilderInitial = $this->createQueryBuilder()
-            ->select('n.*, ph.subtreetags, ph.parentnodeanchor, 0 AS level')
-            ->from($this->tableNames->node(), 'n')
-            // we need to join with the hierarchy relation, because we need the node name.
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'ch', 'ch.parentnodeanchor = n.relationanchorpoint')
-            ->innerJoin('ch', $this->tableNames->node(), 'c', 'c.relationanchorpoint = ch.childnodeanchor')
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery, 'ph', 'n.relationanchorpoint = ph.childnodeanchor')
-            ->andWhereCondition($nodeAggregateIdCondition, 'c');
-        $this->addSubtreeTagConstraints($queryBuilderInitial, 'ph');
-        $this->addSubtreeTagConstraints($queryBuilderInitial, 'ch');
-
-        $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('pn.*, h.subtreetags, h.parentnodeanchor,  ch.level + 1 AS level')
-            ->from('ancestry', 'ch')
-            ->innerJoin('ch', $this->tableNames->node(), 'pn', 'pn.relationanchorpoint = ch.parentnodeanchor')
-            ->innerJoinTableSubquery('pn', $this->hierarchyRelationQuery, 'h', 'h.childnodeanchor = pn.relationanchorpoint');
-        $this->addSubtreeTagConstraints($queryBuilderRecursive);
-
-        $queryBuilderCte = $this->createQueryBuilder()
-            ->select('*')
-            ->from('ancestry', 'pn');
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery(
+            $this->hierarchyRelationQuery->withWhereCondition(
+                StaticWhereCondition::fromString(
+                    'h',
+                    'h.sortpath IN (:ancestorSortPaths)',
+                    Parameters::create(Parameter::stringArray('ancestorSortPaths', $sortPaths))
+                )
+            ),
+            'n',
+            'n.*, h.subtreetags, h.sortpath'
+        );
+        $this->addSubtreeTagConstraints($queryBuilder);
 
         if ($filter->nodeTypes !== null) {
-            $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager), 'pn');
+            $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilder, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager));
         }
-        return compact('queryBuilderInitial', 'queryBuilderRecursive', 'queryBuilderCte');
+        return $queryBuilder;
     }
 
     /**
-     * @return array{queryBuilderInitial: QueryBuilder, queryBuilderRecursive: QueryBuilder, queryBuilderCte: QueryBuilder}
+     * The descendants of a node are the contiguous sort path range below it {@see NodeSortPath}, so this is a
+     * plain index range scan rather than a recursive CTE.
+     *
+     * Every filter is applied row-wise, which yields the same result the recursion did:
+     *
+     * - Subtree tags are materialised onto *every* descendant relation
+     *   {@see SubtreeTagging::addSubtreeTag()}, so excluding a tagged row also excludes its whole subtree.
+     * - Removing a node tombstones every relation of its subtree with a NULL `sortpath`
+     *   {@see NodeRemoval::removeRelationRecursivelyFromDatabaseIncludingNonReferencedNodes()}, and NULL never
+     *   satisfies the range predicate - no orphaned descendants can survive to be picked up here.
+     * - `nodeTypes`, `searchTerm` and `propertyValue` were applied to the outer query even in the CTE version,
+     *   never to the recursive step, so they never pruned in the first place.
+     *
+     * Returns NULL if the entry node is not part of this subgraph, in which case there are no descendants.
      */
-    private function buildDescendantNodesQueries(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter|CountDescendantNodesFilter $filter): array
+    private function buildDescendantNodesQuery(NodeAggregateId $entryNodeAggregateId, FindDescendantNodesFilter|CountDescendantNodesFilter $filter): ?QueryBuilder
     {
-        $nodeAggregateIdCondition = NodeAggregateIdCondition::forNodeAggregateId($entryNodeAggregateId);
+        $entrySortPath = $this->fetchSortPath($entryNodeAggregateId);
+        if ($entrySortPath === null) {
+            return null;
+        }
 
-        $queryBuilderInitial = $this->createQueryBuilder()
-            // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
-            ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, h.sortpath')
-            ->from($this->tableNames->node(), 'n')
-            // we need to join with the hierarchy relation, because we need the node name.
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleParentNodeAggregateId($nodeAggregateIdCondition), 'h', 'h.childnodeanchor = n.relationanchorpoint')
-            ->innerJoin('n', $this->tableNames->node(), 'p', 'p.relationanchorpoint = h.parentnodeanchor')
-            ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery, 'ph', 'ph.childnodeanchor = p.relationanchorpoint')
-            ->whereCondition('p', $nodeAggregateIdCondition);
-        $this->addSubtreeTagConstraints($queryBuilderInitial);
-
-        $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('cn.*, h.subtreetags, pn.nodeaggregateid AS parentNodeAggregateId, pn.level + 1 AS level, h.sortpath')
-            ->from('tree', 'pn')
-            ->innerJoinTableSubquery('pn', $this->hierarchyRelationQuery, 'h', 'h.parentnodeanchor = pn.relationanchorpoint')
-            ->innerJoin('pn', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = h.childnodeanchor');
-        $this->addSubtreeTagConstraints($queryBuilderRecursive);
-
-        $queryBuilderCte = $this->createQueryBuilder()
-            ->select('*')
-            ->from('tree', 'n');
+        $queryBuilder = $this->nodeQueryBuilder->buildBasicNodeQuery(
+            $this->hierarchyRelationQuery->withWhereCondition(self::descendantRangeCondition($entrySortPath)),
+            'n',
+            'n.*, h.subtreetags, h.sortpath'
+        );
+        $this->addSubtreeTagConstraints($queryBuilder);
 
         if ($filter->nodeTypes !== null) {
-            $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilderCte, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager));
+            $this->nodeQueryBuilder->addNodeTypeCriteria($queryBuilder, ExpandedNodeTypeCriteria::create($filter->nodeTypes, $this->nodeTypeManager));
         }
         if ($filter->searchTerm !== null) {
-            $this->nodeQueryBuilder->addSearchTermConstraints($queryBuilderCte, $filter->searchTerm);
+            $this->nodeQueryBuilder->addSearchTermConstraints($queryBuilder, $filter->searchTerm);
         }
         if ($filter->propertyValue !== null) {
-            $this->nodeQueryBuilder->addPropertyValueConstraints($queryBuilderCte, $filter->propertyValue);
+            $this->nodeQueryBuilder->addPropertyValueConstraints($queryBuilder, $filter->propertyValue);
         }
-        return compact('queryBuilderInitial', 'queryBuilderRecursive', 'queryBuilderCte');
+        return $queryBuilder;
+    }
+
+    /**
+     * Restricts hierarchy relations to the descendants of the given path, excluding the node itself.
+     *
+     * This MUST be handed to {@see HierarchyRelationSubquery::withWhereCondition()} and never to
+     * `withPossibleWhereCondition()`: `sortpath` is not layer invariant, so it must not reach the
+     * `id IN (...)` prefilter {@see HierarchyRelationSubquery}.
+     */
+    private static function descendantRangeCondition(NodeSortPath $sortPath): StaticWhereCondition
+    {
+        return StaticWhereCondition::fromString(
+            'h',
+            'h.sortpath >= :descendantRangeStart AND h.sortpath < :descendantRangeEnd',
+            Parameters::create(
+                Parameter::string('descendantRangeStart', $sortPath->rangeStart()),
+                Parameter::string('descendantRangeEnd', $sortPath->rangeEnd()),
+            )
+        );
     }
 
     private function applyOrdering(QueryBuilder $queryBuilder, Ordering $ordering, string $nodeTableAlias = 'n'): void
@@ -828,46 +881,5 @@ final class ContentSubgraph implements ContentSubgraphInterface
             $this->dimensionSpacePoint,
             $this->visibilityConstraints
         );
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    private function fetchCteResults(QueryBuilder $queryBuilderInitial, QueryBuilder $queryBuilderRecursive, QueryBuilder $queryBuilderCte, string $cteTableName = 'cte'): array
-    {
-        $query = <<<SQL
-            WITH RECURSIVE {$cteTableName} AS (
-                {$queryBuilderInitial->getSQL()}
-                UNION
-                {$queryBuilderRecursive->getSQL()}
-            )
-            {$queryBuilderCte->getSQL()}
-        SQL;
-
-        $fullQueryBuilder = (clone $queryBuilderCte)->mergeParametersFromBuilder($queryBuilderInitial)->mergeParametersFromBuilder($queryBuilderRecursive);
-        try {
-            return $this->dbal->fetchAllAssociative($query, $fullQueryBuilder->getParameters(), $fullQueryBuilder->getParameterTypes());
-        } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to fetch CTE result: %s', $e->getMessage()), 1678358108, $e);
-        }
-    }
-
-    private function fetchCteCountResult(QueryBuilder $queryBuilderInitial, QueryBuilder $queryBuilderRecursive, QueryBuilder $queryBuilderCte, string $cteTableName = 'cte'): int
-    {
-        $query = <<<SQL
-            WITH RECURSIVE {$cteTableName} AS (
-                {$queryBuilderInitial->getSQL()}
-                UNION
-                {$queryBuilderRecursive->getSQL()}
-            )
-            {$queryBuilderCte->select('COUNT(*)')->resetOrderBy()->setFirstResult(0)->setMaxResults(1)}
-        SQL;
-        $parameters = array_merge($queryBuilderInitial->getParameters(), $queryBuilderRecursive->getParameters(), $queryBuilderCte->getParameters());
-        $parameterTypes = array_merge($queryBuilderInitial->getParameterTypes(), $queryBuilderRecursive->getParameterTypes(), $queryBuilderCte->getParameterTypes());
-        try {
-            return (int)$this->dbal->fetchOne($query, $parameters, $parameterTypes);
-        } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to fetch CTE count result: %s', $e->getMessage()), 1679047841, $e);
-        }
     }
 }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ContentSubgraph.php
@@ -148,7 +148,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         if ($filter->ordering !== null) {
             $this->applyOrdering($queryBuilder, $filter->ordering);
         }
-        $queryBuilder->addOrderBy('h.position');
+        $queryBuilder->addOrderBy('h.sortpath');
         return $this->fetchNodes($queryBuilder);
     }
 
@@ -291,14 +291,14 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
         $queryBuilderInitial = $this->createQueryBuilder()
             // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
-            ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, 0 AS position')
+            ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, h.sortpath')
             ->from($this->tableNames->node(), 'n')
             ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleChildNodeAggregateId($nodeAggregateIdCondition), 'h', 'h.childnodeanchor = n.relationanchorpoint')
             ->whereCondition('n', $nodeAggregateIdCondition);
         $this->addSubtreeTagConstraints($queryBuilderInitial);
 
         $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('c.*, h.subtreetags, p.nodeaggregateid AS parentNodeAggregateId, p.level + 1 AS level, h.position')
+            ->select('c.*, h.subtreetags, p.nodeaggregateid AS parentNodeAggregateId, p.level + 1 AS level, h.sortpath')
             ->from('tree', 'p')
             ->innerJoinTableSubquery('p', $this->hierarchyRelationQuery, 'h', 'h.parentnodeanchor = p.relationanchorpoint')
             ->innerJoin('p', $this->tableNames->node(), 'c', 'c.relationanchorpoint = h.childnodeanchor');
@@ -313,8 +313,10 @@ final class ContentSubgraph implements ContentSubgraphInterface
         $queryBuilderCte = $this->createQueryBuilder()
             ->select('*')
             ->from('tree')
-            ->orderBy('level')
-            ->addOrderBy('position');
+            // the materialised sort path already encodes depth-first document order across the whole subtree,
+            // so no secondary ordering by level is needed. The column is VARBINARY and therefore compares
+            // byte-wise, which is what base 62 ordering requires {@see NodeSortPath}.
+            ->orderBy('sortpath');
 
         $result = $this->fetchCteResults($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
         /** @var array<string, Subtree[]> $subtreesByParentNodeId */
@@ -431,7 +433,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         if ($filter->pagination !== null) {
             $this->applyPagination($queryBuilderCte, $filter->pagination);
         }
-        $queryBuilderCte->addOrderBy('level')->addOrderBy('position');
+        $queryBuilderCte->addOrderBy('sortpath');
         $nodeRows = $this->fetchCteResults($queryBuilderInitial, $queryBuilderRecursive, $queryBuilderCte, 'tree');
         return $this->nodeFactory->mapNodeRowsToNodes(
             $nodeRows,
@@ -703,7 +705,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
 
         $queryBuilderInitial = $this->createQueryBuilder()
             // @see https://mariadb.com/kb/en/library/recursive-common-table-expressions-overview/#cast-to-avoid-data-truncation
-            ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, 0 AS position')
+            ->select('n.*, h.subtreetags, CAST("ROOT" AS CHAR(50)) AS parentNodeAggregateId, 0 AS level, h.sortpath')
             ->from($this->tableNames->node(), 'n')
             // we need to join with the hierarchy relation, because we need the node name.
             ->innerJoinTableSubquery('n', $this->hierarchyRelationQuery->withPossibleParentNodeAggregateId($nodeAggregateIdCondition), 'h', 'h.childnodeanchor = n.relationanchorpoint')
@@ -713,7 +715,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         $this->addSubtreeTagConstraints($queryBuilderInitial);
 
         $queryBuilderRecursive = $this->createQueryBuilder()
-            ->select('cn.*, h.subtreetags, pn.nodeaggregateid AS parentNodeAggregateId, pn.level + 1 AS level, h.position')
+            ->select('cn.*, h.subtreetags, pn.nodeaggregateid AS parentNodeAggregateId, pn.level + 1 AS level, h.sortpath')
             ->from('tree', 'pn')
             ->innerJoinTableSubquery('pn', $this->hierarchyRelationQuery, 'h', 'h.parentnodeanchor = pn.relationanchorpoint')
             ->innerJoin('pn', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = h.childnodeanchor');

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/Domain/Repository/ProjectionContentGraph.php
@@ -24,6 +24,8 @@ use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelation;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\HierarchyRelationId;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRecord;
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeRelationAnchorPoint;
+use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Projection\NodeSortPath;
+use Neos\ContentGraph\DoctrineDbalAdapter\FractionalIndexing;
 use Neos\ContentGraph\DoctrineDbalAdapter\NodeAggregateIdCondition;
 use Neos\ContentGraph\DoctrineDbalAdapter\SqlTableSubqueryFactory;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
@@ -208,16 +210,16 @@ class ProjectionContentGraph
         return $nodeRow ? NodeRecord::fromDatabaseRow($nodeRow) : null;
     }
 
-    public function determineHierarchyRelationPosition(
+    public function determineHierarchySortPath(
         ?NodeRelationAnchorPoint $parentAnchorPoint,
         ?NodeRelationAnchorPoint $childAnchorPoint,
         ?NodeRelationAnchorPoint $succeedingSiblingAnchorPoint,
         ContentStreamLayers $contentStreamLayers,
         DimensionSpacePoint $dimensionSpacePoint
-    ): int {
+    ): NodeSortPath {
         if (!$parentAnchorPoint && !$childAnchorPoint) {
             throw new \InvalidArgumentException(
-                'You must specify either parent or child node anchor to determine a hierarchy relation position',
+                'You must specify either parent or child node anchor to determine a hierarchy sort path',
                 1519847447
             );
         }
@@ -248,24 +250,24 @@ class ProjectionContentGraph
                 );
             }
 
-            $succeedingSiblingPosition = (int)$succeedingSiblingRelation['position'];
+            $succeedingSiblingSortPath = NodeSortPath::fromString((string)$succeedingSiblingRelation['sortpath']);
             $parentAnchorPoint = NodeRelationAnchorPoint::fromInteger($succeedingSiblingRelation['parentnodeanchor']);
 
             $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($dimensionSpacePoint)->withParentNodeRelationAnchor($parentAnchorPoint);
             $precedingSiblingStatement = <<<SQL
                 SELECT
-                    h.position
+                    h.sortpath
                 FROM
                     {$hierarchyRelationQuery->toSql()} h
                 WHERE
-                    h.position < :position
-                -- select the MAX position
-                ORDER BY h.position DESC
+                    h.sortpath < :sortPath
+                -- select the greatest sort path still below the succeeding sibling
+                ORDER BY h.sortpath DESC
                 LIMIT 1
             SQL;
             try {
                 $precedingSiblingData = $this->dbal->fetchAssociative($precedingSiblingStatement, [
-                    'position' => $succeedingSiblingPosition,
+                    'sortPath' => $succeedingSiblingSortPath->value,
                     ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
                 ], [
                     ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
@@ -273,69 +275,128 @@ class ProjectionContentGraph
             } catch (DBALException $e) {
                 throw new \RuntimeException(sprintf('Failed to load preceding sibling relations for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamLayers->toDebugString(), $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716474957, $e);
             }
-            $precedingSiblingPosition = $precedingSiblingData ? ($precedingSiblingData['position'] ?? null) : null;
-            if (!is_null($precedingSiblingPosition)) {
-                $precedingSiblingPosition = (int)$precedingSiblingPosition;
-            }
+            $precedingSiblingSortPath = $precedingSiblingData ? ($precedingSiblingData['sortpath'] ?? null) : null;
 
-            if (is_null($precedingSiblingPosition)) {
-                $position = $succeedingSiblingPosition - DoctrineDbalContentGraphProjection::RELATION_DEFAULT_OFFSET;
-            } else {
-                $position = ($succeedingSiblingPosition + $precedingSiblingPosition) / 2;
-            }
-        } else {
-            if (!$parentAnchorPoint) {
-                $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($dimensionSpacePoint)->withChildNodeRelationAnchor($childAnchorPoint);
-                $childHierarchyRelationStatement = <<<SQL
-                    SELECT
-                        h.parentnodeanchor
-                    FROM
-                        {$hierarchyRelationQuery->toSql()} h
-                    LIMIT 1
-                SQL;
-                try {
-                    /** @var array<string,mixed> $childHierarchyRelationData */
-                    $childHierarchyRelationData = $this->dbal->fetchAssociative($childHierarchyRelationStatement, [
-                        ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
-                    ], [
-                        ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
-                    ]);
-                } catch (DBALException $e) {
-                    throw new \RuntimeException(sprintf('Failed to load child hierarchy relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamLayers->toDebugString(), $childAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475001, $e);
-                }
-                $parentAnchorPoint = NodeRelationAnchorPoint::fromInteger(
-                    $childHierarchyRelationData['parentnodeanchor']
-                );
-            }
-            $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($dimensionSpacePoint)->withParentNodeRelationAnchor($parentAnchorPoint);
-            $rightmostSucceedingSiblingRelationStatement = <<<SQL
+            // siblings all share the parent prefix, so the new path is that prefix plus a key between both neighbours
+            return $succeedingSiblingSortPath->parent()->child(
+                self::generateFractionalIndexKeyBetween(
+                    $precedingSiblingSortPath !== null
+                        ? NodeSortPath::fromString((string)$precedingSiblingSortPath)->localKey()
+                        : null,
+                    $succeedingSiblingSortPath->localKey()
+                )
+            );
+        }
+
+        if (!$parentAnchorPoint) {
+            $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($dimensionSpacePoint)->withChildNodeRelationAnchor($childAnchorPoint);
+            $childHierarchyRelationStatement = <<<SQL
                 SELECT
-                    h.position
+                    h.parentnodeanchor
                 FROM
                     {$hierarchyRelationQuery->toSql()} h
-                -- select the MAX position
-                ORDER BY h.position DESC
                 LIMIT 1
             SQL;
             try {
-                $rightmostSucceedingSiblingRelationData = $this->dbal->fetchAssociative($rightmostSucceedingSiblingRelationStatement, [
+                /** @var array<string,mixed> $childHierarchyRelationData */
+                $childHierarchyRelationData = $this->dbal->fetchAssociative($childHierarchyRelationStatement, [
                     ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
                 ], [
                     ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
                 ]);
             } catch (DBALException $e) {
-                throw new \RuntimeException(sprintf('Failed to right most succeeding relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamLayers->toDebugString(), $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475046, $e);
+                throw new \RuntimeException(sprintf('Failed to load child hierarchy relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamLayers->toDebugString(), $childAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475001, $e);
             }
-
-            if ($rightmostSucceedingSiblingRelationData) {
-                $position = ((int)$rightmostSucceedingSiblingRelationData['position'])
-                    + DoctrineDbalContentGraphProjection::RELATION_DEFAULT_OFFSET;
-            } else {
-                $position = 0;
-            }
+            $parentAnchorPoint = NodeRelationAnchorPoint::fromInteger(
+                $childHierarchyRelationData['parentnodeanchor']
+            );
         }
 
-        return $position;
+        $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($dimensionSpacePoint)->withParentNodeRelationAnchor($parentAnchorPoint);
+        $rightmostSucceedingSiblingRelationStatement = <<<SQL
+            SELECT
+                h.sortpath
+            FROM
+                {$hierarchyRelationQuery->toSql()} h
+            -- select the greatest sort path, i.e. the last child
+            ORDER BY h.sortpath DESC
+            LIMIT 1
+        SQL;
+        try {
+            $rightmostSucceedingSiblingRelationData = $this->dbal->fetchAssociative($rightmostSucceedingSiblingRelationStatement, [
+                ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
+            ], [
+                ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to right most succeeding relation for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamLayers->toDebugString(), $parentAnchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1716475046, $e);
+        }
+
+        if ($rightmostSucceedingSiblingRelationData) {
+            $rightmostSortPath = NodeSortPath::fromString((string)$rightmostSucceedingSiblingRelationData['sortpath']);
+            return $rightmostSortPath->parent()->child(
+                self::generateFractionalIndexKeyBetween($rightmostSortPath->localKey(), null)
+            );
+        }
+
+        // the parent has no children yet, so no sibling can hand us the prefix and we have to look it up
+        return $this->determineSortPathForAnchorPoint($parentAnchorPoint, $contentStreamLayers, $dimensionSpacePoint)
+            ->child(self::generateFractionalIndexKeyBetween(null, null));
+    }
+
+    /**
+     * The sort path of the hierarchy relation pointing *at* the given anchor point, i.e. the prefix its children inherit.
+     *
+     * Only needed when a parent has no children yet; in every other case an existing sibling already carries the prefix.
+     */
+    public function determineSortPathForAnchorPoint(
+        NodeRelationAnchorPoint $anchorPoint,
+        ContentStreamLayers $contentStreamLayers,
+        DimensionSpacePoint $dimensionSpacePoint
+    ): NodeSortPath {
+        if ($anchorPoint->equals(NodeRelationAnchorPoint::forRootEdge())) {
+            // root edges have no ingoing relation of their own; root nodes carry bare keys without a prefix
+            return NodeSortPath::root();
+        }
+        $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withDimensionSpacePoint($dimensionSpacePoint)->withChildNodeRelationAnchor($anchorPoint);
+        $sortPathStatement = <<<SQL
+            SELECT
+                h.sortpath
+            FROM
+                {$hierarchyRelationQuery->toSql()} h
+            LIMIT 1
+        SQL;
+        try {
+            $sortPath = $this->dbal->fetchOne($sortPathStatement, [
+                ...$hierarchyRelationQuery->getParameters()->toDbalValues(),
+            ], [
+                ...$hierarchyRelationQuery->getParameters()->toDbalTypes(),
+            ]);
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to load sort path for content stream %s, anchor point %s and dimension space point %s from database: %s', $contentStreamLayers->toDebugString(), $anchorPoint->value, $dimensionSpacePoint->toJson(), $e->getMessage()), 1775980010, $e);
+        }
+        if ($sortPath === false) {
+            throw new \RuntimeException(sprintf('Could not fetch sort path for anchor point %s with dimensionSpacePointHash %s', $anchorPoint->value, $dimensionSpacePoint->hash), 1775980011);
+        }
+        return NodeSortPath::fromString((string)$sortPath);
+    }
+
+    /**
+     * {@see FractionalIndexing::generateKeyBetween()} is nullable: it returns null once the integer part would be
+     * decremented past the smallest one. Writing that null into `sortpath` would read back as a removal tombstone,
+     * so fail loudly instead.
+     */
+    private static function generateFractionalIndexKeyBetween(?string $precedingKey, ?string $succeedingKey): string
+    {
+        $key = FractionalIndexing::generateKeyBetween($precedingKey, $succeedingKey);
+        if ($key === null || $key === '') {
+            throw new \RuntimeException(sprintf(
+                'Failed to generate a fractional index key between %s and %s',
+                $precedingKey ?? 'START',
+                $succeedingKey ?? 'END'
+            ), 1775980012);
+        }
+        return $key;
     }
 
     /**
@@ -387,37 +448,6 @@ class ProjectionContentGraph
     }
 
     /**
-     * @return array<string, HierarchyRelation> indexed by the dimension space point hash: ['<dimensionSpacePointHash>' => HierarchyRelation, ...]
-     */
-    public function findIngoingHierarchyRelationsForNode(
-        NodeRelationAnchorPoint $childAnchorPoint,
-        ContentStreamLayers $contentStreamLayers,
-        ?DimensionSpacePointSet $restrictToSet = null
-    ): array {
-        $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withChildNodeRelationAnchor($childAnchorPoint);
-        if ($restrictToSet !== null) {
-            $hierarchyRelationQuery = $hierarchyRelationQuery->withDimensionSpacePoints($restrictToSet);
-        }
-        $ingoingHierarchyRelationsStatement = <<<SQL
-            {$hierarchyRelationQuery->toSql()}
-        SQL;
-        try {
-            $rows = $this->dbal->fetchAllAssociative(
-                $ingoingHierarchyRelationsStatement,
-                $hierarchyRelationQuery->getParameters()->toDbalValues(),
-                $hierarchyRelationQuery->getParameters()->toDbalTypes()
-            );
-        } catch (DBALException $e) {
-            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, child anchor point %s and dimension space points %s from database: %s', $contentStreamLayers->toDebugString(), $childAnchorPoint->value, $restrictToSet?->toJson() ?? '[any]', $e->getMessage()), 1716476299, $e);
-        }
-        $relations = [];
-        foreach ($rows as $row) {
-            $relations[(string)$row['dimensionspacepointhash']] = $this->mapRawDataToHierarchyRelation($row);
-        }
-        return $relations;
-    }
-
-    /**
      *  @return array<int, HierarchyRelation>
      */
     public function findOutgoingHierarchyRelationsForNode(
@@ -444,6 +474,37 @@ class ProjectionContentGraph
         $relations = [];
         foreach ($rows as $row) {
             $relations[] = $this->mapRawDataToHierarchyRelation($row);
+        }
+        return $relations;
+    }
+
+    /**
+     * @return array<string, HierarchyRelation> indexed by the dimension space point hash: ['<dimensionSpacePointHash>' => HierarchyRelation, ...]
+     */
+    public function findIngoingHierarchyRelationsForNode(
+        NodeRelationAnchorPoint $childAnchorPoint,
+        ContentStreamLayers $contentStreamLayers,
+        ?DimensionSpacePointSet $restrictToSet = null
+    ): array {
+        $hierarchyRelationQuery = $this->subqueries->forHierarchyRelation($contentStreamLayers)->withChildNodeRelationAnchor($childAnchorPoint);
+        if ($restrictToSet !== null) {
+            $hierarchyRelationQuery = $hierarchyRelationQuery->withDimensionSpacePoints($restrictToSet);
+        }
+        $ingoingHierarchyRelationsStatement = <<<SQL
+            {$hierarchyRelationQuery->toSql()}
+        SQL;
+        try {
+            $rows = $this->dbal->fetchAllAssociative(
+                $ingoingHierarchyRelationsStatement,
+                $hierarchyRelationQuery->getParameters()->toDbalValues(),
+                $hierarchyRelationQuery->getParameters()->toDbalTypes()
+            );
+        } catch (DBALException $e) {
+            throw new \RuntimeException(sprintf('Failed to load ingoing hierarchy relations for content stream %s, child anchor point %s and dimension space points %s from database: %s', $contentStreamLayers->toDebugString(), $childAnchorPoint->value, $restrictToSet?->toJson() ?? '[any]', $e->getMessage()), 1716476299, $e);
+        }
+        $relations = [];
+        foreach ($rows as $row) {
+            $relations[(string)$row['dimensionspacepointhash']] = $this->mapRawDataToHierarchyRelation($row);
         }
         return $relations;
     }
@@ -569,7 +630,9 @@ class ProjectionContentGraph
             NodeRelationAnchorPoint::fromInteger((int)$rawData['childnodeanchor']),
             DimensionSpacePoint::fromJsonString($dimensionSpacePointJson),
             $rawData['dimensionspacepointhash'],
-            (int)$rawData['position'],
+            // a removal tombstone carries NULL here; it hydrates as the empty root path, which throws
+            // on localKey()/parent() rather than silently sorting first
+            NodeSortPath::fromString((string)($rawData['sortpath'] ?? '')),
             NodeFactory::extractNodeTagsFromJson($rawData['subtreetags']),
         );
     }

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/FractionalIndexing.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/FractionalIndexing.php
@@ -1,0 +1,284 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\ContentGraph\DoctrineDbalAdapter;
+
+/**
+ * PHP Port of "Fractional Indexing" by David Greenspan with a base 62 implementation
+ * @See https://observablehq.com/@dgreensp/implementing-fractional-indexing
+ */
+class FractionalIndexing
+{
+    private const INTEGER_ZERO = "a0";
+
+    private const SMALLEST_INTEGER = "A00000000000000000000000000";
+
+    private const BASE_62_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    /**
+     * `a` is an order key or null (START).
+     * `b` is an order key or null (END).
+     * `a < b` lexicographically if both are non-null.
+     * digits is a string such as '0123456789' for base 10. Digits must be in
+     * ascending character code order!
+     */
+    public static function generateKeyBetween(?string $a, ?string $b, string $digits = self::BASE_62_DIGITS): ?string
+    {
+        if ($a !== null) {
+            self::validateOrderKey($a);
+        }
+
+        if ($b !== null) {
+            self::validateOrderKey($b);
+        }
+
+        if ($a !== null && $b !== null && strcmp($a, $b) >= 0) {
+            throw new \RuntimeException($a . ' >= ' . $b);
+        }
+        if ($a === null && $b === null) {
+            return self::INTEGER_ZERO;
+        }
+        if ($a === null) {
+            $ib = self::getIntegerPart($b);
+            $fb = substr($b, strlen($ib));
+            if ($ib === self::SMALLEST_INTEGER) {
+                return $ib . self::midpoint('', $fb, $digits);
+            }
+            return strcmp($ib, $b) < 0 ? $ib : self::decrementInteger($ib, $digits);
+        }
+
+        if ($b === null) {
+            $ia = self::getIntegerPart($a);
+            $fa = substr($a, strlen($ia));
+            $i = self::incrementInteger($ia, $digits);
+            return $i ?? ($ia . self::midpoint($fa, null, $digits));
+        }
+
+        $ia = self::getIntegerPart($a);
+        $fa = substr($a, strlen($ia));
+        $ib = self::getIntegerPart($b);
+        $fb = substr($b, strlen($ib));
+        if ($ia === $ib) {
+            return $ia . self::midpoint($fa, $fb, $digits);
+        }
+
+        $i = self::incrementInteger($ia, $digits);
+        return strcmp($i, $b) < 0 ? $i : $ia . self::midpoint($fa, null, $digits);
+    }
+
+    /**
+     * same preconditions as generateKeysBetween.
+     * n >= 0.
+     * Returns an array of n distinct keys in sorted order.
+     * If a and b are both null, returns [a0, a1, ...]
+     * If one or the other is null, returns consecutive "integer"
+     * keys.  Otherwise, returns relatively short keys between
+     * a and b.
+     */
+    public static function generateNKeysBetween($a, $b, $n, $digits = self::BASE_62_DIGITS)
+    {
+        if ($n === 0) {
+            return [];
+        }
+        if ($n === 1) {
+            return [self::generateKeyBetween($a, $b, $digits)];
+        }
+        if ($b === null) {
+            $c = self::generateKeyBetween($a, $b, $digits);
+            $result = [$c];
+            for ($i = 0; $i < $n - 1; $i++) {
+                $c = self::generateKeyBetween($c, $b, $digits);
+                $result[] = $c;
+            }
+            return $result;
+        }
+        if ($a === null) {
+            $c = self::generateKeyBetween($a, $b, $digits);
+            $result = [$c];
+            for ($i = 0; $i < $n - 1; $i++) {
+                $c = self::generateKeyBetween($a, $c, $digits);
+                $result[] = $c;
+            }
+
+            return array_reverse($result);
+        }
+        $mid = floor($n / 2);
+        $c = self::generateKeyBetween($a, $b, $digits);
+        return [
+            ...self::generateNKeysBetween($a, $c, $mid, $digits),
+            $c,
+            ...self::generateNKeysBetween($c, $b, $n - $mid - 1, $digits),
+        ];
+    }
+
+    private static function validateOrderKey(string $key): void
+    {
+        if ($key === self::SMALLEST_INTEGER) {
+            throw new \RuntimeException('invalid order key: ' . $key);
+        }
+        $i = self::getIntegerPart($key);
+        $f = substr($key, strlen($i));
+        if (str_ends_with($f, '0')) {
+            throw new \RuntimeException('invalid order key: ' . $key);
+        }
+    }
+
+    private static function getIntegerPart(?string $key): string
+    {
+        $integerPartLength = self::getIntegerLength($key[0]);
+        if ($integerPartLength > strlen($key)) {
+            throw new \RuntimeException('invalid order key: ' . $key);
+        }
+        return substr($key, 0, $integerPartLength);
+    }
+
+    /**
+     * note that this may return null, as there is a smallest integer
+     */
+    private static function decrementInteger(?string $x, string $digits): ?string
+    {
+        self::validateInteger($x);
+        $digs = str_split($x);
+        $head = array_shift($digs);
+
+        $borrow = true;
+        for ($i = count($digs) - 1; $borrow && $i >= 0; $i--) {
+            $d = strpos($digits, $digs[$i]) - 1;
+            if ($d === -1) {
+                $digs[$i] = substr($digits, -1);
+            } else {
+                $digs[$i] = $digits[$d];
+                $borrow = false;
+            }
+        }
+        if ($borrow) {
+            if ($head === 'a') {
+                return 'Z' . substr($digits, -1);
+            }
+            if ($head === 'A') {
+                return null;
+            }
+
+            $h = chr(ord($head) - 1);
+            if (strcmp($h, 'Z') < 0) {
+                $digs[] = substr($digits, -1);
+
+            } else {
+                array_pop($digs);
+            }
+            return $h . implode('', $digs);
+        }
+
+        return $head . implode('', $digs);
+    }
+
+    /**
+     * note that this may return null, as there is a largest integer
+     */
+    private static function incrementInteger(?string $x, string $digits): ?string
+    {
+        self::validateInteger($x);
+        $digs = str_split($x);
+        $head = array_shift($digs);
+
+        $carry = true;
+        for ($i = count($digs) - 1; $carry && $i >= 0; $i--) {
+            $d = strpos($digits, $digs[$i]) + 1;
+            if ($d === strlen($digits)) {
+                $digs[$i] = '0';
+            } else {
+                $digs[$i] = $digits[$d];
+                $carry = false;
+            }
+        }
+
+        if ($carry) {
+            if ($head === 'Z') {
+                return 'a0';
+            }
+            if ($head === 'z') {
+                return null;
+            }
+            $h = chr(ord($head) + 1);
+            if (strcmp($h, 'a') > 0) {
+                $digs[] = '0';
+            } else {
+                array_pop($digs);
+            }
+            return $h . implode('', $digs);
+        }
+
+        return $head . implode('', $digs);
+    }
+
+    /**
+     * `a` may be empty string, `b` is null or non-empty string.
+     * `a < b` lexicographically if `b` is non-null.
+     * no trailing zeros allowed.
+     * digits is a string such as '0123456789' for base 10.  Digits must be in
+     * ascending character code order!
+     */
+    private static function midpoint(string $a, ?string $b, string $digits): string
+    {
+        if ($b !== null && strcmp($a, $b) >= 0) {
+            throw new \RuntimeException($a . ' >= ' . $b);
+        }
+        if (str_ends_with($a, '0') || ($b && str_ends_with($b, '0'))) {
+            throw new \RuntimeException('trailing zero');
+        }
+        if ($b) {
+            // remove longest common prefix.  pad `a` with 0s as we
+            // go.  note that we don't need to pad `b`, because it can't
+            // end before `a` while traversing the common prefix.
+            $n = 0;
+            while (($a[$n] ?? '0') === $b[$n]) {
+                $n++;
+            }
+            if ($n > 0) {
+                return substr($b, 0, $n) . self::midpoint(substr($a, $n), substr($b, $n), $digits);
+            }
+        }
+
+        // first digits (or lack of digit) are different
+        $digitA = $a ? strpos($digits, $a[0]) : 0;
+        $digitB = $b !== null ? strpos($digits, $b[0]) : strlen($digits);
+        if ($digitB - $digitA > 1) {
+            $midDigit = (int)round(0.5 * ($digitA + $digitB));
+            return $digits[$midDigit];
+        }
+        // first digits are consecutive
+        if ($b && strlen($b) > 1) {
+            return $b[0];
+        }
+
+        // `b` is null or has length 1 (a single digit).
+        // the first digit of `a` is the previous digit to `b`,
+        // or 9 if `b` is null.
+        // given, for example, midpoint('49', '5'), return
+        // '4' + midpoint('9', null), which will become
+        // '4' + '9' + midpoint('', null), which is '495'
+        return $digits[$digitA] . self::midpoint(substr($a, 1), null, $digits);
+    }
+
+    private static function validateInteger(?string $int): void
+    {
+        if (strlen($int) !== self::getIntegerLength($int[0])) {
+            throw new \RuntimeException('invalid integer part of order key: ' . $int);
+        }
+    }
+
+    private static function getIntegerLength(mixed $head): int
+    {
+        if (strcmp($head, 'a') >= 0 && strcmp($head, 'z') <= 0) {
+            return ord($head[0]) - ord('a') + 2;
+        }
+
+        if (strcmp($head, 'A') >= 0 && strcmp($head, 'Z') <= 0) {
+            return ord('Z') - ord($head[0]) + 2;
+        }
+
+        throw new \RuntimeException('Invalid order key head: ' . $head);
+    }
+
+
+}

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/FractionalIndexing.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/FractionalIndexing.php
@@ -6,6 +6,8 @@ namespace Neos\ContentGraph\DoctrineDbalAdapter;
 /**
  * PHP Port of "Fractional Indexing" by David Greenspan with a base 62 implementation
  * @See https://observablehq.com/@dgreensp/implementing-fractional-indexing
+ *
+ * @internal
  */
 class FractionalIndexing
 {
@@ -63,7 +65,7 @@ class FractionalIndexing
         }
 
         $i = self::incrementInteger($ia, $digits);
-        return strcmp($i, $b) < 0 ? $i : $ia . self::midpoint($fa, null, $digits);
+        return $i !== null && strcmp($i, $b) < 0 ? $i : $ia . self::midpoint($fa, null, $digits);
     }
 
     /**
@@ -74,8 +76,10 @@ class FractionalIndexing
      * If one or the other is null, returns consecutive "integer"
      * keys.  Otherwise, returns relatively short keys between
      * a and b.
+     *
+     * @return array<int,string|null>
      */
-    public static function generateNKeysBetween($a, $b, $n, $digits = self::BASE_62_DIGITS)
+    public static function generateNKeysBetween(?string $a, ?string $b, int $n, string $digits = self::BASE_62_DIGITS): array
     {
         if ($n === 0) {
             return [];
@@ -102,7 +106,7 @@ class FractionalIndexing
 
             return array_reverse($result);
         }
-        $mid = floor($n / 2);
+        $mid = intdiv($n, 2);
         $c = self::generateKeyBetween($a, $b, $digits);
         return [
             ...self::generateNKeysBetween($a, $c, $mid, $digits),
@@ -123,7 +127,7 @@ class FractionalIndexing
         }
     }
 
-    private static function getIntegerPart(?string $key): string
+    private static function getIntegerPart(string $key): string
     {
         $integerPartLength = self::getIntegerLength($key[0]);
         if ($integerPartLength > strlen($key)) {
@@ -135,11 +139,11 @@ class FractionalIndexing
     /**
      * note that this may return null, as there is a smallest integer
      */
-    private static function decrementInteger(?string $x, string $digits): ?string
+    private static function decrementInteger(string $x, string $digits): ?string
     {
         self::validateInteger($x);
         $digs = str_split($x);
-        $head = array_shift($digs);
+        $head = (string)array_shift($digs);
 
         $borrow = true;
         for ($i = count($digs) - 1; $borrow && $i >= 0; $i--) {
@@ -175,11 +179,11 @@ class FractionalIndexing
     /**
      * note that this may return null, as there is a largest integer
      */
-    private static function incrementInteger(?string $x, string $digits): ?string
+    private static function incrementInteger(string $x, string $digits): ?string
     {
         self::validateInteger($x);
         $digs = str_split($x);
-        $head = array_shift($digs);
+        $head = (string)array_shift($digs);
 
         $carry = true;
         for ($i = count($digs) - 1; $carry && $i >= 0; $i--) {
@@ -260,7 +264,7 @@ class FractionalIndexing
         return $digits[$digitA] . self::midpoint(substr($a, 1), null, $digits);
     }
 
-    private static function validateInteger(?string $int): void
+    private static function validateInteger(string $int): void
     {
         if (strlen($int) !== self::getIntegerLength($int[0])) {
             throw new \RuntimeException('invalid integer part of order key: ' . $int);

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/HierarchyRelationSubquery.php
@@ -103,7 +103,7 @@ use Neos\ContentRepository\Dbal\Query\SqlWhereConditionInterface;
  *   - in theory its safe to access the nodes' node aggregate id which MUST be invariant across all layers
  * - `dimensionspacepointhash` see move dimension space point
  * - `subtreetags` see subtree tagging
- * - `position` see move node
+ * - `sortpath` see move node (and every descendant of a moved node, whose prefix changes with it)
  *
  * Additionally, all of these columns can be set to `NULL` signaling a node removal.
  * Filtering on these candidates would exclude the NULL values and resurrect the node.

--- a/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/src/NodeQueryBuilder.php
@@ -59,7 +59,7 @@ final readonly class NodeQueryBuilder
             ->innerJoin('ch', $this->tableNames->dimensionSpacePoints(), 'cdsp', 'cdsp.hash = ch.dimensionspacepointhash')
             ->innerJoin('ch', $this->tableNames->node(), 'cn', 'cn.relationanchorpoint = ch.childnodeanchor')
             ->whereCondition('pn', $nodeAggregateIdCondition)
-            ->orderBy('ch.position');
+            ->orderBy('ch.sortpath');
     }
 
     public function buildFindRootNodeAggregatesQuery(HierarchyRelationSubquery $hierarchyRelationQuery, FindRootNodeAggregatesFilter $filter): QueryBuilder
@@ -118,14 +118,15 @@ final readonly class NodeQueryBuilder
             ->whereCondition('sn', $nodeAggregateIdCondition);
 
         $parentNodeAnchorSubQuery = (clone $sharedSubQuery)->select('sh.parentnodeanchor');
-        $siblingPositionSubQuery = (clone $sharedSubQuery)->select('sh.position');
+        $siblingSortPathSubQuery = (clone $sharedSubQuery)->select('sh.sortpath');
 
         return $this->buildBasicNodeQuery($hierarchyRelationQuery)
             ->andWhere('h.parentnodeanchor = (' . $parentNodeAnchorSubQuery->getSQL() . ')')
             ->andWhere('n.nodeaggregateid != ' . $nodeAggregateIdCondition->getParameters()->getReference('nodeAggregateId'))
-            ->andWhere('h.position ' . ($preceding ? '<' : '>') . ' (' . $siblingPositionSubQuery->getSQL() . ')')
+            // siblings share the parent prefix, so comparing whole sort paths is equivalent to comparing keys
+            ->andWhere('h.sortpath ' . ($preceding ? '<' : '>') . ' (' . $siblingSortPathSubQuery->getSQL() . ')')
             ->mergeParametersFromBuilder($sharedSubQuery)
-            ->orderBy('h.position', $preceding ? 'DESC' : 'ASC');
+            ->orderBy('h.sortpath', $preceding ? 'DESC' : 'ASC');
     }
 
     public function addNodeTypeCriteria(QueryBuilder $queryBuilder, ExpandedNodeTypeCriteria $constraintsWithSubNodeTypes, string $nodeTableAlias = 'n'): void

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/DescendantNodes.feature
@@ -109,13 +109,13 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "dateProperty > \"1980-12-14\""}' I expect no nodes to be returned
 
       # findDescendantNodes queries with results
-    When I execute the findDescendantNodes query for entry node aggregate id "home" I expect the nodes "terms,contact,a,b,a1,b1,a2,a3,a2a,a2a1,a2a2,a2a2b" to be returned
-    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"nodeTypes": "Neos.ContentRepository.Testing:Page"}' I expect the nodes "a,b,a1,b1,a2,a3,a2a1,a2a2,a2a2b" to be returned
+    When I execute the findDescendantNodes query for entry node aggregate id "home" I expect the nodes "terms,contact,a,a1,a2,a2a,a2a1,a2a2,a2a2b,a3,b,b1" to be returned
+    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"nodeTypes": "Neos.ContentRepository.Testing:Page"}' I expect the nodes "a,a1,a2,a2a1,a2a2,a2a2b,a3,b,b1" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"searchTerm": "a2"}' I expect the nodes "a2,a2a,a2a1,a2a2,a2a2b" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"searchTerm": "a1"}' I expect the nodes "a1,a2a1" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "text ^= \"a1\""}' I expect the nodes "a1" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "text ^= \"a1\" OR text $= \"a1\""}' I expect the nodes "a1,a2a1" to be returned
-    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "stringProperty *= \"späCi\" OR text $= \"a1\""}' I expect the nodes "b,a1,a2a1" to be returned
+    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "stringProperty *= \"späCi\" OR text $= \"a1\""}' I expect the nodes "a1,a2a1,b" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "booleanProperty = true"}' I expect the nodes "a,a2a2b" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "booleanProperty = false"}' I expect the nodes "a3" to be returned
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "integerProperty >= 20"}' I expect the nodes "a1,a2,a2a2b" to be returned
@@ -129,5 +129,5 @@ Feature: Find and count nodes using the findDescendantNodes and countDescendantN
     When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"propertyValue": "dateProperty > \"1980-12-13\""}' I expect the nodes "a2a1,a2a2" to be returned
     # TODO reactivate later, currently behavior between mysql and mariadb different for non string datatypes, mariadb fails here
     # When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"ordering": [{"type": "propertyName", "field": "integerProperty", "direction": "DESCENDING"}]}' I expect the nodes "a2,a1,a2a2b,terms,contact,a,b,b1,a3,a2a,a2a1,a2a2" to be returned
-    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"ordering": [{"type": "propertyName", "field": "booleanProperty", "direction": "ASCENDING"}, {"type": "timestampField", "field": "LAST_MODIFIED", "direction": "DESCENDING"}]}' I expect the nodes "terms,contact,b,a1,b1,a2,a2a,a2a1,a2a2,a3,a2a2b,a" to be returned
-    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"ordering": [{"type": "propertyName", "field": "integerProperty", "direction": "DESCENDING"}], "pagination": {"limit": 3, "offset": 4}}' I expect the nodes "contact,a,b" to be returned and the total count to be 12
+    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"ordering": [{"type": "propertyName", "field": "booleanProperty", "direction": "ASCENDING"}, {"type": "timestampField", "field": "LAST_MODIFIED", "direction": "DESCENDING"}]}' I expect the nodes "terms,contact,a1,a2,a2a,a2a1,a2a2,b,b1,a3,a2a2b,a" to be returned
+    When I execute the findDescendantNodes query for entry node aggregate id "home" and filter '{"ordering": [{"type": "propertyName", "field": "integerProperty", "direction": "DESCENDING"}], "pagination": {"limit": 3, "offset": 4}}' I expect the nodes "contact,a,a2a" to be returned and the total count to be 12

--- a/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
+++ b/Neos.ContentRepository.BehavioralTests/Tests/Behavior/Features/NodeTraversal/FindSubtree.feature
@@ -143,3 +143,51 @@ Feature: Find nodes using the findSubtree query
      b
       b1
     """
+
+  Scenario: A node excluded by the node type filter takes its whole subtree with it
+    # "contact" is a Contact, which the filter below does not include. Its child here is a Page, which the
+    # filter does include - and it must still be dropped, because it is only reachable through an excluded
+    # node. This is the pruning property of findSubtree, and the one behaviour that a flat sort path range
+    # scan {@see NodeSortPath} does not get for free: it is restored by the re-nesting dropping orphans.
+    Given the following CreateNodeAggregateWithNode commands are executed:
+      | nodeAggregateId | nodeName     | nodeTypeName                        | parentNodeAggregateId | initialPropertyValues    | tetheredDescendantNodeAggregateIds |
+      | contactchild    | contactchild | Neos.ContentRepository.Testing:Page | contact               | {"text": "contactchild"} | {}                                 |
+
+    # without a filter it is part of the tree
+    When I execute the findSubtree query for entry node aggregate id "home" I expect the following tree:
+    """
+    home
+     terms
+     contact
+      contactchild
+     a
+      a1
+      a2
+       a2a
+        a2a1
+        a2a2
+      a3
+     b
+      b1
+    """
+    # with the filter, both "contact" and its matching child are gone
+    When I execute the findSubtree query for entry node aggregate id "home" and filter '{"nodeTypes": "Neos.ContentRepository.Testing:Page,Neos.ContentRepository.Testing:SpecialPage"}' I expect the following tree:
+    """
+    home
+     a
+      a1
+      a2
+       a2a
+        a2a1
+        a2a2
+      a3
+     b
+      b1
+    """
+    # but it is reachable when queried from an entry node below the excluded one, since the entry node itself
+    # is never subject to the node type filter
+    When I execute the findSubtree query for entry node aggregate id "contact" and filter '{"nodeTypes": "Neos.ContentRepository.Testing:Page,Neos.ContentRepository.Testing:SpecialPage"}' I expect the following tree:
+    """
+    contact
+     contactchild
+    """

--- a/Neos.ContentRepository.Dbal/Classes/Query/StaticWhereCondition.php
+++ b/Neos.ContentRepository.Dbal/Classes/Query/StaticWhereCondition.php
@@ -16,20 +16,27 @@ final readonly class StaticWhereCondition implements SqlWhereConditionInterface
     private function __construct(
         private string $expectedAlias,
         private string $whereConditionSql,
+        private Parameters $parameters,
     ) {
     }
 
-    public static function fromString(string $expectedAlias, string $whereConditionSql): self
+    /**
+     * The parameters are optional: a caller that executes the statement itself may bind the placeholders
+     * directly. They MUST be passed whenever the condition ends up inside a {@see QueryBuilder}, which
+     * collects the parameters of the subqueries it inlines and has no other way of learning about them.
+     */
+    public static function fromString(string $expectedAlias, string $whereConditionSql, ?Parameters $parameters = null): self
     {
         return new self(
             expectedAlias: $expectedAlias,
             whereConditionSql: $whereConditionSql,
+            parameters: $parameters ?? Parameters::create(),
         );
     }
 
     public function getParameters(): Parameters
     {
-        return Parameters::create();
+        return $this->parameters;
     }
 
     public function toWhereSql(string $alias): string

--- a/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
+++ b/Neos.ContentRepositoryRegistry/Classes/Upgrade/Command/CRUpgradeCommandController.php
@@ -141,6 +141,13 @@ final class CRUpgradeCommandController extends CommandController
      *     - new column hierarchrelation.contentstreamlayer and id
      *     - new table contentstreamlayer
      *
+     *   - fractional indexing of sibling order
+     *     - hierarchyrelation.position (INTEGER) replaced by hierarchyrelation.sortpath (VARBINARY)
+     *       holding a materialised sort path of base 62 fractional index keys, e.g. a0/a0/b3/ZzV
+     *     - the four composite indexes containing `position` are replaced accordingly
+     *     - the values are derived from the events, so a replay regenerates them; no data migration exists
+     *       (and none is possible, the column type changes)
+     *
      * - [future version X ...]
      *
      * The following upgrade is required


### PR DESCRIPTION
# Problem
The current CR implementation with DBAL adapter stores the graph in a relational database. This is in general not the most efficient way of storing graphs. The nodes are stored only with information about there parent/child relations (hierarchy relation) and their siblings (position). This works very well for queries of direct childs and parents.

But if you query nodes within a sub-tree of the graph you have to build the whole graph first and filter afterwards. This is very slow if you do searches on bigger sub-trees, e.g. "find all headlines of the website" or "find all news article from may in all categories".

# Idea
Before Neos 9 we also had this issue, but solved it by **using paths** to store the "position" in the graph on each node. So you can easily reduce the set of possible node candidates, matching your criteria to only a specific subgraph - without building it. 

But there were reasons for changing this in Neos 9.

## CTE vs Path
Using the CTEs (recursive queries) allows us to only store the information about the parent/child relation and the position of below the parent. This makes it easy to move nodes in the tree without the need to update any other children in the path. The tree is build on read. But this requires to build the full tree, to figure out, if a node is part of a subtree or not.

The path stores the position in the tree, which allows it easily to figure this out, without building the tree. You can fetch by simple string comparison all nodes belong to a subtree, or all ancestors by the segements in your path.
But this brings the cost of recalculating the paths on every move move (incl. their children).

Another issues (that already in Neos 8 exists) is the limitation of the path length, which results in the limitation of the graph depth. The index size in the database is limited (based on field type, configuration, etc). So we can't simple let the path grow infinite. With reaching some path lenght the index simply skips the information behind that limit, which makes the path fuzzy/wrong on deep graphs.

## Fractional indexing
See: https://observablehq.com/@dgreensp/implementing-fractional-indexing

The fractional indexing is an idea to keep the path as compact as possible, always allow to move/create node between other nodes.

This approach allows in theory to have "**infinite" space between two fragements**. Which means you can always put a node between to existing nodes, without changing the paths of the existing nodes.

The format is quite compacat, if the nodes are well distributed or created in the right order. Appending or prepending nodes keeps a very compact fragment (1.000.000 nodes -> 5 chars). But there are also circumstances, which will lead to fast increasing fragemens. So if you create/move node into the same gap multiple times (>1000), the fragment can quicky reach the lenght of 169 chars.

But the fragments are rebalanceable, so you can distributes new fragements over all children and reduce the length of each to 2-5 chars (see above).

By combining all fragments of each node (parent-childnode-relation) to a path we have a fully sortable and queriable for the whole CR.

**One thing to highlight is that a path, build with fractional indexing, includes also the position of the child node bekow his parent.** 

Example paths:
```
a0
a0/a0
a0/a0/a0
a0/a0/a1
a0/a0/a2
a0/a0/a1
a0/a0/a3
a0/a0/a4
a0/a0/a5
a0/a0/a6
...
a0/a0/a3/a0
a0/a0/a3/a4/a0HO
a0/a0/a3/a4/a0HO/a0
```


## Advantages

### Better read performance 
With the paths we can filter the result set of nodes to the needed subgraph without building it recursive. So we can save a lot of unecessary work on database level.

### Easier SQL queries
Removing the CTEs will result in easier to read SQL queries.

### Sort order included
As the fragment also contain the position/order of a node between its siblings, we get the sort order included.

### Improved sorting (gaped positions vs. fractional indexing)
Currently we use a "gap" approach for sorting with a static gap of 128. Which also requires rebalancing from time to time. The fractional indexing wouldn't need the rebalancing from pure sorting perspective, as it has always a fragment in between two other. 

## Drawbacks
### More load on write side
The biggest advantage of the CTE is, that we don't need to do changes to the descendents of a moved node. The descendents are still in the same place - from a relative perspective. So they have the same distance in the graph as before.
With paths, we break this as the path contains information of the position of the parents in the graph. So we need to update all descendents of a moved node. This leads also to **materialized node edges** for each descendent node.

Luckily, the path updates are quite cheap, as we only need a string replacement of the path prefix here.

### Limited path length -> graph depth
Due to the limitation of the indexable data, the length of the path is limited - which results in a limitation of the graph. 

The fractional indexing reduces the storage room, especially of siblings (if well distributed or rebalanced), so a broad graph is no concern. But the depth of the graph is strongly bound to the length of the path and caps it by ~120-180 levels (3-6 chars per level).

### Changed query result order
### Path maintenance

## Possible tweaks

Similar to Neos 8, we can allow longer paths than the index can handle. This would allow to store even deeper graphs, but without the performance of an index-fittig-graph. Queries on deeper levels would simply be slower, but still work.


# Performance analysis

I did a quick performance analysis with the [existing benchmark suite](https://github.com/neos/contentrepository-benchmarktests) for the CR. **I had to reduce the maximum graph depth to 250 levels, as the path can't handle deeper graphs due to his length restrictions.**

Scenarios:

| File | Sample | Depth | Breadth |
|---|---|---:|---:|
| `01-BalancedGraph.json` | `twoLevels` | 2 | 10 |
| `01-BalancedGraph.json` | `fourLevels` | 4 | 10 |
| `02-BroadGraph.json` | `firstSample` | 1 | 11110 |
| `03-DeepGraph.json` | `firstSample` | 250 | 1 |

## Subgraph queries (the changed read path)

| Scenario | Metric | cte (before) | path (after) | Change |
|---|---|---:|---:|---:|
| **Balanced** d=2 b=10 | descendants | 3.15 ms | 1.42 ms | **−55%** (2.2×) |
| | subtree | 3.08 ms | 1.60 ms | **−48%** (1.9×) |
| | ancestors | 1.43 ms | 0.35 ms | **−75%** (4.1×) |
| | children / parent / id / reference | 0.5–0.6 ms | 0.5–0.6 ms | ±2% |
| | backReference | 0.64 ms | 0.72 ms | +12% |
| **Balanced** d=4 b=10 | descendants | 290.3 ms | 79.7 ms | **−72%** (3.6×) |
| | subtree | 313.2 ms | 89.9 ms | **−71%** (3.5×) |
| | ancestors | 14.57 ms | 0.48 ms | **−97%** (30.4×) |
| | children / parent / id | 0.3–2.0 ms | 0.3–2.0 ms | ±4% |
| | reference | 0.67 ms | 0.57 ms | −15% |
| | backReference | 5.22 ms | 5.21 ms | −0.2% |
| **Broad** d=1 b=11110 | descendants | 162.3 ms | 74.9 ms | **−54%** (2.2×) |
| | subtree | 177.6 ms | 84.0 ms | **−53%** (2.1×) |
| | ancestors | 15.07 ms | 0.45 ms | **−97%** (33.7×) |
| | children / parent / id / reference | 0.35–2.0 ms | 0.36–2.0 ms | ±5% |
| | backReference | 5.24 ms | 5.43 ms | +4% |
| **Deep** d=250 b=1 | descendants | 73.88 ms | 2.52 ms | **−97%** (29.3×) |
| | subtree | 75.35 ms | 3.26 ms | **−96%** (23.1×) |
| | ancestors | 1.72 ms | 0.43 ms | **−75%** (4.0×) |
| | children / parent / id | 0.33–0.51 ms | 0.37–0.57 ms | +10…+13% |
| | reference | 0.56 ms | 0.67 ms | +20% |
| | backReference | 0.69 ms | 0.77 ms | +12% |

## Command runtime and ContentGraph queries

| Scenario | commandRuntime cte → path | Change | `contentGraphQueryTime.*` |
|---|---|---:|---|
| Balanced d=2 | 884 → 878 ms | −0.7% | all within ±12% (sub-ms, noise) |
| Balanced d=4 | 87 631 → 94 473 ms | +7.8% | within ±16% (sub-ms); ancestors 3.28 → 3.30 ms (+0.5%) |
| Broad | 98 411 → 102 036 ms | +3.7% | within ±18% (sub-ms); ancestors 3.34 → 3.33 ms (−0.2%) |
| Deep | 1 973 → 2 211 ms | +12.1% | within ±23% (sub-ms); ancestors 0.40 → 0.42 ms (+6.8%) |

## Raw per-run values for the metrics that moved

| Scenario | Metric | cte runs 1 / 2 / 3 | path runs 1 / 2 / 3 |
|---|---|---|---|
| Balanced d=2 | descendants | 3.15 / 3.04 / 3.19 ms | 1.42 / 1.37 / 1.42 ms |
| | subtree | 3.21 / 3.08 / 3.08 ms | 1.80 / 1.58 / 1.60 ms |
| | ancestors | 1.40 / 1.43 / 1.47 ms | 0.34 / 0.35 / 0.37 ms |
| Balanced d=4 | descendants | 286.2 / 290.3 / 294.2 ms | 79.7 / 80.6 / 78.8 ms |
| | subtree | 313.2 / 315.3 / 312.6 ms | 89.9 / 87.3 / 90.5 ms |
| | ancestors | 14.60 / 14.47 / 14.57 ms | 0.48 / 0.44 / 0.58 ms |
| Broad | descendants | 163.9 / 162.2 / 162.3 ms | 77.3 / 74.8 / 74.9 ms |
| | subtree | 183.8 / 177.6 / 175.7 ms | 84.0 / 86.5 / 82.9 ms |
| | ancestors | 14.95 / 15.07 / 15.42 ms | 0.54 / 0.45 / 0.44 ms |
| Deep | descendants | 73.9 / 74.6 / 72.3 ms | 2.52 / 2.50 / 2.58 ms |
| | subtree | 75.5 / 73.6 / 75.4 ms | 3.26 / 3.25 / 3.44 ms |
| | ancestors | 1.72 / 1.72 / 1.90 ms | 0.43 / 0.43 / 0.50 ms |

## Result
The benchmark shows a significant impovement of descendants, subtree and ancestors queries with the path-based queries.
But it also shows the costs on write side within the increased command runtime.

I also want to point out, that the current benchmark tests to not cover queries with e.g. NodeType filter or similar, where the path-based queries should show their real benefit. As it allows to reduce the resultset without building the whole subgraph.

# Disclaimer
Most changes of this PR are AI generated and not ment to get merged. It's only an experimental implementation to see effects and limitations of a general change from CTEs to path-based queries in the CR. 