### PR TITLE
BUGFIX: UriPathProjection handles disabled and removed state of newly create variants correctly

### DIFF
--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentNodeInfo.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentNodeInfo.php
@@ -89,6 +89,22 @@ final class DocumentNodeInfo
         return new self($source);
     }
 
+    public function withDisabledLevel(int $disabledLevel): self
+    {
+        $source = $this->source;
+        $source['disabled'] = $disabledLevel;
+
+        return new self($source);
+    }
+
+    public function withRemovedLevel(int $removedLevel): self
+    {
+        $source = $this->source;
+        $source['removed'] = $removedLevel;
+
+        return new self($source);
+    }
+
     public function getNodeAggregateId(): NodeAggregateId
     {
         return NodeAggregateId::fromString($this->source['nodeaggregateid']);

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -409,14 +409,14 @@ final class DocumentUriPathProjection implements ProjectionInterface
                 ));
                 $isSourceNodeExplicitlyDisabled = $parentSourceNode ? $this->isNodeExplicitlyDisabled($sourceNode, $parentSourceNode) : false;
                 $isSourceNodeExplicitlyRemoved = $parentSourceNode ? $this->isNodeExplicitlyRemoved($sourceNode, $parentSourceNode) : false;
-                // transfer disabled and removedstate from parent
+                // transfer disabled- and removed-level from parent and combine with source
                 $targetNode = $targetNode
-                    ->withDisabledLevel($parentNode->getDisableLevel() + ($isSourceNodeExplicitlyDisabled ? 1 : 0))
-                    ->withRemovedLevel($parentNode->getRemovedLevel() + ($isSourceNodeExplicitlyRemoved ? 1 : 0));
+                    ->withDisabledLevel(($parentNode?->getDisableLevel() ?: 0) + ($isSourceNodeExplicitlyDisabled ? 1 : 0))
+                    ->withRemovedLevel(($parentNode?->getRemovedLevel() ?: 0) + ($isSourceNodeExplicitlyRemoved ? 1 : 0));
             } else {
                 $targetNode = $targetNode
-                    ->withDisabledLevel($parentNode->getDisableLevel())
-                    ->withRemovedLevel($parentNode->getRemovedLevel());
+                    ->withDisabledLevel($parentNode?->getDisableLevel() ?: 0)
+                    ->withRemovedLevel($parentNode?->getRemovedLevel() ?: 0);
             }
 
             if ($parentNode !== null) {

--- a/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
+++ b/Neos.Neos/Classes/FrontendRouting/Projection/DocumentUriPathProjection.php
@@ -334,7 +334,8 @@ final class DocumentUriPathProjection implements ProjectionInterface
             $event->nodeAggregateId,
             $event->sourceOrigin,
             $event->peerOrigin,
-            $event->peerSucceedingSiblings
+            $event->peerSucceedingSiblings,
+            false
         );
     }
 
@@ -347,7 +348,8 @@ final class DocumentUriPathProjection implements ProjectionInterface
             $event->nodeAggregateId,
             $event->sourceOrigin,
             $event->generalizationOrigin,
-            $event->variantSucceedingSiblings
+            $event->variantSucceedingSiblings,
+            false
         );
     }
 
@@ -360,7 +362,8 @@ final class DocumentUriPathProjection implements ProjectionInterface
             $event->nodeAggregateId,
             $event->sourceOrigin,
             $event->specializationOrigin,
-            $event->specializationSiblings
+            $event->specializationSiblings,
+            true
         );
     }
 
@@ -369,6 +372,7 @@ final class DocumentUriPathProjection implements ProjectionInterface
         OriginDimensionSpacePoint $sourceOrigin,
         OriginDimensionSpacePoint $targetOrigin,
         InterdimensionalSiblings $interdimensionalSiblings,
+        bool $transferDeletedAndRemovedLevels
     ): void {
         $sourceNode = $this->tryGetNode(fn () => $this->documentUriPathFinder->getByIdAndDimensionSpacePointHash(
             $nodeAggregateId,
@@ -394,6 +398,27 @@ final class DocumentUriPathProjection implements ProjectionInterface
                 $sourceNode->getParentNodeAggregateId(),
                 $interdimensionalSibling->dimensionSpacePoint->hash
             ));
+
+            // deleted and removed level are defined from the parent node values
+            // if subtree tags are to be transferred (as in createSpecialization)
+            // the parent values are raised for all tags set for the handled node
+            if ($transferDeletedAndRemovedLevels) {
+                $parentSourceNode = $this->tryGetNode(fn () => $this->documentUriPathFinder->getByIdAndDimensionSpacePointHash(
+                    $sourceNode->getParentNodeAggregateId(),
+                    $sourceNode->getDimensionSpacePointHash()
+                ));
+                $isSourceNodeExplicitlyDisabled = $parentSourceNode ? $this->isNodeExplicitlyDisabled($sourceNode, $parentSourceNode) : false;
+                $isSourceNodeExplicitlyRemoved = $parentSourceNode ? $this->isNodeExplicitlyRemoved($sourceNode, $parentSourceNode) : false;
+                // transfer disabled and removedstate from parent
+                $targetNode = $targetNode
+                    ->withDisabledLevel($parentNode->getDisableLevel() + ($isSourceNodeExplicitlyDisabled ? 1 : 0))
+                    ->withRemovedLevel($parentNode->getRemovedLevel() + ($isSourceNodeExplicitlyRemoved ? 1 : 0));
+            } else {
+                $targetNode = $targetNode
+                    ->withDisabledLevel($parentNode->getDisableLevel())
+                    ->withRemovedLevel($parentNode->getRemovedLevel());
+            }
+
             if ($parentNode !== null) {
                 $uriPathSegments = explode('/', $sourceNode->getUriPath());
                 $uriPathSegment = $uriPathSegments[array_key_last($uriPathSegments)];
@@ -680,7 +705,7 @@ final class DocumentUriPathProjection implements ProjectionInterface
                 uriPath = TRIM('/' FROM {$this->concatSql(
                     ':newParentUriPath',
                     "'/'",
-                    "TRIM(LEADING '/' FROM SUBSTRING(uriPath, {$sourceUriPathOffset}))"   
+                    "TRIM(LEADING '/' FROM SUBSTRING(uriPath, {$sourceUriPathOffset}))"
                 )}),
                 disabled = disabled + {$disabledDelta},
                 removed = removed + {$removedDelta}

--- a/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
+++ b/Neos.Neos/Tests/Behavior/Features/FrontendRouting/NodeVariationEdgeCases.feature
@@ -378,3 +378,67 @@ Feature: Test cases for node variation edge cases
       | "65901ded4f068dac14ad0dce4f459b29" | "youngest" | "lady-eleonode-rootford/shernode-homes/youngest-mc-nodeface" | "youngest-mc-nodeface"   | "shernode-homes"         | "younger-mc-nodeface"    | null                      | "Neos.Neos:Document" |
       | "9a723c057afa02982dae9d0b541739be" | "youngest" | "lady-eleonode-rootford/shernode-homes/youngest-mc-nodeface" | "youngest-mc-nodeface"   | "shernode-homes"         | "younger-mc-nodeface"    | null                      | "Neos.Neos:Document" |
       | "c60c44685475d0e2e4f2b964e6158ce2" | "youngest" | "lady-eleonode-rootford/shernode-homes/youngest-mc-nodeface" | "youngest-mc-nodeface"   | "shernode-homes"         | "younger-mc-nodeface"    | null                      | "Neos.Neos:Document" |
+
+  Scenario: Peer variants created from disabled source variants must also be disabled in the content graph
+    Given using the following content dimensions:
+      | Identifier | Values | Generalizations |
+      | language   | de, fr |                 |
+    And using the following node types:
+    """yaml
+    'Neos.Neos:Sites':
+      superTypes:
+        'Neos.ContentRepository:Root': true
+    'Neos.Neos:Document':
+      properties:
+        uriPathSegment:
+          type: string
+    'Neos.Neos:Site':
+      superTypes:
+        'Neos.Neos:Document': true
+    """
+    And using identifier "default", I define a content repository
+    And I am in content repository "default"
+    And I am user identified by "initiating-user-identifier"
+    And the command CreateRootWorkspace is executed with payload:
+      | Key                | Value           |
+      | workspaceName      | "live"          |
+      | newContentStreamId | "cs-identifier" |
+    And I am in workspace "live" and dimension space point {"language":"de"}
+    And the command CreateRootNodeAggregateWithNode is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "lady-eleonode-rootford" |
+      | nodeTypeName    | "Neos.Neos:Sites"        |
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                    |
+      | nodeAggregateId           | "shernode-homes"         |
+      | nodeTypeName              | "Neos.Neos:Site"         |
+      | parentNodeAggregateId     | "lady-eleonode-rootford" |
+      | originDimensionSpacePoint | {"language":"de"}        |
+      | nodeName                  | "site"                   |
+    And the command CreateNodeVariant is executed with payload:
+      | Key             | Value             |
+      | nodeAggregateId | "shernode-homes"  |
+      | sourceOrigin    | {"language":"de"} |
+      | targetOrigin    | {"language":"fr"} |
+    And the command CreateNodeAggregateWithNode is executed with payload:
+      | Key                       | Value                      |
+      | nodeAggregateId           | "hidden-source-document"   |
+      | nodeTypeName              | "Neos.Neos:Document"       |
+      | parentNodeAggregateId     | "shernode-homes"           |
+      | originDimensionSpacePoint | {"language":"de"}          |
+      | nodeName                  | "document"                 |
+      | initialPropertyValues     | {"uriPathSegment": "page"} |
+
+    When the command DisableNodeAggregate is executed with payload:
+      | Key                          | Value                    |
+      | nodeAggregateId              | "hidden-source-document" |
+      | coveredDimensionSpacePoint   | {"language":"de"}        |
+      | nodeVariantSelectionStrategy | "allSpecializations"     |
+    And the command CreateNodeVariant is executed with payload:
+      | Key             | Value                    |
+      | nodeAggregateId | "hidden-source-document" |
+      | sourceOrigin    | {"language":"de"}        |
+      | targetOrigin    | {"language":"fr"}        |
+
+    Then I am in dimension space point {"language":"fr"}
+    And I expect the node with aggregate identifier "hidden-source-document" to be explicitly tagged "disabled"


### PR DESCRIPTION
Currently the UriPathProjection will copy the deleted and remove level directly from the source node.

This is incorrect as the values should be calculated from the new target and the tags directy assigned to the varied node.

This change brings the behavior of the documentUriProjection in line with the contentGraphProjection regarding wether subtree tags are to be copied to newly created variants.

- specialization : subtree tags are copied ... `deleted` and `removed` are copied and merged with target parent state
- generalization  : subtree tags are  NOT copied ... `deleted` and `removed` are defined from the parent parent state
- peerVariant : subtree tags are NOT copied ... `deleted` and `removed` are defined from the parent parent state

Resolves: #5972

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

The question wether one should copy subtree-tag informations also during peerVariant or generalizationVariant creation is NOT to be discussed here as this would be a feature that belongs elsewhere.

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-12 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the correct branch:
  - If it's a bugfix, use the [lowest maintained branch which has the bug](https://www.neos.io/features/release-roadmap.html)
  - If it's a non-breaking feature, use the branch of the next version (might be either minor or major)
  - If it's a breaking feature it should typically go into the next major version
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
