### PR TITLE
BUGFIX: Publishing a scope without changes of its own is a no-op

### DIFF
--- a/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
+++ b/Neos.Neos/Classes/Domain/Service/WorkspacePublishingService.php
@@ -132,6 +132,13 @@ final class WorkspacePublishingService
             $ancestorNodeTypeName
         );
 
+        if (
+            $nodeIdsToPublish->isEmpty()
+            && $this->allPendingChangesBelongToAnotherScope($contentRepository, $workspaceName, $ancestorNodeTypeName)
+        ) {
+            return new PublishingResult(0, $crWorkspace->baseWorkspaceName);
+        }
+
         $this->publishNodes($contentRepository, $workspaceName, $nodeIdsToPublish);
         $this->softRemovalGarbageCollector->run($contentRepositoryId);
 
@@ -165,6 +172,13 @@ final class WorkspacePublishingService
             $documentId,
             $ancestorNodeTypeName
         );
+
+        if (
+            $nodeIdsToPublish->isEmpty()
+            && $this->allPendingChangesBelongToAnotherScope($contentRepository, $workspaceName, $ancestorNodeTypeName)
+        ) {
+            return new PublishingResult(0, $crWorkspace->baseWorkspaceName);
+        }
 
         $this->publishNodes($contentRepository, $workspaceName, $nodeIdsToPublish);
         $this->softRemovalGarbageCollector->run($contentRepositoryId);
@@ -213,6 +227,13 @@ final class WorkspacePublishingService
             NodeTypeNameFactory::forSite()
         );
 
+        if (
+            $nodeIdsToDiscard->isEmpty()
+            && $this->allPendingChangesBelongToAnotherScope($contentRepository, $workspaceName, $ancestorNodeTypeName)
+        ) {
+            return new DiscardingResult(0);
+        }
+
         $this->discardNodes($contentRepository, $workspaceName, $nodeIdsToDiscard);
         $this->softRemovalGarbageCollector->run($contentRepositoryId);
 
@@ -242,6 +263,13 @@ final class WorkspacePublishingService
             $documentId,
             $ancestorNodeTypeName
         );
+
+        if (
+            $nodeIdsToDiscard->isEmpty()
+            && $this->allPendingChangesBelongToAnotherScope($contentRepository, $workspaceName, $ancestorNodeTypeName)
+        ) {
+            return new DiscardingResult(0);
+        }
 
         $this->discardNodes($contentRepository, $workspaceName, $nodeIdsToDiscard);
         $this->softRemovalGarbageCollector->run($contentRepositoryId);
@@ -378,6 +406,52 @@ final class WorkspacePublishingService
     {
         $crWorkspace = $this->requireContentRepositoryWorkspace($contentRepository, $workspaceName);
         return $contentRepository->projectionState(ChangeFinder::class)->countByContentStreamId($crWorkspace->currentContentStreamId);
+    }
+
+    /**
+     * Whether every pending change of this workspace can be attributed to an ancestor of the given type.
+     *
+     * This is only consulted when nothing was resolved for the requested scope, in order to tell two very
+     * different situations apart:
+     *
+     * - every change belongs to *another* site or document (e.g. the editor is working in a different site
+     *   of a multi-site content repository). Publishing or discarding the requested scope is then a no-op.
+     * - a change cannot be attributed to any ancestor of that type, for instance because its node no longer
+     *   exists in the workspace. Such a change would silently be left behind, so we must not skip the
+     *   command and let it fail loudly instead.
+     *
+     * @see https://github.com/neos/neos-development-collection/issues/5459 for the underlying problem of
+     *      changes that cannot be attributed to their document or site.
+     */
+    private function allPendingChangesBelongToAnotherScope(
+        ContentRepository $contentRepository,
+        WorkspaceName $workspaceName,
+        NodeTypeName $ancestorNodeTypeName
+    ): bool {
+        $contentGraph = $contentRepository->getContentGraph($workspaceName);
+        foreach ($this->pendingWorkspaceChangesInternal($contentRepository, $workspaceName) as $change) {
+            if ($change->originDimensionSpacePoint === null) {
+                // a change to the node aggregate itself – it can only be attributed if the aggregate still exists
+                if ($contentGraph->findNodeAggregateById($change->nodeAggregateId) === null) {
+                    return false;
+                }
+                continue;
+            }
+
+            $subgraph = $contentGraph->getSubgraph(
+                $change->originDimensionSpacePoint->toDimensionSpacePoint(),
+                VisibilityConstraints::createEmpty()
+            );
+            $ancestorNode = $subgraph->findClosestNode(
+                $change->getLegacyRemovalAttachmentPoint() ?? $change->nodeAggregateId,
+                FindClosestNodeFilter::create(nodeTypes: $ancestorNodeTypeName->value)
+            );
+            if ($ancestorNode === null) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isChangePublishableWithinAncestorScope(


### PR DESCRIPTION
## What I did

`publishChangesInSite()` / `publishChangesInDocument()` (and their discard counterparts) resolve the node ids within the requested scope and pass them to `PublishIndividualNodesFromWorkspace`, which rejects an empty set:

> The command "PublishIndividualNodesFromWorkspace" for workspace `<name>` must contain nodes to publish

There are two very different reasons for that set to be empty, and they currently get the same treatment:

1. **The workspace has no changes in the requested scope.** This is the normal situation in a multi-site content repository: an editor works in site A while pending changes exist in site B. "Publish all" for site A then throws instead of doing nothing — see neos/neos-ui#4151.
2. **Changes exist that should have been part of the scope but could not be attributed to it**, e.g. because their node no longer exists in the workspace. Skipping the command here would silently leave those changes behind forever.

Case 2 is asserted by `Remove node aggregate in user-workspace attempt to publish the site` and must keep failing. My first attempt at this PR returned early for *any* empty set and rightly broke that scenario.

So the two cases are now told apart before the command is issued: if nothing was resolved for the scope, each pending change of the workspace is checked for whether it can be attributed to an ancestor of the scope's type at all. Only if all of them can — and therefore belong to a different site or document — does publishing/discarding return a result with 0 affected changes. If any change cannot be attributed, the command is issued as before and fails loudly.

## How to verify it

In a multi-site setup with a single content repository:

1. Change something in site A, do not publish
2. Switch to site B
3. Use "publish all"

Before: `InvalidArgumentException` (`1737448717`). After: 0 published changes, the change in site A untouched.

The existing behavioural test for the removal case documents the other direction and passes unchanged.

## Notes

This is the content repository side of neos/neos-ui#4151, where the UI counts pending changes workspace-wide but publishes per site — fixed separately in neos/neos-ui#4178. The two are independent: that PR stops the UI from offering unpublishable changes, this one makes an empty scope a no-op for any caller.

The underlying weakness — changes that cannot be attributed to their document or site — is #5459; this PR does not try to solve that, it only stops conflating "nothing to do here" with "something is wrong".

Discarding is affected in the same way through `DiscardIndividualNodesFromWorkspace` (`1737448741`) and is handled alongside.
